### PR TITLE
[win32] Fix various warnings in native libs, treat any new warnings as errors

### DIFF
--- a/bundles/org.eclipse.swt.tools/JNI Generation/org/eclipse/swt/tools/internal/NativesGenerator.java
+++ b/bundles/org.eclipse.swt.tools/JNI Generation/org/eclipse/swt/tools/internal/NativesGenerator.java
@@ -76,12 +76,13 @@ public void generate(JNIClass clazz) {
 	if (i == methods.length) return;
 	sort(methods);
 	generateNativeMacro(clazz);
+	generateWarningSettings();
 	generateExcludes(methods);
 	generate(methods);
 }
 
 public void generate(JNIMethod[] methods) {
-	sort(methods);	
+	sort(methods);
 	for (JNIMethod method : methods) {
 		if ((method.getModifiers() & Modifier.NATIVE) == 0) continue;
 		generate(method);
@@ -122,7 +123,7 @@ void generateCallback(JNIMethod method, String function) {
 		first = false;
 	}
 	outputln(") {");
-	
+
 	output("\t");
 	if (isStruct(flags[0]) || isFloatingPoint(types[0])) {
 		output(types[0]);
@@ -168,7 +169,7 @@ void generateCallback(JNIMethod method, String function) {
 		outputln("\treturn rc;");
 	}
 	outputln("}");
-	
+
 	output("static jlong ");
 	output(method.getName());
 	outputln("(jlong func) {");
@@ -183,7 +184,7 @@ void generateCallback(JNIMethod method, String function) {
 
 public void generate(JNIMethod method) {
 	if (method.getFlag(FLAG_NO_GEN)) return;
-	JNIType returnType = method.getReturnType();	
+	JNIType returnType = method.getReturnType();
 	if (!(returnType.isType("void") || returnType.isPrimitive() || isSystemClass(returnType) || returnType.isType("java.lang.String"))) {
 		output("Warning: bad return type. :");
 		outputln(method.toString());
@@ -246,6 +247,14 @@ void generateNativeMacro(JNIClass clazz) {
 	output("_NATIVE(func) Java_");
 	output(toC(clazz.getName()));
 	outputln("_##func");
+	outputln("#endif");
+	outputln();
+}
+
+void generateWarningSettings() {
+	outputln("#ifdef _WIN32");
+	outputln("  /* Many methods don't use their 'env' and 'that' arguments */");
+	outputln("  #pragma warning (disable: 4100)");
 	outputln("#endif");
 	outputln();
 }

--- a/bundles/org.eclipse.swt.tools/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.swt.tools/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.swt.tools; singleton:=true
-Bundle-Version: 3.109.500.qualifier
+Bundle-Version: 3.109.600.qualifier
 Bundle-ManifestVersion: 2
 Export-Package: org.eclipse.swt.tools.internal; x-internal:=true
 Bundle-ActivationPolicy: lazy

--- a/bundles/org.eclipse.swt.tools/pom.xml
+++ b/bundles/org.eclipse.swt.tools/pom.xml
@@ -19,6 +19,6 @@
   </parent>
   <groupId>org.eclipse.swt</groupId>
   <artifactId>org.eclipse.swt.tools</artifactId>
-  <version>3.109.500-SNAPSHOT</version>
+  <version>3.109.600-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/bundles/org.eclipse.swt/Eclipse SWT AWT/win32/library/swt_awt.c
+++ b/bundles/org.eclipse.swt/Eclipse SWT AWT/win32/library/swt_awt.c
@@ -28,6 +28,9 @@
 JNIEXPORT jlong JNICALL SWT_AWT_NATIVE(getAWTHandle)
 	(JNIEnv *env, jclass that, jobject canvas)
 {
+	/* Suppress warnings about unreferenced parameters */
+	(void)that;
+
 	JAWT awt;
 	JAWT_DrawingSurface* ds;
 	JAWT_DrawingSurfaceInfo* dsi;
@@ -58,6 +61,10 @@ JNIEXPORT jlong JNICALL SWT_AWT_NATIVE(getAWTHandle)
 JNIEXPORT jobject JNICALL SWT_AWT_NATIVE(initFrame)
 	(JNIEnv *env, jclass that, jlong handle, jstring className)
 {
+	/* Suppress warnings about unreferenced parameters */
+	(void)className;
+	(void)that;
+
 	jobject object;
 	jmethodID constructor;
 	
@@ -73,6 +80,9 @@ JNIEXPORT jobject JNICALL SWT_AWT_NATIVE(initFrame)
 JNIEXPORT void JNICALL SWT_AWT_NATIVE(synthesizeWindowActivation)
 (JNIEnv *env, jclass that, jobject frame, jboolean doActivate)
 {
+	/* Suppress warnings about unreferenced parameters */
+	(void)that;
+
 	jmethodID midInit;
     jclass cls = (*env)->FindClass(env, "sun/awt/windows/WEmbeddedFrame");
     if (NULL == cls) return;

--- a/bundles/org.eclipse.swt/Eclipse SWT AWT/win32/library/swt_awt.c
+++ b/bundles/org.eclipse.swt/Eclipse SWT AWT/win32/library/swt_awt.c
@@ -13,7 +13,14 @@
  *******************************************************************************/
 
 #include "swt.h"
+
+/*
+ * External headers will sometimes have warnings above level 2, just
+ * ignore all of them, we can't do anything about it anyway.
+ */
+#pragma warning(push, 2)
 #include "jawt_md.h"
+#pragma warning(pop)
 
 #define SWT_AWT_NATIVE(func) Java_org_eclipse_swt_awt_SWT_1AWT_##func
 

--- a/bundles/org.eclipse.swt/Eclipse SWT OpenGL/glx/library/glx.c
+++ b/bundles/org.eclipse.swt/Eclipse SWT OpenGL/glx/library/glx.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corporation and others.
+ * Copyright (c) 2000, 2022 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -21,6 +21,11 @@
 
 #ifndef GLX_NATIVE
 #define GLX_NATIVE(func) Java_org_eclipse_swt_internal_opengl_glx_GLX_##func
+#endif
+
+#ifdef _WIN32
+  /* Many methods don't use their 'env' and 'that' arguments */
+  #pragma warning (disable: 4100)
 #endif
 
 #ifndef NO_XVisualInfo_1sizeof

--- a/bundles/org.eclipse.swt/Eclipse SWT OpenGL/win32/library/wgl.c
+++ b/bundles/org.eclipse.swt/Eclipse SWT OpenGL/win32/library/wgl.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corporation and others.
+ * Copyright (c) 2000, 2022 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -21,6 +21,11 @@
 
 #ifndef WGL_NATIVE
 #define WGL_NATIVE(func) Java_org_eclipse_swt_internal_opengl_win32_WGL_##func
+#endif
+
+#ifdef _WIN32
+  /* Many methods don't use their 'env' and 'that' arguments */
+  #pragma warning (disable: 4100)
 #endif
 
 #ifndef NO_ChoosePixelFormat

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/cairo/library/cairo.c
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/cairo/library/cairo.c
@@ -15,7 +15,7 @@
  *
  * IBM
  * -  Binding to permit interfacing between Cairo and SWT
- * -  Copyright (C) 2005, 2021 IBM Corp.  All Rights Reserved.
+ * -  Copyright (C) 2005, 2022 IBM Corp.  All Rights Reserved.
  *
  * ***** END LICENSE BLOCK ***** */
 
@@ -28,6 +28,11 @@
 
 #ifndef Cairo_NATIVE
 #define Cairo_NATIVE(func) Java_org_eclipse_swt_internal_cairo_Cairo_##func
+#endif
+
+#ifdef _WIN32
+  /* Many methods don't use their 'env' and 'that' arguments */
+  #pragma warning (disable: 4100)
 #endif
 
 #ifndef NO_CAIRO_1VERSION_1ENCODE

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/cocoa/library/os.c
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/cocoa/library/os.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corporation and others.
+ * Copyright (c) 2000, 2022 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -21,6 +21,11 @@
 
 #ifndef OS_NATIVE
 #define OS_NATIVE(func) Java_org_eclipse_swt_internal_cocoa_OS_##func
+#endif
+
+#ifdef _WIN32
+  /* Many methods don't use their 'env' and 'that' arguments */
+  #pragma warning (disable: 4100)
 #endif
 
 #ifndef NO_AcquireRootMenu

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/common/library/c.c
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/common/library/c.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corporation and others.
+ * Copyright (c) 2000, 2022 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -21,6 +21,11 @@
 
 #ifndef C_NATIVE
 #define C_NATIVE(func) Java_org_eclipse_swt_internal_C_##func
+#endif
+
+#ifdef _WIN32
+  /* Many methods don't use their 'env' and 'that' arguments */
+  #pragma warning (disable: 4100)
 #endif
 
 #ifndef NO_PTR_1sizeof

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/common/library/c.h
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/common/library/c.h
@@ -21,11 +21,8 @@
 #define PTR_sizeof() sizeof(void *)
 
 /* Functions excludes */
-#ifdef _WIN32_WCE
-#define NO_getenv
-#endif /* _WIN32_WCE */
-
 #ifdef _WIN32
+#define NO_getenv
 #define NO_setenv
 #endif /* _WIN32 */
 

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/atk.c
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/atk.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corporation and others. All rights reserved.
+ * Copyright (c) 2000, 2022 IBM Corporation and others. All rights reserved.
  * The contents of this file are made available under the terms
  * of the GNU Lesser General Public License (LGPL) Version 2.1 that
  * accompanies this distribution (lgpl-v21.txt).  The LGPL is also
@@ -22,6 +22,11 @@
 
 #ifndef ATK_NATIVE
 #define ATK_NATIVE(func) Java_org_eclipse_swt_internal_accessibility_gtk_ATK_##func
+#endif
+
+#ifdef _WIN32
+  /* Many methods don't use their 'env' and 'that' arguments */
+  #pragma warning (disable: 4100)
 #endif
 
 #ifndef NO_ATK_1ACTION_1GET_1IFACE

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/gtk3.c
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/gtk3.c
@@ -24,6 +24,11 @@
 #define GTK3_NATIVE(func) Java_org_eclipse_swt_internal_gtk3_GTK3_##func
 #endif
 
+#ifdef _WIN32
+  /* Many methods don't use their 'env' and 'that' arguments */
+  #pragma warning (disable: 4100)
+#endif
+
 #ifndef NO_GTK_1IS_1MENU_1ITEM
 JNIEXPORT jboolean JNICALL GTK3_NATIVE(GTK_1IS_1MENU_1ITEM)
 	(JNIEnv *env, jclass that, jlong arg0)

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/gtk4.c
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/gtk4.c
@@ -24,6 +24,11 @@
 #define GTK4_NATIVE(func) Java_org_eclipse_swt_internal_gtk4_GTK4_##func
 #endif
 
+#ifdef _WIN32
+  /* Many methods don't use their 'env' and 'that' arguments */
+  #pragma warning (disable: 4100)
+#endif
+
 #ifndef NO_gdk_1clipboard_1get_1content
 JNIEXPORT jlong JNICALL GTK4_NATIVE(gdk_1clipboard_1get_1content)
 	(JNIEnv *env, jclass that, jlong arg0)

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/os.c
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/os.c
@@ -24,6 +24,11 @@
 #define GDK_NATIVE(func) Java_org_eclipse_swt_internal_gtk_GDK_##func
 #endif
 
+#ifdef _WIN32
+  /* Many methods don't use their 'env' and 'that' arguments */
+  #pragma warning (disable: 4100)
+#endif
+
 #ifndef NO_GDK_1EVENT_1TYPE
 JNIEXPORT jint JNICALL GDK_NATIVE(GDK_1EVENT_1TYPE)
 	(JNIEnv *env, jclass that, jlong arg0)
@@ -3153,6 +3158,11 @@ JNIEXPORT jlong JNICALL GDK_NATIVE(gdk_1x11_1window_1lookup_1for_1display)
 
 #ifndef GTK_NATIVE
 #define GTK_NATIVE(func) Java_org_eclipse_swt_internal_gtk_GTK_##func
+#endif
+
+#ifdef _WIN32
+  /* Many methods don't use their 'env' and 'that' arguments */
+  #pragma warning (disable: 4100)
 #endif
 
 #ifndef NO_GET_1FUNCTION_1POINTER_1gtk_1false
@@ -10039,6 +10049,11 @@ JNIEXPORT void JNICALL GTK_NATIVE(gtk_1window_1unmaximize)
 #define Graphene_NATIVE(func) Java_org_eclipse_swt_internal_gtk_Graphene_##func
 #endif
 
+#ifdef _WIN32
+  /* Many methods don't use their 'env' and 'that' arguments */
+  #pragma warning (disable: 4100)
+#endif
+
 #ifndef NO_graphene_1rect_1alloc
 JNIEXPORT jlong JNICALL Graphene_NATIVE(graphene_1rect_1alloc)
 	(JNIEnv *env, jclass that)
@@ -10075,6 +10090,11 @@ JNIEXPORT jlong JNICALL Graphene_NATIVE(graphene_1rect_1init)
 
 #ifndef OS_NATIVE
 #define OS_NATIVE(func) Java_org_eclipse_swt_internal_gtk_OS_##func
+#endif
+
+#ifdef _WIN32
+  /* Many methods don't use their 'env' and 'that' arguments */
+  #pragma warning (disable: 4100)
 #endif
 
 #ifndef NO_Call__JJII

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/win32/library/build.bat
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/win32/library/build.bat
@@ -88,6 +88,7 @@ if %ERRORLEVEL% NEQ 0 (
     CALL :ECHO "         Refer steps for SWT Windows native setup: https://www.eclipse.org/swt/swt_win_native.php"
 )
 nmake -f make_win32.mak %1 %2 %3 %4 %5 %6 %7 %8 %9
+IF ERRORLEVEL 1 EXIT 1
 GOTO :EOF
 
 @rem Find Visual Studio

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/win32/library/com.c
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/win32/library/com.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corporation and others.
+ * Copyright (c) 2000, 2022 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -21,6 +21,11 @@
 
 #ifndef COM_NATIVE
 #define COM_NATIVE(func) Java_org_eclipse_swt_internal_ole_win32_COM_##func
+#endif
+
+#ifdef _WIN32
+  /* Many methods don't use their 'env' and 'that' arguments */
+  #pragma warning (disable: 4100)
 #endif
 
 #ifndef NO_CAUUID_1sizeof

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/win32/library/com_custom.cpp
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/win32/library/com_custom.cpp
@@ -263,6 +263,9 @@ public:
 	}
 
 	HRESULT GetTypeInfo(UINT iTInfo, LCID lcid, ITypeInfo **ppTInfo) override {
+    	/* Suppress warnings about unreferenced parameters */
+    	(void)lcid;
+
 		*ppTInfo = nullptr;
 		if (iTInfo != 0) {
 			return DISP_E_BADINDEX;
@@ -274,12 +277,20 @@ public:
 
 	HRESULT GetIDsOfNames(REFIID riid, LPOLESTR *rgszNames, UINT cNames,
 			LCID lcid, DISPID *rgDispId) override {
+    	/* Suppress warnings about unreferenced parameters */
+    	(void)lcid;
+    	(void)riid;
+
 		return pTypeInfo->GetIDsOfNames(rgszNames, cNames, rgDispId);
 	}
 
 	HRESULT Invoke(DISPID dispIdMember, REFIID riid, LCID lcid,
 			WORD wFlags, DISPPARAMS *pDispParams, VARIANT *pVarResult,
 			EXCEPINFO *pExcepInfo, UINT *puArgErr) override {
+    	/* Suppress warnings about unreferenced parameters */
+    	(void)lcid;
+    	(void)riid;
+
 		return pTypeInfo->Invoke(this, dispIdMember, wFlags, pDispParams,
 				pVarResult, pExcepInfo, puArgErr);
 	}
@@ -412,18 +423,29 @@ public:
 JNIEXPORT jlong JNICALL COM_NATIVE(CreateSwtWebView2Callback)
 	(JNIEnv *env, jclass that, jobject callback)
 {
+	/* Suppress warnings about unreferenced parameters */
+	(void)that;
+
 	return (jlong)SwtWebView2Callback::Create(env, callback);
 }
 
 JNIEXPORT jlong JNICALL COM_NATIVE(CreateSwtWebView2Host)
 	(JNIEnv *env, jclass that, jobject host)
 {
+	/* Suppress warnings about unreferenced parameters */
+	(void)that;
+
 	return (jlong)SwtWebView2Host::Create(env, host);
 }
 
 JNIEXPORT jlong JNICALL COM_NATIVE(CreateSwtWebView2Options)
 	(JNIEnv *env, jclass that, jobject host)
 {
+	/* Suppress warnings about unreferenced parameters */
+	(void)env;
+	(void)that;
+	(void)host;
+
 	return (jlong)SwtWebView2Options::Create();
 }
 

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/win32/library/com_custom.cpp
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/win32/library/com_custom.cpp
@@ -211,6 +211,7 @@ public:
 		jclass cls = env->GetObjectClass(host);
 		jmethodID methodID = env->GetMethodID(cls, "CallJava", "(IJJ)J");
 		jobject object = env->NewGlobalRef(host);
+		ITypeInfo *pTypeInfo = nullptr;
 		if (object == nullptr) goto error;
 
 		// NB: CreateDispTypeInfo doesn't support parameters
@@ -221,7 +222,6 @@ public:
 			{L"CallJava", params, 1, 7, CC_STDCALL, ARRAYSIZE(params), DISPATCH_METHOD, VT_BSTR},
 		};
 		static INTERFACEDATA iface = {methods, 1};
-		ITypeInfo *pTypeInfo = nullptr;
 		HRESULT hr = CreateDispTypeInfo(&iface, LOCALE_NEUTRAL, &pTypeInfo);
 		if (hr != S_OK) goto error;
 

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/win32/library/gdip.cpp
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/win32/library/gdip.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corporation and others.
+ * Copyright (c) 2000, 2022 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -21,6 +21,11 @@
 
 #ifndef Gdip_NATIVE
 #define Gdip_NATIVE(func) Java_org_eclipse_swt_internal_gdip_Gdip_##func
+#endif
+
+#ifdef _WIN32
+  /* Many methods don't use their 'env' and 'that' arguments */
+  #pragma warning (disable: 4100)
 #endif
 
 #ifndef NO_BitmapData_1delete

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/win32/library/make_win32.mak
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/win32/library/make_win32.mak
@@ -50,13 +50,13 @@ WGL_OBJS   = wgl.obj wgl_structs.obj wgl_stats.obj
 #NATIVE_STATS = -DNATIVE_STATS
 
 #CFLAGS = $(cdebug) $(cflags) $(cvarsmt) $(CFLAGS) \
-CFLAGS = -O1 -DNDEBUG -DUNICODE -D_UNICODE /c $(cflags) $(cvarsmt) $(CFLAGS) \
+CFLAGS = -O1 /WX /W4 -DNDEBUG -DUNICODE -D_UNICODE /c $(cflags) $(cvarsmt) $(CFLAGS) \
 	-DSWT_VERSION=$(maj_ver)$(min_ver) -DSWT_REVISION=$(rev) $(NATIVE_STATS) -DUSE_ASSEMBLER \
 	/I"$(SWT_JAVA_HOME)\include" /I"$(SWT_JAVA_HOME)\include\win32" /I.
 
 RCFLAGS = $(rcflags) $(rcvars) $(RCFLAGS) -DSWT_FILE_VERSION=\"$(maj_ver).$(min_ver).$(rev).0\" -DSWT_COMMA_VERSION=$(comma_ver)
 ldebug = /RELEASE  /INCREMENTAL:NO /NOLOGO
-dlllflags = -dll
+dlllflags = -dll /WX
 guilibsmt = kernel32.lib  ws2_32.lib mswsock.lib advapi32.lib bufferoverflowu.lib user32.lib gdi32.lib comdlg32.lib winspool.lib
 olelibsmt = ole32.lib uuid.lib oleaut32.lib $(guilibsmt)
 

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/win32/library/os.c
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/win32/library/os.c
@@ -1516,7 +1516,7 @@ JNIEXPORT jboolean JNICALL OS_NATIVE(DwmSetWindowAttribute)
 	jboolean rc = 0;
 	OS_NATIVE_ENTER(env, that, DwmSetWindowAttribute_FUNC);
 	if (arg2) if ((lparg2 = (*env)->GetIntArrayElements(env, arg2, NULL)) == NULL) goto fail;
-	rc = (jboolean)DwmSetWindowAttribute((HDC)arg0, arg1, lparg2, arg3);
+	rc = (jboolean)DwmSetWindowAttribute((HWND)arg0, arg1, lparg2, arg3);
 fail:
 	if (arg2 && lparg2) (*env)->ReleaseIntArrayElements(env, arg2, lparg2, 0);
 	OS_NATIVE_EXIT(env, that, DwmSetWindowAttribute_FUNC);

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/win32/library/os.c
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/win32/library/os.c
@@ -3379,18 +3379,6 @@ JNIEXPORT jint JNICALL OS_NATIVE(GetUpdateRgn)
 }
 #endif
 
-#ifndef NO_GetVersion
-JNIEXPORT jint JNICALL OS_NATIVE(GetVersion)
-	(JNIEnv *env, jclass that)
-{
-	jint rc = 0;
-	OS_NATIVE_ENTER(env, that, GetVersion_FUNC);
-	rc = (jint)GetVersion();
-	OS_NATIVE_EXIT(env, that, GetVersion_FUNC);
-	return rc;
-}
-#endif
-
 #ifndef NO_GetWindow
 JNIEXPORT jlong JNICALL OS_NATIVE(GetWindow)
 	(JNIEnv *env, jclass that, jlong arg0, jint arg1)

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/win32/library/os.c
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/win32/library/os.c
@@ -23,6 +23,11 @@
 #define OS_NATIVE(func) Java_org_eclipse_swt_internal_win32_OS_##func
 #endif
 
+#ifdef _WIN32
+  /* Many methods don't use their 'env' and 'that' arguments */
+  #pragma warning (disable: 4100)
+#endif
+
 #ifndef NO_ACCEL_1sizeof
 JNIEXPORT jint JNICALL OS_NATIVE(ACCEL_1sizeof)
 	(JNIEnv *env, jclass that)

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/win32/library/os.c
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/win32/library/os.c
@@ -8469,7 +8469,7 @@ JNIEXPORT jint JNICALL OS_NATIVE(SetDCBrushColor)
 {
 	jint rc = 0;
 	OS_NATIVE_ENTER(env, that, SetDCBrushColor_FUNC);
-	rc = (jint)SetDCBrushColor(arg0, arg1);
+	rc = (jint)SetDCBrushColor((HDC)arg0, arg1);
 	OS_NATIVE_EXIT(env, that, SetDCBrushColor_FUNC);
 	return rc;
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/win32/library/os.h
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/win32/library/os.h
@@ -41,6 +41,7 @@
 #include <uxtheme.h>
 #include <msctf.h>
 #include <intsafe.h>
+#include <dwmapi.h>
 
 /* Restore warnings */
 #pragma warning(pop)

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/win32/library/os.h
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/win32/library/os.h
@@ -15,6 +15,12 @@
 #ifndef INC_os_H
 #define INC_os_H
 
+/*
+ * Windows headers will sometimes have warnings above level 2, just
+ * ignore all of them, we can't do anything about it anyway.
+ */
+#pragma warning(push, 2)
+
 #include <windows.h>
 #include <WindowsX.h>
 #include <commctrl.h>
@@ -35,6 +41,9 @@
 #include <uxtheme.h>
 #include <msctf.h>
 #include <intsafe.h>
+
+/* Restore warnings */
+#pragma warning(pop)
 
 /* Optional custom definitions to exclude some types */
 #include "defines.h"

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/win32/library/os_custom.c
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/win32/library/os_custom.c
@@ -31,6 +31,9 @@ HRESULT DllGetVersion(DLLVERSIONINFO *dvi)
 HINSTANCE g_hInstance = NULL;
 BOOL WINAPI DllMain(HANDLE hInstDLL, DWORD dwReason, LPVOID lpvReserved)
 {
+	/* Suppress warnings about unreferenced parameters */
+	(void)lpvReserved;
+
 	if (dwReason == DLL_PROCESS_ATTACH) {
 		if (g_hInstance == NULL) g_hInstance = hInstDLL;
 	}
@@ -41,6 +44,10 @@ BOOL WINAPI DllMain(HANDLE hInstDLL, DWORD dwReason, LPVOID lpvReserved)
 JNIEXPORT jlong JNICALL OS_NATIVE(GetLibraryHandle)
 	(JNIEnv *env, jclass that)
 {
+	/* Suppress warnings about unreferenced parameters */
+	(void)env;
+	(void)that;
+
 	jlong rc;
 	OS_NATIVE_ENTER(env, that, GetLibraryHandle_FUNC)
 	rc = (jlong)g_hInstance;
@@ -149,6 +156,10 @@ TYPE_AllowDarkModeForWindowWithTelemetryId Locate_AllowDarkModeForWindowWithTele
 JNIEXPORT jboolean JNICALL OS_NATIVE(AllowDarkModeForWindow)
 (JNIEnv* env, jclass that, jlong arg0, jboolean arg1)
 {
+	/* Suppress warnings about unreferenced parameters */
+	(void)env;
+	(void)that;
+
 	/* Cache the search result for performance reasons */
 	static TYPE_AllowDarkModeForWindow fn_AllowDarkModeForWindow = 0;
 	static TYPE_AllowDarkModeForWindowWithTelemetryId fn_AllowDarkModeForWindowWithTelemetryId = 0;
@@ -235,6 +246,10 @@ TYPE_SetPreferredAppMode Locate_SetPreferredAppMode()
 JNIEXPORT jint JNICALL OS_NATIVE(SetPreferredAppMode)
 (JNIEnv* env, jclass that, jint arg0)
 {
+	/* Suppress warnings about unreferenced parameters */
+	(void)env;
+	(void)that;
+
 	/* Cache the search result for performance reasons */
 	static TYPE_SetPreferredAppMode fn_SetPreferredAppMode = 0;
 	static int isInitialized = 0;
@@ -269,6 +284,10 @@ jboolean isDarkThemeAvailable() {
 JNIEXPORT jboolean JNICALL OS_NATIVE(IsDarkModeAvailable)
 (JNIEnv* env, jclass that)
 {
+	/* Suppress warnings about unreferenced parameters */
+	(void)env;
+	(void)that;
+
 	/* Cache the search result for performance reasons */
 	static jboolean isAvailable = 0;
 	static int isInitialized = 0;

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/win32/library/os_stats.c
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/win32/library/os_stats.c
@@ -263,7 +263,6 @@ char * OS_nativeFunctionNames[] = {
 	"GetTouchInputInfo",
 	"GetUpdateRect",
 	"GetUpdateRgn",
-	"GetVersion",
 	"GetWindow",
 	"GetWindowDC",
 	"GetWindowLong",

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/win32/library/os_stats.h
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/win32/library/os_stats.h
@@ -273,7 +273,6 @@ typedef enum {
 	GetTouchInputInfo_FUNC,
 	GetUpdateRect_FUNC,
 	GetUpdateRgn_FUNC,
-	GetVersion_FUNC,
 	GetWindow_FUNC,
 	GetWindowDC_FUNC,
 	GetWindowLong_FUNC,

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/win32/library/os_structs.c
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/win32/library/os_structs.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corporation and others.
+ * Copyright (c) 2000, 2022 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -4252,11 +4252,11 @@ OSVERSIONINFOEX *getOSVERSIONINFOEXFields(JNIEnv *env, jobject lpObject, OSVERSI
 	jcharArray lpObject1 = (jcharArray)(*env)->GetObjectField(env, lpObject, OSVERSIONINFOEXFc.szCSDVersion);
 	(*env)->GetCharArrayRegion(env, lpObject1, 0, sizeof(lpStruct->szCSDVersion) / sizeof(jchar), (jchar *)lpStruct->szCSDVersion);
 	}
-	lpStruct->wServicePackMajor = (*env)->GetIntField(env, lpObject, OSVERSIONINFOEXFc.wServicePackMajor);
-	lpStruct->wServicePackMinor = (*env)->GetIntField(env, lpObject, OSVERSIONINFOEXFc.wServicePackMinor);
-	lpStruct->wSuiteMask = (*env)->GetIntField(env, lpObject, OSVERSIONINFOEXFc.wSuiteMask);
-	lpStruct->wProductType = (*env)->GetIntField(env, lpObject, OSVERSIONINFOEXFc.wProductType);
-	lpStruct->wReserved = (*env)->GetIntField(env, lpObject, OSVERSIONINFOEXFc.wReserved);
+	lpStruct->wServicePackMajor = (WORD)(*env)->GetIntField(env, lpObject, OSVERSIONINFOEXFc.wServicePackMajor);
+	lpStruct->wServicePackMinor = (WORD)(*env)->GetIntField(env, lpObject, OSVERSIONINFOEXFc.wServicePackMinor);
+	lpStruct->wSuiteMask = (WORD)(*env)->GetIntField(env, lpObject, OSVERSIONINFOEXFc.wSuiteMask);
+	lpStruct->wProductType = (BYTE)(*env)->GetIntField(env, lpObject, OSVERSIONINFOEXFc.wProductType);
+	lpStruct->wReserved = (BYTE)(*env)->GetIntField(env, lpObject, OSVERSIONINFOEXFc.wReserved);
 	return lpStruct;
 }
 

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/win32/org/eclipse/swt/internal/win32/OS.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/win32/org/eclipse/swt/internal/win32/OS.java
@@ -4272,6 +4272,7 @@ public static final native int SetCurrentProcessExplicitAppUserModelID (char[] A
 /** @param hCursor cast=(HCURSOR) */
 public static final native long SetCursor (long hCursor);
 public static final native boolean SetCursorPos (int X, int Y);
+/** @param hdc cast=(HDC) */
 public static final native int SetDCBrushColor (long hdc, int color);
 /**
  * @param hdc cast=(HDC)

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/win32/org/eclipse/swt/internal/win32/OS.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/win32/org/eclipse/swt/internal/win32/OS.java
@@ -31,15 +31,6 @@ public class OS extends C {
 	*/
 	public static final boolean IsDBLocale;
 	/**
-	 * WARNING: This value can't be trusted since Win10. If the launcher's exe
-	 * doesn't have compatibility GUID in its manifest:<br>
-	 *   &lt;supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/&gt;<br>
-	 * then '6.2.9200' will be returned (version number for Win8).
-	 * JDK11 has the compatibility GUID, but Eclipse's launcher doesn't!
-	 * This may cause different behavior in debugger and in released SWT.
-	 */
-	public static final int WIN32_VERSION;
-	/**
 	 * Always reports the correct build number, regardless of manifest and
 	 * compatibility GUIDs. Note that build number alone is sufficient to
 	 * identify Windows version.
@@ -62,10 +53,6 @@ public class OS extends C {
 	public static final int SM_IMMENABLED = 0x52;
 
 	static {
-		/* Get the Windows version */
-		int dwVersion = OS.GetVersion ();
-		WIN32_VERSION = VERSION (dwVersion & 0xff, (dwVersion >> 8) & 0xff);
-
 		/*
 		 * Starting with Windows 10, GetVersionEx() lies about version unless
 		 * application manifest has a proper entry. RtlGetVersion() always
@@ -3010,7 +2997,6 @@ public static final native boolean GetUpdateRect (long hWnd, RECT lpRect, boolea
  * @param hRgn cast=(HRGN)
  */
 public static final native int GetUpdateRgn (long hWnd, long hRgn, boolean bErase);
-public static final native int GetVersion ();
 /** @param hWnd cast=(HWND) */
 public static final native long GetWindow (long hWnd, int uCmd);
 /** @param hWnd cast=(HWND) */

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/win32/org/eclipse/swt/internal/win32/OS.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/win32/org/eclipse/swt/internal/win32/OS.java
@@ -2620,7 +2620,7 @@ public static final native int DrawThemeBackground (long hTheme, long hdc, int i
  * @param pRect flags=no_out
  */
 public static final native int DrawThemeText (long hTheme, long hdc, int iPartId, int iStateId, char[] pszText, int iCharCount, int dwTextFlags, int dwTextFlags2, RECT pRect);
-/** @param hwnd cast=(HDC) */
+/** @param hwnd cast=(HWND) */
 public static final native boolean DwmSetWindowAttribute (long hwnd, int dwAttribute, int[] pvAttribute, int cbAttribute);
 /** @param hdc cast=(HDC) */
 public static final native boolean Ellipse (long hdc, int nLeftRect, int nTopRect, int nRightRect, int nBottomRect);

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/win32/org/eclipse/swt/internal/win32/OSVERSIONINFOEX.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/win32/org/eclipse/swt/internal/win32/OSVERSIONINFOEX.java
@@ -20,10 +20,15 @@ public class OSVERSIONINFOEX {
 	public int    dwBuildNumber;
 	public int    dwPlatformId;
 	public char[] szCSDVersion = new char[128];
+	/** @field cast=(WORD) */
 	public int    wServicePackMajor;
+	/** @field cast=(WORD) */
 	public int    wServicePackMinor;
+	/** @field cast=(WORD) */
 	public int    wSuiteMask;
+	/** @field cast=(BYTE) */
 	public int    wProductType;
+	/** @field cast=(BYTE) */
 	public int    wReserved;
 
 	public static final int sizeof = OS.OSVERSIONINFOEX_sizeof ();

--- a/bundles/org.eclipse.swt/Eclipse SWT WebKit/gtk/library/webkitgtk.c
+++ b/bundles/org.eclipse.swt/Eclipse SWT WebKit/gtk/library/webkitgtk.c
@@ -24,6 +24,11 @@
 #define WebKitGTK_NATIVE(func) Java_org_eclipse_swt_internal_webkit_WebKitGTK_##func
 #endif
 
+#ifdef _WIN32
+  /* Many methods don't use their 'env' and 'that' arguments */
+  #pragma warning (disable: 4100)
+#endif
+
 #ifndef NO_GdkRectangle_1sizeof
 JNIEXPORT jint JNICALL WebKitGTK_NATIVE(GdkRectangle_1sizeof)
 	(JNIEnv *env, jclass that)

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/library/callback.c
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/library/callback.c
@@ -1635,6 +1635,9 @@ fail:
 JNIEXPORT void JNICALL CALLBACK_NATIVE(unbind)
   (JNIEnv *env, jclass that, jobject callback)
 {
+	/* Suppress warning about unreferenced parameter */
+	(void)that;
+
 	int i;
 	for (i=0; i<MAX_CALLBACKS; i++) {
 		if (callbackData[i].callback != NULL && (*env)->IsSameObject(env, callback, callbackData[i].callback)) {
@@ -1648,24 +1651,40 @@ JNIEXPORT void JNICALL CALLBACK_NATIVE(unbind)
 JNIEXPORT jboolean JNICALL CALLBACK_NATIVE(getEnabled)
   (JNIEnv *env, jclass that)
 {
+	/* Suppress warnings about unreferenced parameters */
+	(void)env;
+	(void)that;
+
 	return (jboolean)callbackEnabled;
 }
 
 JNIEXPORT jint JNICALL CALLBACK_NATIVE(getEntryCount)
   (JNIEnv *env, jclass that)
 {
+	/* Suppress warnings about unreferenced parameters */
+	(void)env;
+	(void)that;
+
 	return (jint)callbackEntryCount;
 }
 
 JNIEXPORT void JNICALL CALLBACK_NATIVE(setEnabled)
   (JNIEnv *env, jclass that, jboolean enable)
 {
+	/* Suppress warnings about unreferenced parameters */
+	(void)env;
+	(void)that;
+
 	callbackEnabled = enable;
 }
 
 JNIEXPORT void JNICALL CALLBACK_NATIVE(reset)
   (JNIEnv *env, jclass that)
 {
+	/* Suppress warnings about unreferenced parameters */
+	(void)env;
+	(void)that;
+
 	memset((void *)&callbackData, 0, sizeof(callbackData));
 }
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/library/swt.c
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/library/swt.c
@@ -17,6 +17,9 @@
 JavaVM *JVM = NULL;
 
 JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM *vm, void *reserved) {
+	/* Suppress warning about unreferenced parameter */
+	(void)reserved;
+
 	JVM = vm;
 	return JNI_VERSION_1_4;
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Image.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Image.java
@@ -805,7 +805,7 @@ void initNative(String filename) {
 	* Windows 7 when the image has a position offset in the first frame.
 	* The fix is to not use GDI+ image loading in this case.
 	*/
-	if (OS.WIN32_VERSION >= OS.VERSION(6, 1) && filename.toLowerCase().endsWith(".gif")) gdip = false;
+	if (filename.toLowerCase().endsWith(".gif")) gdip = false;
 	if (gdip) {
 		int length = filename.length();
 		char[] chars = new char[length+1];

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Combo.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Combo.java
@@ -1943,25 +1943,8 @@ public void select (int index) {
 	int count = (int)OS.SendMessage (handle, OS.CB_GETCOUNT, 0, 0);
 	if (0 <= index && index < count) {
 		int selection = (int)OS.SendMessage (handle, OS.CB_GETCURSEL, 0, 0);
-		//corner case for single elements combo boxes for Bug 222752
-		if (OS.WIN32_VERSION < OS.VERSION (6, 2) && getListVisible() && (style & SWT.READ_ONLY) != 0 && count==1 && selection == OS.CB_ERR) {
-			OS.SendMessage (handle, OS.WM_KEYDOWN, OS.VK_DOWN, 0);
-			sendEvent (SWT.Modify);
-			return;
-		}
 		int code = (int)OS.SendMessage (handle, OS.CB_SETCURSEL, index, 0);
 		if (code != OS.CB_ERR && code != selection) {
-			//Workaround for Bug 222752
-			if (OS.WIN32_VERSION < OS.VERSION (6, 2) && getListVisible() && (style & SWT.READ_ONLY) != 0) {
-				int firstKey = OS.VK_UP;
-				int secondKey = OS.VK_DOWN;
-				if (index == 0) {
-					firstKey = OS.VK_DOWN;
-					secondKey = OS.VK_UP;
-				}
-				OS.SendMessage (handle, OS.WM_KEYDOWN, firstKey, 0);
-				OS.SendMessage (handle, OS.WM_KEYDOWN, secondKey, 0);
-			}
 			sendEvent (SWT.Modify);
 			// widget could be disposed at this point
 		}

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Control.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Control.java
@@ -723,19 +723,17 @@ void createHandle () {
 }
 
 void checkGesture () {
-	if (OS.WIN32_VERSION >= OS.VERSION (6, 1)) {
-		int value = OS.GetSystemMetrics (OS.SM_DIGITIZER);
-		if ((value & (OS.NID_READY | OS.NID_MULTI_INPUT)) != 0) {
-			/*
-			 * Feature in Windows 7: All gestures are enabled by default except GID_ROTATE.
-			 * Enable it explicitly by calling SetGestureConfig.
-			 */
-			GESTURECONFIG config = new GESTURECONFIG();
-			config.dwID = OS.GID_ROTATE;
-			config.dwWant = 1;
-			config.dwBlock = 0;
-			OS.SetGestureConfig (handle, 0, 1, config, GESTURECONFIG.sizeof);
-		}
+	int value = OS.GetSystemMetrics (OS.SM_DIGITIZER);
+	if ((value & (OS.NID_READY | OS.NID_MULTI_INPUT)) != 0) {
+		/*
+		 * Feature in Windows 7: All gestures are enabled by default except GID_ROTATE.
+		 * Enable it explicitly by calling SetGestureConfig.
+		 */
+		GESTURECONFIG config = new GESTURECONFIG();
+		config.dwID = OS.GID_ROTATE;
+		config.dwWant = 1;
+		config.dwBlock = 0;
+		OS.SetGestureConfig (handle, 0, 1, config, GESTURECONFIG.sizeof);
 	}
 }
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Label.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Label.java
@@ -115,10 +115,8 @@ long callWindowProc (long hwnd, int msg, long wParam, long lParam) {
 	* clipboard.  This is unwanted. The fix is to avoid
 	* calling the label window proc.
 	*/
-	if (OS.WIN32_VERSION >= OS.VERSION(6, 1)) {
-		switch (msg) {
-			case OS.WM_LBUTTONDBLCLK: return OS.DefWindowProc (hwnd, msg, wParam, lParam);
-		}
+	switch (msg) {
+		case OS.WM_LBUTTONDBLCLK: return OS.DefWindowProc (hwnd, msg, wParam, lParam);
 	}
 	return OS.CallWindowProc (LabelProc, hwnd, msg, wParam, lParam);
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Shell.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Shell.java
@@ -2338,25 +2338,6 @@ LRESULT WM_DESTROY (long wParam, long lParam) {
 }
 
 @Override
-LRESULT WM_ERASEBKGND (long wParam, long lParam) {
-	LRESULT result = super.WM_ERASEBKGND (wParam, lParam);
-	if (result != null) return result;
-	/*
-	* Feature in Windows.  When a shell is resized by dragging
-	* the resize handles, Windows temporarily fills in black
-	* rectangles where the new contents of the shell should
-	* draw.  The fix is to always draw the background of shells.
-	*
-	* NOTE: This only happens on Vista.
-	*/
-	if (OS.WIN32_VERSION == OS.VERSION (6, 0)) {
-		drawBackground (wParam);
-		return LRESULT.ONE;
-	}
-	return result;
-}
-
-@Override
 LRESULT WM_ENTERIDLE (long wParam, long lParam) {
 	LRESULT result = super.WM_ENTERIDLE (wParam, lParam);
 	if (result != null) return result;

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Table.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Table.java
@@ -6313,26 +6313,24 @@ LRESULT WM_HSCROLL (long wParam, long lParam) {
 		* of a table when scrolling, rather than just return
 		* the data for each column when asked.
 		*/
-		if (OS.WIN32_VERSION >= OS.VERSION (6, 0)) {
-			RECT headerRect = new RECT (), rect = new RECT ();
-			OS.GetClientRect (handle, rect);
-			boolean [] visible = new boolean [columnCount];
-			for (int i=0; i<columnCount; i++) {
-				visible [i] = true;
-				headerRect.top = i;
-				headerRect.left = OS.LVIR_BOUNDS;
-				if (OS.SendMessage (handle, OS.LVM_GETSUBITEMRECT, 0, headerRect) != 0) {
-					headerRect.top = rect.top;
-					headerRect.bottom = rect.bottom;
-					visible [i] = OS.IntersectRect(headerRect, rect, headerRect);
-				}
+		RECT headerRect = new RECT (), rect = new RECT ();
+		OS.GetClientRect (handle, rect);
+		boolean [] visible = new boolean [columnCount];
+		for (int i=0; i<columnCount; i++) {
+			visible [i] = true;
+			headerRect.top = i;
+			headerRect.left = OS.LVIR_BOUNDS;
+			if (OS.SendMessage (handle, OS.LVM_GETSUBITEMRECT, 0, headerRect) != 0) {
+				headerRect.top = rect.top;
+				headerRect.bottom = rect.bottom;
+				visible [i] = OS.IntersectRect(headerRect, rect, headerRect);
 			}
-			try {
-				columnVisible = visible;
-				OS.UpdateWindow (handle);
-			} finally {
-				columnVisible = null;
-			}
+		}
+		try {
+			columnVisible = visible;
+			OS.UpdateWindow (handle);
+		} finally {
+			columnVisible = null;
 		}
 	}
 
@@ -6413,26 +6411,24 @@ LRESULT WM_VSCROLL (long wParam, long lParam) {
 		* of a table when scrolling, rather than just return
 		* the data for each column when asked.
 		*/
-		if (OS.WIN32_VERSION >= OS.VERSION (6, 0)) {
-			RECT headerRect = new RECT (), rect = new RECT ();
-			OS.GetClientRect (handle, rect);
-			boolean [] visible = new boolean [columnCount];
-			for (int i=0; i<columnCount; i++) {
-				visible [i] = true;
-				headerRect.top = i;
-				headerRect.left = OS.LVIR_BOUNDS;
-				if (OS.SendMessage (handle, OS.LVM_GETSUBITEMRECT, 0, headerRect) != 0) {
-					headerRect.top = rect.top;
-					headerRect.bottom = rect.bottom;
-					visible [i] = OS.IntersectRect(headerRect, rect, headerRect);
-				}
+		RECT headerRect = new RECT (), rect = new RECT ();
+		OS.GetClientRect (handle, rect);
+		boolean [] visible = new boolean [columnCount];
+		for (int i=0; i<columnCount; i++) {
+			visible [i] = true;
+			headerRect.top = i;
+			headerRect.left = OS.LVIR_BOUNDS;
+			if (OS.SendMessage (handle, OS.LVM_GETSUBITEMRECT, 0, headerRect) != 0) {
+				headerRect.top = rect.top;
+				headerRect.bottom = rect.bottom;
+				visible [i] = OS.IntersectRect(headerRect, rect, headerRect);
 			}
-			try {
-				columnVisible = visible;
-				OS.UpdateWindow (handle);
-			} finally {
-				columnVisible = null;
-			}
+		}
+		try {
+			columnVisible = visible;
+			OS.UpdateWindow (handle);
+		} finally {
+			columnVisible = null;
 		}
 	}
 
@@ -6577,20 +6573,13 @@ LRESULT wmNotifyChild (NMHDR hdr, long wParam, long lParam) {
 				* can never be used from a LVN_GETDISPINFO handler. The fix is to
 				* InvalidateRect() passing the bounds for the entire item.
 				*/
-				if (OS.WIN32_VERSION >= OS.VERSION (6, 0)) {
-					RECT rect = new RECT ();
-					rect.left = OS.LVIR_BOUNDS;
-					ignoreCustomDraw = true;
-					long code = OS.SendMessage (handle, OS. LVM_GETITEMRECT, plvfi.iItem, rect);
-					ignoreCustomDraw = false;
-					if (code != 0) OS.InvalidateRect (handle, rect, true);
-					break;
-				} else {
-					if ((style & SWT.VIRTUAL) != 0 && !item.cached) {
-						OS.SendMessage (handle, OS.LVM_REDRAWITEMS, plvfi.iItem, plvfi.iItem);
-						break;
-					}
-				}
+				RECT rect = new RECT ();
+				rect.left = OS.LVIR_BOUNDS;
+				ignoreCustomDraw = true;
+				long code = OS.SendMessage (handle, OS. LVM_GETITEMRECT, plvfi.iItem, rect);
+				ignoreCustomDraw = false;
+				if (code != 0) OS.InvalidateRect (handle, rect, true);
+				break;
 			}
 
 			/*

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Tree.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Tree.java
@@ -1347,12 +1347,7 @@ LRESULT CDDS_POSTPAINT (NMTVCUSTOMDRAW nmcd, long wParam, long lParam) {
 						* NOTE: This problem only happens on Vista during
 						* WM_NOTIFY with NM_CUSTOMDRAW and CDDS_POSTPAINT.
 						*/
-						long hItem = 0;
-						if (OS.WIN32_VERSION >= OS.VERSION (6, 0)) {
-							hItem = getBottomItem ();
-						} else {
-							hItem = OS.SendMessage (handle, OS.TVM_GETNEXTITEM, OS.TVGN_LASTVISIBLE, 0);
-						}
+						long hItem = getBottomItem ();
 						if (hItem != 0) {
 							RECT rect = new RECT ();
 							if (OS.TreeView_GetItemRect (handle, hItem, rect, false)) {
@@ -1403,12 +1398,7 @@ LRESULT CDDS_POSTPAINT (NMTVCUSTOMDRAW nmcd, long wParam, long lParam) {
 			* NOTE: This problem only happens on Vista during
 			* WM_NOTIFY with NM_CUSTOMDRAW and CDDS_POSTPAINT.
 			*/
-			long hItem = 0;
-			if (OS.WIN32_VERSION >= OS.VERSION (6, 0)) {
-				hItem = getBottomItem ();
-			} else {
-				hItem = OS.SendMessage (handle, OS.TVM_GETNEXTITEM, OS.TVGN_LASTVISIBLE, 0);
-			}
+			long hItem = getBottomItem ();
 			if (hItem != 0) {
 				if (OS.TreeView_GetItemRect (handle, hItem, rect, false)) {
 					height = rect.bottom - rect.top;
@@ -7117,13 +7107,11 @@ LRESULT WM_SETCURSOR (long wParam, long lParam) {
 	* correct Windows 7 behavior but not correct for SWT. The fix
 	* is to always ensure a cursor is set.
 	*/
-	if (OS.WIN32_VERSION >= OS.VERSION (6, 1)) {
-		if (wParam == handle) {
-			int hitTest = (short) OS.LOWORD (lParam);
-			if (hitTest == OS.HTCLIENT) {
-				OS.SetCursor (OS.LoadCursor (0, OS.IDC_ARROW));
-				return LRESULT.ONE;
-			}
+	if (wParam == handle) {
+		int hitTest = (short) OS.LOWORD (lParam);
+		if (hitTest == OS.HTCLIENT) {
+			OS.SetCursor (OS.LoadCursor (0, OS.IDC_ARROW));
+			return LRESULT.ONE;
 		}
 	}
 	return null;

--- a/features/org.eclipse.swt.tools.feature/feature.xml
+++ b/features/org.eclipse.swt.tools.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.swt.tools.feature"
       label="%featureName"
-      version="3.108.600.qualifier"
+      version="3.108.700.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/features/org.eclipse.swt.tools.feature/pom.xml
+++ b/features/org.eclipse.swt.tools.feature/pom.xml
@@ -20,7 +20,7 @@
   </parent>
   <groupId>org.eclipse.swt.tools.feature</groupId>
   <artifactId>org.eclipse.swt.tools.feature</artifactId>
-  <version>3.108.600-SNAPSHOT</version>
+  <version>3.108.700-SNAPSHOT</version>
   <packaging>eclipse-feature</packaging>
   <build>
     <plugins>


### PR DESCRIPTION
Previously, I already changed GTK build to treat warnings as errors, see Bug 570178

The commits come in reverse order: first, (not yet visible) warnings are fixed, and then strict `/W4` is enabled. This is so that each commit can be built successfully and there are no broken commits in the chain.

If you want to see the warnings being fixed (for review purposes), move the last commit to be the first. On the other hand, the nature of the warnings is rather evident from commits that fix them.

The patch set only targets Windows. Other platforms are only trivially affected by injecting new Windows-specific settings into all JNI native sources.

Noteworthy commits (all of them at the end):
* `Get rid of deprecated GetVersion()`
  Clears most of Windows version checks from SWT.
* `Deal with warnings about unreferenced parameters`
  Changes `JniGenerator` to inject warning settings into all generated sources.
* `Fix potentially uninitialized variable`
  That seems to be a good catch, where warning pointed to a potential JVM crash.

Fixes #369