### PR TITLE
Avoid setting focus on invisible children of Composite #616

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Composite.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Composite.java
@@ -1124,7 +1124,7 @@ public boolean setFocus () {
 	checkWidget ();
 	Control [] children = _getChildren ();
 	for (int i= 0; i < children.length; i++) {
-		if (children [i].setFocus ()) return true;
+		if (children [i].getVisible() && children [i].setFocus ()) return true;
 	}
 	return super.setFocus ();
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Composite.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Composite.java
@@ -1073,10 +1073,10 @@ public boolean setFocus () {
 	checkWidget ();
 	Control [] children = _getChildren ();
 	for (Control child : children) {
-		if (child.setRadioFocus (false)) return true;
+		if (child.getVisible() && child.setRadioFocus (false)) return true;
 	}
 	for (Control child : children) {
-		if (child.setFocus ()) return true;
+		if (child.getVisible() && child.setFocus ()) return true;
 	}
 	return super.setFocus ();
 }

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_browser_Browser.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_browser_Browser.java
@@ -1505,6 +1505,17 @@ public void test_setFocus_toChild_beforeOpen() {
 	// The different browsers set focus to a different child
 }
 
+@Test
+@Override
+public void test_setFocus_withInvisibleChild() {
+	// The different browsers set focus to a different child
+}
+
+@Test
+@Override
+public void test_setFocus_withVisibleAndInvisibleChild() {
+	// The different browsers set focus to a different child
+}
 
 /** Text without html tags */
 @Test

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_custom_CCombo.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_custom_CCombo.java
@@ -30,6 +30,7 @@ import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.events.SelectionListener;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.Point;
+import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Text;
 import org.junit.Before;
@@ -48,6 +49,11 @@ public void setUp() {
 	super.setUp();
 	ccombo = new CCombo(shell, 0);
 	setWidget(ccombo);
+}
+
+@Override
+protected Composite getElementExpectedToHaveFocusAfterSetFocusOnParent(Composite visibleChild) {
+	return visibleChild.getParent();
 }
 
 @Override


### PR DESCRIPTION
In the Windows and MacOS implementations of a `Composite`, the `setFocus` method tries to set focus on children even if they are not visible and will thus never receive focus. Depending on the realization of `setFocus` on the children, functionality may be executed that confuses the user as it belongs to a view they do not see (see #616).
The Linux implementation already validates whether a child is visible before setting focus on it. This change makes the implementations consistent across operating systems and ensures the consistent behavior with according regression tests.

https://github.com/eclipse-platform/eclipse.platform.swt/blob/d65eb73da26084e65c3090e7ede0892b3016a112/bundles/org.eclipse.swt/Eclipse%20SWT/gtk/org/eclipse/swt/widgets/Composite.java#L1667-L1675