### PR TITLE
[Linux] Fix natives build when NATIVE_STATS enabled

### DIFF
--- a/bundles/org.eclipse.swt.tools/JNI Generation/org/eclipse/swt/tools/internal/StatsGenerator.java
+++ b/bundles/org.eclipse.swt.tools/JNI Generation/org/eclipse/swt/tools/internal/StatsGenerator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2004, 2013 IBM Corporation and others.
+ * Copyright (c) 2004, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -122,15 +122,21 @@ void generateSourceFile(JNIClass clazz) {
 		if (progress != null) progress.step();
 	}
 	outputln("};");
-	output("#define NATIVE_FUNCTION_COUNT sizeof(");
+	output("#define ");
+	output(className);
+	output("_NATIVE_FUNCTION_COUNT sizeof(");
 	output(className);
 	outputln("_nativeFunctionNames) / sizeof(char*)");
 	output("int ");
 	output(className);
-	outputln("_nativeFunctionCount = NATIVE_FUNCTION_COUNT;");
+	output("_nativeFunctionCount = ");
+	output(className);
+	outputln("_NATIVE_FUNCTION_COUNT;");
 	output("int ");
 	output(className);
-	outputln("_nativeFunctionCallCount[NATIVE_FUNCTION_COUNT];");
+	output("_nativeFunctionCallCount[");
+	output(className);
+	outputln("_NATIVE_FUNCTION_COUNT];");
 	outputln();
 	generateStatsNatives(className);
 	outputln();

