### PR TITLE
GH: Build the swt fragments together with the rest of the build

### DIFF
--- a/.github/aggregator.pom
+++ b/.github/aggregator.pom
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>eclipse.platform.swt</groupId>
+    <artifactId>aggregator</artifactId>
+    <packaging>pom</packaging>
+    <version>1</version>
+	<modules>
+		<module>..</module>
+		<module>../../eclipse.platform.swt.binaries</module>
+	</modules>
+</project>

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -30,6 +30,12 @@ jobs:
       with:
        path: 'eclipse.platform.swt'
        fetch-depth: 0 # required for jgit timestamp provider to work
+    - name: checkout swt.binaries
+      uses: actions/checkout@v3
+      with:
+       path: eclipse.platform.swt.binaries
+       fetch-depth: 0 # required for jgit timestamp provider to work
+       repository: 'eclipse-platform/eclipse.platform.swt.binaries'
     - name: Install Linux requirements
       run: sudo apt-get update -qq && sudo apt-get install -qq -y webkit2gtk-driver
       if: ${{ matrix.config.native == 'gtk.linux.x86_64'}}
@@ -43,7 +49,7 @@ jobs:
       uses: GabrielBB/xvfb-action@v1
       with:
        run: >- 
-        mvn --batch-mode
+        mvn --batch-mode -V -U
         -Pbuild-individual-bundles
         -Pbuild-individual-platform
         -Dswt.build.platform_cp=${{ matrix.config.cp }}
@@ -53,7 +59,8 @@ jobs:
         -Dmaven.test.failure.ignore=true
         -DskipNativeTests=false
         -DfailIfNoTests=false
-        clean verify
+        -f .github/aggregator.pom
+        clean install
        working-directory: eclipse.platform.swt
     - name: Upload Test Results for ${{ matrix.config.name }} / Java-${{ matrix.java }}
       uses: actions/upload-artifact@v3


### PR DESCRIPTION
Currently the fragments are not build but taken from the I-Build in the
Gh actions, this fixes the problem by checkout and build the binary
repository as well.

Fixes https://github.com/eclipse-platform/eclipse.platform.swt/issues/251