### PR TITLE
Add support for Windows on Arm64 (WoA) build

### DIFF
--- a/bundles/org.eclipse.swt/.classpath_win32_aarch64
+++ b/bundles/org.eclipse.swt/.classpath_win32_aarch64
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
+	<classpathentry kind="src" path="Eclipse SWT/win32"/>
+	<classpathentry kind="src" path="Eclipse SWT/common"/>
+	<classpathentry kind="src" path="Eclipse SWT PI/common"/>
+	<classpathentry kind="src" path="Eclipse SWT PI/win32">
+		<attributes>
+			<attribute value="org.eclipse.swt.win32.win32.aarch64" name="org.eclipse.jdt.launching.CLASSPATH_ATTR_LIBRARY_PATH_ENTRY"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" path="Eclipse SWT OLE Win32/win32"/>
+	<classpathentry kind="src" path="Eclipse SWT Accessibility/win32"/>
+	<classpathentry kind="src" path="Eclipse SWT Accessibility/common"/>
+	<classpathentry kind="src" path="Eclipse SWT AWT/win32"/>
+	<classpathentry kind="src" path="Eclipse SWT AWT/common"/>
+	<classpathentry kind="src" path="Eclipse SWT Drag and Drop/win32"/>
+	<classpathentry kind="src" path="Eclipse SWT Drag and Drop/common"/>
+	<classpathentry kind="src" path="Eclipse SWT Printing/win32"/>
+	<classpathentry kind="src" path="Eclipse SWT Printing/common"/>
+	<classpathentry kind="src" path="Eclipse SWT Program/win32"/>
+	<classpathentry kind="src" path="Eclipse SWT Program/common"/>
+	<classpathentry kind="src" path="Eclipse SWT Custom Widgets/common"/>
+	<classpathentry kind="src" path="Eclipse SWT Browser/common"/>
+	<classpathentry kind="src" path="Eclipse SWT Browser/win32"/>
+	<classpathentry kind="src" path="Eclipse SWT OpenGL/win32"/>
+	<classpathentry kind="src" path="Eclipse SWT OpenGL/common"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/win32/library/os_custom.c
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/win32/library/os_custom.c
@@ -63,7 +63,7 @@ BOOL Validate_AllowDarkModeForWindow(const BYTE* functionPtr)
 	 * an ATOM value of 0xA91E which is unlikely to change
 	 */
 
-#if defined(_M_X64) || defined(_M_ARM64)
+#ifdef _M_X64
 	/* Win10 builds from 20236 */
 	if ((functionPtr[0x52] == 0xBA) &&                      // mov     edx,
 	    (*(const DWORD*)(functionPtr + 0x53) == 0xA91E))    //             0A91Eh
@@ -78,6 +78,10 @@ BOOL Validate_AllowDarkModeForWindow(const BYTE* functionPtr)
 		return TRUE;
 	}
 
+	return FALSE;
+#elif defined(_M_ARM64)
+	/* Not implemented yet */
+	functionPtr; /* to prevent: warning C4100: 'functionPtr': unreferenced formal parameter */
 	return FALSE;
 #else
 	#error Unsupported processor type
@@ -111,7 +115,7 @@ TYPE_AllowDarkModeForWindow Locate_AllowDarkModeForWindow()
 
 BOOL Validate_AllowDarkModeForWindowWithTelemetryId(const BYTE* functionPtr)
 {
-#if defined(_M_X64) || defined(_M_ARM64)
+#ifdef _M_X64
 	/* This function is rather long, but it uses an ATOM value of 0xA91E which is unlikely to change */
 
 	/* Win10 builds from 21301 */
@@ -121,6 +125,10 @@ BOOL Validate_AllowDarkModeForWindowWithTelemetryId(const BYTE* functionPtr)
 		return TRUE;
 	}
 
+	return FALSE;
+#elif defined(_M_ARM64)
+	/* Not implemented yet */
+	functionPtr; /* to prevent: warning C4100: 'functionPtr': unreferenced formal parameter */
 	return FALSE;
 #else
 	#error Unsupported processor type
