### PR TITLE
Win Tree: cache column order

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TreeItem.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TreeItem.java
@@ -430,7 +430,7 @@ RECT getBounds (int index, boolean getText, boolean getImage, boolean fullText, 
 	long hwndHeader = parent.hwndHeader;
 	if (hwndHeader != 0) {
 		columnCount = parent.columnCount;
-		firstColumn = index == OS.SendMessage (hwndHeader, OS.HDM_ORDERTOINDEX, 0, 0);
+		firstColumn = index == parent.getFirstColumnIndex();
 	}
 	RECT rect = new RECT ();
 	if (firstColumn) {
@@ -449,12 +449,14 @@ RECT getBounds (int index, boolean getText, boolean getImage, boolean fullText, 
 		}
 		if (fullText || fullImage || clip) {
 			if (hwndHeader != 0) {
-				RECT headerRect = new RECT ();
+				RECT headerRect;
 				if (columnCount != 0) {
-					if (OS.SendMessage (hwndHeader, OS.HDM_GETITEMRECT, index, headerRect) == 0) {
-						return new RECT ();
+					headerRect = parent.getColumnRect(index);
+					if (headerRect == null) {
+						return new RECT();
 					}
 				} else {
+					headerRect = new RECT ();
 					headerRect.right = parent.scrollWidth;
 					if (headerRect.right == 0) headerRect = rect;
 				}
@@ -467,8 +469,8 @@ RECT getBounds (int index, boolean getText, boolean getImage, boolean fullText, 
 		}
 	} else {
 		if (!(0 <= index && index < columnCount)) return new RECT ();
-		RECT headerRect = new RECT ();
-		if (OS.SendMessage (hwndHeader, OS.HDM_GETITEMRECT, index, headerRect) == 0) {
+		RECT headerRect = parent.getColumnRect(index);
+		if (headerRect == null) {
 			return new RECT ();
 		}
 		if (!OS.TreeView_GetItemRect (hwnd, handle, rect, false)) {

--- a/tests/org.eclipse.swt.tests.win32/JUnit Tests/org/eclipse/swt/tests/win32/AllWin32Tests.java
+++ b/tests/org.eclipse.swt.tests.win32/JUnit Tests/org/eclipse/swt/tests/win32/AllWin32Tests.java
@@ -14,6 +14,7 @@
  */
 package org.eclipse.swt.tests.win32;
 
+import org.eclipse.swt.tests.win32.widgets.TestTreeColumn;
 import org.eclipse.swt.tests.win32.widgets.Test_org_eclipse_swt_widgets_Display;
 import org.junit.runner.JUnitCore;
 import org.junit.runner.RunWith;
@@ -24,6 +25,7 @@ import org.junit.runners.Suite;
 @Suite.SuiteClasses({
 	Test_org_eclipse_swt_dnd_DND.class,
 	Test_org_eclipse_swt_widgets_Display.class,
+	TestTreeColumn.class
 })
 
 public class AllWin32Tests {

--- a/tests/org.eclipse.swt.tests.win32/JUnit Tests/org/eclipse/swt/tests/win32/widgets/TestTreeColumn.java
+++ b/tests/org.eclipse.swt.tests.win32/JUnit Tests/org/eclipse/swt/tests/win32/widgets/TestTreeColumn.java
@@ -1,0 +1,155 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Joerg Kubitz
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Joerg Kubitz - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.swt.tests.win32.widgets;
+
+import static org.junit.Assert.assertEquals;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.widgets.Shell;
+import org.eclipse.swt.widgets.Tree;
+import org.eclipse.swt.widgets.TreeColumn;
+import org.junit.Test;
+
+public class TestTreeColumn {
+
+	@Test
+	public void test_ColumnOrder()
+			throws NoSuchMethodException, SecurityException, IllegalAccessException, InvocationTargetException {
+		Method getColumnIndex = Tree.class.getDeclaredMethod("getColumnIndex", int.class);
+		getColumnIndex.setAccessible(true);
+		Method getColumnIndexFromOS = Tree.class.getDeclaredMethod("getColumnIndexFromOS", int.class);
+		getColumnIndexFromOS.setAccessible(true);
+		Shell shell = new Shell();
+		Tree tree = new Tree(shell, 0);
+		List<TreeColumn> treeColumns = new ArrayList<>();
+		try {
+			assertEquals(0, (int) getColumnIndexFromOS.invoke(tree, 0));
+			assertEquals(0, (int) getColumnIndexFromOS.invoke(tree, 1));
+			assertEquals(0, (int) getColumnIndex.invoke(tree, 0));
+			assertEquals(0, (int) getColumnIndex.invoke(tree, 1));
+			for (; treeColumns.size() < 12;) { // create
+				{
+					int[] columnOrder = tree.getColumnOrder();
+					assertEquals(treeColumns.size(), columnOrder.length);
+					assertEquals(treeColumns.size(), tree.getColumnCount());
+					for (int i = 0; i < treeColumns.size(); i++) {
+						assertEquals(i, (int) getColumnIndexFromOS.invoke(tree, i));
+						assertEquals(i, (int) getColumnIndex.invoke(tree, i));
+					}
+				}
+				TreeColumn treeColumn = new TreeColumn(tree, SWT.NULL);
+				treeColumns.add(treeColumn);
+			}
+
+			{ // reverse order
+				int[] reversedColumnOrder = new int[treeColumns.size()];
+				for (int i = 0; i < treeColumns.size(); i++) {
+					reversedColumnOrder[i] = treeColumns.size() - i - 1;
+				}
+				tree.setColumnOrder(reversedColumnOrder);
+				reversedColumnOrder = null;
+				int[] columnOrder = tree.getColumnOrder();
+				assertEquals(treeColumns.size(), columnOrder.length);
+				assertEquals(treeColumns.size(), tree.getColumnCount());
+				for (int i = 0; i < treeColumns.size(); i++) {
+					assertEquals(treeColumns.size() - i - 1, (int) getColumnIndexFromOS.invoke(tree, i));
+					assertEquals(treeColumns.size() - i - 1, (int) getColumnIndex.invoke(tree, i));
+				}
+			}
+			for (; !treeColumns.isEmpty();) { // remove
+				TreeColumn treeColumn = treeColumns.get(treeColumns.size() / 2);
+				treeColumn.dispose();
+				treeColumns.remove(treeColumn);
+				int[] columnOrder = tree.getColumnOrder();
+				assertEquals(treeColumns.size(), columnOrder.length);
+				assertEquals(treeColumns.size(), tree.getColumnCount());
+				for (int i = 0; i < treeColumns.size(); i++) {
+					// still reversed
+					assertEquals(treeColumns.size() - i - 1, (int) getColumnIndexFromOS.invoke(tree, i));
+					assertEquals(treeColumns.size() - i - 1, (int) getColumnIndex.invoke(tree, i));
+				}
+			}
+		} finally {
+			treeColumns.forEach(TreeColumn::dispose);
+			tree.dispose();
+			shell.dispose();
+		}
+	}
+
+	volatile static Object blackhole;
+	/** performance measurement **/
+	public static void main(String[] args) throws Exception {
+		Shell shell = new Shell();
+
+		Method getColumnIndexFromOS = Tree.class.getDeclaredMethod("getColumnIndexFromOS", int.class);
+		getColumnIndexFromOS.setAccessible(true);
+		Method getColumnRect = Tree.class.getDeclaredMethod("getColumnRect", int.class);
+		getColumnRect.setAccessible(true);
+		Method getColumnIndex = Tree.class.getDeclaredMethod("getColumnIndex", int.class);
+		getColumnIndex.setAccessible(true);
+		Tree tree = new Tree(shell, 0);
+		TreeColumn treeColumn = new TreeColumn(tree, SWT.NULL);
+		int count = 10000000;
+		try {
+			long overhead;
+			{
+				long n0 = System.nanoTime();
+				for (int i = 0; i < count; i++) {
+					blackhole = 0;
+				}
+				long n1 = System.nanoTime();
+				overhead = (n1 - n0);
+				System.out.println((n1 - n0) / count + "ns/nothing");
+				// ~ 6ns (nothing)
+			}
+			{
+				long n0 = System.nanoTime();
+				for (int i = 0; i < count; i++) {
+					blackhole = getColumnIndexFromOS.invoke(tree, 0);
+				}
+				long n1 = System.nanoTime();
+				System.out.println((n1 - n0 - overhead) / count + "ns/getColumnIndexFromOS");
+				// ~ 400ns
+			}
+			{
+				long n0 = System.nanoTime();
+				for (int i = 0; i < count; i++) {
+					blackhole = getColumnRect.invoke(tree, 0);
+				}
+				long n1 = System.nanoTime();
+				System.out.println((n1 - n0 - overhead) / count + "ns/getColumnRect");
+				// ~ 480ns
+			}
+			{
+				long n0 = System.nanoTime();
+				for (int i = 0; i < count; i++) {
+					blackhole = getColumnIndex.invoke(tree, 0);
+				}
+				long n1 = System.nanoTime();
+				System.out.println((n1 - n0 - overhead) / count + "ns/getColumnIndex");
+				// ~ 6ns (cached)
+			}
+
+		} finally {
+			treeColumn.dispose();
+			tree.dispose();
+			shell.dispose();
+		}
+	}
+}

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_TreeColumn.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_TreeColumn.java
@@ -18,6 +18,9 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.SelectionAdapter;
 import org.eclipse.swt.events.SelectionEvent;
@@ -205,6 +208,53 @@ public void test_setTextLjava_lang_String() {
 	}
 }
 
+@Test
+public void test_ColumnOrder() {
+	Tree tree = new Tree(shell, 0);
+	List<TreeColumn> treeColumns = new ArrayList<>();
+	try {
+		for (;treeColumns.size()<12;) { // create
+			int[] columnOrder = tree.getColumnOrder();
+			assertEquals(treeColumns.size(), columnOrder.length);
+			assertEquals(treeColumns.size(), tree.getColumnCount());
+			for (int i = 0; i < treeColumns.size(); i++) {
+				assertEquals(i, columnOrder[i]);
+			}
+			TreeColumn treeColumn = new TreeColumn(tree, SWT.NULL);
+			treeColumns.add(treeColumn);
+		}
+
+		{ // reverse order
+			int[] reversedColumnOrder = new int[treeColumns.size()];
+			for (int i = 0; i < treeColumns.size(); i++) {
+				reversedColumnOrder[i] = treeColumns.size() - i - 1;
+			}
+			tree.setColumnOrder(reversedColumnOrder);
+			reversedColumnOrder = null;
+			int[] columnOrder = tree.getColumnOrder();
+			assertEquals(treeColumns.size(), columnOrder.length);
+			assertEquals(treeColumns.size(), tree.getColumnCount());
+			for (int i = 0; i < treeColumns.size(); i++) {
+				assertEquals(treeColumns.size() - i - 1, columnOrder[i]);
+			}
+		}
+		for (;!treeColumns.isEmpty();) { // remove
+			TreeColumn treeColumn = treeColumns.get(treeColumns.size() / 2);
+			treeColumn.dispose();
+			treeColumns.remove(treeColumn);
+			int[] columnOrder = tree.getColumnOrder();
+			assertEquals(treeColumns.size(), columnOrder.length);
+			assertEquals(treeColumns.size(), tree.getColumnCount());
+			for (int i = 0; i < treeColumns.size(); i++) {
+				// still reversed
+				assertEquals(treeColumns.size() - i - 1, columnOrder[i]);
+			}
+		}
+	} finally {
+		treeColumns.forEach(TreeColumn::dispose);
+		tree.dispose();
+	}
+}
 /* custom */
 protected TreeColumn treeColumn;
 protected Tree tree;


### PR DESCRIPTION
Since order is frequently needed but rarely changed. Especially the index of the first column is frequently used for each TreeItem.
On Win even such simple systemcalls are more then 50 times slower then jvm internal cache.