### PR TITLE
Bug 493455 - [win32] fix: source position ignored when drawing transparent image

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/GC.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/GC.java
@@ -1287,7 +1287,7 @@ void drawBitmapAlpha(Image srcImage, int srcX, int srcY, int srcWidth, int srcHe
 		long oldSrcBitmap = OS.SelectObject(srcHdc, srcImage.handle);
 		blend.SourceConstantAlpha = (byte)sourceAlpha;
 		blend.AlphaFormat = OS.AC_SRC_ALPHA;
-		OS.AlphaBlend(handle, destX, destY, destWidth, destHeight, srcHdc, 0, 0, srcWidth, srcHeight, blend);
+		OS.AlphaBlend(handle, destX, destY, destWidth, destHeight, srcHdc, srcX, srcY, srcWidth, srcHeight, blend);
 		OS.SelectObject(srcHdc, oldSrcBitmap);
 		OS.DeleteDC(srcHdc);
 		return;

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_GC.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_GC.java
@@ -641,6 +641,49 @@ public void test_toString() {
 	assertTrue(s.length() > 0);
 }
 
+@Test
+public void test_bug493455_drawImageAlpha_srcPos() {
+	RGB red = new RGB(255, 0, 0);
+	RGB green = new RGB(0, 255, 0);
+
+	ImageData initImageData = new ImageData(200, 200, 32, new PaletteData(0xff, 0xff00, 0xff0000));
+	initImageData.alphaData = new byte[200 * 200];
+	Image srcImage = new Image(display, initImageData);
+
+	GC srcImageGc = new GC(srcImage);
+	srcImageGc.setAdvanced(true);
+	srcImageGc.setBackground(new Color(red));
+	srcImageGc.fillRectangle(0, 0, 200, 200);
+	srcImageGc.setBackground(new Color(green));
+	srcImageGc.fillRectangle(100, 50, 100, 150);
+	srcImageGc.dispose();
+
+	gc.drawImage(srcImage, 100, 50, 100, 150, 0, 0, 100, 150);
+
+	ImageData srcImageData = srcImage.getImageData();
+	srcImage.dispose();
+
+	ImageData testImageData = image.getImageData();
+
+	assertNotNull(srcImageData.alphaData);
+
+	for (int i = 0; i < 200; ++i) {
+		for (int j = 0; j < 200; ++j) {
+			RGB expected = (i < 100 || j < 50) ? red : green;
+			RGB actual = srcImageData.palette.getRGB(srcImageData.getPixel(i, j));
+			assertEquals(expected, actual);
+		}
+	}
+
+	for (int i = 0; i < 100; ++i) {
+		for (int j = 0; j < 150; ++j) {
+			RGB rgb = testImageData.palette.getRGB(testImageData.getPixel(i, j));
+			assertEquals(green, rgb);
+		}
+	}
+
+}
+
 /* custom */
 Display display;
 Shell shell;


### PR DESCRIPTION
Fixes a regression introduced with commit 22797d3f9f09ca67bfd29c864f2aaf8eb452c75c that was reported in [Bug 493455 (comment 51)](https://bugs.eclipse.org/bugs/show_bug.cgi?id=493455#c51).