### PR TITLE
Add support for WebkitGtk linked against libsoup-3.0.so

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT WebKit/gtk/library/webkitgtk.h
+++ b/bundles/org.eclipse.swt/Eclipse SWT WebKit/gtk/library/webkitgtk.h
@@ -41,7 +41,10 @@
 	static void *var = NULL; \
 	if (!initialized) { \
 		void* handle = 0; \
-		handle = dlopen("libwebkit2gtk-4.0.so.37", LOAD_FLAGS); /* webkit2 */ \
+		handle = dlopen("libwebkit2gtk-4.0.so.37", LOAD_FLAGS); /* webkit2/libsoup2 */ \
+		if (!handle) { \
+				handle = dlopen("libwebkit2gtk-4.1.so.0", LOAD_FLAGS); /* webkit2/libsoup3 */ \
+		} \
 		if (handle) { \
 			var = dlsym(handle, #name); \
 		} \


### PR DESCRIPTION
WebkitGtk gained compile time option to compile/link against libsoup2 or libsoup3, in order to differentiate between both there is no *.so version for WebkitGtk - libwebkit2gtk-4.1.so.0 . As WebkitGtk backend in SWT is fully dynamic, support for it is a matter of enhancing SWT's dlopen calls to try the new one too.

Details are available at
https://fedoraproject.org/wiki/Changes/libsoup_3:_Part_One .

Fixes https://github.com/eclipse-platform/eclipse.platform.swt/issues/379