### PR TITLE
Use java.util.concurrent for Synchronizer.messages #74

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Display.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Display.java
@@ -1782,10 +1782,6 @@ Menu [] getMenus (Decorations shell) {
 	return result;
 }
 
-int getMessageCount () {
-	return synchronizer.getMessageCount ();
-}
-
 Dialog getModalDialog () {
 	return modalDialog;
 }
@@ -5166,7 +5162,7 @@ public final Consumer<Error> getErrorHandler () {
  */
 public boolean sleep () {
 	checkDevice ();
-	if (getMessageCount () != 0) return true;
+	if (!synchronizer.isMessagesEmpty()) return true;
 	sendPreExternalEventDispatchEvent ();
 	try {
 		addPool();

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Display.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Display.java
@@ -2548,10 +2548,6 @@ int getLastEventTime () {
 	return lastEventTime;
 }
 
-int getMessageCount () {
-	return synchronizer.getMessageCount ();
-}
-
 Dialog getModalDialog () {
 	return modalDialog;
 }
@@ -5566,7 +5562,7 @@ public boolean sleep () {
 		runSettings = true;
 		return false;
 	}
-	if (getMessageCount () != 0) return true;
+	if (!synchronizer.isMessagesEmpty()) return true;
 	sendPreExternalEventDispatchEvent ();
 	if (!GTK.GTK4) GDK.gdk_threads_leave ();
 	/*
@@ -5606,7 +5602,7 @@ public boolean sleep () {
 			OS.g_main_context_check (context, max_priority [0], fds, nfds);
 			OS.g_main_context_release (context);
 		}
-	} while (!result && getMessageCount () == 0 && !wake);
+	} while (!result && synchronizer.isMessagesEmpty() && !wake);
 	wake = false;
 	if (!GTK.GTK4) GDK.gdk_threads_enter ();
 	sendPostExternalEventDispatchEvent ();

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Display.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Display.java
@@ -311,7 +311,7 @@ public class Display extends Device {
 	static final short [] ACCENTS = new short [] {'~', '`', '\'', '^', '"'};
 
 	/* Sync/Async Widget Communication */
-	Synchronizer synchronizer = new Synchronizer (this);
+	Synchronizer synchronizer;
 	Consumer<RuntimeException> runtimeExceptionHandler = DefaultExceptionHandler.RUNTIME_EXCEPTION_HANDLER;
 	Consumer<Error> errorHandler = DefaultExceptionHandler.RUNTIME_ERROR_HANDLER;
 	boolean runMessagesInIdle = false, runMessagesInMessageProc = true;
@@ -2730,6 +2730,7 @@ public long internal_new_GC (GCData data) {
  */
 @Override
 protected void init () {
+	this.synchronizer = new Synchronizer (this); // Field initialization happens after super constructor
 	super.init ();
 	DPIUtil.setDeviceZoom (getDeviceZoom ());
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Display.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Display.java
@@ -1383,7 +1383,7 @@ public Widget findWidget (Widget widget, long id) {
 
 long foregroundIdleProc (long code, long wParam, long lParam) {
 	if (code >= 0) {
-		if (getMessageCount () != 0) {
+		if (!synchronizer.isMessagesEmpty()) {
 			sendPostExternalEventDispatchEvent ();
 			if (runMessagesInIdle) {
 				if (runMessagesInMessageProc) {
@@ -2107,17 +2107,6 @@ MenuItem getMenuItem (int id) {
 	if (0 <= id && id < items.length) return items [id];
 	return null;
 }
-
-int getMessageCount () {
-	/*
-	 * On Windows10 (update 18272), an NPE is seen in below code which leads to a
-	 * possible crash, adding a null check for synchronizer instance. For more
-	 * details refer bug 540762
-	 */
-	if (synchronizer != null) return synchronizer.getMessageCount ();
-	return 0;
-}
-
 
 Shell getModalShell () {
 	if (modalShells == null) return null;
@@ -4762,7 +4751,7 @@ int shiftedKey (int key) {
  */
 public boolean sleep () {
 	checkDevice ();
-	if (getMessageCount () != 0) return true;
+	if (!synchronizer.isMessagesEmpty()) return true;
 	sendPreExternalEventDispatchEvent ();
 	boolean result = OS.WaitMessage ();
 	sendPostExternalEventDispatchEvent ();


### PR DESCRIPTION
Synchronizer.messages grew with constant size leading to O(n^2)
performance for n messages.
Also the costly "synchronized" can be avoided by using
java.util.concurrent DataStructures.

The message queue size (which is not O(1) for java.util.concurrent) is
not needed since only checks for isEmpty() are used.