### PR TITLE
Issue #214 - Incorrect keycode conversion displayed when key pressed …

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Widget.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Widget.java
@@ -1980,7 +1980,6 @@ boolean setKeyState (Event javaEvent, long event) {
 
 				short [] keyCode = new short [1];
 				if (GTK.GTK4) {
-					keyCode[0] = (short) GDK.gdk_key_event_get_keycode(event);
 					keyval[0] = (short) GDK.gdk_key_event_get_keyval(event);
 					javaEvent.keyCode = (int) GDK.gdk_keyval_to_unicode (keyval [0]);
 				} else {

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Widget.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Widget.java
@@ -1981,7 +1981,8 @@ boolean setKeyState (Event javaEvent, long event) {
 				short [] keyCode = new short [1];
 				if (GTK.GTK4) {
 					keyCode[0] = (short) GDK.gdk_key_event_get_keycode(event);
-					javaEvent.keyCode = keyCode[0];
+					keyval[0] = (short) GDK.gdk_key_event_get_keyval(event);
+					javaEvent.keyCode = (int) GDK.gdk_keyval_to_unicode (keyval [0]);
 				} else {
 					GDK.gdk_event_get_keycode(event, keyCode);
 					if (GDK.gdk_keymap_translate_keyboard_state (keymap, keyCode[0],


### PR DESCRIPTION
…in Snippet 25

+ get translated keyval from GTK4

The issue was that in GTK4, keyval and keycode are auto translated without requiring a keymap.
This was a very trivial fix of getting keyval and converting it into keycode using gdk_keyval_to_unicode

Signed-off-by: Jason Wang <jaswan@redhat.com>