### PR TITLE
[GTK4] SegFault on X11 in Display#getCursorControl()

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Composite.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Composite.java
@@ -397,9 +397,19 @@ void createHandle (int index, boolean fixed, boolean scrolled) {
 					+ "refer to https://bugs.eclipse.org/bugs/show_bug.cgi?id=514487 for development status.").printStackTrace();
 			}
 		} else {
-			socketHandle = GTK.gtk_socket_new ();
-			if (socketHandle == 0) error (SWT.ERROR_NO_HANDLES);
-			GTK3.gtk_container_add (handle, socketHandle);
+			if (GTK.GTK4) {
+				// From Emmanuele Bassi:
+				// "[Embedding external windows is] not possible any more. Socket/plug were available only on X11,
+				// and foreign windowing system surfaces were a massive complication in the backend code."
+				if (Device.DEBUG) {
+					new SWTError (SWT.ERROR_INVALID_ARGUMENT, "SWT.EMBEDDED is not supported for GTK >= 4.")
+							.printStackTrace ();
+				}
+			} else {
+				socketHandle = GTK.gtk_socket_new ();
+				if (socketHandle == 0) error (SWT.ERROR_NO_HANDLES);
+				GTK3.gtk_container_add (handle, socketHandle);
+			}
 		}
 	}
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Display.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Display.java
@@ -1903,12 +1903,12 @@ public Control getCursorControl () {
 		}
 		handle = user_data [0];
 	} else {
-		/*
-		* Feature in GTK. gdk_window_at_pointer() will not return a window
-		* if the pointer is over a foreign embedded window. The fix is to use
-		* XQueryPointer to find the containing GDK window.
-		*/
-		if (!OS.isX11()) return null;
+		// Feature in GTK. The gdk_device_get_[surface/window]_at_position() functions will not return a
+		// surface/window if the pointer is over a foreign embedded window. The fix is to use XQueryPointer
+		// to find the containing GDK window (see bug 177368.)
+		// However embedding foreign windows is not supported by the Wayland backend for GTK3 and is not
+		// supported at all on GTK4, so skip the heuristic in these situations.
+		if (!OS.isX11() || GTK.GTK4) return null;
 		long gdkDisplay = GDK.gdk_display_get_default();
 		if (OS.isX11()) {
 			GDK.gdk_x11_display_error_trap_push(gdkDisplay);


### PR DESCRIPTION
SWT segfaults using GTK4/X11 backend when moving the mouse cursor out of the window:

Reproducer:

```
	public static void main(String[] args) {
		final Display display = new Display();
		Shell shell = new Shell(display);
		shell.setLayout(new FillLayout());
		
		Text text = new Text(shell,SWT.NONE);
		text.setText("This is a text box.");

		shell.setText("GTK4Test");
		shell.open();
		while (!shell.isDisposed()) {
			if (!display.readAndDispatch()) {
				display.sleep();
			}
		}
		display.dispose();
	}
```

To reproduce, move mouse into, and then out of, the application window.

Resulting seg fault looks like this:

```
Stack: [0x00007f1c5c100000,0x00007f1c5c200000],  sp=0x00007f1c5c1fd2e8,  free space=1012k
Native frames: (J=compiled Java code, A=aot compiled Java code, j=interpreted, Vv=VM code, C=native code)
C  [libX11.so.6+0x31244]  XDefaultRootWindow+0x4
j  org.eclipse.swt.internal.gtk.OS.XDefaultRootWindow(J)J+0
j  org.eclipse.swt.widgets.Display.getCursorControl()Lorg/eclipse/swt/widgets/Control;+143
j  org.eclipse.swt.widgets.Control.gtk4_leave_event(JJ)V+34
j  org.eclipse.swt.widgets.Widget.leaveProc(JJJ)V+32
j  org.eclipse.swt.widgets.Display.leaveProc(JJ)V+25
v  ~StubRoutines::call_stub
V  [libjvm.so+0x8cd9db]  JavaCalls::call_helper(JavaValue*, methodHandle const&, JavaCallArguments*, Thread*)+0x3bb
V  [libjvm.so+0x952cac]  jni_invoke_nonstatic(JNIEnv_*, JavaValue*, _jobject*, JNICallType, _jmethodID*, JNI_ArgumentPusher*, Thread*) [clone .constprop.2]+0x2dc
V  [libjvm.so+0x955cb6]  jni_CallLongMethodV+0x166
C  [libswt-gtk-4958r2.so+0x867f6]  callback+0x50b
C  [libswt-gtk-4958r2.so+0x43c59]  fn14_2+0x2a
C  [libgobject-2.0.so.0+0x30b79]  g_signal_emit_valist+0x11f9
C  [libgobject-2.0.so.0+0x30cb3]  g_signal_emit+0x93

Java frames: (J=compiled Java code, j=interpreted, Vv=VM code)
j  org.eclipse.swt.internal.gtk.OS.XDefaultRootWindow(J)J+0
j  org.eclipse.swt.widgets.Display.getCursorControl()Lorg/eclipse/swt/widgets/Control;+143
j  org.eclipse.swt.widgets.Control.gtk4_leave_event(JJ)V+34
j  org.eclipse.swt.widgets.Widget.leaveProc(JJJ)V+32
j  org.eclipse.swt.widgets.Display.leaveProc(JJ)V+25
v  ~StubRoutines::call_stub
J 232  org.eclipse.swt.internal.gtk.OS.g_main_context_iteration(JZ)Z (0 bytes) @ 0x00007f1c482d8594 [0x00007f1c482d8540+0x0000000000000054]
J 233 c1 org.eclipse.swt.widgets.Display.readAndDispatch()Z (88 bytes) @ 0x00007f1c40ddbab4 [0x00007f1c40ddb8e0+0x00000000000001d4]
j  gtk4.Main.main([Ljava/lang/String;)V+58
v  ~StubRoutines::call_stub
```

We shouldn't use the `XDefaultRootWindow` Xlib function in GTK4 (the GTK3->4 migration guide says if we really *really* wanted to access the root window, we would call `gdk_x11_display_get_xrootwindow` instead.)

But we don't actually need to access the root window at all here.

The failing code was added in 11d9126 as a workaround for problems with detecting when the cursor is still over the application window when the cursor is over an embedded external window. However Emmanuele Bassi says that [embedding external windows is intentionally not supported on GTK4 ](https://www.reddit.com/r/gnome/comments/10vi4oo/gtk4_embedding_external_window/j7hwlpu/) so we can skip the workaround in this case.

Signed-off-by: Mat Booth <mat.booth@gmail.com>