### PR TITLE
Bug 577878 - [GTK] Limit Table/Tree drag image to contol's width

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/gtk/org/eclipse/swt/dnd/TreeTableCommon.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/gtk/org/eclipse/swt/dnd/TreeTableCommon.java
@@ -37,22 +37,16 @@ class TreeTableCommon {
 		long originalList = list;
 
 		Display display = control.getDisplay();
-		if (count == 1) {
-			long path = OS.g_list_nth_data (list, 0);
-			long icon = GTK.gtk_tree_view_create_row_drag_icon (handle, path);
-			dragSourceImage =  Image.gtk_new (display, SWT.ICON, icon, 0);
-			GTK.gtk_tree_path_free (path);
-		} else {
-			int width = 0, height = 0;
-			int[] w = new int[1], h = new int[1];
-			int[] yy = new int[count], hh = new int[count];
-			long [] icons = new long [count];
-			GdkRectangle rect = new GdkRectangle ();
-			for (int i=0; i<count; i++) {
-				long path = OS.g_list_data (list);
-				GTK.gtk_tree_view_get_cell_area (handle, path, 0, rect);
-				icons[i] = GTK.gtk_tree_view_create_row_drag_icon(handle, path);
-				switch (Cairo.cairo_surface_get_type(icons[i])) {
+		int width = 0, height = 0;
+		int[] w = new int[1], h = new int[1];
+		int[] yy = new int[count], hh = new int[count];
+		long [] icons = new long [count];
+		GdkRectangle rect = new GdkRectangle ();
+		for (int i=0; i<count; i++) {
+			long path = OS.g_list_data (list);
+			GTK.gtk_tree_view_get_cell_area (handle, path, 0, rect);
+			icons[i] = GTK.gtk_tree_view_create_row_drag_icon(handle, path);
+			switch (Cairo.cairo_surface_get_type(icons[i])) {
 				case Cairo.CAIRO_SURFACE_TYPE_IMAGE:
 					w[0] = Cairo.cairo_image_surface_get_width(icons[i]);
 					h[0] = Cairo.cairo_image_surface_get_height(icons[i]);
@@ -61,15 +55,30 @@ class TreeTableCommon {
 					w[0] = Cairo.cairo_xlib_surface_get_width(icons[i]);
 					h[0] = Cairo.cairo_xlib_surface_get_height(icons[i]);
 					break;
-				}
-				width = Math.max(width, w[0]);
-				height = rect.y + h[0] - yy[0];
-				yy[i] = rect.y;
-				hh[i] = h[0];
-				list = OS.g_list_next (list);
-				GTK.gtk_tree_path_free (path);
 			}
-			long surface = Cairo.cairo_image_surface_create(Cairo.CAIRO_FORMAT_ARGB32, width, height);
+			width = Math.max(width, w[0]);
+			height = rect.y + h[0] - yy[0];
+			yy[i] = rect.y;
+			hh[i] = h[0];
+			list = OS.g_list_next (list);
+			GTK.gtk_tree_path_free (path);
+		}
+		OS.g_list_free (originalList);
+		list = originalList = 0;
+
+		// Limit image size to Control's size. This is to avoid
+		// images that are too wide when wide columns are present.
+		// Windows and macOS also limit width to Control's width.
+		GtkAllocation controlSize = new GtkAllocation();
+		GTK.gtk_widget_get_allocation(handle, controlSize);
+		int sourceWidth = width;
+		width = Math.min(width, controlSize.width);
+
+		long surface;
+		if ((count == 1) && (sourceWidth == width)) {
+			surface = icons[0];
+		} else {
+			surface = Cairo.cairo_image_surface_create(Cairo.CAIRO_FORMAT_ARGB32, width, height);
 			if (surface == 0) SWT.error(SWT.ERROR_NO_HANDLES);
 			long cairo = Cairo.cairo_create(surface);
 			if (cairo == 0) SWT.error(SWT.ERROR_NO_HANDLES);
@@ -81,9 +90,9 @@ class TreeTableCommon {
 				Cairo.cairo_surface_destroy(icons[i]);
 			}
 			Cairo.cairo_destroy(cairo);
-			dragSourceImage = Image.gtk_new (display, SWT.ICON, surface, 0);
 		}
-		OS.g_list_free (originalList);
+
+		dragSourceImage = Image.gtk_new (display, SWT.ICON, surface, 0);
 		return dragSourceImage;
 	}
 }


### PR DESCRIPTION
Continuation from https://git.eclipse.org/r/c/platform/eclipse.platform.swt/+/192265