### PR TITLE
Don't execute listeners on disposed widgets and items.

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/EventTable.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/EventTable.java
@@ -90,6 +90,10 @@ public void sendEvent (Event event) {
 					} catch (Error | RuntimeException ex) {
 						exceptions.stash (ex);
 					}
+					if (event.widget != null && event.widget.isDisposed()
+							|| event.item != null && event.item.isDisposed()) {
+						break;
+					}
 				}
 			}
 		}


### PR DESCRIPTION
The problem occurs when there are multiple listeners of the same type and one of them triggers widget dispose (either directly or via its parent).

Note that SWT.Dispose events are not affected, because they are sent before the widget is marked as disposed.

Inspired by eclipse-platform/eclipse.platform.ui#164.