### PR TITLE
Fix javadoc.

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/Event.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/Event.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2011 IBM Corporation and others.
+ * Copyright (c) 2000, 2022 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -204,13 +204,15 @@ public class Event {
 	 * For detailed information, see {@link Widget#setKeyState} per
 	 * platform.
 	 *
-	 * For debugging, see
-	 * <ul>
-	 *  <li>Unit tests {@link Test_org_eclipse_swt_events_KeyEvent}</li>
-	 *  <li>Files with names containing 'Issue0351_EventKeyCode'</li>
-	 * </ul>
 	 *
 	 * @see org.eclipse.swt.SWT
+	 */
+	/*
+	 * For debugging, see
+	 * <ul>
+	 *  <li>Unit tests Test_org_eclipse_swt_events_KeyEvent</li>
+	 *  <li>Files with names containing 'Issue0351_EventKeyCode'</li>
+	 * </ul>
 	 */
 	public int keyCode;
 


### PR DESCRIPTION
One can not link to tests in javadoc as javadoc for them is not generated nor it should ever be.
Moved the debugging part to plain old comment for people looking at the code.

Fixes issue created by https://github.com/eclipse-platform/eclipse.platform.swt/issues/351