### PR TITLE
Added an option to overrule the last file dialog location on Windows

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/FileDialog.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/FileDialog.java
@@ -294,7 +294,7 @@ public String open () {
 		char[] path = (filterPath.replace('/', '\\') + "\0").toCharArray();
 		if (COM.SHCreateItemFromParsingName(path, 0, COM.IID_IShellItem, ppv) == COM.S_OK) {
 			IShellItem psi = new IShellItem(ppv[0]);
-			fileDialog.SetDefaultFolder(psi);
+			fileDialog.SetFolder(psi);
 			psi.Release();
 		}
 	}

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/FileDialog.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/FileDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2022 IBM Corporation and others.
+ * Copyright (c) 2000, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -297,6 +297,8 @@ public String open () {
 			fileDialog.SetFolder(psi);
 			psi.Release();
 		}
+	} else {
+		fileDialog.ClearClientData();
 	}
 
 	/* Set initial filename */


### PR DESCRIPTION
As suggested in https://bugs.eclipse.org/bugs/show_bug.cgi?id=577190 I made it configurable, so hopefully everyone is happy. The main reason is that it is inconsistent across platforms (only Windows "misbehaves") and your application may want to store the last saved location on its own per perspective / data type etc.

To test, run `Snippet72` on Windows. Select a file from another folder say `C:\Windows\win.ini`. Run it twice to verify it uses the preset location. Remove `setFilterForcePath` to bring back the legacy behavior where it by default will just ignore the set filter path if you used any save dialog before.