### PR TITLE
Remove apitools.ee.feature from Oomph setup.

### DIFF
--- a/bundles/org.eclipse.swt.tools/Oomph/platformSwt.setup
+++ b/bundles/org.eclipse.swt.tools/Oomph/platformSwt.setup
@@ -220,8 +220,6 @@
         name="org.eclipse.jdt.feature.group"/>
     <requirement
         name="org.eclipse.pde.feature.group"/>
-    <requirement
-        name="org.eclipse.pde.api.tools.ee.feature.feature.group"/>
     <repository
         url="${eclipse.latest.p2}"/>
   </setupTask>


### PR DESCRIPTION
Not needed at all and to be removed via
https://github.com/eclipse-pde/eclipse.pde/pull/147