### PR TITLE
Mixed RTL text(with LTR) is not rendered correctly in StyledText widget

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/BidiUtil.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/BidiUtil.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corporation and others.
+ * Copyright (c) 2000, 2022 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -503,7 +503,7 @@ public static int resolveTextDirection (String text) {
 			OS.MoveMemory(order, result.lpOrder, 4);
 			if (order[0] == 0) {
 				textDirection = SWT.LEFT_TO_RIGHT;
-				break;
+				// Do-not break here, instead scan the complete text for any RTL possibility
 			}
 		}
 	}

--- a/tests/org.eclipse.swt.tests.win32/ManualTests/org/eclipse/swt/tests/win32/snippets/Bug579626_English_ArabicTest.java
+++ b/tests/org.eclipse.swt.tests.win32/ManualTests/org/eclipse/swt/tests/win32/snippets/Bug579626_English_ArabicTest.java
@@ -1,0 +1,35 @@
+package org.eclipse.swt.tests.win32.snippets;
+
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.custom.StyledText;
+import org.eclipse.swt.layout.GridLayout;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Shell;
+import org.eclipse.swt.widgets.Text;
+
+class Bug579626_English_ArabicTest {
+
+    private static final String MIXED_TEXT = "English جارِ التحميل";
+
+    public static void main(String[] args) {
+        final Display display = new Display();
+        Shell shell = new Shell(display);
+        shell.setLayout(new GridLayout());
+
+        System.out.println(MIXED_TEXT);
+        // This is rendered correctly
+        Text text = new Text(shell, SWT.BORDER);
+        text.setText(MIXED_TEXT);
+
+        // This is not rendered correctly
+        StyledText styled = new StyledText(shell, SWT.BORDER | SWT.MULTI);
+        styled.setText(MIXED_TEXT);
+
+        shell.pack();
+        shell.open();
+
+        while(!shell.isDisposed()) {
+            if(!display.readAndDispatch()) display.sleep();
+        }
+    }
+}


### PR DESCRIPTION
#44
- Fixed BidiUtil#resolveTextDirection() to work for complete string(not
just first character of the string)

Change-Id: I62ca926cee5cec294f5eacdbaee703f8e50e3c68
Signed-off-by: Niraj Modi <niraj.modi@in.ibm.com>