### PR TITLE
[GTK4] Flood of CSS parsing errors when launching IDE

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/ToolBar.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/ToolBar.java
@@ -633,7 +633,7 @@ int setBounds (int x, int y, int width, int height, boolean move, boolean resize
 @Override
 void setBackgroundGdkRGBA (long context, long handle, GdkRGBA rgba) {
 	// Form background string
-	String css = "toolbar {background-color: " + display.gtk_rgba_to_css_string(rgba) + "}";
+	String css = "toolbar {background-color: " + display.gtk_rgba_to_css_string(rgba) + ";}";
 
 	// Cache background color
 	this.cssBackground = css;


### PR DESCRIPTION
Missing semicolon caused Gtk to spit out many css parsing errors. Adding this semicolon fixes the issue.

Signed-off-by: Joel Majano <jmajano@redhat.com>