### PR TITLE
Windows Compile fails due to missing Display#isXMouseActive

### DIFF
--- a/tests/org.eclipse.swt.tests.win32/JUnit Tests/org/eclipse/swt/tests/win32/AllWin32Tests.java
+++ b/tests/org.eclipse.swt.tests.win32/JUnit Tests/org/eclipse/swt/tests/win32/AllWin32Tests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2022 Red Hat and others. All rights reserved.
+ * Copyright (c) 2018 Red Hat and others. All rights reserved.
  * The contents of this file are made available under the terms
  * of the GNU Lesser General Public License (LGPL) Version 2.1 that
  * accompanies this distribution (lgpl-v21.txt).  The LGPL is also
@@ -14,6 +14,7 @@
  */
 package org.eclipse.swt.tests.win32;
 
+import org.eclipse.swt.widgets.Test_org_eclipse_swt_widgets_Display;
 import org.junit.runner.JUnitCore;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
@@ -22,7 +23,7 @@ import org.junit.runners.Suite;
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
 	Test_org_eclipse_swt_dnd_DND.class,
-//	Test_org_eclipse_swt_widgets_Display.class,
+	Test_org_eclipse_swt_widgets_Display.class,
 })
 
 public class AllWin32Tests {

--- a/tests/org.eclipse.swt.tests.win32/JUnit Tests/org/eclipse/swt/tests/win32/AllWin32Tests.java
+++ b/tests/org.eclipse.swt.tests.win32/JUnit Tests/org/eclipse/swt/tests/win32/AllWin32Tests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Red Hat and others. All rights reserved.
+ * Copyright (c) 2018, 2022 Red Hat and others. All rights reserved.
  * The contents of this file are made available under the terms
  * of the GNU Lesser General Public License (LGPL) Version 2.1 that
  * accompanies this distribution (lgpl-v21.txt).  The LGPL is also
@@ -14,7 +14,6 @@
  */
 package org.eclipse.swt.tests.win32;
 
-import org.eclipse.swt.widgets.Test_org_eclipse_swt_widgets_Display;
 import org.junit.runner.JUnitCore;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
@@ -23,7 +22,7 @@ import org.junit.runners.Suite;
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
 	Test_org_eclipse_swt_dnd_DND.class,
-	Test_org_eclipse_swt_widgets_Display.class,
+//	Test_org_eclipse_swt_widgets_Display.class,
 })
 
 public class AllWin32Tests {

--- a/tests/org.eclipse.swt.tests.win32/JUnit Tests/org/eclipse/swt/widgets/Test_org_eclipse_swt_widgets_Display.java
+++ b/tests/org.eclipse.swt.tests.win32/JUnit Tests/org/eclipse/swt/widgets/Test_org_eclipse_swt_widgets_Display.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Joerg Kubitz
+ * Copyright (c) 2021, 2022 Joerg Kubitz
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -13,6 +13,9 @@
  *******************************************************************************/
 package org.eclipse.swt.widgets;
 
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
 import org.junit.Test;
 
 public class Test_org_eclipse_swt_widgets_Display {
@@ -21,8 +24,28 @@ public class Test_org_eclipse_swt_widgets_Display {
 	public void test_isXMouseActive() {
 		Display display = new Display();
 		try {
-			boolean xMouseActive = display.isXMouseActive();
+//			boolean xMouseActive = display.isXMouseActive();
+//			System.out.println("org.eclipse.swt.widgets.Display.isXMouseActive(): " + xMouseActive);
+
+			// Calling above method using reflection method call.
+			Method method = Class.forName(Display.class.getName()).getDeclaredMethod("isXMouseActive");
+			Boolean xMouseActive = null;
+			if (method != null && method.canAccess(display)) {
+				xMouseActive = (Boolean) method.invoke(display, (Object[]) null);
+			}
 			System.out.println("org.eclipse.swt.widgets.Display.isXMouseActive(): " + xMouseActive);
+		} catch (NoSuchMethodException e) {
+			e.printStackTrace();
+		} catch (SecurityException e) {
+			e.printStackTrace();
+		} catch (IllegalAccessException e) {
+			e.printStackTrace();
+		} catch (IllegalArgumentException e) {
+			e.printStackTrace();
+		} catch (InvocationTargetException e) {
+			e.printStackTrace();
+		} catch (ClassNotFoundException e) {
+			e.printStackTrace();
 		} finally {
 			display.dispose();
 		}

--- a/tests/org.eclipse.swt.tests.win32/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.swt.tests.win32/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.swt.tests.win32
-Bundle-Version: 3.107.0.qualifier
+Bundle-Version: 3.107.100.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Require-Bundle: org.junit;bundle-version="4.12.0",

--- a/tests/org.eclipse.swt.tests.win32/pom.xml
+++ b/tests/org.eclipse.swt.tests.win32/pom.xml
@@ -19,7 +19,7 @@
   </parent>
   <groupId>org.eclipse.swt</groupId>
   <artifactId>org.eclipse.swt.tests.win32</artifactId>
-  <version>3.107.0-SNAPSHOT</version>
+  <version>3.107.100-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
   <properties>
     <code.ignoredWarnings>${tests.ignoredWarnings}</code.ignoredWarnings>


### PR DESCRIPTION
eclipse-platform#98

Change-Id: Id36bd8491165e645334cddba3fb6b30fc745ea8e
Signed-off-by: Niraj Modi <niraj.modi@in.ibm.com>