### PR TITLE
Add more debug info for AllBrowserTests (#108)

### DIFF
--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/AllBrowserTests.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/AllBrowserTests.java
@@ -14,11 +14,14 @@
 package org.eclipse.swt.tests.junit;
 
 
+import org.eclipse.test.TracingSuite;
+import org.eclipse.test.TracingSuite.TracingOptions;
 import org.junit.runner.JUnitCore;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 
-@RunWith(Suite.class)
+@RunWith(TracingSuite.class)
+@TracingOptions(stackDumpTimeoutSeconds = 60)
 @Suite.SuiteClasses({
 	Test_org_eclipse_swt_browser_Browser.class,
 })


### PR DESCRIPTION
- use TracingSuite to dump after hanging for 60 seconds
- make sure all tests run in same (sorted) order on all systems/JVM's
- print system properties and environment at startup
- print memory use after each test

See https://github.com/eclipse-platform/eclipse.platform.swt/issues/108