### PR TITLE
[Win32] Restore historical FileDialog behavior

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT PI/win32/org/eclipse/swt/internal/win32/OS.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/win32/org/eclipse/swt/internal/win32/OS.java
@@ -504,6 +504,7 @@ public class OS extends C {
 	public static final int FOS_PICKFOLDERS = 0x20;
 	public static final int FOS_FORCEFILESYSTEM = 0x40;
 	public static final int FOS_ALLOWMULTISELECT = 0x200;
+	public static final int FOS_FILEMUSTEXIST = 0x1000;
 	public static final int FR_PRIVATE = 0x10;
 	public static final int FSHIFT = 0x4;
 	public static final int FVIRTKEY = 0x1;

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/FileDialog.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/FileDialog.java
@@ -231,6 +231,7 @@ public String open () {
 	int[] options = new int[1];
 	fileDialog.GetOptions(options);
 	options[0] |= OS.FOS_FORCEFILESYSTEM | OS.FOS_NOCHANGEDIR;
+	options[0] &= ~OS.FOS_FILEMUSTEXIST;
 	if ((style & SWT.SAVE) != 0) {
 		if (!overwrite) options[0] &= ~OS.FOS_OVERWRITEPROMPT;
 	} else {
@@ -293,8 +294,7 @@ public String open () {
 		char[] path = (filterPath.replace('/', '\\') + "\0").toCharArray();
 		if (COM.SHCreateItemFromParsingName(path, 0, COM.IID_IShellItem, ppv) == COM.S_OK) {
 			IShellItem psi = new IShellItem(ppv[0]);
-			// Bug 577190: Hard override the filter path using SetFolder.
-			fileDialog.SetFolder(psi);
+			fileDialog.SetDefaultFolder(psi);
 			psi.Release();
 		}
 	}


### PR DESCRIPTION
Miration to COM API in Bug 571571 resulted in unexpected changes in behavior. This patch restores original behavior.

 * Allow non-existent file names in SWT.OPEN dialog (Bug 579359).

 * Let the system remember last used directory and override FileDialog.setFilterPath (Bug 577773 and #95).
   This change reverts the fix for Bug 577190 and Bug 578415.

@niraj-modi please see my comment https://bugs.eclipse.org/bugs/show_bug.cgi?id=577190#c17