### PR TITLE
#536: [GTK] Shell.open: incorrect order of bringToTop and setVisible

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Shell.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Shell.java
@@ -2029,7 +2029,6 @@ long notifyState (long object, long arg0) {
  */
 public void open () {
 	checkWidget ();
-	bringToTop (false);
 	setVisible (true);
 	if (isDisposed ()) return;
 	/*


### PR DESCRIPTION
bringToTop is ignored if the shell is not visible. Without the shell being activated, the behavior of restoreFocus requires the undesired shell activation of setFocus.