### PR TITLE
Add support for AllowDarkModeForWindowWithTelemetryId for Windows 11 22H2

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT PI/win32/library/os_custom.c
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/win32/library/os_custom.c
@@ -121,6 +121,13 @@ BOOL Validate_AllowDarkModeForWindowWithTelemetryId(const BYTE* functionPtr)
 		return TRUE;
 	}
 
+	/* Win11 builds from 22621 */
+	if ((functionPtr[0x15] == 0xBA) &&                      // mov      edx,
+		(*(const DWORD*)(functionPtr + 0x16) == 0xA91E))    //              0A91Eh
+	{
+		return TRUE;
+	}
+
 	return FALSE;
 #else
 	#error Unsupported processor type


### PR DESCRIPTION
The `AllowDarkModeForWindowWithTelemetryId` method was changed again in Windows 11 22H2. I haven't checked Windows 10 to see if the `AllowDarkModeForWindow` method was changed in Windows 10 22H2 or what the build number is for Windows 10 22H2.