### PR TITLE
Issue #247 - [GTK][Wayland] Drag&drop gets stuck

### DIFF
--- a/tests/org.eclipse.swt.tests/ManualTests/org/eclipse/swt/tests/manual/Issue0247_WaylandDragDropGetsStuck.java
+++ b/tests/org.eclipse.swt.tests/ManualTests/org/eclipse/swt/tests/manual/Issue0247_WaylandDragDropGetsStuck.java
@@ -1,0 +1,80 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Syntevo and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Syntevo - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.swt.tests.manual;
+
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.dnd.*;
+import org.eclipse.swt.layout.*;
+import org.eclipse.swt.widgets.*;
+
+public class Issue0247_WaylandDragDropGetsStuck {
+	public static void main(String[] args) {
+		final Display display = new Display ();
+
+		final Shell shell = new Shell (display);
+		shell.setLayout (new GridLayout (1, true));
+
+		Label hint = new Label (shell, 0);
+		hint.setText (
+			"1) Use Linux with Wayland\n" +
+			"2) Drag TreeItem\n" +
+			"3) Issue 0247: Dragging begins immediately when mouse is moved without any move threshold\n" +
+			"4) Move mouse over TreeItem slowly and double-click once in a while\n" +
+			"5) Issue 0247: Sometimes, counter will grow, indicating that there's an unfinished drag.\n" +
+			"   You will also see it by DRAGGING indicator being stuck.\n"
+		);
+
+		Tree control = new Tree (shell, SWT.BORDER);
+		for (int i = 0; i < 5; i++) {
+			new TreeItem(control, 0).setText("TreeItem #" + i);
+		}
+
+		Label labelIsDrag = new Label(shell, 0);
+		labelIsDrag.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
+
+		final int[] numActiveDrags = new int[1];
+		DragSource dragSource = new DragSource (control, DND.DROP_MOVE | DND.DROP_COPY);
+		dragSource.setTransfer (TextTransfer.getInstance ());
+		dragSource.addDragListener (new DragSourceListener() {
+			@Override
+			public void dragStart(DragSourceEvent event) {
+				labelIsDrag.setText("DRAGGING");
+				numActiveDrags[0]++;
+			}
+
+			@Override
+			public void dragSetData(DragSourceEvent event) {
+				event.data = "Data";
+			}
+
+			@Override
+			public void dragFinished(DragSourceEvent event) {
+				numActiveDrags[0]--;
+				labelIsDrag.setText("" + numActiveDrags[0]);
+			}
+		});
+
+		shell.pack ();
+		shell.open ();
+
+		while (!shell.isDisposed ()) {
+			if (!display.readAndDispatch ()) {
+				display.sleep ();
+			}
+		}
+
+		display.dispose ();
+	}
+}


### PR DESCRIPTION
Fixes #247

The problem was introduced in patch for Bug 541635, which accidentally
ignored calculated `dragging` variable, causing drag to begin
immediately when mouse is moved.

Also, it introduced a crazy loop, which, if it proceeds to second
iteration, will loop forever, because GTK events can't be processed when
main thread is busy running the infinite loop. Luckily, it seems that
the loop always exited on first iteration, and its meaning was simply to
`return false` when mouse is not down.

The reason why drag&drop can become stuck is not exactly clear, but I'm
confident that it was related to very short drag&drop mouse move
threshold (basically, 1px). With the regular threshold, the bug may
still be present, but it's almost impossible to reproduce.

The real case behind this bug is that when actual human double-clicks a
TreeItem, sometimes mouse will be moved very slightly when doing so,
which started a drag&drop, which got stuck and caused further problems
in applications which were puzzled by never ending drag&drop. Also, it
results in `TreeDragSourceEffect` image leak, because it never receives
the drag end event.