### PR TITLE
[GTK4] Linkage error in Buttons with SWT.ARROW style

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/gtk4.c
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/gtk4.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2022 IBM Corporation and others.
+ * Copyright (c) 2000, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -833,6 +833,20 @@ fail:
 	if (arg0 && lparg0) (*env)->ReleaseByteArrayElements(env, arg0, lparg0, 0);
 	GTK4_NATIVE_EXIT(env, that, gtk_1image_1new_1from_1icon_1name_FUNC);
 	return rc;
+}
+#endif
+
+#ifndef NO_gtk_1image_1set_1from_1icon_1name
+JNIEXPORT void JNICALL GTK4_NATIVE(gtk_1image_1set_1from_1icon_1name)
+	(JNIEnv *env, jclass that, jlong arg0, jbyteArray arg1)
+{
+	jbyte *lparg1=NULL;
+	GTK4_NATIVE_ENTER(env, that, gtk_1image_1set_1from_1icon_1name_FUNC);
+	if (arg1) if ((lparg1 = (*env)->GetByteArrayElements(env, arg1, NULL)) == NULL) goto fail;
+	gtk_image_set_from_icon_name((GtkImage *)arg0, (const gchar *)lparg1);
+fail:
+	if (arg1 && lparg1) (*env)->ReleaseByteArrayElements(env, arg1, lparg1, 0);
+	GTK4_NATIVE_EXIT(env, that, gtk_1image_1set_1from_1icon_1name_FUNC);
 }
 #endif
 

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/gtk4_stats.c
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/gtk4_stats.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2022 IBM Corporation and others.
+ * Copyright (c) 2000, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -89,6 +89,7 @@ char * GTK4_nativeFunctionNames[] = {
 	"gtk_1im_1context_1filter_1keypress",
 	"gtk_1image_1clear",
 	"gtk_1image_1new_1from_1icon_1name",
+	"gtk_1image_1set_1from_1icon_1name",
 	"gtk_1image_1set_1from_1paintable",
 	"gtk_1init_1check",
 	"gtk_1keyval_1trigger_1new",

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/gtk4_stats.h
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/gtk4_stats.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2022 IBM Corporation and others.
+ * Copyright (c) 2000, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -99,6 +99,7 @@ typedef enum {
 	gtk_1im_1context_1filter_1keypress_FUNC,
 	gtk_1image_1clear_FUNC,
 	gtk_1image_1new_1from_1icon_1name_FUNC,
+	gtk_1image_1set_1from_1icon_1name_FUNC,
 	gtk_1image_1set_1from_1paintable_FUNC,
 	gtk_1init_1check_FUNC,
 	gtk_1keyval_1trigger_1new_FUNC,

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/org/eclipse/swt/internal/gtk4/GTK4.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/org/eclipse/swt/internal/gtk4/GTK4.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Syntevo and others.
+ * Copyright (c) 2021, 2023 Syntevo and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -474,6 +474,11 @@ public class GTK4 {
 	public static final native void gtk_image_set_from_paintable(long image, long paintable);
 	/** @param icon_name cast=(const char *) */
 	public static final native long gtk_image_new_from_icon_name(byte[] icon_name);
+	/**
+	 * @param image cast=(GtkImage *)
+	 * @param icon_name cast=(const gchar *)
+	 */
+	public static final native void gtk_image_set_from_icon_name(long image, byte[] icon_name);
 	/** @param image cast=(GtkImage *) */
 	public static final native void gtk_image_clear(long image);
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Button.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Button.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2022 IBM Corporation and others.
+ * Copyright (c) 2000, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -851,7 +851,11 @@ void _setAlignment (int alignment) {
 			case SWT.LEFT: arrowType = isRTL ? GTK.GTK_NAMED_ICON_GO_NEXT : GTK.GTK_NAMED_ICON_GO_PREVIOUS; break;
 			case SWT.RIGHT: arrowType = isRTL ? GTK.GTK_NAMED_ICON_GO_PREVIOUS : GTK.GTK_NAMED_ICON_GO_NEXT; break;
 		}
-		GTK3.gtk_image_set_from_icon_name (arrowHandle, arrowType, GTK.GTK_ICON_SIZE_MENU);
+		if (GTK.GTK4) {
+			GTK4.gtk_image_set_from_icon_name (arrowHandle, arrowType);
+		} else {
+			GTK3.gtk_image_set_from_icon_name (arrowHandle, arrowType, GTK.GTK_ICON_SIZE_MENU);
+		}
 		return;
 	}
 	if ((alignment & (SWT.LEFT | SWT.RIGHT | SWT.CENTER)) == 0) return;
@@ -1184,10 +1188,14 @@ void setOrientation (boolean create) {
 		if (labelHandle != 0) GTK.gtk_widget_set_direction (labelHandle, dir);
 		if (imageHandle != 0) GTK.gtk_widget_set_direction (imageHandle, dir);
 		if (arrowHandle != 0) {
-			byte[] arrowType  = (style & SWT.RIGHT_TO_LEFT) != 0 ? GTK.GTK_NAMED_ICON_GO_NEXT : GTK.GTK_NAMED_ICON_GO_PREVIOUS;
-			switch (style & (SWT.LEFT | SWT.RIGHT)) {
-				case SWT.LEFT: GTK3.gtk_image_set_from_icon_name (arrowHandle, arrowType, GTK.GTK_ICON_SIZE_MENU); break;
-				case SWT.RIGHT: GTK3.gtk_image_set_from_icon_name (arrowHandle, arrowType, GTK.GTK_ICON_SIZE_MENU); break;
+			if ((style & (SWT.LEFT | SWT.RIGHT)) != 0) {
+				byte[] arrowType = (style & SWT.RIGHT_TO_LEFT) != 0 ? GTK.GTK_NAMED_ICON_GO_NEXT
+						: GTK.GTK_NAMED_ICON_GO_PREVIOUS;
+				if (GTK.GTK4) {
+					GTK4.gtk_image_set_from_icon_name (arrowHandle, arrowType);
+				} else {
+					GTK3.gtk_image_set_from_icon_name (arrowHandle, arrowType, GTK.GTK_ICON_SIZE_MENU);
+				}
 			}
 		}
 	}

--- a/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet366.java
+++ b/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet366.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2016 Red Hat Inc.
+ * Copyright (c) 2015, 2023 Red Hat Inc and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -16,6 +16,7 @@ package org.eclipse.swt.snippets;
 import java.util.concurrent.atomic.*;
 
 import org.eclipse.swt.*;
+import org.eclipse.swt.events.*;
 import org.eclipse.swt.layout.*;
 import org.eclipse.swt.widgets.*;
 
@@ -54,21 +55,21 @@ public class Snippet366 {
 		orientationGroup.setText ("Orientation group");
 
 		final AtomicInteger prevDir = new AtomicInteger (0);
-		final Button alignmentButton = new Button (orientationGroup, SWT.ARROW | SWT.RIGHT);
-		alignmentButton.addListener (SWT.MouseDown, event -> {
+		final Button orientationButton = new Button (orientationGroup, SWT.ARROW | SWT.RIGHT);
+		orientationButton.addSelectionListener (SelectionListener.widgetSelectedAdapter (event -> {
 			switch (prevDir.get ()) {
 				case 0:
-					alignmentButton.setOrientation (SWT.LEFT_TO_RIGHT);
+					orientationButton.setOrientation (SWT.LEFT_TO_RIGHT);
 					prevDir.set (1);
 					break;
 				case 1:
-					alignmentButton.setOrientation (SWT.RIGHT_TO_LEFT);
+					orientationButton.setOrientation (SWT.RIGHT_TO_LEFT);
 					prevDir.set (0);
 					break;
 				default:
 					break;
 			}
-		});
+		}));
 	}
 
 	private static void makeAlignGroup () {
@@ -78,7 +79,7 @@ public class Snippet366 {
 
 		final AtomicInteger prevDir = new AtomicInteger (0);
 		final Button alignmentButton = new Button (alignGroup, SWT.ARROW | SWT.UP);
-		alignmentButton.addListener (SWT.MouseDown, event -> {
+		alignmentButton.addSelectionListener (SelectionListener.widgetSelectedAdapter (event -> {
 			switch (prevDir.get ()) {
 				case 0:
 					alignmentButton.setAlignment (SWT.RIGHT);
@@ -98,7 +99,7 @@ public class Snippet366 {
 				default:
 					break;
 			}
-		});
+		}));
 	}
 
 	private static void makeArrowGroup () {

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Button.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Button.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corporation and others.
+ * Copyright (c) 2000, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -163,7 +163,7 @@ public void test_setAlignmentI() {
 	button.setAlignment(SWT.UP); // bad value for push button
 	assertNotEquals(SWT.UP, button.getAlignment());
 
-
+	// Test setting the direction of the arrow icon for arrow icon buttons
 	Button arrowButton = new Button(shell, SWT.ARROW);
 	arrowButton.setAlignment(SWT.LEFT);
 	assertEquals(SWT.LEFT, arrowButton.getAlignment());
@@ -184,6 +184,28 @@ public void test_setAlignmentI() {
 	int alignment = 55; // some bogus number
 	button.setAlignment(alignment);
 	assertNotEquals(alignment, button.getAlignment());
+}
+
+@Test
+public void test_setOrientation() {
+	button.setOrientation (SWT.RIGHT_TO_LEFT);
+	assertEquals(SWT.RIGHT_TO_LEFT, button.getOrientation());
+
+	button.setOrientation (SWT.LEFT_TO_RIGHT);
+	assertEquals(SWT.LEFT_TO_RIGHT, button.getOrientation());
+
+	// Test setting the orientation of the arrow icon for arrow icon buttons
+	Button arrowButton = new Button(shell, SWT.ARROW | SWT.RIGHT);
+	arrowButton.setOrientation (SWT.LEFT_TO_RIGHT);
+	assertEquals(SWT.LEFT_TO_RIGHT, arrowButton.getOrientation());
+
+	arrowButton.setOrientation (SWT.RIGHT_TO_LEFT);
+	assertEquals(SWT.RIGHT_TO_LEFT, arrowButton.getOrientation());
+	arrowButton.dispose();
+
+	int alignment = 55; // some bogus number
+	button.setOrientation(alignment);
+	assertNotEquals(alignment, button.getOrientation());
 }
 
 @Test

--- a/tests/org.eclipse.swt.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.swt.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.swt.tests
-Bundle-Version: 3.106.2000.qualifier
+Bundle-Version: 3.106.2100.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.swt.tests.junit,

--- a/tests/org.eclipse.swt.tests/pom.xml
+++ b/tests/org.eclipse.swt.tests/pom.xml
@@ -19,7 +19,7 @@
   </parent>
   <groupId>org.eclipse.swt</groupId>
   <artifactId>org.eclipse.swt.tests</artifactId>
-  <version>3.106.2000-SNAPSHOT</version>
+  <version>3.106.2100-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
   <properties>
     <code.ignoredWarnings>${tests.ignoredWarnings}</code.ignoredWarnings>


### PR DESCRIPTION
When setting the alignment or orientation of arrow buttons we get a UnsatisfiedLinkError, which can be seen in a GTK4 unit test failure and in the non-functioning of SWT Snippet366:

```
Exception in thread "main" java.lang.UnsatisfiedLinkError: 'void org.eclipse.swt.internal.gtk3.GTK3.gtk_image_set_from_icon_name(long, byte[], int)'
	at org.eclipse.swt.internal.gtk3.GTK3.gtk_image_set_from_icon_name(Native Method)
	at org.eclipse.swt.widgets.Button.setOrientation(Button.java:1190)
	at org.eclipse.swt.widgets.Control.setOrientation(Control.java:5808)
	at org.eclipse.swt.snippets.Snippet366.lambda$0(Snippet366.java:62)
	at org.eclipse.swt.events.SelectionListener$1.widgetSelected(SelectionListener.java:84)
	at org.eclipse.swt.widgets.TypedListener.handleEvent(TypedListener.java:252)
	at org.eclipse.swt.widgets.EventTable.sendEvent(EventTable.java:89)
	at org.eclipse.swt.widgets.Display.sendEvent(Display.java:5855)
	at org.eclipse.swt.widgets.Widget.sendEvent(Widget.java:1529)
	at org.eclipse.swt.widgets.Display.runDeferredEvents(Display.java:5065)
	at org.eclipse.swt.widgets.Display.readAndDispatch(Display.java:4517)
	at org.eclipse.swt.snippets.Snippet366.main(Snippet366.java:46)
```

Add a new GTK4 function `gtk_image_set_from_icon_name()` which is the same as the GTK3 version but with fewer arguments, and call it instead when on GTK4.

This change fixes the `Button#test_setAlignmentI` unit test when run on GTK4 and adds a new test `Button#test_setOrientation` to cover the orientation case.

Also, update Snippet366 to make it more correct (i.e. use selection listener instead of mousedown listener since some platforms might swallow the mousedown event for buttons.)