### PR TITLE
Test_org_eclipse_swt_graphics_TextLayout#test_getLineOffsets() JUnit failing on Windows.

### DIFF
--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_TextLayout.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_TextLayout.java
@@ -301,7 +301,7 @@ public void test_getLineOffsets() {
 		offsets = layout.getLineOffsets();
 		expected = new int [] {0, 1, 2, 3, 4};
 		assertArrayEquals(expected, offsets);
-		layout.setWidth(width / 2 );
+		layout.setWidth(width / 2 + 1);
 		offsets = layout.getLineOffsets();
 		expected = new int [] {0, 2, 4};
 		assertArrayEquals(expected, offsets);


### PR DESCRIPTION
Fixes #311

Signed-off-by: Niraj Modi <niraj.modi@in.ibm.com>