### PR TITLE
[Jenkins-Build] Fix access of 'skipCommit' pipeline parameter

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -325,7 +325,7 @@ pipeline {
 						sh """
 							# Check for the master-branch as late as possible to have as much of the same behaviour as possible
 							if [[ '${BRANCH_NAME}' == master ]] || [[ '${BRANCH_NAME}' =~ R[0-9]+_[0-9]+(_[0-9]+)?_maintenance ]]; then
-								if [[ ${skipCommit} != true ]]; then
+								if [[ ${params.skipCommit} != true ]]; then
 									
 									#Don't rebase and just fail in case another commit has been pushed to the master/maintanance branch in the meantime
 									


### PR DESCRIPTION
The parameter 'skipCommit' was accessed in a interpolated Groovy GString and therefore needs to be accessed via the params-object.

This was forgotten in commit c760d4b788fb45419f54c491e0dc6c58c3318e62 but for some reason did not show up in the verification build.