### PR TITLE
Build on standard centos-latest Jenkins agents

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,10 +29,10 @@ spec:
     command: [ "uid_entrypoint", "cat" ]
     resources:
       requests:
-        memory: "4Gi"
+        memory: "2Gi"
         cpu: "1"
       limits:
-        memory: "4Gi"
+        memory: "2Gi"
         cpu: "1"
     volumeMounts:
     - name: "settings-xml"


### PR DESCRIPTION
An attempt to fix the missing resources to start the previously specified kubernetes agents (as desribed in https://github.com/eclipse-platform/eclipse.platform.swt/issues/513#issuecomment-1371416710) by just running this repos build on the standard `centos-latest` agents.

This only works if the `centos-latest` agents are capable to build the swt-natives for gtk.linux.x86_64, but the verification build will tell us this.
A less disruptive way would probably be to require less memory (my guess is that this is the limiting factor).