### PR TITLE
Bug 579626 part2- RTL text is not rendered correctly on TextLayout #37

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/TextLayout.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/TextLayout.java
@@ -2760,10 +2760,10 @@ StyleItem[] itemize () {
 	// enable font ligatures
 	scriptControl.fMergeNeutralItems = true;
 	/*
-	 * When Bidi is enabled i.e. RIGHT_TO_LEFT Arabic like characters are used, it's
-	 * not rendered properly. For more details refer bug 579626.
+	 * When RIGHT_TO_LEFT Arabic like characters are used, it's not rendered
+	 * properly. For more details refer bug 579626(SWT issue #37)
 	 */
-	if (!scriptState.fArabicNumContext) {
+	if (BidiUtil.resolveTextDirection(text) != SWT.RIGHT_TO_LEFT) {
 		/*
 		 * With font ligatures enabled: CJK characters are not rendered properly when
 		 * used in Java comments, workaround is to avoid ligatures between ascii and

--- a/tests/org.eclipse.swt.tests.win32/ManualTests/org/eclipse/swt/tests/win32/snippets/Bug579626_ArabicTest.java
+++ b/tests/org.eclipse.swt.tests.win32/ManualTests/org/eclipse/swt/tests/win32/snippets/Bug579626_ArabicTest.java
@@ -1,0 +1,35 @@
+package org.eclipse.swt.tests.win32.snippets;
+
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.custom.StyledText;
+import org.eclipse.swt.layout.GridLayout;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Shell;
+import org.eclipse.swt.widgets.Text;
+
+class Bug579626_ArabicTest {
+
+	private static final String ARABIC_TEXT = "جارِ التحميل";
+
+	public static void main(String[] args) {
+		final Display display = new Display();
+		Shell shell = new Shell(display);
+		shell.setLayout(new GridLayout());
+
+		// This is rendered correctly
+		Text text = new Text(shell, SWT.BORDER);
+		text.setText(ARABIC_TEXT);
+
+		// This is not rendered correctly
+		StyledText styled = new StyledText(shell, SWT.BORDER | SWT.MULTI);
+		styled.setText(ARABIC_TEXT);
+
+		shell.pack();
+		shell.open();
+
+		while (!shell.isDisposed()) {
+			if (!display.readAndDispatch())
+				display.sleep();
+		}
+	}
+}


### PR DESCRIPTION
- Updated check to correctly/consistently identify RIGHT_TO_LEFT
scenario.

Change-Id: Ic1aafc83f0fe68d52cf4c45790cb1fea5c2ecf46
Signed-off-by: Niraj Modi <niraj.modi@in.ibm.com>