### PR TITLE
Skip test that fails on Linux docker image on PR validation only (#294)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -80,6 +80,7 @@ spec:
 	}
 	environment {
 		MAVEN_OPTS = "-Xmx4G"
+		PR_VALIDATION_BUILD = "true"
 	}
 	stages {
 		stage('Prepare environment') {

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_custom_StyledText.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_custom_StyledText.java
@@ -4870,6 +4870,9 @@ public void test_clickUpdatesCaretPosition() {
 
 @Test
 public void test_caretSizeAndPositionVariableGlyphMetrics() {
+	// See https://github.com/eclipse-platform/eclipse.platform.swt/issues/294
+	assumeFalse("Test doesn't work on Linux docker image in jenkins PR validation build",
+			SwtTestUtil.isLinux && Boolean.parseBoolean(System.getenv("PR_VALIDATION_BUILD")));
 	text.setText("abcd");
 	text.setMargins(2, 0, 0, 0); // keep leftMargin as it affects behavior
 	text.setLineSpacing(0);


### PR DESCRIPTION
If the problem can't be fixed / debugged properly, we should disable the test, otherwise other issues might be not noticed for new PR's.

Workaround for
https://github.com/eclipse-platform/eclipse.platform.swt/issues/294