### PR TITLE
Part2: Mixed RTL text(with LTR) is not rendered correctly in StyledText

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/BidiUtil.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/BidiUtil.java
@@ -494,6 +494,10 @@ public static int resolveTextDirection (String text) {
 			textDirection = SWT.RIGHT_TO_LEFT;
 			break;
 		}
+		if (textDirection == SWT.LEFT_TO_RIGHT) {
+			// If textDirection is already LTR, skip probing for LTR again.
+			continue;
+		}
 		ltrProbe[2] = ch;
 		OS.GetCharacterPlacement(hdc, ltrProbe, ltrProbe.length, 0, result, OS.GCP_REORDER);
 		OS.MoveMemory(order, result.lpOrder + 4, 4);


### PR DESCRIPTION
- BidiUtil#resolveTextDirection() to avoid re-probing for LRT
eclipse-platform#44