### PR TITLE
[Cocoa] Avoid NPE in Control.calculateVisibleRegion()

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Control.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Control.java
@@ -769,9 +769,9 @@ boolean becomeFirstResponder (long id, long sel) {
 
 void calculateVisibleRegion (NSView view, long visibleRgn, boolean clipChildren) {
 	long tempRgn = OS.NewRgn ();
-	if (!view.isHiddenOrHasHiddenAncestor() && isDrawing()) {
+	NSWindow window; // https://bugs.eclipse.org/bugs/show_bug.cgi?id=559198
+	if (!view.isHiddenOrHasHiddenAncestor() && isDrawing() && (window = view.window ()) != null) {
 		long childRgn = OS.NewRgn ();
-		NSWindow window = view.window ();
 		NSView contentView = window.contentView();
 		NSView frameView = contentView.superview();
 		NSRect bounds = contentView.visibleRect();


### PR DESCRIPTION
```
java.lang.NullPointerException: Cannot invoke "org.eclipse.swt.internal.cocoa.NSWindow.contentView()" because "window" is null
 at org.eclipse.swt.widgets.Control.calculateVisibleRegion(Control.java:775)
 at org.eclipse.swt.widgets.Control.getVisibleRegion(Control.java:2060)
 at org.eclipse.swt.widgets.Control.isObscured(Control.java:2341)
 at org.eclipse.swt.widgets.Scrollable.scrollClipViewToPoint(Scrollable.java:347)
 at org.eclipse.swt.widgets.Display.windowProc(Display.java:6754)
```

Fixes #614.
Fixes https://bugs.eclipse.org/bugs/show_bug.cgi?id=559198.