### PR TITLE
Bump SWT minor version segment, StyledText.dispose() moved up to super

### DIFF
--- a/bundles/org.eclipse.swt/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.swt/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.swt; singleton:=true
-Bundle-Version: 3.121.100.qualifier
+Bundle-Version: 3.122.0.qualifier
 Bundle-ManifestVersion: 2
 Bundle-Localization: plugin
 DynamicImport-Package: org.eclipse.swt.accessibility2

--- a/bundles/org.eclipse.swt/pom.xml
+++ b/bundles/org.eclipse.swt/pom.xml
@@ -21,7 +21,7 @@
     </parent>
     <groupId>org.eclipse.swt</groupId>
     <artifactId>org.eclipse.swt</artifactId>
-    <version>3.121.100-SNAPSHOT</version>
+    <version>3.122.0-SNAPSHOT</version>
     <packaging>eclipse-plugin</packaging>
 
     <properties>


### PR DESCRIPTION
Fixed API tools error. Change in #448 is compatible, but requires version bump.

See https://download.eclipse.org/eclipse/downloads/drops4/I20221031-1800/apitools/analysis/html/org.eclipse.swt/report.html