### PR TITLE
Revert "Switch JNI_VERSION to 10"

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/os_custom.c
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/os_custom.c
@@ -2116,7 +2116,7 @@ jlong call_accessible_object_function (const char *method_name, const char *meth
 	}
 
 	// Get the JNIEnv pointer
-	if ((*JVM)->GetEnv(JVM, (void **)&env, JNI_VERSION_10)) {
+	if ((*JVM)->GetEnv(JVM, (void **)&env, JNI_VERSION_1_2)) {
 		g_critical("Error fetching the JNIEnv pointer\n");
 		return 0;
 	}

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/library/callback.c
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/library/callback.c
@@ -1896,7 +1896,7 @@ jlong callback(int index, ...)
 	}
 #endif
 
-	(*JVM)->GetEnv(JVM, (void **)&env, JNI_VERSION_10);
+	(*JVM)->GetEnv(JVM, (void **)&env, JNI_VERSION_1_4);
 
 	if (env == NULL) {
 		(*JVM)->AttachCurrentThreadAsDaemon(JVM, (void **)&env, NULL);

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/library/swt.c
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/library/swt.c
@@ -21,7 +21,7 @@ JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM *vm, void *reserved) {
 	(void)reserved;
 
 	JVM = vm;
-	return JNI_VERSION_10;
+	return JNI_VERSION_1_4;
 }
 
 void throwOutOfMemory(JNIEnv *env) {


### PR DESCRIPTION
Reverts eclipse-platform/eclipse.platform.swt#410

Windows build still uses Java 8.