### PR TITLE
Issue #420: "swt.autoScale" should add new "half" option

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/DPIUtil.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/DPIUtil.java
@@ -55,9 +55,9 @@ public class DPIUtil {
 	 *     generally rounded down (e.g. at 150%, will use 100%), unless close to
 	 *     the next integer multiple (currently at 175%, will use 200%).</li>
 	 * <li><b>integer200</b>: like <b>integer</b>, but the maximal zoom level is 200%.</li>
-	 * <li><b>half</b>: deviceZoom depends on the current display resolution,
+	 * <li><b>half-even</b>: deviceZoom depends on the current display resolution,
 	 *     but only uses integer multiples of 50%. The detected native zoom is
-	 *     rounded to the closest permissible value.</li>
+	 *     rounded to the closest permissible value, with tie-breaker towards even.</li>
 	 * <li><b>quarter</b>: deviceZoom depends on the current display resolution,
 	 *     but only uses integer multiples of 25%. The detected native zoom is
 	 *     rounded to the closest permissible value.</li>
@@ -460,7 +460,7 @@ public static int getZoomForAutoscaleProperty (int nativeDeviceZoom) {
 	if (autoScaleValue != null) {
 		if ("false".equalsIgnoreCase (autoScaleValue)) {
 			zoom = 100;
-		} else if ("half".equalsIgnoreCase (autoScaleValue)) {
+		} else if ("half-even".equalsIgnoreCase (autoScaleValue)) {
 			// Math.round rounds 125->150 and 175->200, 
 			// Math.rint rounds 125->100 and 175->200 matching
 			// "integer200"

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/DPIUtil.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/DPIUtil.java
@@ -55,7 +55,7 @@ public class DPIUtil {
 	 *     generally rounded down (e.g. at 150%, will use 100%), unless close to
 	 *     the next integer multiple (currently at 175%, will use 200%).</li>
 	 * <li><b>integer200</b>: like <b>integer</b>, but the maximal zoom level is 200%.</li>
-	 * <li><b>half-even</b>: deviceZoom depends on the current display resolution,
+	 * <li><b>half</b>: deviceZoom depends on the current display resolution,
 	 *     but only uses integer multiples of 50%. The detected native zoom is
 	 *     rounded to the closest permissible value, with tie-breaker towards even.</li>
 	 * <li><b>quarter</b>: deviceZoom depends on the current display resolution,
@@ -460,7 +460,7 @@ public static int getZoomForAutoscaleProperty (int nativeDeviceZoom) {
 	if (autoScaleValue != null) {
 		if ("false".equalsIgnoreCase (autoScaleValue)) {
 			zoom = 100;
-		} else if ("half-even".equalsIgnoreCase (autoScaleValue)) {
+		} else if ("half".equalsIgnoreCase (autoScaleValue)) {
 			// Math.round rounds 125->150 and 175->200, 
 			// Math.rint rounds 125->100 and 175->200 matching
 			// "integer200"

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/DPIUtil.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/DPIUtil.java
@@ -10,6 +10,7 @@
  *
  * Contributors:
  *     IBM Corporation - initial API and implementation
+ *     Daniel Krügler - #420 - [High DPI] "swt.autoScale" should add new "half" option
  *******************************************************************************/
 package org.eclipse.swt.internal;
 
@@ -54,6 +55,9 @@ public class DPIUtil {
 	 *     generally rounded down (e.g. at 150%, will use 100%), unless close to
 	 *     the next integer multiple (currently at 175%, will use 200%).</li>
 	 * <li><b>integer200</b>: like <b>integer</b>, but the maximal zoom level is 200%.</li>
+	 * <li><b>half</b>: deviceZoom depends on the current display resolution,
+	 *     but only uses integer multiples of 50%. The detected native zoom is
+	 *     rounded to the closest permissible value.</li>
 	 * <li><b>quarter</b>: deviceZoom depends on the current display resolution,
 	 *     but only uses integer multiples of 25%. The detected native zoom is
 	 *     rounded to the closest permissible value.</li>
@@ -456,8 +460,10 @@ public static int getZoomForAutoscaleProperty (int nativeDeviceZoom) {
 	if (autoScaleValue != null) {
 		if ("false".equalsIgnoreCase (autoScaleValue)) {
 			zoom = 100;
+		} else if ("half".equalsIgnoreCase (autoScaleValue)) {
+			zoom = Math.round (nativeDeviceZoom / 50f) * 50;
 		} else if ("quarter".equalsIgnoreCase (autoScaleValue)) {
-			zoom = (int) (Math.round (nativeDeviceZoom / 25f) * 25);
+			zoom = Math.round (nativeDeviceZoom / 25f) * 25;
 		} else if ("exact".equalsIgnoreCase (autoScaleValue)) {
 			zoom = nativeDeviceZoom;
 		} else {

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/DPIUtil.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/DPIUtil.java
@@ -461,9 +461,10 @@ public static int getZoomForAutoscaleProperty (int nativeDeviceZoom) {
 		if ("false".equalsIgnoreCase (autoScaleValue)) {
 			zoom = 100;
 		} else if ("half".equalsIgnoreCase (autoScaleValue)) {
-			// Math.round would round 125->150 and 175->200, 
-			// using truncation round 125->100 and 175->150
-			zoom = (nativeDeviceZoom / 50) * 50;
+			// Math.round rounds 125->150 and 175->200, 
+			// Math.rint rounds 125->100 and 175->200 matching
+			// "integer200"
+			zoom = (int) Math.rint(nativeDeviceZoom / 50d) * 50;
 		} else if ("quarter".equalsIgnoreCase (autoScaleValue)) {
 			zoom = Math.round(nativeDeviceZoom / 25f) * 25;
 		} else if ("exact".equalsIgnoreCase (autoScaleValue)) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/DPIUtil.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/DPIUtil.java
@@ -461,9 +461,11 @@ public static int getZoomForAutoscaleProperty (int nativeDeviceZoom) {
 		if ("false".equalsIgnoreCase (autoScaleValue)) {
 			zoom = 100;
 		} else if ("half".equalsIgnoreCase (autoScaleValue)) {
-			zoom = Math.round (nativeDeviceZoom / 50f) * 50;
+			// Math.round would round 125->150 and 175->200, 
+			// using truncation round 125->100 and 175->150
+			zoom = (nativeDeviceZoom / 50) * 50;
 		} else if ("quarter".equalsIgnoreCase (autoScaleValue)) {
-			zoom = Math.round (nativeDeviceZoom / 25f) * 25;
+			zoom = Math.round(nativeDeviceZoom / 25f) * 25;
 		} else if ("exact".equalsIgnoreCase (autoScaleValue)) {
 			zoom = nativeDeviceZoom;
 		} else {

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/DPIUtil.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/DPIUtil.java
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     IBM Corporation - initial API and implementation
- *     Daniel Krügler - #420 - [High DPI] "swt.autoScale" should add new "half" option
+ *     Daniel Kruegler - #420 - [High DPI] "swt.autoScale" should add new "half" option
  *******************************************************************************/
 package org.eclipse.swt.internal;
 


### PR DESCRIPTION
- Add new "half" option for the "swt.autoScale" system property and evaluate in DPIUtil#getZoomForAutoscaleProperty
- Remove unneeded casts to int (Math.round with float argument already returns int)

Signed-off-by: Daniel Krügler <daniel.kruegler@gmail.com>