### PR TITLE
AllBrowserTests running out of file descriptors on Linux (Fixes #108)

### DIFF
--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Composite.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Composite.java
@@ -115,6 +115,7 @@ public void test_setVisibility_and_sizing() {
 	Point compSize = visibilityComposite.getSize();
 	assertTrue("Composite should be aprox 500 by 463 px, but instead it is: " + compSize.toString(),
 			compSize.x > 100 && compSize.y > 100); // If this is 1x1 or 0x0 then there was some fault in layout.
+	visibilityShell.dispose();
 }
 
 @Test

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Control.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Control.java
@@ -1075,7 +1075,7 @@ protected void consistencyEvent(final int paramA, final int paramB,
 						Assert.assertTrue(test,
 							ConsistencyUtility.postShellIconify(display, pt[1], paramA));
 						if(control instanceof Shell) {
-							display.syncExec(new Thread() {
+							display.syncExec(new Runnable() {
 								@Override
 								public void run() {
 									((Shell)control).setMinimized(false);
@@ -1084,7 +1084,7 @@ protected void consistencyEvent(final int paramA, final int paramB,
 							fail("Iconifying a non shell control");
 						break;
 				}
-				display.asyncExec(new Thread() {
+				display.asyncExec(new Runnable() {
 					@Override
 					public void run() {
 						shell.dispose();

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Widget.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Widget.java
@@ -75,7 +75,7 @@ public void tearDown() {
 		}
 	}
 	assertTrue(shell.isDisposed());
-	if(SwtTestUtil.isCocoa) {
+	if(SwtTestUtil.isCocoa || SwtTestUtil.isGTK) {
 		// process pending events to properly close the shell
 		while (display != null && !display.isDisposed() && display.readAndDispatch()) {
 		}
@@ -213,7 +213,7 @@ protected void hookExpectedEvents(Widget w, String[] types, final java.util.List
 }
 
 protected String getTestName() {
-	String test = name.getMethodName();
+	String test = "" + name.getMethodName();
 	int index = test.lastIndexOf('_');
 	if(index != -1)
 		test = test.substring(index+1);


### PR DESCRIPTION
- drain SWT event queue after every test

This fixes growing number of opened file descriptors (GTK events not
processed so browser processes created by test wait for the GTK events
and don't release allocated resources).

- added started threads count info
- added opened file descriptors info on Linux
- added system limits dump on Linux
- dispose all shells / browsers created by test
- dispose shell leaking in test_setVisibility_and_sizing
- assert that all shells and browsers are disposed

See https://github.com/eclipse-platform/eclipse.platform.swt/issues/108