### PR TITLE
Javadoc in Button#setImage still references to other platforms

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Button.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Button.java
@@ -894,10 +894,7 @@ public void setGrayed(boolean grayed) {
  * Sets the receiver's image to the argument, which may be
  * <code>null</code> indicating that no image should be displayed.
  * <p>
- * Note that a Button can display an image and text simultaneously
- * on Windows (starting with XP), GTK+ and OSX.  On other platforms,
- * a Button that has an image and text set into it will display the
- * image or text that was set most recently.
+ * Note that a Button can display an image and text simultaneously.
  * </p>
  * @param image the image to display on the receiver (may be <code>null</code>)
  *

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Button.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Button.java
@@ -1127,10 +1127,7 @@ public void setGrayed (boolean grayed) {
  * Sets the receiver's image to the argument, which may be
  * <code>null</code> indicating that no image should be displayed.
  * <p>
- * Note that a Button can display an image and text simultaneously
- * on Windows (starting with XP), GTK+ and OSX.  On other platforms,
- * a Button that has an image and text set into it will display the
- * image or text that was set most recently.
+ * Note that a Button can display an image and text simultaneously.
  * </p>
  * @param image the image to display on the receiver (may be <code>null</code>)
  *

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Button.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Button.java
@@ -837,10 +837,7 @@ public boolean setFocus () {
  * Sets the receiver's image to the argument, which may be
  * <code>null</code> indicating that no image should be displayed.
  * <p>
- * Note that a Button can display an image and text simultaneously
- * on Windows (starting with XP), GTK+ and OSX.  On other platforms,
- * a Button that has an image and text set into it will display the
- * image or text that was set most recently.
+ * Note that a Button can display an image and text simultaneously.
  * </p>
  * @param image the image to display on the receiver (may be <code>null</code>)
  *


### PR DESCRIPTION
Javadoc in Button#setImage still references to other platforms in addition to GTK, Win32 and MacOS

Fixes #7