### PR TITLE
Bug 579470 - Add ToolItem background and foreground color properties

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT PI/win32/library/os.c
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/win32/library/os.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corporation and others.
+ * Copyright (c) 2000, 2022 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -8459,6 +8459,18 @@ JNIEXPORT jboolean JNICALL OS_NATIVE(SetCursorPos)
 	OS_NATIVE_ENTER(env, that, SetCursorPos_FUNC);
 	rc = (jboolean)SetCursorPos(arg0, arg1);
 	OS_NATIVE_EXIT(env, that, SetCursorPos_FUNC);
+	return rc;
+}
+#endif
+
+#ifndef NO_SetDCBrushColor
+JNIEXPORT jint JNICALL OS_NATIVE(SetDCBrushColor)
+	(JNIEnv *env, jclass that, jlong arg0, jint arg1)
+{
+	jint rc = 0;
+	OS_NATIVE_ENTER(env, that, SetDCBrushColor_FUNC);
+	rc = (jint)SetDCBrushColor(arg0, arg1);
+	OS_NATIVE_EXIT(env, that, SetDCBrushColor_FUNC);
 	return rc;
 }
 #endif

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/win32/library/os_stats.c
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/win32/library/os_stats.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corporation and others.
+ * Copyright (c) 2000, 2022 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -628,6 +628,7 @@ char * OS_nativeFunctionNames[] = {
 	"SetCurrentProcessExplicitAppUserModelID",
 	"SetCursor",
 	"SetCursorPos",
+	"SetDCBrushColor",
 	"SetDIBColorTable",
 	"SetFocus",
 	"SetForegroundWindow",

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/win32/library/os_stats.h
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/win32/library/os_stats.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corporation and others.
+ * Copyright (c) 2000, 2022 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -638,6 +638,7 @@ typedef enum {
 	SetCurrentProcessExplicitAppUserModelID_FUNC,
 	SetCursor_FUNC,
 	SetCursorPos_FUNC,
+	SetDCBrushColor_FUNC,
 	SetDIBColorTable_FUNC,
 	SetFocus_FUNC,
 	SetForegroundWindow_FUNC,

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/win32/org/eclipse/swt/internal/win32/OS.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/win32/org/eclipse/swt/internal/win32/OS.java
@@ -343,6 +343,7 @@ public class OS extends C {
 	public static final int CW_USEDEFAULT = 0x80000000;
 	public static final int CWP_SKIPINVISIBLE = 0x0001;
 	public static final String DATETIMEPICK_CLASS = "SysDateTimePick32"; //$NON-NLS-1$
+	public static final int DC_BRUSH = 18;
 	public static final int DCX_CACHE = 0x2;
 	public static final int DEFAULT_CHARSET = 0x1;
 	public static final int DEFAULT_GUI_FONT = 0x11;
@@ -1310,6 +1311,7 @@ public class OS extends C {
 	public static final int S_OK = 0x0;
 	public static final int TABP_BODY = 10;
 	public static final int TBCDRF_USECDCOLORS = 0x800000;
+	public static final int TBCDRF_NOBACKGROUND = 0x00400000;
 	public static final int TBIF_COMMAND = 0x20;
 	public static final int TBIF_STATE = 0x4;
 	public static final int TBIF_IMAGE = 0x1;
@@ -1318,6 +1320,7 @@ public class OS extends C {
 	public static final int TBIF_STYLE = 0x8;
 	public static final int TBIF_TEXT = 0x2;
 	public static final int TB_GETEXTENDEDSTYLE = 0x400 + 85;
+	public static final int TB_GETRECT = 0x400 + 51;
 	public static final int TBM_GETLINESIZE = 0x418;
 	public static final int TBM_GETPAGESIZE = 0x416;
 	public static final int TBM_GETPOS = 0x400;
@@ -4265,6 +4268,7 @@ public static final native int SetCurrentProcessExplicitAppUserModelID (char[] A
 /** @param hCursor cast=(HCURSOR) */
 public static final native long SetCursor (long hCursor);
 public static final native boolean SetCursorPos (int X, int Y);
+public static final native int SetDCBrushColor (long hdc, int color);
 /**
  * @param hdc cast=(HDC)
  * @param pColors cast=(RGBQUAD *),flags=no_out critical

--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/ToolBar.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/ToolBar.java
@@ -774,8 +774,15 @@ void setBounds (int x, int y, int width, int height, boolean move, boolean resiz
 @Override
 void setFont(NSFont font) {
 	for (int i = 0; i < itemCount; i++) {
-		ToolItem item = items[i];
-		if (item.button != null) ((NSButton)item.button).setAttributedTitle(item.createString());
+		items[i].updateStyle ();
+	}
+}
+
+@Override
+void setForeground (double [] color) {
+	super.setForeground (color);
+	for (int i = 0; i < itemCount; i++) {
+		items[i].updateStyle ();
 	}
 }
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/ToolBar.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/ToolBar.java
@@ -683,23 +683,12 @@ void setFontDescription (long font) {
 	relayout ();
 }
 
-void restoreBackground () {
-	/*
-	 * We need to restore the cached background color in order to prevent
-	 * setting the foreground color from overriding the background color
-	 * (or replacing it with black).
-	 */
-	long context = GTK.gtk_widget_get_style_context(handle);
-	String finalCss = display.gtk_css_create_css_color_string (this.cssBackground, this.cssForeground, SWT.BACKGROUND);
-	gtk_css_provider_load_from_css (context, finalCss);
-}
-
 @Override
 void setForegroundGdkRGBA (GdkRGBA rgba) {
 	super.setForegroundGdkRGBA (rgba);
 	ToolItem [] items = getItems ();
 	for (int i = 0; i < items.length; i++) {
-		items[i].setForegroundRGBA (rgba);
+		items[i].updateStyle ();
 	}
 }
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ToolItem.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ToolItem.java
@@ -48,6 +48,7 @@ public class ToolItem extends Item {
 	Image disabledImage2;
 	int id;
 	short cx;
+	int foreground = -1, background = -1;
 
 /**
  * Constructs a new instance of this class given its parent
@@ -287,6 +288,27 @@ public Image getDisabledImage () {
 }
 
 /**
+ * Returns the receiver's background color.
+ * <p>
+ * Note: This operation is a hint and may be overridden by the platform.
+ * For example, on some versions of Windows the background of a TabFolder,
+ * is a gradient rather than a solid color.
+ * </p>
+ * @return the background color
+ *
+ * @exception SWTException <ul>
+ *    <li>ERROR_WIDGET_DISPOSED - if the receiver has been disposed</li>
+ *    <li>ERROR_THREAD_INVALID_ACCESS - if not called from the thread that created the receiver</li>
+ * </ul>
+ *
+ * @since 3.120
+ */
+public Color getBackground () {
+	checkWidget ();
+	return Color.win32_new (display, parent.getBackgroundPixel (this));
+}
+
+/**
  * Returns <code>true</code> if the receiver is enabled, and
  * <code>false</code> otherwise. A disabled control is typically
  * not selectable from the user interface and draws with an
@@ -309,6 +331,23 @@ public boolean getEnabled () {
 	long hwnd = parent.handle;
 	long fsState = OS.SendMessage (hwnd, OS.TB_GETSTATE, id, 0);
 	return (fsState & OS.TBSTATE_ENABLED) != 0;
+}
+
+/**
+ * Returns the foreground color that the receiver will use to draw.
+ *
+ * @return the receiver's foreground color
+ *
+ * @exception SWTException <ul>
+ *    <li>ERROR_WIDGET_DISPOSED - if the receiver has been disposed</li>
+ *    <li>ERROR_THREAD_INVALID_ACCESS - if not called from the thread that created the receiver</li>
+ * </ul>
+ *
+ * @since 3.120
+ */
+public Color getForeground () {
+	checkWidget ();
+	return Color.win32_new (display, parent.getForegroundPixel (this));
 }
 
 /**
@@ -458,6 +497,13 @@ boolean isTabGroup () {
 	return (previous.getStyle () & SWT.SEPARATOR) != 0;
 }
 
+void redraw () {
+	RECT rect = new RECT ();
+	if (OS.SendMessage (parent.handle, OS.TB_GETRECT, id, rect) != 0) {
+		OS.InvalidateRect (parent.handle, rect, true);
+	}
+}
+
 @Override
 void releaseWidget () {
 	super.releaseWidget ();
@@ -555,6 +601,37 @@ void selectRadio () {
 	int j = index + 1;
 	while (j < items.length && items [j].setRadioSelection (false)) j++;
 	setSelection (true);
+}
+
+/**
+ * Sets the receiver's background color to the color specified
+ * by the argument, or to the default system color for the control
+ * if the argument is null.
+ * <p>
+ * Note: This operation is a hint and may be overridden by the platform.
+ * </p>
+ * @param color the new color (or null)
+ *
+ * @exception IllegalArgumentException <ul>
+ *    <li>ERROR_INVALID_ARGUMENT - if the argument has been disposed</li>
+ * </ul>
+ * @exception SWTException <ul>
+ *    <li>ERROR_WIDGET_DISPOSED - if the receiver has been disposed</li>
+ *    <li>ERROR_THREAD_INVALID_ACCESS - if not called from the thread that created the receiver</li>
+ * </ul>
+ *
+ * @since 3.120
+ */
+public void setBackground (Color color) {
+	checkWidget ();
+	if (color != null && color.isDisposed ()) {
+		error (SWT.ERROR_INVALID_ARGUMENT);
+	}
+	parent.state |= CUSTOM_DRAW_ITEM;
+	int pixel = (color != null) ? color.handle : -1;
+	if (pixel == background) return;
+	background = pixel;
+	redraw ();
 }
 
 /**
@@ -710,6 +787,37 @@ public void setDisabledImage (Image image) {
 	parent.layout(isImageSizeChanged(disabledImage, image));
 	disabledImage = image;
 	updateImages (getEnabled () && parent.getEnabled ());
+}
+
+/**
+ * Sets the receiver's foreground color to the color specified
+ * by the argument, or to the default system color for the control
+ * if the argument is null.
+ * <p>
+ * Note: This operation is a hint and may be overridden by the platform.
+ * </p>
+ * @param color the new color (or null)
+ *
+ * @exception IllegalArgumentException <ul>
+ *    <li>ERROR_INVALID_ARGUMENT - if the argument has been disposed</li>
+ * </ul>
+ * @exception SWTException <ul>
+ *    <li>ERROR_WIDGET_DISPOSED - if the receiver has been disposed</li>
+ *    <li>ERROR_THREAD_INVALID_ACCESS - if not called from the thread that created the receiver</li>
+ * </ul>
+ *
+ * @since 3.120
+ */
+public void setForeground (Color color) {
+	checkWidget ();
+	if (color != null && color.isDisposed ()) {
+		error (SWT.ERROR_INVALID_ARGUMENT);
+	}
+	parent.state |= CUSTOM_DRAW_ITEM;
+	int pixel = (color != null) ? color.handle : -1;
+	if (pixel == foreground) return;
+	foreground = pixel;
+	redraw ();
 }
 
 /**

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Widget.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Widget.java
@@ -102,6 +102,9 @@ public abstract class Widget {
 	/* Mouse cursor is over the widget flag */
 	static final int MOUSE_OVER = 1<<23;
 
+	/* Child item requires custom draw */
+	static final int CUSTOM_DRAW_ITEM = 1<<24;
+
 	/* Default size for widgets */
 	static final int DEFAULT_WIDTH	= 64;
 	static final int DEFAULT_HEIGHT	= 64;

--- a/bundles/org.eclipse.swt/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.swt/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.swt; singleton:=true
-Bundle-Version: 3.119.100.qualifier
+Bundle-Version: 3.120.0.qualifier
 Bundle-ManifestVersion: 2
 Bundle-Localization: plugin
 DynamicImport-Package: org.eclipse.swt.accessibility2

--- a/bundles/org.eclipse.swt/build.xml
+++ b/bundles/org.eclipse.swt/build.xml
@@ -9,7 +9,7 @@
     https://www.eclipse.org/legal/epl-2.0/
 
     SPDX-License-Identifier: EPL-2.0
-   
+
     Contributors:
         IBM Corporation - initial API and implementation
  -->
@@ -18,7 +18,7 @@
 
 	<target name="init">
 		<property name="plugin" value="org.eclipse.swt" />
-		<property name="version.suffix" value="3.118.100" />
+		<property name="version.suffix" value="3.120.0" />
 		<property name="full.name" value="${plugin}_${version.suffix}" />
 		<property name="temp.folder" value="${basedir}/temp.folder" />
 		<property name="plugin.destination" value="${basedir}" />

--- a/bundles/org.eclipse.swt/pom.xml
+++ b/bundles/org.eclipse.swt/pom.xml
@@ -21,7 +21,7 @@
     </parent>
     <groupId>org.eclipse.swt</groupId>
     <artifactId>org.eclipse.swt</artifactId>
-    <version>3.119.100-SNAPSHOT</version>
+    <version>3.120.0-SNAPSHOT</version>
     <packaging>eclipse-plugin</packaging>
 
     <properties>

--- a/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet153.java
+++ b/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet153.java
@@ -14,41 +14,73 @@
 package org.eclipse.swt.snippets;
 
 /*
- * ToolBar example snippet: update a status line when the mouse enters a tool item
+ * ToolBar example snippet: item colors and status text
  *
  * For a list of all SWT example snippets see
  * http://www.eclipse.org/swt/snippets/
  */
 import org.eclipse.swt.*;
 import org.eclipse.swt.graphics.*;
+import org.eclipse.swt.layout.*;
 import org.eclipse.swt.widgets.*;
 
 public class Snippet153 {
 
-static String statusText = "";
 public static void main(String[] args) {
-	final Display display = new Display();
+	Display display = new Display();
 	Shell shell = new Shell(display);
 	shell.setText("Snippet 153");
-	shell.setBounds(10, 10, 200, 200);
-	final ToolBar bar = new ToolBar(shell, SWT.BORDER);
-	bar.setBounds(10, 10, 150, 50);
-	final Label statusLine = new Label(shell, SWT.BORDER);
-	statusLine.setBounds(10, 90, 150, 30);
-	new ToolItem(bar, SWT.NONE).setText("item 1");
-	new ToolItem(bar, SWT.NONE).setText("item 2");
-	new ToolItem(bar, SWT.NONE).setText("item 3");
-	bar.addMouseMoveListener(e -> {
-		ToolItem item = bar.getItem(new Point(e.x, e.y));
-		String name = "";
-		if (item != null) {
-			name = item.getText();
-		}
-		if (!statusText.equals(name)) {
-			statusLine.setText(name);
-			statusText = name;
+	RowLayout layout = new RowLayout(SWT.VERTICAL);
+	layout.fill = true;
+	shell.setLayout(layout);
+	ToolBar bar = new ToolBar(shell, SWT.BORDER);
+	Label statusLine = new Label(shell, SWT.BORDER);
+	ToolItem toggle = new ToolItem(bar, SWT.CHECK);
+	toggle.setText("Toggle Bar Colors");
+	new ToolItem(bar, SWT.SEPARATOR);
+	new ToolItem(bar, SWT.PUSH).setText("Push Button");
+	new ToolItem(bar, SWT.DROP_DOWN).setText("Drop Down");
+
+	toggle.addListener(SWT.Selection, event -> {
+		if (toggle.getSelection()) {
+			bar.setForeground(display.getSystemColor(SWT.COLOR_GREEN));
+			bar.setBackground(display.getSystemColor(SWT.COLOR_BLUE));
+		} else {
+			bar.setForeground(null);
+			bar.setBackground(null);
 		}
 	});
+
+	Listener barListener = new Listener() {
+		ToolItem item;
+		String statusText = "";
+
+		@Override
+		public void handleEvent(Event event) {
+			if (item != null) {
+				item.setForeground(null);
+				item.setBackground(null);
+			}
+			if (event.type == SWT.MouseMove) {
+				item = bar.getItem(new Point(event.x, event.y));
+			} else {
+				item = null;
+			}
+			if (item != null) {
+				item.setForeground(display.getSystemColor(SWT.COLOR_RED));
+				item.setBackground(display.getSystemColor(SWT.COLOR_YELLOW));
+			}
+			String name = (item != null) ? item.getText() : "";
+			if (!statusText.equals(name)) {
+				statusLine.setText(name);
+				statusText = name;
+			}
+		}
+	};
+	bar.addListener(SWT.MouseMove, barListener);
+	bar.addListener(SWT.MouseExit, barListener);
+
+	shell.pack();
 	shell.open();
 	while (!shell.isDisposed()) {
 		if (!display.readAndDispatch()) display.sleep();

--- a/tests/org.eclipse.swt.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.swt.tests/META-INF/MANIFEST.MF
@@ -8,7 +8,7 @@ Bundle-Localization: plugin
 Export-Package: org.eclipse.swt.tests.junit,
  org.eclipse.swt.tests.junit.performance
 Require-Bundle: org.junit;bundle-version="4.12.0",
- org.eclipse.swt;bundle-version="3.118.100",
+ org.eclipse.swt;bundle-version="3.120.0",
  org.eclipse.test.performance;bundle-version="3.13.0"
 Eclipse-BundleShape: dir
 Bundle-RequiredExecutionEnvironment: JavaSE-11


### PR DESCRIPTION
This patch adds new API for recoloring ToolItems. SWT version is bumped to 3.120.0.

Recolored toolbar buttons look decent, but there is some space for discussion. In particular, GTK drop-down buttons are made of two parts (the main button and the arrow button) and the patch recolors them individually. Also, separators ignore color properties, but in theory it's possible for them to respect foreground color.

Snippet153 has been extended for testing this patch. I've tested it on the latest stable versions of macOS, Windows and GNOME (GTK 3.24).