### PR TITLE
Get rid of references to o.e.swt.tests.fragments.feature

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -117,7 +117,6 @@
     <module>examples/org.eclipse.swt.examples.launcher</module>
     <module>examples/org.eclipse.swt.examples.ole.win32</module>
     <module>examples/org.eclipse.swt.examples.views</module>
-    <!--module>tests/org.eclipse.swt.tests.fragments.feature</module-->
     <module>tests/org.eclipse.swt.tests</module>
     <module>features/org.eclipse.swt.tools.feature</module>
   </modules>

--- a/tests/org.eclipse.swt.tests.cocoa/pom.xml
+++ b/tests/org.eclipse.swt.tests.cocoa/pom.xml
@@ -29,24 +29,6 @@
     <plugins>
       <plugin>
         <groupId>org.eclipse.tycho</groupId>
-        <artifactId>target-platform-configuration</artifactId>
-        <configuration>
-          <!-- Make all platform-specific fragments available (and optional) via a feature -->
-	      <dependency-resolution>
-	         <extraRequirements>
-	            <requirement>
-	               <type>eclipse-feature</type>
-	               <id>org.eclipse.swt.tests.fragments.feature</id>
-	               <versionRange>0.0.0</versionRange>
-	            </requirement>
-	         </extraRequirements>
-	      </dependency-resolution>
-	      <!-- but only resolve against current environment as we don't want all fragments simultaneously in test -->
-	      <environments combine.self="override"/> <!--  we only want platform specific artifacts here -->
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.eclipse.tycho</groupId>
         <artifactId>tycho-surefire-plugin</artifactId>
         <configuration>
           <!-- When adding a test suite in the future, make sure to specify os-jvm-flags in argLine. See swt.tests pom.xml -->

--- a/tests/org.eclipse.swt.tests.win32/pom.xml
+++ b/tests/org.eclipse.swt.tests.win32/pom.xml
@@ -29,24 +29,6 @@
     <plugins>
       <plugin>
         <groupId>org.eclipse.tycho</groupId>
-        <artifactId>target-platform-configuration</artifactId>
-        <configuration>
-          <!-- Make all platform-specific fragments available (and optional) via a feature -->
-	      <dependency-resolution>
-	         <extraRequirements>
-	            <requirement>
-	               <type>eclipse-feature</type>
-	               <id>org.eclipse.swt.tests.fragments.feature</id>
-	               <versionRange>0.0.0</versionRange>
-	            </requirement>
-	         </extraRequirements>
-	      </dependency-resolution>
-	      <!-- but only resolve against current environment as we don't want all fragments simultaneously in test -->
-	      <environments combine.self="override"/> <!--  we only want platform specific artifacts here -->
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.eclipse.tycho</groupId>
         <artifactId>tycho-surefire-plugin</artifactId>
         <configuration>
           <skipTests>true</skipTests> <!-- Skip all tests on build servers, because it contains platform specific code -->


### PR DESCRIPTION
It's gone for months as tests have been run with plain surefire for
years already.
Finishes what was started with
https://git.eclipse.org/r/c/platform/eclipse.platform.swt/+/189807