### PR TITLE
Add minimal sonarcloud parameters to pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,18 @@
   <properties>
     <tycho.scmUrl>scm:git:https://github.com/eclipse-platform/eclipse.platform.swt.git</tycho.scmUrl>
     <os-jvm-flags></os-jvm-flags>
+
+    <!-- for sonarcloud: -->
+    <!-- needs to be adapted on every fork: <sonar.organization>eclipse-platform</sonar.organization> -->
+    <sonar.host.url>https://sonarcloud.io</sonar.host.url>
+    <!-- for build-individual-bundles: -->
+    <sonar.moduleKey>${artifactId}</sonar.moduleKey>
+    <!-- sonar fails to analyze .java files but can analyse compiled binaries: -->
+    <sonar.java.binaries>target</sonar.java.binaries>
+    <!-- sonar fails to analyse C sources. Disable them: -->
+    <sonar.c.file.suffixes>-</sonar.c.file.suffixes>
+    <sonar.cpp.file.suffixes>-</sonar.cpp.file.suffixes>
+    <sonar.objc.file.suffixes>-</sonar.objc.file.suffixes>
   </properties>
 
   <!-- 


### PR DESCRIPTION
This itself does not enable sonarcloud. But just in case someone would like to run sonarcloud on a fork: At least these parameters need to be added till a result can be obtained.
Example result see:
https://sonarcloud.io/summary/overall?id=jukzi_eclipse.platform.swt