### PR TITLE
Extracting common code between RTFWriter and HTMLWriter in a base class

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/HTMLWriter.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/HTMLWriter.java
@@ -225,12 +225,28 @@ class HTMLWriter extends StyledTextWriterBase {
 	// ==== Helper methods ====
 
 	@Override
-	String escapeText(String text) {
-		return text
-				.replaceAll("&", "&amp;")
-				.replaceAll("\"", "&quot;")
-				.replaceAll("<", "&lt;")
-				.replaceAll(">", "&gt;");
+	String escapeText(String string) {
+		// The resulting string is at least as long as the original.
+		StringBuilder result = new StringBuilder(string.length());
+		string.chars().forEach(ch -> {
+			switch (ch) {
+				case '&':
+					result.append("&amp;");
+					break;
+				case '"':
+					result.append("&quot;");
+					break;
+				case '<':
+					result.append("&lt;");
+					break;
+				case '>':
+					result.append("&gt;");
+					break;
+				default:
+					result.append((char) ch);
+			}
+		});
+		return result.toString();
 	}
 
 	// TODO: do we also want support for alpha?

--- a/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/RTFWriter.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/RTFWriter.java
@@ -19,19 +19,18 @@ import org.eclipse.swt.*;
 import org.eclipse.swt.graphics.*;
 
 /**
- * The <code>RTFWriter</code> class is used to write widget content as
+ * The {@code RTFWriter} class is used to write widget content as
  * rich text. The implementation complies with the RTF specification
  * version 1.5.
- * <p>
- * toString() is guaranteed to return a valid RTF string only after
- * close() has been called.
- * </p><p>
- * Whole and partial lines and line breaks can be written. Lines will be
- * formatted using the styles queried from the LineStyleListener, if
- * set, or those set directly in the widget. All styles are applied to
- * the RTF stream like they are rendered by the widget. In addition, the
- * widget font name and size is used for the whole text.
- * </p>
+ *
+ * <p>{@code toString()} is guaranteed to return a valid formatted string only after
+ * {@code close()} has been called.</p>
+ *
+ * <p>Whole and partial lines and line breaks can be written. Lines will be
+ * formatted using the styles queried from the {@link LineStyleListener},
+ * if set, or those set directly in the widget. All styles are applied to
+ * the stream like they are rendered by the widget. In addition, the
+ * widget font name and size is used for the whole text.</p>
  */
 class RTFWriter extends TextWriter {
 	private final StyledText styledText;
@@ -42,13 +41,12 @@ class RTFWriter extends TextWriter {
 
 	/**
 	 * Creates a RTF writer that writes content starting at offset "start"
-	 * in the document.  <code>start</code> and <code>length</code>can be set to specify partial
-	 * lines.
+	 * in the document. {@code start} and {@code length} can be set to specify
+	 * partial lines.
 	 *
-	 * @param start start offset of content to write, 0 based from
-	 * 	beginning of document
+	 * @param start start offset of content to write, 0 based from beginning of document
 	 * @param length length of content to write
-	 * @param styledText the {@link StyledText} to read from
+	 * @param styledText the widget to produce the RTF from
 	 */
 	public RTFWriter(StyledText styledText, int start, int length) {
 		super(start, length);
@@ -59,10 +57,12 @@ class RTFWriter extends TextWriter {
 		colorTable.add(this.styledText.getBackground());
 		fontTable.add(this.styledText.getFont());
 	}
+
 	/**
-	 * Closes the RTF writer. Once closed no more content can be written.
-	 * <b>NOTE:</b>  <code>toString()</code> does not return a valid RTF string until
-	 * <code>close()</code> has been called.
+	 * Closes the writer. Once closed no more content can be written.
+	 *
+	 * <p><b>NOTE:</b> {@code toString()} does not return a valid formatted string until
+	 * {@code close()} has been called.</p>
 	 */
 	@Override
 	public void close() {
@@ -72,78 +72,21 @@ class RTFWriter extends TextWriter {
 			super.close();
 		}
 	}
+
 	/**
-	 * Returns the index of the specified color in the RTF color table.
+	 * Appends the specified segment of "string" to the output data.
+	 * Copy from {@code start} up to, but excluding, {@code end}.
 	 *
-	 * @param color the color
-	 * @param defaultIndex return value if color is null
-	 * @return the index of the specified color in the RTF color table
-	 * 	or "defaultIndex" if "color" is null.
-	 */
-	int getColorIndex(Color color, int defaultIndex) {
-		if (color == null) return defaultIndex;
-		int index = colorTable.indexOf(color);
-		if (index == -1) {
-			index = colorTable.size();
-			colorTable.add(color);
-		}
-		return index;
-	}
-	/**
-	 * Returns the index of the specified color in the RTF color table.
-	 *
-	 * @param color the color
-	 * @param defaultIndex return value if color is null
-	 * @return the index of the specified color in the RTF color table
-	 * 	or "defaultIndex" if "color" is null.
-	 */
-	int getFontIndex(Font font) {
-		int index = fontTable.indexOf(font);
-		if (index == -1) {
-			index = fontTable.size();
-			fontTable.add(font);
-		}
-		return index;
-	}
-	/**
-	 * Appends the specified segment of "string" to the RTF data.
-	 * Copy from <code>start</code> up to, but excluding, <code>end</code>.
-	 *
-	 * @param string string to copy a segment from. Must not contain
-	 * 	line breaks. Line breaks should be written using writeLineDelimiter()
+	 * @param string string to copy a segment from. Must not contain line breaks.
+	 *  Line breaks should be written using {@link #writeLineDelimiter()}
 	 * @param start start offset of segment. 0 based.
 	 * @param end end offset of segment
 	 */
-	void write(String string, int start, int end) {
-		for (int index = start; index < end; index++) {
-			char ch = string.charAt(index);
-			if (ch > 0x7F) {
-				// write the sub string from the last escaped character
-				// to the current one. Fixes bug 21698.
-				if (index > start) {
-					write(string.substring(start, index));
-				}
-				write("\\u");
-				write(Integer.toString((short) ch));
-				write('?');						// ANSI representation (1 byte long, \\uc1)
-				start = index + 1;
-			} else if (ch == '}' || ch == '{' || ch == '\\') {
-				// write the sub string from the last escaped character
-				// to the current one. Fixes bug 21698.
-				if (index > start) {
-					write(string.substring(start, index));
-				}
-				write('\\');
-				write(ch);
-				start = index + 1;
-			}
-		}
-		// write from the last escaped character to the end.
-		// Fixes bug 21698.
-		if (start < end) {
-			write(string.substring(start, end));
-		}
+	void writeEscaped(String string, int start, int end) {
+		String textToWrite = string.substring(start, end);
+		write(escapeText(textToWrite));
 	}
+
 	/**
 	 * Writes the RTF header including font table and color table.
 	 */
@@ -188,91 +131,106 @@ class RTFWriter extends TextWriter {
 		header.append(" ");
 		write(header.toString(), 0);
 	}
+
 	/**
 	 * Appends the specified line text to the RTF data.  Lines will be formatted
 	 * using the styles queried from the LineStyleListener, if set, or those set
 	 * directly in the widget.
 	 *
 	 * @param line line text to write as RTF. Must not contain line breaks
-	 * 	Line breaks should be written using writeLineDelimiter()
+	 *  Line breaks should be written using {@link #writeLineDelimiter(String)}
 	 * @param lineOffset offset of the line. 0 based from the start of the
-	 * 	widget document. Any text occurring before the start offset or after the
-	 * 	end offset specified during object creation is ignored.
-	 * @exception SWTException <ul>
-	 *   <li>ERROR_IO when the writer is closed.</li>
-	 * </ul>
+	 *  widget document. Any text occurring before the start offset or after the
+	 *  end offset specified during object creation is ignored.
+	 *
+	 * @throws SWTException {@code ERROR_IO} when the writer is closed.
 	 */
 	@Override
 	public void writeLine(String line, int lineOffset) {
 		if (isClosed()) {
 			SWT.error(SWT.ERROR_IO);
 		}
+
 		int lineIndex = styledText.content.getLineAtOffset(lineOffset);
-		int lineAlignment, lineIndent;
+		int lineAlignment;
+		int lineIndent;
 		boolean lineJustify;
+		int verticalIndent;
 		int[] ranges;
 		StyleRange[] styles;
+
 		StyledTextEvent event = styledText.getLineStyleData(lineOffset, line);
 		if (event != null) {
+			verticalIndent = event.verticalIndent;
 			lineAlignment = event.alignment;
 			lineIndent = event.indent;
 			lineJustify = event.justify;
 			ranges = event.ranges;
 			styles = event.styles;
 		} else {
+			verticalIndent = styledText.renderer.getLineVerticalIndent(lineIndex);
 			lineAlignment = styledText.renderer.getLineAlignment(lineIndex, styledText.alignment);
 			lineIndent =  styledText.renderer.getLineIndent(lineIndex, styledText.indent);
 			lineJustify = styledText.renderer.getLineJustify(lineIndex, styledText.justify);
 			ranges = styledText.renderer.getRanges(lineOffset, line.length());
 			styles = styledText.renderer.getStyleRanges(lineOffset, line.length(), false);
 		}
-		if (styles == null) styles = new StyleRange[0];
-		Color lineBackground = styledText.renderer.getLineBackground(lineIndex, null);
+
+		if (styles == null) {
+			styles = new StyleRange[0];
+		}
+
 		event = styledText.getLineBackgroundData(lineOffset, line);
-		if (event != null && event.lineBackground != null) lineBackground = event.lineBackground;
-		writeStyledLine(line, lineOffset, ranges, styles, lineBackground, lineIndent, lineAlignment, lineJustify);
+		Color lineBackground = (event != null && event.lineBackground != null)
+				? event.lineBackground
+				: styledText.renderer.getLineBackground(lineIndex, null);
+
+		writeStyledLine(line, lineOffset, ranges, styles, lineBackground, lineIndent, verticalIndent, lineAlignment, lineJustify);
 	}
+
 	/**
 	 * Appends the specified line delimiter to the RTF data.
 	 *
 	 * @param lineDelimiter line delimiter to write as RTF.
-	 * @exception SWTException <ul>
-	 *   <li>ERROR_IO when the writer is closed.</li>
-	 * </ul>
+	 *
+	 * @throws SWTException {@code ERROR_IO} when the writer is closed.
 	 */
 	@Override
 	public void writeLineDelimiter(String lineDelimiter) {
 		if (isClosed()) {
 			SWT.error(SWT.ERROR_IO);
 		}
-		write(lineDelimiter, 0, lineDelimiter.length());
+		write(lineDelimiter);
 		write("\\par ");
 	}
+
 	/**
 	 * Appends the specified line text to the RTF data.
-	 * <p>
-	 * Use the colors and font styles specified in "styles" and "lineBackground".
+	 *
+	 * <p>Use the colors and font styles specified in {@code styles} and {@code lineBackground}.
 	 * Formatting is written to reflect the text rendering by the text widget.
-	 * Style background colors take precedence over the line background color.
-	 * Background colors are written using the \chshdng0\chcbpat tag (vs. the \cb tag).
-	 * </p>
+	 * Style background colors take precedence over the line background color.</p>
 	 *
 	 * @param line line text to write as RTF. Must not contain line breaks
-	 * 	Line breaks should be written using writeLineDelimiter()
+	 *  Line breaks should be written using writeLineDelimiter()
 	 * @param lineOffset offset of the line. 0 based from the start of the
-	 * 	widget document. Any text occurring before the start offset or after the
-	 * 	end offset specified during object creation is ignored.
+	 *  widget document. Any text occurring before the start offset or after the
+	 *  end offset specified during object creation is ignored.
 	 * @param styles styles to use for formatting. Must not be null.
 	 * @param lineBackground line background color to use for formatting.
-	 * 	May be null.
+	 *  May be null.
 	 */
-	void writeStyledLine(String line, int lineOffset, int ranges[], StyleRange[] styles, Color lineBackground, int indent, int alignment, boolean justify) {
+	void writeStyledLine(String line, int lineOffset, int ranges[], StyleRange[] styles,
+			Color lineBackground, int indent, int verticalIndent, int alignment, boolean justify) {
+
 		int lineLength = line.length();
 		int startOffset = getStart();
 		int writeOffset = startOffset - lineOffset;
-		if (writeOffset >= lineLength) return;
+		if (writeOffset >= lineLength) {
+			return;
+		}
 		int lineIndex = Math.max(0, writeOffset);
-	
+
 		write("\\fi");
 		write(indent);
 		switch (alignment) {
@@ -280,16 +238,21 @@ class RTFWriter extends TextWriter {
 			case SWT.CENTER: write("\\qc"); break;
 			case SWT.RIGHT: write("\\qr"); break;
 		}
-		if (justify) write("\\qj");
+		if (justify) {
+			write("\\qj");
+		}
 		write(" ");
-	
+
 		if (lineBackground != null) {
+			// Background colors are written using the {@code \chshdng0\chcbpat} tag (vs. the {@code \cb} tag).
 			write("{\\chshdng0\\chcbpat");
 			write(getColorIndex(lineBackground, DEFAULT_BACKGROUND));
 			write(" ");
 		}
+
 		int endOffset = startOffset + super.getCharCount();
 		int lineEndOffset = Math.min(lineLength, endOffset - lineOffset);
+
 		for (int i = 0; i < styles.length; i++) {
 			StyleRange style = styles[i];
 			int start, end;
@@ -304,7 +267,7 @@ class RTFWriter extends TextWriter {
 			if (end < writeOffset) {
 				continue;
 			}
-			// style starts beyond line end or RTF write end
+			// style starts beyond line end or write end
 			if (start >= lineEndOffset) {
 				break;
 			}
@@ -313,7 +276,7 @@ class RTFWriter extends TextWriter {
 				// copy to start of style
 				// style starting beyond end of write range or end of line
 				// is guarded against above.
-				write(line, lineIndex, start);
+				writeEscaped(line, lineIndex, start);
 				lineIndex = start;
 			}
 			// write styled text
@@ -348,11 +311,12 @@ class RTFWriter extends TextWriter {
 				write("\\strike");
 			}
 			write(" ");
+
 			// copy to end of style or end of write range or end of line
 			int copyEnd = Math.min(end, lineEndOffset);
 			// guard against invalid styles and let style processing continue
 			copyEnd = Math.max(copyEnd, lineIndex);
-			write(line, lineIndex, copyEnd);
+			writeEscaped(line, lineIndex, copyEnd);
 			if ((fontStyle & SWT.BOLD) != 0) {
 				write("\\b0");
 			}
@@ -368,10 +332,68 @@ class RTFWriter extends TextWriter {
 			write("}");
 			lineIndex = copyEnd;
 		}
-		// write unstyled text at the end of the line
+
+		// write the unstyled text at the end of the line
 		if (lineIndex < lineEndOffset) {
-			write(line, lineIndex, lineEndOffset);
+			writeEscaped(line, lineIndex, lineEndOffset);
 		}
-		if (lineBackground != null) write("}");
+		if (lineBackground != null) {
+			write("}");
+		}
+	}
+
+	// ==== Helper methods ====
+
+	static String escapeText(String string) {
+		StringBuilder result = new StringBuilder(string.length());
+		string.chars().forEach(ch -> {
+			if (ch > 0x7F) {
+				result.append("\\u");
+				result.append(Integer.toString((short) ch));
+				result.append('?'); // ANSI representation (1 byte long, \\uc1)
+			} else if (ch == '}' || ch == '{' || ch == '\\') {
+				result.append('\\');
+				result.append((char) ch);
+			} else {
+				// Fixes bug 21698.
+				result.append((char) ch);
+			}
+        });
+        return result.toString();
+	}
+
+	/**
+	 * Returns the index of the specified color in the RTF color table.
+	 *
+	 * @param color the color
+	 * @param defaultIndex return value if color is null
+	 * @return the index of the specified color in the RTF color table
+	 *  or "defaultIndex" if "color" is null.
+	 */
+	int getColorIndex(Color color, int defaultIndex) {
+		if (color == null) return defaultIndex;
+		int index = colorTable.indexOf(color);
+		if (index == -1) {
+			index = colorTable.size();
+			colorTable.add(color);
+		}
+		return index;
+	}
+
+	/**
+	 * Returns the index of the specified color in the RTF color table.
+	 *
+	 * @param color the color
+	 * @param defaultIndex return value if color is null
+	 * @return the index of the specified color in the RTF color table
+	 *  or "defaultIndex" if "color" is null.
+	 */
+	int getFontIndex(Font font) {
+		int index = fontTable.indexOf(font);
+		if (index == -1) {
+			index = fontTable.size();
+			fontTable.add(font);
+		}
+		return index;
 	}
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/RTFWriter.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/RTFWriter.java
@@ -19,9 +19,8 @@ import org.eclipse.swt.*;
 import org.eclipse.swt.graphics.*;
 
 /**
- * The {@code RTFWriter} class is used to write widget content as
- * rich text. The implementation complies with the RTF specification
- * version 1.5.
+ * The {@code RTFWriter} class is used to write styled content as rich text.
+ * The implementation complies with the RTF specification version 1.5.
  *
  * <p>{@code toString()} is guaranteed to return a valid formatted string only after
  * {@code close()} has been called.</p>
@@ -32,25 +31,14 @@ import org.eclipse.swt.graphics.*;
  * the stream like they are rendered by the widget. In addition, the
  * widget font name and size is used for the whole text.</p>
  */
-class RTFWriter extends TextWriter {
-	private final StyledText styledText;
+class RTFWriter extends StyledTextWriterBase {
 	static final int DEFAULT_FOREGROUND = 0;
 	static final int DEFAULT_BACKGROUND = 1;
 	List<Color> colorTable;
 	List<Font> fontTable;
 
-	/**
-	 * Creates a RTF writer that writes content starting at offset "start"
-	 * in the document. {@code start} and {@code length} can be set to specify
-	 * partial lines.
-	 *
-	 * @param start start offset of content to write, 0 based from beginning of document
-	 * @param length length of content to write
-	 * @param styledText the widget to produce the RTF from
-	 */
 	public RTFWriter(StyledText styledText, int start, int length) {
-		super(start, length);
-		this.styledText = styledText;
+		super(styledText, start, length);
 		colorTable = new ArrayList<>();
 		fontTable = new ArrayList<>();
 		colorTable.add(this.styledText.getForeground());
@@ -58,12 +46,6 @@ class RTFWriter extends TextWriter {
 		fontTable.add(this.styledText.getFont());
 	}
 
-	/**
-	 * Closes the writer. Once closed no more content can be written.
-	 *
-	 * <p><b>NOTE:</b> {@code toString()} does not return a valid formatted string until
-	 * {@code close()} has been called.</p>
-	 */
 	@Override
 	public void close() {
 		if (!isClosed()) {
@@ -74,22 +56,9 @@ class RTFWriter extends TextWriter {
 	}
 
 	/**
-	 * Appends the specified segment of "string" to the output data.
-	 * Copy from {@code start} up to, but excluding, {@code end}.
-	 *
-	 * @param string string to copy a segment from. Must not contain line breaks.
-	 *  Line breaks should be written using {@link #writeLineDelimiter()}
-	 * @param start start offset of segment. 0 based.
-	 * @param end end offset of segment
-	 */
-	void writeEscaped(String string, int start, int end) {
-		String textToWrite = string.substring(start, end);
-		write(escapeText(textToWrite));
-	}
-
-	/**
 	 * Writes the RTF header including font table and color table.
 	 */
+	@Override
 	void writeHeader() {
 		StringBuilder header = new StringBuilder();
 		FontData fontData = styledText.getFont().getFontData()[0];
@@ -132,69 +101,6 @@ class RTFWriter extends TextWriter {
 		write(header.toString(), 0);
 	}
 
-	/**
-	 * Appends the specified line text to the output data. Lines will be formatted
-	 * using the styles queried from the LineStyleListener, if set, or those set
-	 * directly in the widget.
-	 *
-	 * @param line line text to write. Must not contain line breaks
-	 *  Line breaks should be written using {@link #writeLineDelimiter(String)}
-	 * @param lineOffset offset of the line. 0 based from the start of the
-	 *  widget document. Any text occurring before the start offset or after the
-	 *  end offset specified during object creation is ignored.
-	 *
-	 * @throws SWTException {@code ERROR_IO} when the writer is closed.
-	 */
-	@Override
-	public void writeLine(String line, int lineOffset) {
-		if (isClosed()) {
-			SWT.error(SWT.ERROR_IO);
-		}
-
-		int lineIndex = styledText.content.getLineAtOffset(lineOffset);
-		int lineAlignment;
-		int lineIndent;
-		boolean lineJustify;
-		int verticalIndent;
-		int[] ranges;
-		StyleRange[] styles;
-
-		StyledTextEvent event = styledText.getLineStyleData(lineOffset, line);
-		if (event != null) {
-			verticalIndent = event.verticalIndent;
-			lineAlignment = event.alignment;
-			lineIndent = event.indent;
-			lineJustify = event.justify;
-			ranges = event.ranges;
-			styles = event.styles;
-		} else {
-			verticalIndent = styledText.renderer.getLineVerticalIndent(lineIndex);
-			lineAlignment = styledText.renderer.getLineAlignment(lineIndex, styledText.alignment);
-			lineIndent = styledText.renderer.getLineIndent(lineIndex, styledText.indent);
-			lineJustify = styledText.renderer.getLineJustify(lineIndex, styledText.justify);
-			ranges = styledText.renderer.getRanges(lineOffset, line.length());
-			styles = styledText.renderer.getStyleRanges(lineOffset, line.length(), false);
-		}
-
-		if (styles == null) {
-			styles = new StyleRange[0];
-		}
-
-		event = styledText.getLineBackgroundData(lineOffset, line);
-		Color lineBackground = (event != null && event.lineBackground != null)
-				? event.lineBackground
-				: styledText.renderer.getLineBackground(lineIndex, null);
-
-		writeStyledLine(line, lineOffset, ranges, styles, lineBackground, lineIndent, verticalIndent, lineAlignment, lineJustify);
-	}
-
-	/**
-	 * Appends the specified line delimiter to the output data.
-	 *
-	 * @param lineDelimiter line delimiter to write as RTF.
-	 *
-	 * @throws SWTException {@code ERROR_IO} when the writer is closed.
-	 */
 	@Override
 	public void writeLineDelimiter(String lineDelimiter) {
 		if (isClosed()) {
@@ -204,87 +110,7 @@ class RTFWriter extends TextWriter {
 		write("\\par ");
 	}
 
-	/**
-	 * Appends the specified line text to the output data.
-	 *
-	 * <p>Use the colors and font styles specified in {@code styles} and {@code lineBackground}.
-	 * Formatting is written to reflect the text rendering by the text widget.
-	 * Style background colors take precedence over the line background color.</p>
-	 *
-	 * @param line line text to write as RTF. Must not contain line breaks
-	 *  Line breaks should be written using writeLineDelimiter()
-	 * @param lineOffset offset of the line. 0 based from the start of the
-	 *  widget document. Any text occurring before the start offset or after the
-	 *  end offset specified during object creation is ignored.
-	 * @param styles styles to use for formatting. Must not be null.
-	 * @param lineBackground line background color to use for formatting.
-	 *  May be null.
-	 */
-	void writeStyledLine(String line, int lineOffset, int ranges[], StyleRange[] styles,
-			Color lineBackground, int indent, int verticalIndent, int alignment, boolean justify) {
-
-		int lineLength = line.length();
-		int startOffset = getStart();
-		int writeOffset = startOffset - lineOffset;
-		if (writeOffset >= lineLength) {
-			return;
-		}
-		int lineIndex = Math.max(0, writeOffset);
-
-		String atLineEnd = writeLineStart(lineBackground, indent, verticalIndent, alignment, justify);
-
-		int endOffset = startOffset + super.getCharCount();
-		int lineEndOffset = Math.min(lineLength, endOffset - lineOffset);
-
-		for (int i = 0; i < styles.length; i++) {
-			StyleRange style = styles[i];
-			int start, end;
-			if (ranges != null) {
-				start = ranges[i << 1] - lineOffset;
-				end = start + ranges[(i << 1) + 1];
-			} else {
-				start = style.start - lineOffset;
-				end = start + style.length;
-			}
-			// skip over partial first line
-			if (end < writeOffset) {
-				continue;
-			}
-			// style starts beyond line end or write end
-			if (start >= lineEndOffset) {
-				break;
-			}
-			// write any unstyled text
-			if (lineIndex < start) {
-				// copy to start of style
-				// style starting beyond end of write range or end of line
-				// is guarded against above.
-				writeEscaped(line, lineIndex, start);
-				lineIndex = start;
-			}
-			// write styled text
-			String atSpanEnd = writeSpanStart(style);
-
-			// copy to end of style or end of write range or end of line
-			int copyEnd = Math.min(end, lineEndOffset);
-			// guard against invalid styles and let style processing continue
-			copyEnd = Math.max(copyEnd, lineIndex);
-			writeEscaped(line, lineIndex, copyEnd);
-
-			writeSpanEnd(atSpanEnd);
-
-			lineIndex = copyEnd;
-		}
-
-		// write the unstyled text at the end of the line
-		if (lineIndex < lineEndOffset) {
-			writeEscaped(line, lineIndex, lineEndOffset);
-		}
-
-		writeLineEnd(atLineEnd);
-	}
-
-	// Returns the text to append at the end of the line
+	@Override
 	String writeLineStart(Color lineBackground, int indent, int verticalIndent, int alignment, boolean justify) {
 		write("\\fi");
 		write(indent);
@@ -305,14 +131,11 @@ class RTFWriter extends TextWriter {
 			write(" ");
 		}
 
+		// This is what will be used to close the line
 		return lineBackground == null ? "" : "}";
 	}
 
-	void writeLineEnd(String prepared) {
-		write(prepared);
-	}
-
-	// Returns the text to append at the end of the styled span
+	@Override
 	String writeSpanStart(StyleRange style) {
 		write("{\\cf");
 		write(getColorIndex(style.foreground, DEFAULT_FOREGROUND));
@@ -346,6 +169,7 @@ class RTFWriter extends TextWriter {
 		}
 		write(" ");
 
+		// This is what will be used to close the span
 		StringBuilder toCloseSpan = new StringBuilder();
 		if ((fontStyle & SWT.BOLD) != 0) {
 			toCloseSpan.append("\\b0");
@@ -363,13 +187,10 @@ class RTFWriter extends TextWriter {
 		return toCloseSpan.toString();
 	}
 
-	void writeSpanEnd(String prepared) {
-		write(prepared);
-	}
-
 	// ==== Helper methods ====
 
-	static String escapeText(String string) {
+	@Override
+	String escapeText(String string) {
 		StringBuilder result = new StringBuilder(string.length());
 		string.chars().forEach(ch -> {
 			if (ch > 0x7F) {
@@ -395,7 +216,7 @@ class RTFWriter extends TextWriter {
 	 * @return the index of the specified color in the RTF color table
 	 *  or "defaultIndex" if "color" is null.
 	 */
-	int getColorIndex(Color color, int defaultIndex) {
+	private int getColorIndex(Color color, int defaultIndex) {
 		if (color == null) return defaultIndex;
 		int index = colorTable.indexOf(color);
 		if (index == -1) {
@@ -413,7 +234,7 @@ class RTFWriter extends TextWriter {
 	 * @return the index of the specified color in the RTF color table
 	 *  or "defaultIndex" if "color" is null.
 	 */
-	int getFontIndex(Font font) {
+	private int getFontIndex(Font font) {
 		int index = fontTable.indexOf(font);
 		if (index == -1) {
 			index = fontTable.size();

--- a/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/RTFWriter.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/RTFWriter.java
@@ -191,6 +191,7 @@ class RTFWriter extends StyledTextWriterBase {
 
 	@Override
 	String escapeText(String string) {
+		// The resulting string is at least as long as the original.
 		StringBuilder result = new StringBuilder(string.length());
 		string.chars().forEach(ch -> {
 			if (ch > 0x7F) {
@@ -205,7 +206,7 @@ class RTFWriter extends StyledTextWriterBase {
 				result.append((char) ch);
 			}
 		});
-        return result.toString();
+		return result.toString();
 	}
 
 	/**

--- a/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/StyledTextWriterBase.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/StyledTextWriterBase.java
@@ -19,7 +19,7 @@ import org.eclipse.swt.graphics.*;
 /**
  * The base class encapsulating the logic used to write styled content as
  * a rich format (HTML, RTF, maybe more). It contains the common parts:
- * iterates on lines, then on each line iterates on plain text and StyleRange(s).
+ * iterates on lines, then on each line iterates on plain text and {@link StyleRange}(s).
  *
  * <p>{@code toString()} is guaranteed to return a valid formatted string only after
  * {@code close()} has been called.</p>

--- a/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/StyledTextWriterBase.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/StyledTextWriterBase.java
@@ -1,0 +1,255 @@
+/*******************************************************************************
+ * Copyright (c) 2000, 2022 IBM Corporation and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.swt.custom;
+
+import org.eclipse.swt.*;
+import org.eclipse.swt.graphics.*;
+
+/**
+ * The base class encapsulating the logic used to write styled content as
+ * a rich format (HTML, RTF, maybe more). It contains the common parts:
+ * iterates on lines, then on each line iterates on plain text and StyleRange(s).
+ *
+ * <p>{@code toString()} is guaranteed to return a valid formatted string only after
+ * {@code close()} has been called.</p>
+ *
+ * <p>Whole and partial lines and line breaks can be written. Lines will be
+ * formatted using the styles queried from the {@link LineStyleListener},
+ * if set, or those set directly in the widget. All styles are applied to
+ * the stream like they are rendered by the widget. In addition, the
+ * widget font name and size is used for the whole text.</p>
+ */
+abstract class StyledTextWriterBase extends TextWriter {
+	final StyledText styledText;
+
+	/**
+	 * Creates a writer that processed content starting at offset "start"
+	 * in the document. {@code start} and {@code length} can be set to specify
+	 * partial lines.
+	 *
+	 * @param start start offset of content to write, 0 based from beginning of document
+	 * @param length length of content to write
+	 * @param styledText the widget to produce the RTF from
+	 */
+	public StyledTextWriterBase(StyledText styledText, int start, int length) {
+		super(start, length);
+		this.styledText = styledText;
+	}
+
+	/**
+	 * Appends the specified segment of "string" to the output data.
+	 * Copy from {@code start} up to, but excluding, {@code end}.
+	 *
+	 * @param string string to copy a segment from. Must not contain line breaks.
+	 *  Line breaks should be written using {@link #writeLineDelimiter()}
+	 * @param start start offset of segment. 0 based.
+	 * @param end end offset of segment
+	 */
+	void writeEscaped(String string, int start, int end) {
+		String textToWrite = string.substring(start, end);
+		write(escapeText(textToWrite));
+	}
+
+	/**
+	 * Appends the specified line text to the output data. Lines will be formatted
+	 * using the styles queried from the LineStyleListener, if set, or those set
+	 * directly in the widget.
+	 *
+	 * @param line line text to write. Must not contain line breaks
+	 *  Line breaks should be written using {@link #writeLineDelimiter(String)}
+	 * @param lineOffset offset of the line. 0 based from the start of the
+	 *  widget document. Any text occurring before the start offset or after the
+	 *  end offset specified during object creation is ignored.
+	 *
+	 * @throws SWTException {@code ERROR_IO} when the writer is closed.
+	 */
+	@Override
+	public void writeLine(String line, int lineOffset) {
+		if (isClosed()) {
+			SWT.error(SWT.ERROR_IO);
+		}
+
+		int lineIndex = styledText.content.getLineAtOffset(lineOffset);
+		int lineAlignment;
+		int lineIndent;
+		boolean lineJustify;
+		int verticalIndent;
+		int[] ranges;
+		StyleRange[] styles;
+
+		StyledTextEvent event = styledText.getLineStyleData(lineOffset, line);
+		if (event != null) {
+			verticalIndent = event.verticalIndent;
+			lineAlignment = event.alignment;
+			lineIndent = event.indent;
+			lineJustify = event.justify;
+			ranges = event.ranges;
+			styles = event.styles;
+		} else {
+			verticalIndent = styledText.renderer.getLineVerticalIndent(lineIndex);
+			lineAlignment = styledText.renderer.getLineAlignment(lineIndex, styledText.alignment);
+			lineIndent = styledText.renderer.getLineIndent(lineIndex, styledText.indent);
+			lineJustify = styledText.renderer.getLineJustify(lineIndex, styledText.justify);
+			ranges = styledText.renderer.getRanges(lineOffset, line.length());
+			styles = styledText.renderer.getStyleRanges(lineOffset, line.length(), false);
+		}
+
+		if (styles == null) {
+			styles = new StyleRange[0];
+		}
+
+		event = styledText.getLineBackgroundData(lineOffset, line);
+		Color lineBackground = (event != null && event.lineBackground != null)
+				? event.lineBackground
+				: styledText.renderer.getLineBackground(lineIndex, null);
+
+		writeStyledLine(line, lineOffset, ranges, styles, lineBackground, lineIndent, verticalIndent, lineAlignment, lineJustify);
+	}
+
+	/**
+	 * Appends the specified line text to the output data.
+	 *
+	 * <p>Use the colors and font styles specified in {@code styles} and {@code lineBackground}.
+	 * Formatting is written to reflect the text rendering by the text widget.
+	 * Style background colors take precedence over the line background color.</p>
+	 *
+	 * @param line line text to write as RTF. Must not contain line breaks
+	 *  Line breaks should be written using writeLineDelimiter()
+	 * @param lineOffset offset of the line. 0 based from the start of the
+	 *  widget document. Any text occurring before the start offset or after the
+	 *  end offset specified during object creation is ignored.
+	 * @param styles styles to use for formatting. Must not be null.
+	 * @param lineBackground line background color to use for formatting.
+	 *  May be null.
+	 */
+	void writeStyledLine(String line, int lineOffset, int ranges[], StyleRange[] styles,
+			Color lineBackground, int indent, int verticalIndent, int alignment, boolean justify) {
+
+		int lineLength = line.length();
+		int startOffset = getStart();
+		int writeOffset = startOffset - lineOffset;
+		if (writeOffset >= lineLength) {
+			return;
+		}
+		int lineIndex = Math.max(0, writeOffset);
+
+		String atLineEnd = writeLineStart(lineBackground, indent, verticalIndent, alignment, justify);
+
+		int endOffset = startOffset + super.getCharCount();
+		int lineEndOffset = Math.min(lineLength, endOffset - lineOffset);
+
+		for (int i = 0; i < styles.length; i++) {
+			StyleRange style = styles[i];
+			int start, end;
+			if (ranges != null) {
+				start = ranges[i << 1] - lineOffset;
+				end = start + ranges[(i << 1) + 1];
+			} else {
+				start = style.start - lineOffset;
+				end = start + style.length;
+			}
+			// skip over partial first line
+			if (end < writeOffset) {
+				continue;
+			}
+			// style starts beyond line end or write end
+			if (start >= lineEndOffset) {
+				break;
+			}
+			// write any unstyled text
+			if (lineIndex < start) {
+				// copy to start of style
+				// style starting beyond end of write range or end of line
+				// is guarded against above.
+				writeEscaped(line, lineIndex, start);
+				lineIndex = start;
+			}
+			// write styled text
+			String atSpanEnd = writeSpanStart(style);
+
+			// copy to end of style or end of write range or end of line
+			int copyEnd = Math.min(end, lineEndOffset);
+			// guard against invalid styles and let style processing continue
+			copyEnd = Math.max(copyEnd, lineIndex);
+			writeEscaped(line, lineIndex, copyEnd);
+
+			writeSpanEnd(atSpanEnd);
+
+			lineIndex = copyEnd;
+		}
+
+		// write the unstyled text at the end of the line
+		if (lineIndex < lineEndOffset) {
+			writeEscaped(line, lineIndex, lineEndOffset);
+		}
+
+		writeLineEnd(atLineEnd);
+	}
+
+	/**
+	 * Writes the part that only shows once, at the beginning of the output data.
+	 */
+	abstract void writeHeader();
+
+	/**
+	 * Takes plain text and returns the same text escaped using the rules of the output format.
+	 * @param text the text to escape
+	 * @return the escaped text
+	 */
+	abstract String escapeText(String text);
+
+	/**
+	 * Invoked at the beginning of each line in the original widget.
+	 *
+	 * <p>It should output whatever tags are appropriate to start a new line in the output format.<br>
+	 * It will return the text that has to be output at the end of the line.</p>
+	 *
+	 * @return the text to append at the end of the line
+	 */
+	abstract String writeLineStart(Color lineBackground, int indent, int verticalIndent, int alignment, boolean justify);
+
+	/**
+	 * Invoked at the end of of each line in the original widget.
+	 *
+	 * <p>It receives whatever text {@link #writeLineStart(Color,int,int,int,boolean)} returned
+	 * and it will output it. A class might override it to do more.</p>
+	 *
+	 * @param prepared the leftover text prepared by {@code writeLineStart}
+	 */
+	void writeLineEnd(String prepared) {
+		write(prepared);
+	}
+
+	/**
+	 * Invoked at the beginning of each styled span fragment in the original widget.
+	 *
+	 * <p>It should output whatever tags are appropriate to start a formatted span in the output format.<br>
+	 * It will return the text that has to be output at the end of the span (to close it).</p>
+	 *
+	 * @return the text to append at the end of the styled span
+	 */
+	abstract String writeSpanStart(StyleRange style);
+
+	/**
+	 * Invoked at the end of of each styled span fragment in the original widget.
+	 *
+	 * <p>It receives whatever text {@link #writeSpanStart(StyleRange)} returned
+	 * and it will output it. A class might override it to do more.</p>
+	 *
+	 * @param prepared the leftover text prepared by {@code writeSpanStart}
+	 */
+	void writeSpanEnd(String prepared) {
+		write(prepared);
+	}
+}


### PR DESCRIPTION
I don't know if it is generic enough to support other future formats.
But at least it puts in a common place the relatively complicated code that iterates and  outputs the line styled ranges.

I've tried to split it into separate commits that might be easier to follow, but I don't know if you prefer that style, or one single commit.
Let me know and I can squash.
Or only squash after you reviewed.

Also, if you think it is overengineered and not worth doing, that's also fine.

Thanks,
Mihai