### PR TITLE
[GTK] Disabled toolbar icons and button images are double size on hi-res screen

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/graphics/Image.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/graphics/Image.java
@@ -274,7 +274,7 @@ public Image(Device device, Image srcImage, int flag) {
 	boolean hasAlpha = format == Cairo.CAIRO_FORMAT_ARGB32;
 	surface = Cairo.cairo_image_surface_create(format, width, height);
 	if (surface == 0) SWT.error(SWT.ERROR_NO_HANDLES);
-	if (DPIUtil.useCairoAutoScale()) {
+	if (DPIUtil.getDeviceZoom() != currentDeviceZoom && DPIUtil.useCairoAutoScale()) {
 		double scaleFactor = DPIUtil.getDeviceZoom() / 100f;
 		Cairo.cairo_surface_set_device_scale(surface, scaleFactor, scaleFactor);
 	}

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/internal/ImageList.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/internal/ImageList.java
@@ -281,6 +281,20 @@ void set (int index, Image image) {
 	long surface = convertSurface(image);
 	int w = Cairo.cairo_image_surface_get_width(surface);
 	int h = Cairo.cairo_image_surface_get_height(surface);
+
+	/*SWT Issue 315:
+	 * if device scale returns something other than 1,
+	 * cairo_image_surface_get_width() and ...height() return the scaled
+	 * dimensions since its treating the pixels as display pixels instead of logical pixels
+	 * that surfaces use. This causes a second scaling to occur, which is incorrect.
+	 * Divide w and h by the device scale to return correct dimensions.
+	 */
+	double sx[] = new double[1];
+	double sy[] = new double[1];
+	Cairo.cairo_surface_get_device_scale(image.surface, sx, sy);
+	w /= (int)sx[0];
+	h /= (int)sy[0];
+
 	Rectangle bounds;
 	if (DPIUtil.useCairoAutoScale()) {
 		bounds = image.getBounds();


### PR DESCRIPTION
This issue was caused by logic running Cairo scaling multiple times when it was not necessary.
There are two locations that were problematic, one, Image.java was applying a second scale when copying an image.
Two, ImageList.java was interpreting width/height returned from a Cairo function incorrectly.

+ Guarded cairo_surface_set_device_scale call if copy and original have the same device zoom in Image.java
+ Corrected width and height variables to interpret size correctly in ImageList.java

Signed-off-by: Joel Majano <jmajano@redhat.com>

Fixes #315 