### PR TITLE
Align 'version.suffix' property to version of o.e.swt in build.xml

### DIFF
--- a/bundles/org.eclipse.swt/build.xml
+++ b/bundles/org.eclipse.swt/build.xml
@@ -18,7 +18,7 @@
 
 	<target name="init">
 		<property name="plugin" value="org.eclipse.swt" />
-		<property name="version.suffix" value="3.120.0" />
+		<property name="version.suffix" value="3.122.100" />
 		<property name="full.name" value="${plugin}_${version.suffix}" />
 		<property name="temp.folder" value="${basedir}/temp.folder" />
 		<property name="plugin.destination" value="${basedir}" />


### PR DESCRIPTION
Maybe that build script is not used, which could by why this miss-alignment was not noted?