### PR TITLE
RTFTransfer fix, small fixes for empty clipboard and TextTransfer IDs

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/gtk/org/eclipse/swt/dnd/ClipboardProxy.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/gtk/org/eclipse/swt/dnd/ClipboardProxy.java
@@ -237,14 +237,12 @@ private boolean setData_gtk4(Clipboard owner, Object[] data, Transfer[] dataType
 }
 
 private boolean setContentFromType(long clipboard, String string, Object data) {
-
-	//TextTransfer
-	if(data.getClass() == String.class) {
-		GTK4.gdk_clipboard_set_text(clipboard, Converter.javaStringToCString((String)data));
+	if(data != null) {
+		if(string.equals("STRING") || string.equals("text/rtf")) {
+			GTK4.gdk_clipboard_set_text(clipboard, Converter.javaStringToCString((String)data));
+		}
 		return true;
 	}
-
-
 	return false;
 }
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/gtk/org/eclipse/swt/dnd/RTFTransfer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/gtk/org/eclipse/swt/dnd/RTFTransfer.java
@@ -34,11 +34,11 @@ public class RTFTransfer extends ByteArrayTransfer {
 
 	private static RTFTransfer _instance = new RTFTransfer();
 	private static final String TEXT_RTF = "text/rtf"; //$NON-NLS-1$
-	private static final int TEXT_RTF_ID = registerType(TEXT_RTF);
+	private static final int TEXT_RTF_ID = GTK.GTK4 ? 0 : registerType(TEXT_RTF);
 	private static final String TEXT_RTF2 = "TEXT/RTF"; //$NON-NLS-1$
-	private static final int TEXT_RTF2_ID = registerType(TEXT_RTF2);
+	private static final int TEXT_RTF2_ID = GTK.GTK4 ? 0 : registerType(TEXT_RTF2);
 	private static final String APPLICATION_RTF = "application/rtf"; //$NON-NLS-1$
-	private static final int APPLICATION_RTF_ID = registerType(APPLICATION_RTF);
+	private static final int APPLICATION_RTF_ID = GTK.GTK4 ? 0 : registerType(APPLICATION_RTF);
 
 private RTFTransfer() {}
 
@@ -103,11 +103,17 @@ public Object nativeToJava(TransferData transferData){
 
 @Override
 protected int[] getTypeIds() {
+	if(GTK.GTK4) {
+		return new int[] {(int) OS.G_TYPE_STRING()};
+	}
 	return new int[] {TEXT_RTF_ID, TEXT_RTF2_ID, APPLICATION_RTF_ID};
 }
 
 @Override
 protected String[] getTypeNames() {
+	if(GTK.GTK4) {
+		return new String[] {TEXT_RTF};
+	}
 	return new String[] {TEXT_RTF, TEXT_RTF2, APPLICATION_RTF};
 }
 

--- a/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/gtk/org/eclipse/swt/dnd/TextTransfer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/gtk/org/eclipse/swt/dnd/TextTransfer.java
@@ -42,9 +42,9 @@ public class TextTransfer extends ByteArrayTransfer {
 	private static final String COMPOUND_TEXT = "COMPOUND_TEXT"; //$NON-NLS-1$
 	private static final String UTF8_STRING = "UTF8_STRING"; //$NON-NLS-1$
 	private static final String STRING = "STRING"; //$NON-NLS-1$
-	private static final int COMPOUND_TEXT_ID = registerType(COMPOUND_TEXT);
-	private static final int UTF8_STRING_ID = registerType(UTF8_STRING);
-	private static final int STRING_ID = registerType(STRING);
+	private static final int COMPOUND_TEXT_ID = GTK.GTK4 ? 0 : registerType(COMPOUND_TEXT);
+	private static final int UTF8_STRING_ID = GTK.GTK4 ? 0 : registerType(UTF8_STRING);
+	private static final int STRING_ID = GTK.GTK4 ? 0 : registerType(STRING);
 
 private TextTransfer() {}
 

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/gtk4.c
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/gtk4.c
@@ -46,6 +46,16 @@ JNIEXPORT void JNICALL GTK4_NATIVE(gdk_1clipboard_1get_1formats)
 }
 #endif
 
+#ifndef NO_gdk_1clipboard_1set
+JNIEXPORT void JNICALL GTK4_NATIVE(gdk_1clipboard_1set)
+	(JNIEnv *env, jclass that, jlong arg0, jint arg1, jlong arg2)
+{
+	GTK4_NATIVE_ENTER(env, that, gdk_1clipboard_1set_FUNC);
+	gdk_clipboard_set((GdkClipboard*)arg0, (GType)arg1, arg2);
+	GTK4_NATIVE_EXIT(env, that, gdk_1clipboard_1set_FUNC);
+}
+#endif
+
 #ifndef NO_gdk_1clipboard_1set_1text
 JNIEXPORT void JNICALL GTK4_NATIVE(gdk_1clipboard_1set_1text)
 	(JNIEnv *env, jclass that, jlong arg0, jbyteArray arg1)

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/gtk4_stats.c
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/gtk4_stats.c
@@ -23,6 +23,7 @@
 char * GTK4_nativeFunctionNames[] = {
 	"gdk_1clipboard_1get_1content",
 	"gdk_1clipboard_1get_1formats",
+	"gdk_1clipboard_1set",
 	"gdk_1clipboard_1set_1text",
 	"gdk_1content_1formats_1builder_1add_1mime_1type",
 	"gdk_1content_1formats_1builder_1free_1to_1formats",

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/gtk4_stats.h
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/gtk4_stats.h
@@ -33,6 +33,7 @@ extern char* GTK4_nativeFunctionNames[];
 typedef enum {
 	gdk_1clipboard_1get_1content_FUNC,
 	gdk_1clipboard_1get_1formats_FUNC,
+	gdk_1clipboard_1set_FUNC,
 	gdk_1clipboard_1set_1text_FUNC,
 	gdk_1content_1formats_1builder_1add_1mime_1type_FUNC,
 	gdk_1content_1formats_1builder_1free_1to_1formats_FUNC,

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/org/eclipse/swt/internal/gtk/OS.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/org/eclipse/swt/internal/gtk/OS.java
@@ -155,6 +155,7 @@ public class OS extends C {
 	public static final int G_LOG_LEVEL_MASK = 0xfffffffc;
 	public static final int G_APP_INFO_CREATE_NONE = 0;
 	public static final int G_APP_INFO_CREATE_SUPPORTS_URIS  = (1 << 1);
+	public static final int GTK_TYPE_TEXT_BUFFER = 21;
 	public static final int PANGO_ALIGN_LEFT = 0;
 	public static final int PANGO_ALIGN_CENTER = 1;
 	public static final int PANGO_ALIGN_RIGHT = 2;

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/org/eclipse/swt/internal/gtk4/GTK4.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/org/eclipse/swt/internal/gtk4/GTK4.java
@@ -567,6 +567,11 @@ public class GTK4 {
 	public static final native void gdk_clipboard_set_text(long clipboard, byte[] text);
 	/**
 	 * @param clipboard cast=(GdkClipboard*)
+	 * @param type cast=(GType)
+	 */
+	public static final native void gdk_clipboard_set(long clipboard, int type, long data);
+	/**
+	 * @param clipboard cast=(GdkClipboard*)
 	 */
 	public static final native void gdk_clipboard_get_formats(long clipboard);
 	/**


### PR DESCRIPTION
- added handling for Rich text (RTF)
- Fixed errors logged to console if trying to paste with empty clipboard
- made sure registerType is not called in TextTransfer

I discussed other ways of doing RTF with the GTK devs through IRC. There were a few suggestions that did not work, and their suggestion was to use the gdk_clipboard_read function. Since this function is async, it adds another level of complexity that did not exist with the wait_for_contents function in GTK3. The solution implemented was the most reasonable one, and maintains similar functionality. 

