### PR TITLE
Create rebase.yml file for rebasing through GitHub PR page

### DIFF
--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -1,0 +1,19 @@
+name: Automatic Rebase
+on:
+  issue_comment:
+    types: [created]
+jobs:
+  rebase:
+    name: Rebase
+    if: github.event.issue.pull_request != '' && contains(github.event.comment.body, '/rebase') 
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the latest code
+        uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0 # otherwise, you will fail to push refs to dest repo
+      - name: Automatic Rebase
+        uses: cirrus-actions/rebase@1.7
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This allows the use of "/rebase" in a comment within a PR to rebase the changes. 

Right now, you need to rebase locally then push to GitHub to rebase, which can be tedious for old PRs. Having this feature will make it much easier to rebase those not so recent changes.

Tycho already does this, see here:
https://github.com/eclipse/tycho/blob/master/.github/workflows/rebase.yml