### PR TITLE
Fix Browser tests failing in I-build

### DIFF
--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_browser_Browser.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_browser_Browser.java
@@ -592,11 +592,13 @@ public void test_LocationListener_ProgressListener_noExtraEvents() {
 	shell.open();
 	browser.setText("Hello world");
 
+	// Wait for changed and completed events that are mandatory
+	waitForPassCondition(() -> changedCount.get() == 1 && completedCount.get() == 1);
 	// We have to wait to check that no extra events are fired.
 	// On Gtk, Quad Core, pcie this takes 80 ms. ~600ms for stability.
 	waitForMilliseconds(600);
 	boolean passed = changedCount.get() == 1 && completedCount.get() == 1;
-	String errorMsg = "\nIncorrect event sequences. Events missing or too many fired:"
+	String errorMsg = "\nIncorrect event sequences. Too many fired:"
 			+ "\nExpected one of each, but received:"
 			+ "\nChanged count: " + changedCount.get()
 			+ "\nCompleted count: " + completedCount.get();

--- a/tests/org.eclipse.swt.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.swt.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.swt.tests
-Bundle-Version: 3.106.1800.qualifier
+Bundle-Version: 3.106.1900.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.swt.tests.junit,

--- a/tests/org.eclipse.swt.tests/pom.xml
+++ b/tests/org.eclipse.swt.tests/pom.xml
@@ -19,7 +19,7 @@
   </parent>
   <groupId>org.eclipse.swt</groupId>
   <artifactId>org.eclipse.swt.tests</artifactId>
-  <version>3.106.1800-SNAPSHOT</version>
+  <version>3.106.1900-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
   <properties>
     <code.ignoredWarnings>${tests.ignoredWarnings}</code.ignoredWarnings>


### PR DESCRIPTION
Wait for the events that have to appear first before checking that no extra events are received.
Fixes https://github.com/eclipse-platform/eclipse.platform.swt/issues/110