@@ -198,7 +206,7 @@ JNIEXPORT jboolean JNICALL OS_NATIVE(AllowDarkModeForWindow)
 
 BOOL Validate_SetPreferredAppMode(const BYTE* functionPtr)
 {
-#if defined(_M_X64) || defined(_M_ARM64)
+#ifdef _M_X64
 	/*
 	 * This function is very simple, so validate entire body.
 	 * The only thing we don't know is the variable address.
@@ -212,6 +220,10 @@ BOOL Validate_SetPreferredAppMode(const BYTE* functionPtr)
 		(functionPtr[0x00] == 0x8B) && (functionPtr[0x01] == 0x05) &&   // mov     eax,dword ptr [uxtheme!g_preferredAppMode]
 		(functionPtr[0x06] == 0x87) && (functionPtr[0x07] == 0x0D) &&   // xchg    ecx,dword ptr [uxtheme!g_preferredAppMode]
 		(functionPtr[0x0C] == 0xC3);                                    // ret
+#elif defined(_M_ARM64)
+	/* Not implemented yet */
+	functionPtr; /* to prevent: warning C4100: 'functionPtr': unreferenced formal parameter */
+	return FALSE;
 #else
 	#error Unsupported processor type
 #endif

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/win32/library/os_custom.c
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/win32/library/os_custom.c
@@ -63,7 +63,7 @@ BOOL Validate_AllowDarkModeForWindow(const BYTE* functionPtr)
 	 * an ATOM value of 0xA91E which is unlikely to change
 	 */
 
-#ifdef _M_X64
+#if defined(_M_X64) || defined(_M_ARM64)
 	/* Win10 builds from 20236 */
 	if ((functionPtr[0x52] == 0xBA) &&                      // mov     edx,
 	    (*(const DWORD*)(functionPtr + 0x53) == 0xA91E))    //             0A91Eh
@@ -111,7 +111,7 @@ TYPE_AllowDarkModeForWindow Locate_AllowDarkModeForWindow()
 
 BOOL Validate_AllowDarkModeForWindowWithTelemetryId(const BYTE* functionPtr)
 {
-#ifdef _M_X64
+#if defined(_M_X64) || defined(_M_ARM64)
 	/* This function is rather long, but it uses an ATOM value of 0xA91E which is unlikely to change */
 
 	/* Win10 builds from 21301 */
@@ -198,7 +198,7 @@ JNIEXPORT jboolean JNICALL OS_NATIVE(AllowDarkModeForWindow)
 
 BOOL Validate_SetPreferredAppMode(const BYTE* functionPtr)
 {
-#ifdef _M_X64
+#if defined(_M_X64) || defined(_M_ARM64)
 	/*
 	 * This function is very simple, so validate entire body.
 	 * The only thing we don't know is the variable address.

--- a/bundles/org.eclipse.swt/buildSWT.xml
+++ b/bundles/org.eclipse.swt/buildSWT.xml
@@ -79,6 +79,10 @@
 		</antcall>
 		<antcall target="check_fragment_libraries">
 			<param name="library_count" value="4"/>
+			<param name="fragment" value="org.eclipse.swt.win32.win32.aarch64"/>
+		</antcall>
+		<antcall target="check_fragment_libraries">
+			<param name="library_count" value="4"/>
 			<param name="fragment" value="org.eclipse.swt.win32.win32.x86_64"/>
 		</antcall>
 	</target>
@@ -86,15 +90,15 @@
 	<target name="check_fragment_libraries" depends="get_version">
 		<echo>Checking ${fragment}</echo>
 		<property name="checkdir" value="~/build/check_libraries"/>
-		<property name="library_count" value="31"/>
+		<property name="library_count" value="35"/>
 		<property name="fragment" value=""/>
-		<fileset id="match" dir="${repo.bin}/bundles/${fragment}" includes="**/org.eclipse.swt.gtk.linux.aarch64/**, **/org.eclipse.swt.gtk.linux.ppc64le/**, **/org.eclipse.swt.gtk.linux.x86_64/**, **/org.eclipse.swt.win32.win32.x86_64/**, **/org.eclipse.swt.cocoa.macosx.aarch64/**, **/org.eclipse.swt.cocoa.macosx.x86_64/**">
+		<fileset id="match" dir="${repo.bin}/bundles/${fragment}" includes="**/org.eclipse.swt.gtk.linux.aarch64/**, **/org.eclipse.swt.gtk.linux.ppc64le/**, **/org.eclipse.swt.gtk.linux.x86_64/**, **/org.eclipse.swt.win32.win32.aarch64/**, **/org.eclipse.swt.win32.win32.x86_64/**, **/org.eclipse.swt.cocoa.macosx.aarch64/**, **/org.eclipse.swt.cocoa.macosx.x86_64/**">
 			<filename regex="[0-9][0-9][0-9][0-9]"/>
 			<filename regex="${swt_version}"/>
 			<exclude name="**/.git/**"/>
 		</fileset>
 		<echo>Matched files ${toString:match}</echo>
-		<fileset id="not_match" dir="${repo.bin}/bundles/${fragment}" includes="**/org.eclipse.swt.gtk.linux.aarch64/**, **/org.eclipse.swt.gtk.linux.ppc64le/**, **/org.eclipse.swt.gtk.linux.x86_64/**, **/org.eclipse.swt.win32.win32.x86_64/**, **/org.eclipse.swt.cocoa.macosx.aarch64/**, **/org.eclipse.swt.cocoa.macosx.x86_64/**">
+		<fileset id="not_match" dir="${repo.bin}/bundles/${fragment}" includes="**/org.eclipse.swt.gtk.linux.aarch64/**, **/org.eclipse.swt.gtk.linux.ppc64le/**, **/org.eclipse.swt.gtk.linux.x86_64/**, **/org.eclipse.swt.win32.win32.aarch64/**, **/org.eclipse.swt.win32.win32.x86_64/**, **/org.eclipse.swt.cocoa.macosx.aarch64/**, **/org.eclipse.swt.cocoa.macosx.x86_64/**">
 			<filename regex="[0-9][0-9][0-9][0-9]"/>
 			<filename regex="${swt_version}" negate="true"/>
 			<exclude name="**/.git/**"/>
@@ -254,6 +258,9 @@
 		</antcall>
 		<antcall target="build_classes">
 			<param name="cp" value=".classpath_win32"/>
+		</antcall>
+		<antcall target="build_classes">
+			<param name="cp" value=".classpath_win32_aarch64"/>
 		</antcall>
 		
 		<antcall target="check_preprocessing"/>

--- a/pom.xml
+++ b/pom.xml
@@ -171,6 +171,11 @@
 	            	<environment>
 						<os>win32</os>
 						<ws>win32</ws>
+						<arch>aarch64</arch>
+					</environment>
+	            	<environment>
+						<os>win32</os>
+						<ws>win32</ws>
 						<arch>x86_64</arch>
 					</environment>
 	            </environments>


### PR DESCRIPTION
New environment triplet win32/win32/aarch64 is added.

Changes are made to the 'org.eclipse.swt' bundle to support successful compile of the new SWT native libraries (*.dll) for Arm64.