### PR TITLE
 Dependabot security alert: Ant

### DIFF
--- a/bundles/org.eclipse.swt/pom.xml
+++ b/bundles/org.eclipse.swt/pom.xml
@@ -89,7 +89,7 @@
                             <dependency>
                                 <groupId>org.apache.ant</groupId>
                                 <artifactId>ant</artifactId>
-                                <version>1.10.9</version>
+                                <version>[1.10.11,)</version>
                             </dependency>
                         </dependencies>
                     </plugin>


### PR DESCRIPTION
Improper Handling of Length Parameter Inconsistency in Apache Ant
When reading a specially crafted TAR archive an Apache Ant build can be made to allocate large amounts of memory that finally leads to an out of memory error, even for small inputs. This can be used to disrupt builds using Apache Ant. Apache Ant prior to 1.9.16 and 1.10.11 were affected.