### PR TITLE
Make sure to dispose TextLayout on test failure.

### DIFF
--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_TextLayout.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_TextLayout.java
@@ -281,31 +281,33 @@ public void test_getLineOffsets() {
 	 * Test has been adapted to work on Mac as well.
 	 */
 	TextLayout layout = new TextLayout(display);
-	String text = "0123456\n890123\n";
-	layout.setText(text);
-	int[] offsets = layout.getLineOffsets();
-	int[] expected = (SwtTestUtil.isCocoa) ? new int [] {0, 8, 15} : new int [] {0, 8, 15, 15} ;
-	assertArrayEquals(expected, offsets);
-	layout.setText("");
-	offsets = layout.getLineOffsets();
-	expected = new int [] {0, 0};
-	assertArrayEquals(expected, offsets);
-	layout.setText("\n");
-	offsets = layout.getLineOffsets();
-	expected = (SwtTestUtil.isCocoa) ? new int [] {0, 1} : new int [] {0, 1, 1};
-	assertArrayEquals(expected, offsets);
-	layout.setText("WMWM");
-	int width = layout.getBounds().width;
-	layout.setWidth(width / 4 + 1);
-	offsets = layout.getLineOffsets();
-	expected = new int [] {0, 1, 2, 3, 4};
-	assertArrayEquals(expected, offsets);
-	layout.setWidth(width / 2 + 1);
-	offsets = layout.getLineOffsets();
-	expected = new int [] {0, 2, 4};
-	assertArrayEquals(expected, offsets);
-
-	layout.dispose();
+	try {
+		String text = "0123456\n890123\n";
+		layout.setText(text);
+		int[] offsets = layout.getLineOffsets();
+		int[] expected = (SwtTestUtil.isCocoa) ? new int [] {0, 8, 15} : new int [] {0, 8, 15, 15} ;
+		assertArrayEquals(expected, offsets);
+		layout.setText("");
+		offsets = layout.getLineOffsets();
+		expected = new int [] {0, 0};
+		assertArrayEquals(expected, offsets);
+		layout.setText("\n");
+		offsets = layout.getLineOffsets();
+		expected = (SwtTestUtil.isCocoa) ? new int [] {0, 1} : new int [] {0, 1, 1};
+		assertArrayEquals(expected, offsets);
+		layout.setText("WMWM");
+		int width = layout.getBounds().width;
+		layout.setWidth(width / 4 + 1);
+		offsets = layout.getLineOffsets();
+		expected = new int [] {0, 1, 2, 3, 4};
+		assertArrayEquals(expected, offsets);
+		layout.setWidth(width / 2 );
+		offsets = layout.getLineOffsets();
+		expected = new int [] {0, 2, 4};
+		assertArrayEquals(expected, offsets);
+	} finally {
+		layout.dispose();
+	}
 }
 
 @Test


### PR DESCRIPTION
Should reduce failing tests on Jenkins build.