### PR TITLE
[Jenkins-Build] Migrate push steps from ANT to Jenkins pipeline

### DIFF
--- a/bundles/org.eclipse.swt/buildSWT.xml
+++ b/bundles/org.eclipse.swt/buildSWT.xml
@@ -963,39 +963,6 @@
 	<!-- targets to run the builds on the Eclipse Foundation Hudson in master-slave setup -->
 	<!-- ******************************************************************************** -->
 	
-	<target name="push_remote_from_workspace" depends="get_tag">
-		<exec dir="${repo.src}" executable="git" failonerror="true">
-			<arg line="fetch"/>
-		</exec>
-		<exec dir="${repo.src}" executable="git" failonerror="true">
-			<arg line="status"/>
-		</exec>
-		<exec dir="${repo.src}" executable="git" failonerror="true">
-			<arg line="rebase origin/${TAG}"/>
-		</exec>
-		<exec dir="${repo.src}" executable="git" failonerror="true">
-			<arg line="push origin HEAD:refs/heads/${TAG}"/>
-		</exec>
-		<exec dir="${repo.bin}" executable="git" failonerror="true">
-			<arg line="fetch"/>
-		</exec>
-		<exec dir="${repo.bin}" executable="git" failonerror="true">
-			<arg line="status"/>
-		</exec>
-		<exec dir="${repo.bin}" executable="git" failonerror="true">
-			<arg line="rebase origin/${TAG}"/>
-		</exec>
-		<exec dir="${repo.bin}" executable="git" failonerror="true">
-			<arg line="push origin HEAD:refs/heads/${TAG}"/>
-		</exec>
-		<exec dir="${repo.src}" executable="git" failonerror="true">
-			<arg line="push origin refs/tags/${swt_tag}"/>
-		</exec>
-		<exec dir="${repo.bin}" executable="git" failonerror="true">
-			<arg line="push origin refs/tags/${swt_tag}"/>
-		</exec>
-	</target>
-	
 	<target name="new_build_with_create_file" depends="check_build_changed, check_natives_changed" if="build_changed">
 		<!-- Update the version files -->
 		<property name="increment_version_target" value="increment_version"/>


### PR DESCRIPTION
Replace the ant target `push_remote_from_workspace` by equivalent steps in the Jenkins pipeline.

This is part of the continued effort to simplify the SWT build and migrate off ANT scripts, as tracked in https://github.com/eclipse-platform/eclipse.platform.swt/issues/513.
It also has the advantage that for commits pushed to maintenance branches the follow-up commits created by the build pipeline are pushed to the same branch automatically.

Generally I suggest to backport the pipeline as it is after this change to active maintenance branches in order to avoid the need to build maintenance binaries locally.
This would eventually make the jobs in https://ci.eclipse.org/releng/view/SWT%20Natives/ obsolete.


