### PR TITLE
[GTK4] Call gtk_window_destroy if widget to be destroyed is a GtkWindow

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Control.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Control.java
@@ -4845,7 +4845,13 @@ void destroyWidget() {
 	if (GTK.GTK4) {
 		// Remove widget from hierarchy  by removing it from parent container
 		if (parent != null) {
-			OS.swt_fixed_remove(parent.parentingHandle(), fixedHandle);
+			long currHandle = topHandle();
+			if(GTK.GTK_IS_WINDOW(currHandle)) {
+				GTK4.gtk_window_destroy(currHandle);
+			}
+			else {
+				OS.swt_fixed_remove(parent.parentingHandle(), fixedHandle);
+			}
 		}
 		releaseHandle();
 	} else {


### PR DESCRIPTION
Previously, when the dialog was closed in Snippet 50, an swt_fixed_remove assertion error was logged in the console (issue #49). With this patch that no longer happens. 

- added a call to gtk_window_destroy which happens only if GTK_IS_WINDOW is true.

Tested using Snippet 50. 