### PR TITLE
Fail matrix job if there are test-failures as well as show delta

### DIFF
--- a/.github/workflows/junit.yml
+++ b/.github/workflows/junit.yml
@@ -10,7 +10,13 @@ jobs:
   unit-test-results:
     name: Unit Test Results
     runs-on: ubuntu-latest
-    if: github.event.workflow_run.conclusion == 'success'
+    if: github.event.workflow_run.conclusion != 'skipped'
+    permissions:
+      checks: write
+      pull-requests: write
+      contents: read
+      issues: read
+      actions: read
 
     steps:
       - name: Download and Extract Artifacts
@@ -33,6 +39,8 @@ jobs:
         id: test-results
         with:
           commit: ${{ github.event.workflow_run.head_sha }}
+          event_file: artifacts/Event File/event.json
+          event_name: ${{ github.event.workflow_run.event }}
           files: "artifacts/**/*.xml"
       - name: Set badge color
         if: github.ref == 'refs/heads/master'

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -13,6 +13,15 @@ on:
     branches: [ master ]
 
 jobs:
+  event_file:
+    name: "Event File"
+    runs-on: ubuntu-latest
+    steps:
+    - name: Upload
+      uses: actions/upload-artifact@v3
+      with:
+        name: Event File
+        path: ${{ github.event_path }}
   build:
     runs-on: ${{ matrix.config.os }}
     strategy:
@@ -66,16 +75,17 @@ jobs:
         -DforkCount=1
         -Dcompare-version-with-baselines.skip=false
         -Dmaven.compiler.failOnWarning=true
-        -Dmaven.test.failure.ignore=true
+        --fail-at-end
         -DskipNativeTests=false
         -DfailIfNoTests=false
         --global-toolchains ${{ github.workspace }}/eclipse.platform.swt/.github/toolchains.xml
         clean install
        working-directory: eclipse.platform.swt
     - name: Upload Test Results for ${{ matrix.config.name }} / Java-${{ matrix.java }}
+      if: always()
       uses: actions/upload-artifact@v3
       with:
         name: test-results-${{ matrix.config.native }}-java${{ matrix.java }}
-        if-no-files-found: error
+        if-no-files-found: warn
         path: |
           ${{ github.workspace }}/**/target/surefire-reports/*.xml


### PR DESCRIPTION
Currently the matrix job succeeds if there are test-failures, this can be confusing for people. Also we can modernize the usage of the Test results check to show a +/- delta compared to current master build.

Fix https://github.com/eclipse-platform/eclipse.platform.swt/issues/594
FYI @iloveeclipse @mbooth101 