### PR TITLE
Issue #48 FileDialog created displays error if no fileFilter Path set

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/FileDialog.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/FileDialog.java
@@ -479,8 +479,6 @@ void presetChooserDialog () {
 
 				if (fileName.length() > 0) {
 					GTK4.gtk_file_chooser_set_file (handle, file, 0);
-				} else {
-					GTK4.gtk_file_chooser_set_current_folder (handle, file, 0);
 				}
 			}
 


### PR DESCRIPTION
+if no filename set defaults to location of file

The issue was caused by if no filename was set then it would try to open file "" as a default which creates an error. This is simply fixed by if no filename is set then set the filename to location of the file

Signed-off-by: Jason Wang <jaswan@redhat.com>

Original Issue #48 