### PR TITLE
CTabFolder should allow to listen on tab count changes

### DIFF
--- a/bundles/org.eclipse.swt/.settings/.api_filters
+++ b/bundles/org.eclipse.swt/.settings/.api_filters
@@ -153,6 +153,12 @@
         </filter>
     </resource>
     <resource path="Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CTabFolder2Listener.java" type="org.eclipse.swt.custom.CTabFolder2Listener">
+        <filter id="404000815">
+            <message_arguments>
+                <message_argument value="org.eclipse.swt.custom.CTabFolder2Listener"/>
+                <message_argument value="itemsCount(CTabFolderEvent)"/>
+            </message_arguments>
+        </filter>
         <filter id="576720909">
             <message_arguments>
                 <message_argument value="SWTEventListener"/>

--- a/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CTabFolder.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CTabFolder.java
@@ -744,6 +744,14 @@ Image createButtonImage(Display display, int button) {
 	image = new Image(display, new AutoScaleImageDataProvider(display, imageData, DPIUtil.getDeviceZoom()));
 	return image;
 }
+
+private void notifyItemCountChange() {
+	CTabFolderEvent e = new CTabFolderEvent(this);
+	for (CTabFolder2Listener listener : folderListeners) {
+		listener.itemsCount(e);
+	}
+}
+
 void createItem (CTabItem item, int index) {
 	if (0 > index || index > getItemCount ())SWT.error (SWT.ERROR_INVALID_RANGE);
 	item.parent = this;
@@ -769,6 +777,7 @@ void createItem (CTabItem item, int index) {
 	} else {
 		updateFolder(REDRAW_TABS);
 	}
+	notifyItemCountChange();
 }
 void destroyItem (CTabItem item) {
 	if (inDispose) return;
@@ -789,6 +798,7 @@ void destroyItem (CTabItem item) {
 		updateButtons();
 		setButtonBounds();
 		redraw();
+		notifyItemCountChange();
 		return;
 	}
 
@@ -820,6 +830,7 @@ void destroyItem (CTabItem item) {
 
 	requestLayout();
 	updateFolder(UPDATE_TAB_HEIGHT | REDRAW_TABS);
+	notifyItemCountChange();
 }
 
 /**
@@ -1631,7 +1642,6 @@ void onKeyDown (Event event) {
 						Rectangle chevronRect = chevronItem.getBounds();
 						chevronRect = event.display.map(chevronTb, this, chevronRect);
 						CTabFolderEvent e = new CTabFolderEvent(this);
-						e.widget = this;
 						e.time = event.time;
 						e.x = chevronRect.x;
 						e.y = chevronRect.y;
@@ -1953,7 +1963,6 @@ void onMouse(Event event) {
 					redraw(item.closeRect.x, item.closeRect.y, item.closeRect.width, item.closeRect.height, false);
 					if (!selected) return;
 					CTabFolderEvent e = new CTabFolderEvent(this);
-					e.widget = this;
 					e.time = event.time;
 					e.item = item;
 					e.doit = true;
@@ -2016,7 +2025,6 @@ void onPageTraversal(Event event) {
 					Rectangle chevronRect = chevronItem.getBounds();
 					chevronRect = event.display.map(chevronTb, this, chevronRect);
 					CTabFolderEvent e = new CTabFolderEvent(this);
-					e.widget = this;
 					e.time = event.time;
 					e.x = chevronRect.x;
 					e.y = chevronRect.y;
@@ -2151,7 +2159,6 @@ void onSelection(Event event) {
 	}
 	if (event.widget == maxItem) {
 		CTabFolderEvent e = new CTabFolderEvent(this);
-		e.widget = CTabFolder.this;
 		e.time = event.time;
 		for (CTabFolder2Listener folderListener : folderListeners) {
 			if (maximized) {
@@ -2162,7 +2169,6 @@ void onSelection(Event event) {
 		}
 	} else if (event.widget == minItem) {
 		CTabFolderEvent e = new CTabFolderEvent(this);
-		e.widget = CTabFolder.this;
 		e.time = event.time;
 		for (CTabFolder2Listener folderListener : folderListeners) {
 			if (minimized) {
@@ -2175,7 +2181,6 @@ void onSelection(Event event) {
 		Rectangle chevronRect = chevronItem.getBounds();
 		chevronRect = event.display.map(chevronTb, this, chevronRect);
 		CTabFolderEvent e = new CTabFolderEvent(this);
-		e.widget = this;
 		e.time = event.time;
 		e.x = chevronRect.x;
 		e.y = chevronRect.y;

--- a/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CTabFolder2Listener.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CTabFolder2Listener.java
@@ -116,6 +116,34 @@ public void restore(CTabFolderEvent event);
 public void showList(CTabFolderEvent event);
 
 /**
+ * Sent when the tab items count changes
+ * 
+ * @param event from observed tab folder
+ * @since 3.124
+ */
+public default void itemsCount(CTabFolderEvent event) {
+	// do nothing by default
+}
+
+/**
+ * Static helper method to create a <code>CTabFolder2Listener</code> for the
+ * {@link #itemsCount(CTabFolderEvent e)}) method, given a lambda expression or
+ * a method reference.
+ *
+ * @param c the consumer of the event
+ * @return CTabFolder2Listener
+ * @since 3.124
+ */
+public static CTabFolder2Listener itemsCountAdapter(Consumer<CTabFolderEvent> c) {
+	return new CTabFolder2Adapter() {
+		@Override
+		public void itemsCount(CTabFolderEvent e) {
+			c.accept(e);
+		}
+	};
+}
+
+/**
  * Static helper method to create a <code>CTabFolder2Listener</code> for the
  * {@link #close(CTabFolderEvent e)}) method, given a lambda expression or a method reference.
  *

--- a/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CTabFolderEvent.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CTabFolderEvent.java
@@ -73,6 +73,7 @@ public class CTabFolderEvent extends TypedEvent {
  */
 CTabFolderEvent(Widget w) {
 	super(w);
+	this.widget = w;
 }
 
 /**

--- a/bundles/org.eclipse.swt/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.swt/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.swt; singleton:=true
-Bundle-Version: 3.123.100.qualifier
+Bundle-Version: 3.124.0.qualifier
 Bundle-ManifestVersion: 2
 Bundle-Localization: plugin
 DynamicImport-Package: org.eclipse.swt.accessibility2

--- a/bundles/org.eclipse.swt/pom.xml
+++ b/bundles/org.eclipse.swt/pom.xml
@@ -21,7 +21,7 @@
     </parent>
     <groupId>org.eclipse.swt</groupId>
     <artifactId>org.eclipse.swt</artifactId>
-    <version>3.123.100-SNAPSHOT</version>
+    <version>3.124.0-SNAPSHOT</version>
     <packaging>eclipse-plugin</packaging>
 
     <properties>


### PR DESCRIPTION
- added CTabFolder2Listener.itemsCount(CTabFolderEvent) API
- added CTabFolder2Listener.itemsCountAdapter(Consumer<CTabFolderEvent>) API
- updated CTabFolder to notify CTabFolder2Listener on creating/removing items
- added unit test
- bumped minor version segment for new API added

Fixes https://github.com/eclipse-platform/eclipse.platform.swt/issues/620