### PR TITLE
Fix oval window close button on Gtk under Wayland

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/org/eclipse/swt/internal/gtk/swt_theming_fixes_gtk_3_24_5.css
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/org/eclipse/swt/internal/gtk/swt_theming_fixes_gtk_3_24_5.css
@@ -1,3 +1,3 @@
 button {
-	padding: 4px 8px;
+	padding: 4px 4px;
 }


### PR DESCRIPTION
This was caused by a fix for
https://bugs.eclipse.org/bugs/show_bug.cgi?id=549117 which set the css
for buttons on latest Gtk versions to have different paddings for
top/bottom and left/right.
Changing it to be equal returns the proper round size of the close
button while preserving the fix in the mentioned.