### PR TITLE
ToolItem with SWT.CHECK is not well displayed when checked and with background setted.

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ToolBar.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ToolBar.java
@@ -735,7 +735,7 @@ void layoutItems () {
 			}
 		}
 	}
-	
+
 	/*
 	 * Feature in Windows. When a tool bar is not flagged TBSTYLE_LIST already (SWT.RIGHT)
 	 * and contains both text and images, but not text + image in a single item,
@@ -1691,7 +1691,6 @@ LRESULT wmNotifyChild (NMHDR hdr, long wParam, long lParam) {
 						RECT rect = new RECT (nmcd.left, nmcd.top, nmcd.right, nmcd.bottom);
 						OS.SetDCBrushColor (nmcd.hdc, child.background);
 						OS.FillRect (nmcd.hdc, rect, OS.GetStockObject (OS.DC_BRUSH));
-						result |= OS.TBCDRF_NOBACKGROUND;
 					}
 					return new LRESULT (result);
 				}

--- a/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet153.java
+++ b/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet153.java
@@ -39,6 +39,7 @@ public static void main(String[] args) {
 	toggle.setText("Toggle Bar Colors");
 	new ToolItem(bar, SWT.SEPARATOR);
 	new ToolItem(bar, SWT.PUSH).setText("Push Button");
+	new ToolItem(bar, SWT.CHECK).setText("Check Button");
 	new ToolItem(bar, SWT.DROP_DOWN).setText("Drop Down");
 
 	toggle.addListener(SWT.Selection, event -> {


### PR DESCRIPTION
ToolItem with SWT.CHECK is not well displayed when checked and with background setted.

Fix : https://github.com/eclipse-platform/eclipse.platform.swt/issues/541