### PR TITLE
Stabilize CCombo setFocus test on GH action

### DIFF
--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_custom_CCombo.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_custom_CCombo.java
@@ -199,7 +199,7 @@ public void test_setFocus() {
 			ccombo.setEnabled(true);
 			ccombo.setVisible(true);
 			ccombo.setFocus();
-			processEvents(0, null);
+			processEvents(100, () -> ccombo.isFocusControl());
 			assertTrue(ccombo.isFocusControl());
 			Control focusControl = ccombo.getDisplay().getFocusControl();
 			assertTrue(focusControl instanceof Text);


### PR DESCRIPTION
Process events for 100ms or until combo gains focus. It's needed as focus event is not immediate and depends on machine speed, WS and etc.