### PR TITLE
Part4: Table remains visible though setVisible(false) was called

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Table.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Table.java
@@ -4239,7 +4239,8 @@ void fixVisibility () {
 	 * Note: For empty tables we can ignore the required visibility state.
 	 */
 	int itemCount = (int)OS.SendMessage (handle, OS.LVM_GETITEMCOUNT, 0, 0);
-	if (itemCount > 0) {
+	boolean isVirtual = (style & SWT.VIRTUAL) != 0;
+	if (isVirtual && itemCount > 0) {
 		boolean expectedVisibility = OS.IsWindowVisible (handle);
 		boolean currentVisibility = ((style & OS.WS_VISIBLE) != 0);
 		if (currentVisibility != expectedVisibility) {


### PR DESCRIPTION
- Fix Eclipse code completion popup which is currently empty unless
re-triggered.

Change-Id: I2c985d221d2d8048e5ad63a184145bff63906b7c
Signed-off-by: Niraj Modi <niraj.modi@in.ibm.com>