### PR TITLE
[a11y] part2 - Content Types Preference description can't be read by JAWS

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Link.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Link.java
@@ -116,7 +116,7 @@ public Link(Composite parent, int style) {
 	this.getAccessible().addAccessibleListener(new AccessibleAdapter() {
 		@Override
 		public void getName(AccessibleEvent e) {
-			e.result = Link.this.getText();
+			e.result = text;
 		}
 	});
 }


### PR DESCRIPTION
- Minor code refactoring: improves original fix done via #341
- This fix improves #340

Signed-off-by: Niraj Modi <niraj.modi@in.ibm.com>