### PR TITLE
make Display.Displays size 1 by default #74

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Display.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Display.java
@@ -333,7 +333,7 @@ public class Display extends Device {
 
 	/* Multiple Displays. */
 	static Display Default;
-	static Display [] Displays = new Display [4];
+	static Display [] Displays = new Display [1];
 
 	/* Skinning support */
 	static final int GROW_SIZE = 1024;

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Display.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Display.java
@@ -496,7 +496,7 @@ public class Display extends Device {
 
 	/* Multiple Displays. */
 	static Display Default;
-	static Display [] Displays = new Display [4];
+	static Display [] Displays = new Display [1];
 
 	/* Skinning support */
 	Widget [] skinList = new Widget [GROW_SIZE];

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Display.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Display.java
@@ -493,7 +493,7 @@ public class Display extends Device {
 
 	/* Multiple Displays */
 	static Display Default;
-	static Display [] Displays = new Display [4];
+	static Display [] Displays = new Display [1];
 
 	/* Multiple Monitors */
 	Monitor[] monitors = null;


### PR DESCRIPTION
There is only 1 display - no need to search in an array of 4 displays
during Display.findDisplay()

It's a minor optimization for Display.findDisplay (). The greatest
bottle neck is still the "synchronized" statement.