### PR TITLE
[GTK4] Text entered in StyledText does not show up until window resized

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Control.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Control.java
@@ -6772,10 +6772,11 @@ boolean traverseMnemonic (char key) {
 public void update () {
 	checkWidget ();
 	update (false, true);
+
 }
 
 void update (boolean all, boolean flush) {
-//	checkWidget();
+	if(GTK.GTK4) GTK.gtk_widget_queue_draw(handle);
 	if (!GTK.gtk_widget_get_visible (topHandle ())) return;
 	if (!GTK.gtk_widget_get_realized (handle)) return;
 	long window = paintWindow ();


### PR DESCRIPTION
When entering text using a keyboard in StyledText snippets or TextEditor example, text would not show up until the window was resized.

+ Added gtk_widget_queue_draw in update()

Signed-off-by: Joel Majano <jmajano@redhat.com>

Tested with TextEditor.java and a simple StyledText snippet.

Tracked in #228 