### PR TITLE
Bug 579299 - [GTK4]  Call gtk_focus_out_event when window loses focus

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Widget.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Widget.java
@@ -800,7 +800,8 @@ void gtk4_focus_enter_event(long controller, long event) {}
  * @param event the type of event, should be FocusIn or FocusOut
  */
 void gtk4_focus_window_event(long handle, long event) {
-	gtk_focus_in_event (handle, event);
+	if(event == SWT.FocusIn) gtk_focus_in_event (handle, event);
+	else gtk_focus_out_event(handle, event);
 }
 
 /**


### PR DESCRIPTION
When a window lost focus, gtk_focus_out_event was not being called in GTK4. 