### PR TITLE
fix org.eclipse.swt.widgets.Synchronizer.moveAllEventsTo(Synchronizer)

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/Synchronizer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/Synchronizer.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.swt.widgets;
 
+import java.util.*;
 import java.util.concurrent.*;
 
 import org.eclipse.swt.*;
@@ -63,7 +64,12 @@ public Synchronizer (Display display) {
  * @param toReceiveTheEvents the synchronizer that will receive the events
  */
 void moveAllEventsTo (Synchronizer toReceiveTheEvents) {
+	// Drain target queue and add it later again to insert at the beginning of the
+	// queue for backward compatibility:
+	java.util.List<RunnableLock> tail = new ArrayList<>();
+	toReceiveTheEvents.messages.removeIf(tail::add);
 	messages.removeIf(toReceiveTheEvents.messages::add);
+	toReceiveTheEvents.messages.addAll(tail);
 }
 
 

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Display.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Display.java
@@ -1278,6 +1278,8 @@ public void test_setSynchronizerLorg_eclipse_swt_widgets_Synchronizer() {
 	final Display display = new Display();
 	final boolean[] asyncExec0Ran = new boolean[] {false};
 	final boolean[] asyncExec1Ran = new boolean[] {false};
+	final boolean[] asyncExec2Ran = new boolean[] {false};
+	final boolean[] asyncExec3Ran = new boolean[] {false};
 
 	try {
 		try {
@@ -1300,15 +1302,20 @@ public void test_setSynchronizerLorg_eclipse_swt_widgets_Synchronizer() {
 		}
 
 		MySynchronizer mySynchronizer = new MySynchronizer(display);
+		mySynchronizer.asyncExec(() -> asyncExec3Ran[0] = asyncExec2Ran[0]); // assert it runs after 2
 		display.asyncExec(() -> asyncExec0Ran[0] = true);
+		display.asyncExec(() -> asyncExec2Ran[0] = asyncExec0Ran[0]); // assert it runs after 0
 		display.setSynchronizer(mySynchronizer);
 		display.asyncExec(() -> asyncExec1Ran[0] = true);
 		assertFalse(asyncExec0Ran[0]);
 		assertFalse(asyncExec1Ran[0]);
+		assertFalse(asyncExec2Ran[0]);
 		while (display.readAndDispatch()) {}
 		assertTrue(mySynchronizer.invoked);
 		assertTrue(asyncExec0Ran[0]);
 		assertTrue(asyncExec1Ran[0]);
+		assertTrue(asyncExec2Ran[0]);
+		assertTrue(asyncExec3Ran[0]);
 	} finally {
 		display.dispose();
 	}


### PR DESCRIPTION
Insert at the beginning of the queue for backward compatibility

see https://github.com/eclipse-platform/eclipse.platform.swt/pull/77#pullrequestreview-958834521
@mickaelistria 