### PR TITLE
Ignore test_VisibilityWindowListener_eventSize size check on WebKitGTK

### DIFF
--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_browser_Browser.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_browser_Browser.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corporation and others.
+ * Copyright (c) 2000, 2022 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -1196,7 +1196,7 @@ public void test_VisibilityWindowListener_eventSize() {
 	browserChild.dispose();
 
 	boolean passed = false;
-	if (SwtTestUtil.isCocoa) {
+	if (!SwtTestUtil.isWindows) {
 		// On Cocoa, event height/width aren't respected if declared by javascript.
 		passed = finishedWithoutTimeout && result.get().x != 0 && result.get().y != 0;
 	} else

--- a/tests/org.eclipse.swt.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.swt.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.swt.tests
-Bundle-Version: 3.106.1700.qualifier
+Bundle-Version: 3.106.1800.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.swt.tests.junit,

--- a/tests/org.eclipse.swt.tests/pom.xml
+++ b/tests/org.eclipse.swt.tests/pom.xml
@@ -19,7 +19,7 @@
   </parent>
   <groupId>org.eclipse.swt</groupId>
   <artifactId>org.eclipse.swt.tests</artifactId>
-  <version>3.106.1700-SNAPSHOT</version>
+  <version>3.106.1800-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
   <properties>
     <code.ignoredWarnings>${tests.ignoredWarnings}</code.ignoredWarnings>


### PR DESCRIPTION
It's same engine as on Cocoa (Webkit) and event size is just ignored.
Fixes long standing test failure on Linux.