### PR TITLE
Revert "Synchronizer does not need to notify if nobody is waiting #81

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/Synchronizer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/Synchronizer.java
@@ -137,10 +137,8 @@ boolean runAsyncMessages (boolean all) {
 				if (display != null && !display.isDisposed()) {
 					display.sendPostEvent(SWT.None);
 				}
-				if (syncThread!=null) {
-					syncThread = null;
-					lock.notifyAll();
-				}
+				syncThread = null;
+				lock.notifyAll ();
 			}
 		}
 	} while (all);


### PR DESCRIPTION
This reverts commit 1a57687d2eae3329f77fe40487ddc7700ccccb9e.

Reason for revert: this patch breaks Eclipse test execution in IDE.
After the test that starts IDE is done, IDE is not shut down anymore.