### PR TITLE
[GTK4] Add WebkitGtk support

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Browser/common/org/eclipse/swt/browser/Browser.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Browser/common/org/eclipse/swt/browser/Browser.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2003, 2021 IBM Corporation and others.
+ * Copyright (c) 2003, 2022 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -104,8 +104,7 @@ public Browser (Composite parent, int style) {
 	String errMsg = " because there is no underlying browser available.\n";
 	switch (SWT.getPlatform()) {
 	case "gtk":
-		errMsg = errMsg + "Please ensure that WebKit with its GTK 3.x bindings is installed (WebKit2 API level is preferred)."
-				+ " Additionally, please note that GTK4 does not currently have Browser support.\n";
+		errMsg = errMsg + "Please ensure that WebKit with its GTK 3.x/4.x bindings is installed.";
 		break;
 	case "cocoa":
 		errMsg = errMsg + "SWT failed to load the WebKit library.\n";

--- a/bundles/org.eclipse.swt/Eclipse SWT Browser/gtk/org/eclipse/swt/browser/BrowserFactory.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Browser/gtk/org/eclipse/swt/browser/BrowserFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010, 2021 IBM Corporation and others.
+ * Copyright (c) 2010, 2022 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -19,7 +19,6 @@ class BrowserFactory {
 
 WebBrowser createWebBrowser (int style) {
 	if (OS.IsWin32) return null;
-	if (GTK.GTK4) return null;
 	boolean webkitInstalled = WebKit.IsInstalled ();
 	if (!webkitInstalled) return null;
 

--- a/bundles/org.eclipse.swt/Eclipse SWT WebKit/gtk/library/webkitgtk.h
+++ b/bundles/org.eclipse.swt/Eclipse SWT WebKit/gtk/library/webkitgtk.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2018 IBM Corporation and others. All rights reserved.
+ * Copyright (c) 2009, 2022 IBM Corporation and others. All rights reserved.
  * The contents of this file are made available under the terms
  * of the GNU Lesser General Public License (LGPL) Version 2.1 that
  * accompanies this distribution (lgpl-v21.txt).  The LGPL is also
@@ -41,12 +41,17 @@
 	static void *var = NULL; \
 	if (!initialized) { \
 		void* handle = 0; \
-		handle = dlopen("libwebkit2gtk-4.0.so.37", LOAD_FLAGS); /* webkit2/libsoup2 */ \
-		if (!handle) { \
+		char *gtk4 = getenv("SWT_GTK4"); \
+		if (gtk4 != NULL || strcmp(gtk4, "1") != 0) { \
+			handle = dlopen("libwebkit2gtk-5.0.so.0", LOAD_FLAGS); \
+		} else { \
+			handle = dlopen("libwebkit2gtk-4.0.so.37", LOAD_FLAGS); /* webkit2/libsoup2 */ \
+			if (!handle) { \
 				handle = dlopen("libwebkit2gtk-4.1.so.0", LOAD_FLAGS); /* webkit2/libsoup3 */ \
+			} \
 		} \
 		if (handle) { \
-			var = dlsym(handle, #name); \
+			var = dlsym(handle,	#name); \
 		} \
 		CHECK_DLERROR \
 		initialized = 1; \


### PR DESCRIPTION
Now that Fedora 37 ships webkitgtk compiled against Gtk 4.x the new *.so name is finally known so we know which lib to dlopen. Guards preventing Browser instantiation when running Gtk 4.x are removed.
Extra change was to no longer manually connect signals like button_press/release, focus_in/out and etc. as they are by default now as per https://trac.webkit.org/changeset/262184/webkit (the web view is always the target of the events, so we don't really  need to send the events to GTK to process them.)