### PR TITLE
#450/Bug 578929 - Control.setFocus brings windows to front

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Control.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Control.java
@@ -1461,6 +1461,7 @@ public boolean forceFocus () {
 	Decorations shell = menuShell ();
 	shell.setSavedFocus (this);
 	if (!isEnabled () || !isVisible () || !isActive ()) return false;
+	if (display.getActiveShell() != shell && !Display.isActivateShellOnForceFocus()) return false;
 	if (isFocusControl ()) return true;
 	shell.setSavedFocus (null);
 	NSView focusView = focusView ();

--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Display.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Display.java
@@ -6946,4 +6946,7 @@ static long windowProc(long id, long sel, long arg0, long arg1, long arg2, long 
 	}
 }
 
+static boolean isActivateShellOnForceFocus() {
+	return "true".equals(System.getProperty("org.eclipse.swt.internal.activateShellOnForceFocus", "false")); //$NON-NLS-1$
+}
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Control.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Control.java
@@ -2944,6 +2944,7 @@ public boolean forceFocus () {
 	Shell shell = getShell ();
 	shell.setSavedFocus (this);
 	if (!isEnabled () || !isVisible ()) return false;
+	if (display.getActiveShell() != shell && !Display.isActivateShellOnForceFocus()) return false;
 	shell.bringToTop (false);
 	return forceFocus (focusHandle ());
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Display.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Display.java
@@ -6244,4 +6244,7 @@ static int _getDeviceZoom (long monitor_num) {
 	return DPIUtil.mapDPIToZoom (dpi);
 }
 
+static boolean isActivateShellOnForceFocus() {
+	return "true".equals(System.getProperty("org.eclipse.swt.internal.activateShellOnForceFocus", "false")); //$NON-NLS-1$
+}
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Shell.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Shell.java
@@ -1604,6 +1604,7 @@ long gtk_focus_in_event (long widget, long event) {
 	} else {
 		ignoreFocusIn = false;
 	}
+	restoreFocus();
 	return 0;
 }
 
@@ -2030,6 +2031,8 @@ long notifyState (long object, long arg0) {
 public void open () {
 	checkWidget ();
 	setVisible (true);
+	// force is necessary, because otherwise it won't do anything
+	bringToTop (true);
 	if (isDisposed ()) return;
 	/*
 	 * When no widget has been given focus, or another push button has focus,

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Control.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Control.java
@@ -1071,6 +1071,7 @@ public boolean forceFocus () {
 	Decorations shell = menuShell ();
 	shell.setSavedFocus (this);
 	if (!isEnabled () || !isVisible () || !isActive ()) return false;
+	if (display.getActiveShell() != shell && !Display.isActivateShellOnForceFocus()) return false;
 	if (isFocusControl ()) return true;
 	shell.setSavedFocus (null);
 	/*

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Display.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Display.java
@@ -5194,4 +5194,7 @@ static char [] withCrLf (char [] string) {
 	return result;
 }
 
+static boolean isActivateShellOnForceFocus() {
+	return "true".equals(System.getProperty("org.eclipse.swt.internal.activateShellOnForceFocus", "false")); //$NON-NLS-1$
+}
 }


### PR DESCRIPTION
If the application is in the background and the GUI is updated, especially a different control is getting focused, it might happen that the shell will be brought to front. This patch should fix that.

To get the previous behavior (activate the shell on control.forceFocus(), set the system property
"org.eclipse.swt.internal.activateShellOnForceFocus" to "true").

If you want an application window be brought to front, instead of relying on control.forceFocus() to bring the shell to front, use shell.forceActive().

Shell.open: an explicit bringToTop() is needed now, because the implicit one from setFocus/forceFocus() is not happening any more. For the first shell it needs to be forced, because otherwise it won't do anything (display.activeShell is null).