### PR TITLE
Revert "Issue #450 - Control.setFocus must not bring the application to front if it is in the background"

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Control.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Control.java
@@ -1444,7 +1444,7 @@ public boolean forceFocus () {
 	if (display.focusEvent == SWT.FocusOut) return false;
 	Decorations shell = menuShell ();
 	shell.setSavedFocus (this);
-	if (!isEnabled () || !isVisible () || !isActive () || display.getActiveShell() != getShell()) return false;
+	if (!isEnabled () || !isVisible () || !isActive ()) return false;
 	if (isFocusControl ()) return true;
 	shell.setSavedFocus (null);
 	NSView focusView = focusView ();

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Control.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Control.java
@@ -2913,7 +2913,7 @@ public boolean forceFocus () {
 	if (display.focusEvent == SWT.FocusOut) return false;
 	Shell shell = getShell ();
 	shell.setSavedFocus (this);
-	if (!isEnabled () || !isVisible () || display.getActiveShell() != getShell()) return false;
+	if (!isEnabled () || !isVisible ()) return false;
 	shell.bringToTop (false);
 	return forceFocus (focusHandle ());
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Shell.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Shell.java
@@ -1601,7 +1601,6 @@ long gtk_focus_in_event (long widget, long event) {
 	display.activePending = false;
 	if (!ignoreFocusIn) {
 		sendEvent (SWT.Activate);
-		restoreFocus();
 	} else {
 		ignoreFocusIn = false;
 	}

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Control.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Control.java
@@ -1070,7 +1070,7 @@ public boolean forceFocus () {
 	if (display.focusEvent == SWT.FocusOut) return false;
 	Decorations shell = menuShell ();
 	shell.setSavedFocus (this);
-	if (!isEnabled () || !isVisible () || !isActive () || display.getActiveShell() != getShell()) return false;
+	if (!isEnabled () || !isVisible () || !isActive ()) return false;
 	if (isFocusControl ()) return true;
 	shell.setSavedFocus (null);
 	/*


### PR DESCRIPTION
This reverts commit 961810fe5fb0991171cc0d0f7849fd90e0e350fa.

The change causes regression in the code that opens new shells and expects some widget to have a focus in that new shell.

See comments on
https://github.com/eclipse-platform/eclipse.platform.swt/issues/450