### PR TITLE
Synchronizer does not need to notify if nobody is waiting #81

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/Synchronizer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/Synchronizer.java
@@ -190,8 +190,10 @@ boolean runAsyncMessages (boolean all) {
 				if (display != null && !display.isDisposed()) {
 					display.sendPostEvent(SWT.None);
 				}
-				syncThread = null;
-				lock.notifyAll ();
+				if (syncThread!=null) {
+					syncThread = null;
+					lock.notifyAll();
+				}
 			}
 		}
 	} while (all);


### PR DESCRIPTION
When messages have been enqueued for async execution there is no thread
waiting anyway.