### PR TITLE
Issue #256 - [cocoa] Menus does not show on macOS 13 Ventura

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Shell.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Shell.java
@@ -2072,6 +2072,30 @@ public void setVisible (boolean visible) {
 	}
 }
 
+void preventShellActivateJvmCrash () {
+	/*
+	 * Bug 578171: There is new code in macOS 12 that remembers which
+	 * Shell was active before menu popup was shown and tries to
+	 * re-activate after menu popup is closed. Unfortunately there is a
+	 * bug in this code: if window list changes, it activates a wrong
+	 * Shell.
+	 *
+	 * This is a bug on its own, but worse yet, this causes a JVM crash
+	 * because activating a new Shell causes menu bar to reset its
+	 * internal data, which is unexpected to the macOS's menu tracking
+	 * loop.
+	 *
+	 * Both bugs are bugs of macOS itself. The workaround is to cancel
+	 * menu tracking just before showing Shell.
+	 *
+	 * The condition should be for (macOS >= 12), but it's not possible
+	 * to reliably distinguish 11 from 12, see comment for OS.VERSION.
+	 */
+	if (OS.isBigSurOrLater ()) {
+		Display.cancelRootMenuTracking ();
+	}
+}
+
 void setWindowVisible (boolean visible, boolean key) {
 	if (visible) {
 		if ((state & HIDDEN) == 0) return;
@@ -2092,6 +2116,8 @@ void setWindowVisible (boolean visible, boolean key) {
 		topView ().setHidden (false);
 		invalidateVisibleRegion();
 		if (window != null) {
+			preventShellActivateJvmCrash ();
+
 			if ((style & (SWT.SHEET)) != 0) {
 				NSApplication application = NSApplication.sharedApplication();
 				application.beginSheet(window, parentWindow (), null, 0, 0);


### PR DESCRIPTION
It was caused by undocumented setting used to prevent Bug 578171.

This patch changes the workaround to a different one, where instead
of trying to make menu behave, it's now canceled just before showing
Shell.

Fixes #256 