### PR TITLE
[Issue 367] Button Image is wrong size at hi-res scale

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/gtk3.c
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/gtk3.c
@@ -1118,6 +1118,16 @@ fail:
 }
 #endif
 
+#ifndef NO_gtk_1image_1set_1from_1pixbuf
+JNIEXPORT void JNICALL GTK3_NATIVE(gtk_1image_1set_1from_1pixbuf)
+	(JNIEnv *env, jclass that, jlong arg0, jlong arg1)
+{
+	GTK3_NATIVE_ENTER(env, that, gtk_1image_1set_1from_1pixbuf_FUNC);
+	gtk_image_set_from_pixbuf((GtkImage *)arg0, (GdkPixbuf *)arg1);
+	GTK3_NATIVE_EXIT(env, that, gtk_1image_1set_1from_1pixbuf_FUNC);
+}
+#endif
+
 #ifndef NO_gtk_1image_1set_1from_1surface
 JNIEXPORT void JNICALL GTK3_NATIVE(gtk_1image_1set_1from_1surface)
 	(JNIEnv *env, jclass that, jlong arg0, jlong arg1)

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/gtk3_stats.c
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/gtk3_stats.c
@@ -113,6 +113,7 @@ char * GTK3_nativeFunctionNames[] = {
 	"gtk_1image_1new_1from_1icon_1name",
 	"gtk_1image_1new_1from_1surface",
 	"gtk_1image_1set_1from_1icon_1name",
+	"gtk_1image_1set_1from_1pixbuf",
 	"gtk_1image_1set_1from_1surface",
 	"gtk_1init_1check",
 	"gtk_1label_1set_1line_1wrap",

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/gtk3_stats.h
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/gtk3_stats.h
@@ -123,6 +123,7 @@ typedef enum {
 	gtk_1image_1new_1from_1icon_1name_FUNC,
 	gtk_1image_1new_1from_1surface_FUNC,
 	gtk_1image_1set_1from_1icon_1name_FUNC,
+	gtk_1image_1set_1from_1pixbuf_FUNC,
 	gtk_1image_1set_1from_1surface_FUNC,
 	gtk_1init_1check_FUNC,
 	gtk_1label_1set_1line_1wrap_FUNC,

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/org/eclipse/swt/internal/gtk3/GTK3.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/org/eclipse/swt/internal/gtk3/GTK3.java
@@ -893,6 +893,11 @@ public class GTK3 {
 	 */
 	public static final native void gtk_image_set_from_surface(long image, long surface);
 	/**
+	 * @param image cast=(GtkImage *)
+	 * @param pixbuf cast=(GdkPixbuf *)
+	 */
+	public static final native void gtk_image_set_from_pixbuf(long image, long pixbuf);
+	/**
 	 * @param icon_name cast=(const gchar *)
 	 * @param size cast=(GtkIconSize)
 	 */

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Button.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Button.java
@@ -1162,7 +1162,10 @@ private void _setImage (Image image) {
 			OS.g_object_unref(pixbuf);
 			GTK4.gtk_picture_set_paintable(imageHandle, texture);
 		} else {
-			GTK3.gtk_image_set_from_surface(imageHandle, image.surface);
+			ImageData imgData = image.getImageData();
+			long pixbuf = GDK.gdk_pixbuf_get_from_surface(image.surface, 0, 0, imgData.width, imgData.height);
+			GTK3.gtk_image_set_from_pixbuf(imageHandle, pixbuf);
+			OS.g_object_unref(pixbuf);
 		}
 	} else {
 		if (GTK.GTK4) {


### PR DESCRIPTION
Button image was incorrectly scaled due to set_from_surface not behaving as expected.

+ Refactored image setting to use GdkPixbuf instead, which fixes the issue.
+ Added gtk_image_set_from_pixbuf to GTK3.java

Signed-off-by: Joel Majano <majanojoel@gmail.com>

Fixes #367 