### PR TITLE
[GTK4] Clipboard Port: Fix for ImageTransfer and getAvailableTypeNames

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/gtk/org/eclipse/swt/dnd/Clipboard.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/gtk/org/eclipse/swt/dnd/Clipboard.java
@@ -15,6 +15,7 @@ package org.eclipse.swt.dnd;
 
 
 import org.eclipse.swt.*;
+import org.eclipse.swt.graphics.*;
 import org.eclipse.swt.internal.*;
 import org.eclipse.swt.internal.gtk.*;
 import org.eclipse.swt.internal.gtk3.*;
@@ -348,6 +349,18 @@ private Object getContents_gtk4(Transfer transfer, int clipboards) {
 		}
 		return str;
 	}
+	if(transfer.getTypeIds()[0] == (int)GDK.GDK_TYPE_PIXBUF()) {
+		ImageData imgData = null;
+		OS.g_value_init(value, GDK.GDK_TYPE_PIXBUF());
+		if (!GTK4.gdk_content_provider_get_value (contents, value, null)) return null;
+		long pixbufObj = OS.g_value_get_object(value);
+		if (pixbufObj != 0) {
+			Image img = Image.gtk_new_from_pixbuf(Display.getCurrent(), SWT.BITMAP, pixbufObj);
+			imgData = img.getImageData();
+			img.dispose();
+		}
+		return imgData;
+	}
 	//TODO: [GTK4] Other cases
 	return null;
 }
