### PR TITLE
Add Codeowners file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,3 @@
+**/gtk/* @sravanlakkimsetti @akurtakov
+**/win32/*  @niraj-modi @iloveeclipse
+**/cocoa/* @lshanmug


### PR DESCRIPTION
Specifies owners for platform specific parts only.
Fixes #66 .