### PR TITLE
Fix Clipboard ImageTransfer not working on Linux x86_64

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/gtk/org/eclipse/swt/dnd/ImageTransfer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/gtk/org/eclipse/swt/dnd/ImageTransfer.java
@@ -114,7 +114,7 @@ public void javaToNative(Object object, TransferData transferData) {
 		transferData.pValue = buffer[0];
 		transferData.length = (int)(len[0] + 3) / 4 * 4;
 		transferData.result = 1;
-		transferData.format = 32;
+		transferData.format = 16;
 	}
 	image.dispose();
 }


### PR DESCRIPTION
- Change value of transferData.format from 32 to 16
- See #146