### PR TITLE
Issue #450 - Control.setFocus must not bring the application to front…

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Control.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Control.java
@@ -1444,7 +1444,7 @@ public boolean forceFocus () {
 	if (display.focusEvent == SWT.FocusOut) return false;
 	Decorations shell = menuShell ();
 	shell.setSavedFocus (this);
-	if (!isEnabled () || !isVisible () || !isActive ()) return false;
+	if (!isEnabled () || !isVisible () || !isActive () || display.getActiveShell() != getShell()) return false;
 	if (isFocusControl ()) return true;
 	shell.setSavedFocus (null);
 	NSView focusView = focusView ();

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Control.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Control.java
@@ -2913,7 +2913,7 @@ public boolean forceFocus () {
 	if (display.focusEvent == SWT.FocusOut) return false;
 	Shell shell = getShell ();
 	shell.setSavedFocus (this);
-	if (!isEnabled () || !isVisible ()) return false;
+	if (!isEnabled () || !isVisible () || display.getActiveShell() != getShell()) return false;
 	shell.bringToTop (false);
 	return forceFocus (focusHandle ());
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Shell.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Shell.java
@@ -1601,6 +1601,7 @@ long gtk_focus_in_event (long widget, long event) {
 	display.activePending = false;
 	if (!ignoreFocusIn) {
 		sendEvent (SWT.Activate);
+		restoreFocus();
 	} else {
 		ignoreFocusIn = false;
 	}

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Control.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Control.java
@@ -1070,7 +1070,7 @@ public boolean forceFocus () {
 	if (display.focusEvent == SWT.FocusOut) return false;
 	Decorations shell = menuShell ();
 	shell.setSavedFocus (this);
-	if (!isEnabled () || !isVisible () || !isActive ()) return false;
+	if (!isEnabled () || !isVisible () || !isActive () || display.getActiveShell() != getShell()) return false;
 	if (isFocusControl ()) return true;
 	shell.setSavedFocus (null);
 	/*


### PR DESCRIPTION
… if it is in the background

This should prevent bringing the application to front, if the active shell is different from the control's shell. The only way of changing the control that has the focus, is by invoking control.setFocus(). If the shell also should be brought to front,
control.getShell().setActive() should be invoked before invoking control.setFocus().