### PR TITLE
Re-enable enhanced issue recording in Jenkins pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -305,10 +305,8 @@ pipeline {
 				always {
 					junit 'eclipse.platform.swt/tests/*.test*/target/surefire-reports/*.xml'
 					archiveArtifacts artifacts: '**/*.log,**/*.html,**/target/*.jar,**/target/*.zip'
-					//TODO: re-enable this on releng Jenkins?!
-					// discoverGitReferenceBuild referenceJob: 'eclipse.platform.swt/master'
-					// recordIssues publishAllIssues: true, tools: [java(), mavenConsole(), javaDoc()]
-					publishIssues issues:[scanForIssues(tool: java()), scanForIssues(tool: mavenConsole())]
+					discoverGitReferenceBuild referenceJob: 'eclipse.platform.swt/master'
+					recordIssues publishAllIssues: true, tools: [java(), mavenConsole(), javaDoc()]
 				}
 			}
 		}


### PR DESCRIPTION
This reverts parts of commit 0447a9e50a962595debac122966d4ef978356af8, which was necessary since the Eclipse Releng JIPP was not setup for this.
This required https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/2546.

FYI @laeubi.