### PR TITLE
Issue #591: Fix test failure on MacOS

### DIFF
--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Button.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Button.java
@@ -188,6 +188,15 @@ public void test_setAlignmentI() {
 
 @Test
 public void test_setOrientation() {
+	if (SwtTestUtil.isCocoa) {
+		// Button#setOrientation() does nothing on MacOS
+		if (SwtTestUtil.verbose) {
+			System.out.println(
+					"Excluded test_setOrientation(org.eclipse.swt.tests.junit.Test_org_eclipse_swt_widgets_Button).");
+		}
+		return;
+	}
+
 	button.setOrientation (SWT.RIGHT_TO_LEFT);
 	assertEquals(SWT.RIGHT_TO_LEFT, button.getOrientation());
 


### PR DESCRIPTION
The test was introduced as part of dfaed5e but unfortunately the method under test has no effect on MacOS, so don't run the test on that platform.

For history see also:
https://bugs.eclipse.org/bugs/show_bug.cgi?id=261270
