### PR TITLE
Add canPaste method to StyledText

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/StyledText.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/StyledText.java
@@ -7165,6 +7165,34 @@ void paintObject(GC gc, int x, int y, int ascent, int descent, StyleRange style,
 	}
 }
 /**
+ * Detects if any of the content types in the clipboard are in a format
+ * that can be pasted into a {@code StyledText}.
+ *
+ * <p>The formats currently supported are plain text, HTML, and RTF.</p>
+ *
+ * @param clipboard the clipboard to check for supported types
+ * @return true if any of he types in clipboard can be pasted into a {@code StyledText}.
+ *
+ * @since 3.121
+ */
+public static boolean canPaste(Clipboard clipboard) {
+	TransferData[] types = clipboard.getAvailableTypes();
+	Transfer[] transfers = new Transfer[] {
+			TextTransfer.getInstance(),
+			HTMLTransfer.getInstance(),
+			RTFTransfer.getInstance()
+	};
+	for (TransferData type : types) {
+		for (Transfer transfer : transfers) {
+			if (transfer.isSupportedType(type)) {
+				System.out.printf("%s.isSupportedType(%s)", transfer, type);
+				return true;
+			}
+		}
+	}
+	return false;
+}
+/**
  * Replaces the selection with the text on the <code>DND.CLIPBOARD</code>
  * clipboard  or, if there is no selection,  inserts the text at the current
  * caret offset.   If the widget has the SWT.SINGLE style and the

--- a/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/StyledText.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/StyledText.java
@@ -7165,29 +7165,18 @@ void paintObject(GC gc, int x, int y, int ascent, int descent, StyleRange style,
 	}
 }
 /**
- * Detects if any of the content types in the clipboard are in a format
- * that can be pasted into a {@code StyledText}.
+ * Detects if the provided Clipboard content can be pasted into this widget.
  *
- * <p>The formats currently supported are plain text, HTML, and RTF.</p>
- *
- * @param clipboard the clipboard to check for paste
- * @return true if any of he types in clipboard can be pasted into a {@code StyledText}.
+ * @param clipboard the clipboard to check for paste support.
+ * @return true if any of the content in clipboard can be pasted.
  *
  * @since 3.121
  */
 public static boolean canPaste(Clipboard clipboard) {
-	TransferData[] types = clipboard.getAvailableTypes();
-	Transfer[] transfers = new Transfer[] {
-			TextTransfer.getInstance(),
-			HTMLTransfer.getInstance(),
-			RTFTransfer.getInstance()
-	};
-	for (TransferData type : types) {
-		for (Transfer transfer : transfers) {
-			if (transfer.isSupportedType(type)) {
-				System.out.printf("%s.isSupportedType(%s)", transfer, type);
-				return true;
-			}
+	Transfer textTransfer = TextTransfer.getInstance();
+	for (TransferData type : clipboard.getAvailableTypes()) {
+		if (textTransfer.isSupportedType(type)) {
+			return true;
 		}
 	}
 	return false;

--- a/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/StyledText.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/StyledText.java
@@ -7170,7 +7170,7 @@ void paintObject(GC gc, int x, int y, int ascent, int descent, StyleRange style,
  *
  * <p>The formats currently supported are plain text, HTML, and RTF.</p>
  *
- * @param clipboard the clipboard to check for supported types
+ * @param clipboard the clipboard to check for paste
  * @return true if any of he types in clipboard can be pasted into a {@code StyledText}.
  *
  * @since 3.121

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_custom_StyledText.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_custom_StyledText.java
@@ -52,6 +52,7 @@ import org.eclipse.swt.custom.TextChangeListener;
 import org.eclipse.swt.custom.VerifyKeyListener;
 import org.eclipse.swt.dnd.Clipboard;
 import org.eclipse.swt.dnd.HTMLTransfer;
+import org.eclipse.swt.dnd.ImageTransfer;
 import org.eclipse.swt.dnd.RTFTransfer;
 import org.eclipse.swt.dnd.TextTransfer;
 import org.eclipse.swt.dnd.Transfer;
@@ -64,6 +65,8 @@ import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.Font;
 import org.eclipse.swt.graphics.FontData;
 import org.eclipse.swt.graphics.GlyphMetrics;
+import org.eclipse.swt.graphics.Image;
+import org.eclipse.swt.graphics.ImageData;
 import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.graphics.RGB;
 import org.eclipse.swt.graphics.Rectangle;
@@ -2218,6 +2221,32 @@ public void test_invokeActionI() {
 	assertEquals("LineW", text.getText());
 
 	text.invokeAction(ST.TOGGLE_OVERWRITE);
+}
+
+@Test
+public void test_canPaste() {
+	Clipboard clipboard = new Clipboard(text.getDisplay());
+
+	// Put some plain text in the clipboard, supported for paste.
+	clipboard.setContents(
+			new String[] {"Line\n"},
+			new Transfer[] {TextTransfer.getInstance()});
+	assertTrue(StyledText.canPaste(clipboard));
+
+	// Put an image in the clipboard, not supported for paste into a StyledText
+	Image image = new Image(text.getDisplay(), 10, 10);
+	clipboard.setContents(
+			new ImageData[] {image.getImageData()},
+			new Transfer[] {ImageTransfer.getInstance()});
+	assertFalse(StyledText.canPaste(clipboard));
+
+	// Put some styled text. That helper method puts in the clipboard
+	// all the supported formats (plain text, RTF, and HTML).
+	rtfCopy();
+	assertTrue(StyledText.canPaste(clipboard));
+
+	clipboard.dispose();
+	image.dispose();
 }
 
 @Test


### PR DESCRIPTION
Handy to have, to make some code simpler.
See for example https://github.com/eclipse-pde/eclipse.pde/pull/363, where 14 classes have to do the same thing.
And they have to know (and keep up with) what formats `StyledText` supports.
