### PR TITLE
Issue #600: [win32] Fix failing test_isXMouseActive test

### DIFF
--- a/tests/org.eclipse.swt.tests.win32/JUnit Tests/org/eclipse/swt/tests/win32/AllWin32Tests.java
+++ b/tests/org.eclipse.swt.tests.win32/JUnit Tests/org/eclipse/swt/tests/win32/AllWin32Tests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Red Hat and others. All rights reserved.
+ * Copyright (c) 2018, 2023 Red Hat and others. All rights reserved.
  * The contents of this file are made available under the terms
  * of the GNU Lesser General Public License (LGPL) Version 2.1 that
  * accompanies this distribution (lgpl-v21.txt).  The LGPL is also
@@ -24,6 +24,7 @@ import org.junit.runners.Suite;
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
 	Test_org_eclipse_swt_dnd_DND.class,
+	Test_org_eclipse_swt_events_KeyEvent.class,
 	Test_org_eclipse_swt_widgets_Display.class,
 	TestTreeColumn.class
 })

--- a/tests/org.eclipse.swt.tests.win32/pom.xml
+++ b/tests/org.eclipse.swt.tests.win32/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright (c) 2017 Conrad Groth and others.
+  Copyright (c) 2017, 2023 Conrad Groth and others.
   All rights reserved. This program and the accompanying materials
   are made available under the terms of the Eclipse Distribution License v1.0
   which accompanies this distribution, and is available at
@@ -33,7 +33,8 @@
         <groupId>org.eclipse.tycho</groupId>
         <artifactId>tycho-surefire-plugin</artifactId>
         <configuration>
-          <skipTests>${skipNativeTests}</skipTests> 
+          <skipTests>${skipNativeTests}</skipTests>
+          <testClass>org.eclipse.swt.tests.win32.AllWin32Tests</testClass>
         </configuration>
       </plugin>
     </plugins>


### PR DESCRIPTION
This test is executed twice by the github actions verification, but only fails the second time.

Without explicit configuration, the tycho-surefire plugin just globs all the tests in the bundle, which in the presence of an explicit test suite, will result in the duplicate execution of tests.

This change explicitly configures tycho to execute the test suite, and adds the Test_org_eclipse_swt_events_KeyEvent test to the test suite, from which it was missing.