### PR TITLE
Add methods to execute tasks as CompletableFuture with a "busy" user feedback to BusyIndicator

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/SwtRunnable.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/SwtRunnable.java
@@ -1,0 +1,30 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Christoph Läubrich and others
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.swt;
+
+/**
+ * A method that returns no result and may throw a checked exception of the given
+ * type.
+ * @since 3.122
+ *
+ */
+@FunctionalInterface
+public interface SwtRunnable<E extends Exception> {
+	/**
+	 * runs a given action, or throws an exception.
+	 *
+	 * @throws E the Exception of given type
+	 */
+	void run() throws E;
+}


### PR DESCRIPTION
Currently it is very hard in SWT to have code that takes a bit longer than executed directly but do not take long enought to show "heavy" feedback to the user like a progress monitor. BusyIndicator claims to help with this task but is hard to be used correctly and cumbersume to use when it comes to further work with the result data, and the Snippet130 demonstrate this complexity quite well: https://github.com/eclipse-platform/eclipse.platform.swt/blob/master/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet130.java

This adds new methods to BusyIndicator that allows easy usage by integration using CompletableFutures. The Snippet 130 is adjusted to show this much more modern aproach that shows how easy is is to acomplish non blocking mid-lenth running operations.

This is another one towards
- https://github.com/eclipse-platform/eclipse.platform.swt/issues/64