--- a/bundles/org.eclipse.swt.tools/NativeStats/org/eclipse/swt/tools/internal/NativeStats.java
+++ b/bundles/org.eclipse.swt.tools/NativeStats/org/eclipse/swt/tools/internal/NativeStats.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2004, 2016 IBM Corporation and others.
+ * Copyright (c) 2004, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -18,7 +18,7 @@ import java.lang.reflect.*;
 import java.util.*;
 
 /**
- * Instructions on how to use the NativeStats tool with a standlaone SWT example:
+ * Instructions on how to use the NativeStats tool with a standalone SWT example:
  * 
  * 1) Compile the SWT native libraries defining the NATIVE_STATS flag (i.e. uncomment line in makefile).
  * 2) Add the following code around the sections of interest to dump the
@@ -39,9 +39,8 @@ public class NativeStats {
 	
 	Map<String, NativeFunction[]> snapshot;
 	
-	final static String[] classes = new String[]{"OS", "ATK", "GTK", "XPCOM", "COM", "AGL", "Gdip", "GLX", "Cairo", "WGL"};
+	final static String[] classes = new String[]{"OS", "ATK", "GDK", "GTK", "GTK3", "GTK4", "Graphene", "XPCOM", "COM", "AGL", "Gdip", "GLX", "Cairo", "WGL"};
 
-	
 	public static class NativeFunction implements Comparable<Object> {
 		String name;
 		int callCount;
@@ -184,9 +183,25 @@ public static final native int GLX_GetFunctionCount();
 public static final native String GLX_GetFunctionName(int index);
 public static final native int GLX_GetFunctionCallCount(int index);
 
+public static final native int GDK_GetFunctionCount();
+public static final native String GDK_GetFunctionName(int index);
+public static final native int GDK_GetFunctionCallCount(int index);
+
 public static final native int GTK_GetFunctionCount();
 public static final native String GTK_GetFunctionName(int index);
 public static final native int GTK_GetFunctionCallCount(int index);
+
+public static final native int GTK3_GetFunctionCount();
+public static final native String GTK3_GetFunctionName(int index);
+public static final native int GTK3_GetFunctionCallCount(int index);
+
+public static final native int GTK4_GetFunctionCount();
+public static final native String GTK4_GetFunctionName(int index);
+public static final native int GTK4_GetFunctionCallCount(int index);
+
+public static final native int Graphene_GetFunctionCount();
+public static final native String Graphene_GetFunctionName(int index);
+public static final native int Graphene_GetFunctionCallCount(int index);
 
 public static final native int XPCOM_GetFunctionCount();
 public static final native String XPCOM_GetFunctionName(int index);

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/atk_stats.c
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/atk_stats.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corporation and others. All rights reserved.
+ * Copyright (c) 2000, 2023 IBM Corporation and others. All rights reserved.
  * The contents of this file are made available under the terms
  * of the GNU Lesser General Public License (LGPL) Version 2.1 that
  * accompanies this distribution (lgpl-v21.txt).  The LGPL is also
@@ -67,9 +67,9 @@ char * ATK_nativeFunctionNames[] = {
 	"memmove__Lorg_eclipse_swt_internal_accessibility_gtk_AtkTextRectangle_2JI",
 	"memmove__Lorg_eclipse_swt_internal_accessibility_gtk_AtkValueIface_2J",
 };
-#define NATIVE_FUNCTION_COUNT sizeof(ATK_nativeFunctionNames) / sizeof(char*)
-int ATK_nativeFunctionCount = NATIVE_FUNCTION_COUNT;
-int ATK_nativeFunctionCallCount[NATIVE_FUNCTION_COUNT];
+#define ATK_NATIVE_FUNCTION_COUNT sizeof(ATK_nativeFunctionNames) / sizeof(char*)
+int ATK_nativeFunctionCount = ATK_NATIVE_FUNCTION_COUNT;
+int ATK_nativeFunctionCallCount[ATK_NATIVE_FUNCTION_COUNT];
 
 #define STATS_NATIVE(func) Java_org_eclipse_swt_tools_internal_NativeStats_##func
 

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/gtk3_stats.c
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/gtk3_stats.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2022 IBM Corporation and others.
+ * Copyright (c) 2000, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -249,9 +249,9 @@ char * GTK3_nativeFunctionNames[] = {
 	"memmove__Lorg_eclipse_swt_internal_gtk3_GdkEventMotion_2JJ",
 	"memmove__Lorg_eclipse_swt_internal_gtk3_GdkEventWindowState_2JJ",
 };
-#define NATIVE_FUNCTION_COUNT sizeof(GTK3_nativeFunctionNames) / sizeof(char*)
-int GTK3_nativeFunctionCount = NATIVE_FUNCTION_COUNT;
-int GTK3_nativeFunctionCallCount[NATIVE_FUNCTION_COUNT];
+#define GTK3_NATIVE_FUNCTION_COUNT sizeof(GTK3_nativeFunctionNames) / sizeof(char*)
+int GTK3_nativeFunctionCount = GTK3_NATIVE_FUNCTION_COUNT;
+int GTK3_nativeFunctionCallCount[GTK3_NATIVE_FUNCTION_COUNT];
 
 #define STATS_NATIVE(func) Java_org_eclipse_swt_tools_internal_NativeStats_##func
 

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/gtk4_stats.c
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/gtk4_stats.c
@@ -156,9 +156,9 @@ char * GTK4_nativeFunctionNames[] = {
 	"gtk_1window_1set_1icon_1name",
 	"gtk_1window_1unminimize",
 };
-#define NATIVE_FUNCTION_COUNT sizeof(GTK4_nativeFunctionNames) / sizeof(char*)
-int GTK4_nativeFunctionCount = NATIVE_FUNCTION_COUNT;
-int GTK4_nativeFunctionCallCount[NATIVE_FUNCTION_COUNT];
+#define GTK4_NATIVE_FUNCTION_COUNT sizeof(GTK4_nativeFunctionNames) / sizeof(char*)
+int GTK4_nativeFunctionCount = GTK4_NATIVE_FUNCTION_COUNT;
+int GTK4_nativeFunctionCallCount[GTK4_NATIVE_FUNCTION_COUNT];
 
 #define STATS_NATIVE(func) Java_org_eclipse_swt_tools_internal_NativeStats_##func
 

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/make_linux.mak
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/make_linux.mak
@@ -74,7 +74,11 @@ ATKLIBS = `pkg-config --libs-only-L atk` -latk-1.0
 GLXLIBS = -lGL -lGLU -lm
 
 # Uncomment for Native Stats tool
-#NATIVE_STATS = -DNATIVE_STATS
+#SWT_NATIVE_STATS=1
+# Can be set via environment like: export SWT_NATIVE_STATS=1
+ifdef SWT_NATIVE_STATS
+NATIVE_STATS = -DNATIVE_STATS
+endif
 
 WEBKITLIBS = `pkg-config --libs-only-l gio-2.0`
 WEBKITCFLAGS = `pkg-config --cflags gio-2.0`

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/os_stats.c
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/os_stats.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2022 IBM Corporation and others. All rights reserved.
+ * Copyright (c) 2000, 2023 IBM Corporation and others. All rights reserved.
  * The contents of this file are made available under the terms
  * of the GNU Lesser General Public License (LGPL) Version 2.1 that
  * accompanies this distribution (lgpl-v21.txt).  The LGPL is also
@@ -237,9 +237,9 @@ char * GDK_nativeFunctionNames[] = {
 	"gdk_1x11_1window_1get_1xid",
 	"gdk_1x11_1window_1lookup_1for_1display",
 };
-#define NATIVE_FUNCTION_COUNT sizeof(GDK_nativeFunctionNames) / sizeof(char*)
-int GDK_nativeFunctionCount = NATIVE_FUNCTION_COUNT;
-int GDK_nativeFunctionCallCount[NATIVE_FUNCTION_COUNT];
+#define GDK_NATIVE_FUNCTION_COUNT sizeof(GDK_nativeFunctionNames) / sizeof(char*)
+int GDK_nativeFunctionCount = GDK_NATIVE_FUNCTION_COUNT;
+int GDK_nativeFunctionCallCount[GDK_NATIVE_FUNCTION_COUNT];
 
 #define STATS_NATIVE(func) Java_org_eclipse_swt_tools_internal_NativeStats_##func
 
@@ -817,9 +817,9 @@ char * GTK_nativeFunctionNames[] = {
 	"gtk_1window_1unfullscreen",
 	"gtk_1window_1unmaximize",
 };
-#define NATIVE_FUNCTION_COUNT sizeof(GTK_nativeFunctionNames) / sizeof(char*)
-int GTK_nativeFunctionCount = NATIVE_FUNCTION_COUNT;
-int GTK_nativeFunctionCallCount[NATIVE_FUNCTION_COUNT];
+#define GTK_NATIVE_FUNCTION_COUNT sizeof(GTK_nativeFunctionNames) / sizeof(char*)
+int GTK_nativeFunctionCount = GTK_NATIVE_FUNCTION_COUNT;
+int GTK_nativeFunctionCallCount[GTK_NATIVE_FUNCTION_COUNT];
 
 #define STATS_NATIVE(func) Java_org_eclipse_swt_tools_internal_NativeStats_##func
 
@@ -849,9 +849,9 @@ char * Graphene_nativeFunctionNames[] = {
 	"graphene_1rect_1free",
 	"graphene_1rect_1init",
 };
-#define NATIVE_FUNCTION_COUNT sizeof(Graphene_nativeFunctionNames) / sizeof(char*)
-int Graphene_nativeFunctionCount = NATIVE_FUNCTION_COUNT;
-int Graphene_nativeFunctionCallCount[NATIVE_FUNCTION_COUNT];
+#define Graphene_NATIVE_FUNCTION_COUNT sizeof(Graphene_nativeFunctionNames) / sizeof(char*)
+int Graphene_nativeFunctionCount = Graphene_NATIVE_FUNCTION_COUNT;
+int Graphene_nativeFunctionCallCount[Graphene_NATIVE_FUNCTION_COUNT];
 
 #define STATS_NATIVE(func) Java_org_eclipse_swt_tools_internal_NativeStats_##func
 
@@ -1273,9 +1273,9 @@ char * OS_nativeFunctionNames[] = {
 	"swt_1set_1lock_1functions",
 	"ubuntu_1menu_1proxy_1get",
 };
-#define NATIVE_FUNCTION_COUNT sizeof(OS_nativeFunctionNames) / sizeof(char*)
-int OS_nativeFunctionCount = NATIVE_FUNCTION_COUNT;
-int OS_nativeFunctionCallCount[NATIVE_FUNCTION_COUNT];
+#define OS_NATIVE_FUNCTION_COUNT sizeof(OS_nativeFunctionNames) / sizeof(char*)
+int OS_nativeFunctionCount = OS_NATIVE_FUNCTION_COUNT;
+int OS_nativeFunctionCallCount[OS_NATIVE_FUNCTION_COUNT];
 
 #define STATS_NATIVE(func) Java_org_eclipse_swt_tools_internal_NativeStats_##func
 


### PR DESCRIPTION
When native stats collection is enabled, i.e. by passing `-DNATIVE_STATS` to the compiler then the natives fail to build:

```
os_stats.c:820: error: "NATIVE_FUNCTION_COUNT" redefined [-Werror]
  820 | #define NATIVE_FUNCTION_COUNT sizeof(GTK_nativeFunctionNames) /
      sizeof(char*)
os_stats.c:240: note: this is the location of the previous definition
  240 | #define NATIVE_FUNCTION_COUNT sizeof(GDK_nativeFunctionNames) /
      sizeof(char*)
```

This change causes the generator to prefix the NATIVE_FUNCTION_COUNT macro name with the class whose native functions are being counted and includes regenerated *_stats.c files.

The change also fixes up the NativeStats tool to know about the discrete GTK libraries and allows native stats tool to be activated by environment variable instead of requiring user to manually change the makefile.