### PR TITLE
[Build] Skip default checkout, add timestamps and only use tabs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,14 +1,16 @@
 pipeline {
 	options {
+		skipDefaultCheckout() // Specialiced checkout is performed below
+		timestamps()
 		timeout(time: 90, unit: 'MINUTES')
 		buildDiscarder(logRotator(numToKeepStr:'5'))
 		disableConcurrentBuilds(abortPrevious: true)
 	}
-  agent {
-    kubernetes {
-      label 'swtbuild-pod'
-      defaultContainer 'container'
-      yaml """
+	agent {
+		kubernetes {
+			label 'swtbuild-pod'
+			defaultContainer 'container'
+			yaml """
 apiVersion: v1
 kind: Pod
 spec:
@@ -20,7 +22,7 @@ spec:
         cpu: "100m"
       limits:
         memory: "512Mi"
-        cpu: "500m"  
+        cpu: "500m"
   - name: container
     image: akurtakov/swtbuild@sha256:43085feb91b1703e019a282188d996607385dcd746a7441cb7d2ca453a0adcc9
     tty: true
@@ -74,20 +76,23 @@ spec:
     persistentVolumeClaim:
       claimName: tools-claim-jiro-platform
 """
-    }
-  }
-  environment {
-        MAVEN_OPTS = "-Xmx4G"
-  }
+		}
+	}
+	environment {
+		MAVEN_OPTS = "-Xmx4G"
+	}
 	stages {
-		stage('Prepare-environment') {
+		stage('Prepare environment') {
 			steps {
 				container('container') {
 					dir ('eclipse.platform.swt') {
 						checkout scm
 					}
 					dir ('eclipse.platform.swt.binaries') {
-					    checkout([$class: 'GitSCM', branches: [[name: '*/master']], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'CloneOption', timeout: 120, depth: 1, shallow: true]], submoduleCfg: [], userRemoteConfigs: [[url: 'https://github.com/eclipse-platform/eclipse.platform.swt.binaries.git']]])
+						checkout([$class: 'GitSCM', branches: [[name: '*/master']],
+							extensions: [[$class: 'CloneOption', timeout: 120, depth: 1, shallow: true]],
+							userRemoteConfigs: [[url: 'https://github.com/eclipse-platform/eclipse.platform.swt.binaries.git']]
+						])
 					}
 				}
 			}
@@ -96,17 +101,24 @@ spec:
 			steps {
 				container('container') {
 					wrap([$class: 'Xvnc', useXauthority: true]) {
-					    withEnv(["JAVA_HOME=${ tool 'openjdk-jdk17-latest' }"]) {
-					        dir ('eclipse.platform.swt.binaries') {
-					    	    sh '/opt/tools/apache-maven/latest/bin/mvn --batch-mode -Pbuild-individual-bundles -DforceContextQualifier=zzz -Dnative=gtk.linux.x86_64 -Dcompare-version-with-baselines.skip=true -Dmaven.compiler.failOnWarning=true install '
-					        }
-					        dir ('eclipse.platform.swt') {
-					    	    sh '/opt/tools/apache-maven/latest/bin/mvn --batch-mode -Pbuild-individual-bundles -DcheckAllWS=true -DforkCount=0 -Dcompare-version-with-baselines.skip=false -Dmaven.compiler.failOnWarning=true \
-						    	    -Dmaven.test.failure.ignore=true -Dmaven.test.error.ignore=true \
-						    	    clean verify '
-					        }
-					    }
-				    }
+						withEnv(["JAVA_HOME=${ tool 'openjdk-jdk17-latest' }"]) {
+							dir ('eclipse.platform.swt.binaries') {
+								sh '''
+									/opt/tools/apache-maven/latest/bin/mvn install \
+										--batch-mode -Pbuild-individual-bundles -DforceContextQualifier=zzz -Dnative=gtk.linux.x86_64 \
+										-Dcompare-version-with-baselines.skip=true -Dmaven.compiler.failOnWarning=true
+								'''
+							}
+							dir ('eclipse.platform.swt') {
+								sh '''
+									/opt/tools/apache-maven/latest/bin/mvn clean verify \
+										--batch-mode -Pbuild-individual-bundles -DcheckAllWS=true -DforkCount=0 \
+										-Dcompare-version-with-baselines.skip=false -Dmaven.compiler.failOnWarning=true \
+										-Dmaven.test.failure.ignore=true -Dmaven.test.error.ignore=true
+								'''
+							}
+						}
+					}
 				}
 			}
 			post {


### PR DESCRIPTION
Skip the unncessary default check-out, because the build operates only on the later site-by-site checked-out sources of o.e.swt and o.e.swt.binaries. Skipping the default checkout can save about a minute for each verification build.

Only use tabs for indentation except for the yml section, where tabs are not supported.
And format lines to make them shorter.