### PR TITLE
Avoid synchronized in Device.isDisposed #74

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/graphics/Device.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/graphics/Device.java
@@ -36,7 +36,8 @@ public abstract class Device implements Drawable {
 	Object trackingLock;
 
 	/* Disposed flag */
-	boolean disposed, warnings;
+	volatile boolean disposed;
+	boolean warnings;
 
 	Color COLOR_BLACK, COLOR_DARK_RED, COLOR_DARK_GREEN, COLOR_DARK_YELLOW, COLOR_DARK_BLUE;
 	Color COLOR_DARK_MAGENTA, COLOR_DARK_CYAN, COLOR_GRAY, COLOR_DARK_GRAY, COLOR_RED, COLOR_TRANSPARENT;
@@ -243,7 +244,7 @@ public void dispose () {
 			}
 
 			destroy ();
-			disposed = true;
+			disposed = true;			
 			if (tracking) {
 				synchronized (trackingLock) {
 					printErrors ();
@@ -663,9 +664,7 @@ public abstract void internal_dispose_GC (long hDC, GCData data);
  * @return <code>true</code> when the device is disposed and <code>false</code> otherwise
  */
 public boolean isDisposed () {
-	synchronized (Device.class) {
-		return disposed;
-	}
+	return disposed;
 }
 
 /**

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/graphics/Device.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/graphics/Device.java
@@ -69,7 +69,7 @@ public abstract class Device implements Drawable {
 	Object trackingLock;
 
 	/* Disposed flag */
-	boolean disposed;
+	volatile boolean disposed;
 
 	/* Warning and Error Handlers */
 	long logProc;
@@ -883,9 +883,7 @@ public abstract void internal_dispose_GC (long hDC, GCData data);
  * @return <code>true</code> when the device is disposed and <code>false</code> otherwise
  */
 public boolean isDisposed () {
-	synchronized (Device.class) {
-		return disposed;
-	}
+	return disposed;
 }
 
 /**

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Device.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Device.java
@@ -54,7 +54,7 @@ public abstract class Device implements Drawable {
 	long fontCollection;
 	String[] loadedFonts;
 
-	boolean disposed;
+	volatile boolean disposed;
 
 	/* Auto-Scaling*/
 	boolean enableAutoScaling = true;
@@ -766,9 +766,7 @@ public abstract void /*long*/ internal_dispose_GC (long hDC, GCData data);
  * @return <code>true</code> when the device is disposed and <code>false</code> otherwise
  */
 public boolean isDisposed () {
-	synchronized (Device.class) {
-		return disposed;
-	}
+	return disposed;
 }
 
 /**


### PR DESCRIPTION
Device.isDisposed() is called much more frequently then dispose() and
should not be costly synchronized. The isDisposed() check in dispose()
is still synchronized so that still there will be no double dispose().