@@ -539,6 +552,8 @@ public TransferData[] getAvailableTypes() {
  */
 public TransferData[] getAvailableTypes(int clipboards) {
 	checkWidget();
+
+	//TODO: [GTK4] This currently will not work in GTK4
 	TransferData[] result = null;
 	if ((clipboards & DND.CLIPBOARD) != 0) {
 		int[] types = getAvailableClipboardTypes();
@@ -585,6 +600,12 @@ public TransferData[] getAvailableTypes(int clipboards) {
  */
 public String[] getAvailableTypeNames() {
 	checkWidget();
+	if(GTK.GTK4) {
+		long formatsCStr = GTK4.gdk_content_formats_to_string(GTK4.gdk_clipboard_get_formats(Clipboard.GTKCLIPBOARD));
+		String formatsStr = Converter.cCharPtrToJavaString(formatsCStr, true);
+		String[] types = formatsStr.split(" ");
+		return types;
+	}
 	int[] types1 = getAvailableClipboardTypes();
 	int[] types2 = getAvailablePrimaryTypes();
 	String[] result = new String[types1.length + types2.length];
@@ -636,12 +657,6 @@ private  int[] getAvailablePrimaryTypes() {
 	return types;
 }
 private int[] getAvailableClipboardTypes () {
-
-	if(GTK.GTK4) {
-		/*TODO: can use gdk_clipboard_get_formats and gdk_content_formats_to_string
-		 *Then from the comma separated list of formats find their respective IDs
-		 */
-	}
 
 	int[] types = new int[0];
 	long selection_data  = gtk_clipboard_wait_for_contents(GTKCLIPBOARD, TARGET);

--- a/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/gtk/org/eclipse/swt/dnd/ClipboardProxy.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/gtk/org/eclipse/swt/dnd/ClipboardProxy.java
@@ -236,15 +236,13 @@ private boolean setData_gtk4(Clipboard owner, Object[] data, Transfer[] dataType
 }
 
 private boolean setContentFromType(long clipboard, String string, Object data) {
-	if(data != null) {
+	if (data == null ) SWT.error(SWT.ERROR_NULL_ARGUMENT);
+	else {
 		if(string.equals("STRING") || string.equals("text/rtf")) {
 			GTK4.gdk_clipboard_set_text(clipboard, Converter.javaStringToCString((String)data));
 		}
-		else if(string.equals("PIXBUF")) {
-			if (data == null ) SWT.error(SWT.ERROR_NULL_ARGUMENT);
-			else if(!(data instanceof ImageData)) {
-				DND.error(DND.ERROR_INVALID_DATA);
-			}
+		if(string.equals("PIXBUF")) {
+			if(!(data instanceof ImageData)) DND.error(DND.ERROR_INVALID_DATA);
 			ImageData imgData = (ImageData)data;
 			Image image = new Image(Display.getCurrent(), imgData);
 			long pixbuf = ImageList.createPixbuf(image);

--- a/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/gtk/org/eclipse/swt/dnd/ClipboardProxy.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/gtk/org/eclipse/swt/dnd/ClipboardProxy.java
@@ -14,6 +14,8 @@
 package org.eclipse.swt.dnd;
 
 
+import org.eclipse.swt.*;
+import org.eclipse.swt.graphics.*;
 import org.eclipse.swt.internal.*;
 import org.eclipse.swt.internal.gtk.*;
 import org.eclipse.swt.internal.gtk3.*;
@@ -220,8 +222,6 @@ boolean setData(Clipboard owner, Object[] data, Transfer[] dataTypes, int clipbo
 
 private boolean setData_gtk4(Clipboard owner, Object[] data, Transfer[] dataTypes, int clipboards) {
 	boolean result = false;
-
-	//Handle the text transfer case first
 	for (int i = 0; i < dataTypes.length; i++) {
 		Transfer transfer = dataTypes[i];
 		String[] typeNames = transfer.getTypeNames();
@@ -232,7 +232,6 @@ private boolean setData_gtk4(Clipboard owner, Object[] data, Transfer[] dataType
 			activeClipboard = owner;
 		}
 	}
-	//TODO: [GTK4] Other cases for setting data
 	return result;
 }
 
@@ -240,6 +239,19 @@ private boolean setContentFromType(long clipboard, String string, Object data) {
 	if(data != null) {
 		if(string.equals("STRING") || string.equals("text/rtf")) {
 			GTK4.gdk_clipboard_set_text(clipboard, Converter.javaStringToCString((String)data));
+		}
+		else if(string.equals("PIXBUF")) {
+			if (data == null ) SWT.error(SWT.ERROR_NULL_ARGUMENT);
+			else if(!(data instanceof ImageData)) {
+				DND.error(DND.ERROR_INVALID_DATA);
+			}
+			ImageData imgData = (ImageData)data;
+			Image image = new Image(Display.getCurrent(), imgData);
+			long pixbuf = ImageList.createPixbuf(image);
+			if (pixbuf != 0) {
+				GTK4.gdk_clipboard_set(clipboard, GDK.GDK_TYPE_PIXBUF(), pixbuf);
+			}
+			image.dispose();
 		}
 		return true;
 	}

--- a/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/gtk/org/eclipse/swt/dnd/ImageTransfer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/gtk/org/eclipse/swt/dnd/ImageTransfer.java
@@ -40,27 +40,27 @@ public class ImageTransfer extends ByteArrayTransfer {
 	private static ImageTransfer _instance = new ImageTransfer();
 
 	private static final String JPEG = "image/jpeg"; //$NON-NLS-1$
-	private static final int JPEG_ID = registerType(JPEG);
+	private static final int JPEG_ID = GTK.GTK4 ? 0: registerType(JPEG);
 	private static final String PNG = "image/png"; //$NON-NLS-1$
-	private static final int PNG_ID = registerType(PNG);
+	private static final int PNG_ID = GTK.GTK4 ? 0:registerType(PNG);
 	private static final String BMP = "image/bmp"; //$NON-NLS-1$
-	private static final int BMP_ID = registerType(BMP);
+	private static final int BMP_ID = GTK.GTK4 ? 0:registerType(BMP);
 	private static final String EPS = "image/eps"; //$NON-NLS-1$
-	private static final int EPS_ID = registerType(EPS);
+	private static final int EPS_ID = GTK.GTK4 ? 0:registerType(EPS);
 	private static final String PCX = "image/pcx"; //$NON-NLS-1$
-	private static final int PCX_ID = registerType(PCX);
+	private static final int PCX_ID = GTK.GTK4 ? 0:registerType(PCX);
 	private static final String PPM = "image/ppm"; //$NON-NLS-1$
-	private static final int PPM_ID = registerType(PPM);
+	private static final int PPM_ID = GTK.GTK4 ? 0:registerType(PPM);
 	private static final String RGB = "image/ppm"; //$NON-NLS-1$
-	private static final int RGB_ID = registerType(RGB);
+	private static final int RGB_ID = GTK.GTK4 ? 0:registerType(RGB);
 	private static final String TGA = "image/tga"; //$NON-NLS-1$
-	private static final int TGA_ID = registerType(TGA);
+	private static final int TGA_ID = GTK.GTK4 ? 0:registerType(TGA);
 	private static final String XBM = "image/xbm"; //$NON-NLS-1$
-	private static final int XBM_ID = registerType(XBM);
+	private static final int XBM_ID = GTK.GTK4 ? 0:registerType(XBM);
 	private static final String XPM = "image/xpm"; //$NON-NLS-1$
-	private static final int XPM_ID = registerType(XPM);
+	private static final int XPM_ID = GTK.GTK4 ? 0:registerType(XPM);
 	private static final String XV = "image/xv"; //$NON-NLS-1$
-	private static final int XV_ID = registerType(XV);
+	private static final int XV_ID = GTK.GTK4 ? 0:registerType(XV);
 
 private ImageTransfer() {}
 
@@ -116,7 +116,7 @@ public void javaToNative(Object object, TransferData transferData) {
 		transferData.result = 1;
 		// The following value has been changed from 32 to 8 as a simple fix for #146
 		// See https://www.cc.gatech.edu/data_files/public/doc/gtk/tutorial/gtk_tut-16.html where it states:
-		// "The format field is actually important here - the X server uses it to figure out whether the data 
+		// "The format field is actually important here - the X server uses it to figure out whether the data
 		// needs to be byte-swapped or not. Usually it will be 8 - i.e. a character - or 32 - i.e. a. integer."
 		transferData.format = 8;
 	}
@@ -156,11 +156,17 @@ public Object nativeToJava(TransferData transferData) {
 
 @Override
 protected int[] getTypeIds(){
+	if(GTK.GTK4) {
+		return new int[] {(int) GDK.GDK_TYPE_PIXBUF()};
+	}
 	return new int[]{PNG_ID, BMP_ID, EPS_ID, JPEG_ID, PCX_ID, PPM_ID, RGB_ID, TGA_ID, XBM_ID, XPM_ID, XV_ID};
 }
 
 @Override
 protected String[] getTypeNames(){
+	if(GTK.GTK4) {
+		return new String[]{"PIXBUF"};
+	}
 	return new String[]{PNG, BMP, EPS, JPEG, PCX, PPM, RGB, TGA, XBM, XPM, XV};
 }
 

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/gtk4.c
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/gtk4.c
@@ -37,18 +37,20 @@ JNIEXPORT jlong JNICALL GTK4_NATIVE(gdk_1clipboard_1get_1content)
 #endif
 
 #ifndef NO_gdk_1clipboard_1get_1formats
-JNIEXPORT void JNICALL GTK4_NATIVE(gdk_1clipboard_1get_1formats)
+JNIEXPORT jlong JNICALL GTK4_NATIVE(gdk_1clipboard_1get_1formats)
 	(JNIEnv *env, jclass that, jlong arg0)
 {
+	jlong rc = 0;
 	GTK4_NATIVE_ENTER(env, that, gdk_1clipboard_1get_1formats_FUNC);
-	gdk_clipboard_get_formats((GdkClipboard*)arg0);
+	rc = (jlong)gdk_clipboard_get_formats((GdkClipboard*)arg0);
 	GTK4_NATIVE_EXIT(env, that, gdk_1clipboard_1get_1formats_FUNC);
+	return rc;
 }
 #endif
 
 #ifndef NO_gdk_1clipboard_1set
 JNIEXPORT void JNICALL GTK4_NATIVE(gdk_1clipboard_1set)
-	(JNIEnv *env, jclass that, jlong arg0, jint arg1, jlong arg2)
+	(JNIEnv *env, jclass that, jlong arg0, jlong arg1, jlong arg2)
 {
 	GTK4_NATIVE_ENTER(env, that, gdk_1clipboard_1set_FUNC);
 	gdk_clipboard_set((GdkClipboard*)arg0, (GType)arg1, arg2);
@@ -104,6 +106,18 @@ JNIEXPORT jlong JNICALL GTK4_NATIVE(gdk_1content_1formats_1builder_1new)
 	GTK4_NATIVE_ENTER(env, that, gdk_1content_1formats_1builder_1new_FUNC);
 	rc = (jlong)gdk_content_formats_builder_new();
 	GTK4_NATIVE_EXIT(env, that, gdk_1content_1formats_1builder_1new_FUNC);
+	return rc;
+}
+#endif
+
+#ifndef NO_gdk_1content_1formats_1to_1string
+JNIEXPORT jlong JNICALL GTK4_NATIVE(gdk_1content_1formats_1to_1string)
+	(JNIEnv *env, jclass that, jlong arg0)
+{
+	jlong rc = 0;
+	GTK4_NATIVE_ENTER(env, that, gdk_1content_1formats_1to_1string_FUNC);
+	rc = (jlong)gdk_content_formats_to_string((GdkContentFormats *)arg0);
+	GTK4_NATIVE_EXIT(env, that, gdk_1content_1formats_1to_1string_FUNC);
 	return rc;
 }
 #endif

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/gtk4_stats.c
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/gtk4_stats.c
@@ -28,6 +28,7 @@ char * GTK4_nativeFunctionNames[] = {
 	"gdk_1content_1formats_1builder_1add_1mime_1type",
 	"gdk_1content_1formats_1builder_1free_1to_1formats",
 	"gdk_1content_1formats_1builder_1new",
+	"gdk_1content_1formats_1to_1string",
 	"gdk_1content_1provider_1get_1value",
 	"gdk_1toplevel_1focus",
 	"gdk_1toplevel_1get_1state",

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/gtk4_stats.h
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/gtk4_stats.h
@@ -38,6 +38,7 @@ typedef enum {
 	gdk_1content_1formats_1builder_1add_1mime_1type_FUNC,
 	gdk_1content_1formats_1builder_1free_1to_1formats_FUNC,
 	gdk_1content_1formats_1builder_1new_FUNC,
+	gdk_1content_1formats_1to_1string_FUNC,
 	gdk_1content_1provider_1get_1value_FUNC,
 	gdk_1toplevel_1focus_FUNC,
 	gdk_1toplevel_1get_1state_FUNC,

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/os.c
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/os.c
@@ -12920,6 +12920,18 @@ JNIEXPORT jlong JNICALL OS_NATIVE(g_1value_1get_1int64)
 }
 #endif
 
+#ifndef NO_g_1value_1get_1object
+JNIEXPORT jlong JNICALL OS_NATIVE(g_1value_1get_1object)
+	(JNIEnv *env, jclass that, jlong arg0)
+{
+	jlong rc = 0;
+	OS_NATIVE_ENTER(env, that, g_1value_1get_1object_FUNC);
+	rc = (jlong)g_value_get_object((GValue *)arg0);
+	OS_NATIVE_EXIT(env, that, g_1value_1get_1object_FUNC);
+	return rc;
+}
+#endif
+
 #ifndef NO_g_1value_1get_1string
 JNIEXPORT jlong JNICALL OS_NATIVE(g_1value_1get_1string)
 	(JNIEnv *env, jclass that, jlong arg0)

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/os_stats.c
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/os_stats.c
@@ -1092,6 +1092,7 @@ char * OS_nativeFunctionNames[] = {
 	"g_1value_1get_1float",
 	"g_1value_1get_1int",
 	"g_1value_1get_1int64",
+	"g_1value_1get_1object",
 	"g_1value_1get_1string",
 	"g_1value_1init",
 	"g_1value_1peek_1pointer",

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/os_stats.h
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/os_stats.h
@@ -1066,6 +1066,7 @@ typedef enum {
 	g_1value_1get_1float_FUNC,
 	g_1value_1get_1int_FUNC,
 	g_1value_1get_1int64_FUNC,
+	g_1value_1get_1object_FUNC,
 	g_1value_1get_1string_FUNC,
 	g_1value_1init_FUNC,
 	g_1value_1peek_1pointer_FUNC,

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/org/eclipse/swt/internal/gtk/OS.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/org/eclipse/swt/internal/gtk/OS.java
@@ -1382,6 +1382,8 @@ public static final native void g_value_set_string (long value, long v_string);
 /** @param value cast=(GValue *) */
 public static final native long g_value_get_string (long value);
 /** @param value cast=(GValue *) */
+public static final native long g_value_get_object (long value);
+/** @param value cast=(GValue *) */
 public static final native void g_value_unset (long value);
 /** @param value cast=(const GValue *) */
 public static final native long g_value_peek_pointer(long value);

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/org/eclipse/swt/internal/gtk4/GTK4.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/org/eclipse/swt/internal/gtk4/GTK4.java
@@ -569,11 +569,11 @@ public class GTK4 {
 	 * @param clipboard cast=(GdkClipboard*)
 	 * @param type cast=(GType)
 	 */
-	public static final native void gdk_clipboard_set(long clipboard, int type, long data);
+	public static final native void gdk_clipboard_set(long clipboard, long type, long data);
 	/**
 	 * @param clipboard cast=(GdkClipboard*)
 	 */
-	public static final native void gdk_clipboard_get_formats(long clipboard);
+	public static final native long gdk_clipboard_get_formats(long clipboard);
 	/**
 	 * @param clipboard cast=(GdkClipboard*)
 	 */
@@ -584,6 +584,7 @@ public class GTK4 {
 	 * @param error cast=(GError **)
 	 */
 	public static final native boolean gdk_content_provider_get_value(long provider, long value, long[] error);
-
+	/** @param formats cast=(GdkContentFormats *) */
+	public static final native long gdk_content_formats_to_string(long formats);
 
 }


### PR DESCRIPTION
Part of the fixes required for https://bugs.eclipse.org/bugs/show_bug.cgi?id=574949

- Added some required functions to OS.java and GTK4.java
- Added handling of images (pixbufs) to Clipboard.java/ClipboardProxy.java
- Restored functionality of getAvailableTypeNames

Tested with ClipboardExample.java from swt.examples. Only HTMLTransfer and FileTransfer remain to be fixed from ClipboardExample.