### PR TITLE
[Build] Perform swt.binaries clone non-shallow to speed it up

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -89,8 +89,8 @@ spec:
 						checkout scm
 					}
 					dir ('eclipse.platform.swt.binaries') {
-						checkout([$class: 'GitSCM', branches: [[name: '*/master']],
-							extensions: [[$class: 'CloneOption', timeout: 120, depth: 1, shallow: true]],
+						checkout([$class: 'GitSCM', branches: [[name: 'refs/heads/master']],
+							extensions: [[$class: 'CloneOption', timeout: 120]],
 							userRemoteConfigs: [[url: 'https://github.com/eclipse-platform/eclipse.platform.swt.binaries.git']]
 						])
 					}


### PR DESCRIPTION
In other PRs I had the impression that a non-shallow clone significantly speed up the cloning (contrary to the intuition).