### PR TITLE
Fix #256 Menus does not show on macOS Ventura

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT PI/cocoa/org/eclipse/swt/internal/cocoa/OS.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/cocoa/org/eclipse/swt/internal/cocoa/OS.java
@@ -178,7 +178,7 @@ public class OS extends C {
 	 * Custom message that will be sent when setTheme is called for example from Platform UI code.
 	 */
 	public static final long sel_appAppearanceChanged = OS.sel_registerName("appAppearanceChanged");
-	
+
 	/**
 	 * Experimental API for dark theme.
 	 * <p>
@@ -193,7 +193,7 @@ public class OS extends C {
 	 * On GTK, behavior may be different as the boolean flag doesn't force dark
 	 * theme instead it specify that dark theme is preferred.
 	 * </p>
-	 * 
+	 *
 	 * @param isDarkTheme <code>true</code> for dark theme
 	 */
 	public static void setTheme(boolean isDarkTheme) {
@@ -221,6 +221,15 @@ public class OS extends C {
 	public static boolean isBigSurOrLater () {
 		// See comment for OS.VERSION for an explanation
 		return OS.VERSION >= OS.VERSION(10, 16, 0);
+	}
+
+	/**
+	 * @return true for macOS Ventura or later, returns false for earlier
+	 * versions
+	 */
+	public static boolean isVenturaOrLater () {
+		// See comment for OS.VERSION for an explanation
+		return OS.VERSION >= OS.VERSION(13, 0, 0);
 	}
 
 /** JNI natives */

--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Display.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Display.java
@@ -891,15 +891,16 @@ static private void configureSystemOptions () {
 	 * internal data, which is unexpected to the macOS's menu tracking
 	 * loop.
 	 *
-	 * Both bugs are bugs of macOS itself. The workaround is to disable
-	 * the new macOS 12 behavior.
+	 * Both bugs are bugs of macOS itself but appears to have been fixed in
+	 * macOS 13 (Ventura). The workaround is to disable the new macOS 12
+	 * behavior.
 	 *
-	 * The condition should be for (macOS >= 12), but it's not possible
+	 * The condition should be for (macOS >= 12 and <13), but it's not possible
 	 * to reliably distinguish 11 from 12, see comment for OS.VERSION.
 	 * That's fine: older macOS don't know this setting and will not
 	 * check for it anyway.
 	 */
-	if (OS.isBigSurOrLater ()) {
+	if (OS.isBigSurOrLater() && !OS.isVenturaOrLater()) {
 		// The name of the option is misleading. What it really means
 		// is whether '-[NSMenuWindowManagerWindow _setVisible:]' shall
 		// save/restore current key window or not.


### PR DESCRIPTION
This fix basically disables the workaround for [Eclipse issue 578171](https://bugs.eclipse.org/bugs/show_bug.cgi?id=578171)  if running on macOS 13 (Ventura) or later. I have not found related information in the [macOS release notes](https://developer.apple.com/documentation/macos-release-notes/macos-13-release-notes), but I think it is safe to assume that the issue referenced in 578171 has been fixed.