### PR TITLE
Explicitly disable API tools execution

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,8 @@
     <sonar.c.file.suffixes>-</sonar.c.file.suffixes>
     <sonar.cpp.file.suffixes>-</sonar.cpp.file.suffixes>
     <sonar.objc.file.suffixes>-</sonar.objc.file.suffixes>
+    <skipAPIDescription>true</skipAPIDescription>
+    <skipAPIAnalysis>true</skipAPIAnalysis>
   </properties>
 
   <!-- 


### PR DESCRIPTION
Currently SWT do not use the API tools in the build verification, but enabling the profile (-Papi-check) leads to multiple errors and then fails the build.

To allow using this build to unify the verification build infrastructure, SWT can simply declare that even if the profiles are active they are skipped.