### PR TITLE
Build SWT-natives against Java-17 JDK header files

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -123,7 +123,7 @@ pipeline {
 									'''
 								}
 								dir("org.eclipse.swt.${PLATFORM}/tmpdir") {
-									stash name:"swt.binaries.sources.${PLATFORM}",	includes: "org.eclipse.swt.${PLATFORM}.master.zip"
+									stash name:"swt.binaries.sources.${PLATFORM}", includes: "org.eclipse.swt.${PLATFORM}.master.zip"
 								}
 							}
 						}
@@ -157,13 +157,7 @@ pipeline {
 												rm org.eclipse.swt.${PLATFORM}.master.zip
 												mkdir libs
 												
-												#TODO: unify build script arguments?!
-												if [[ ${PLATFORM} == cocoa.macosx.* ]]; then
-													sw_vers -productVersion
-													sh build.sh install
-												elif [[ ${PLATFORM} == gtk.linux.* ]]; then
-													sh build.sh clean install
-												fi
+												sh build.sh install
 												ls -1R libs
 											'''
 										} else {
@@ -173,7 +167,6 @@ pipeline {
 													rm org.eclipse.swt.%PLATFORM%.master.zip
 													mkdir libs
 													
-													@rem rustup show
 													cmd /c build.bat x86_64 all install
 													ls -1R libs
 												'''

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/cocoa/library/build.sh
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/cocoa/library/build.sh
@@ -15,12 +15,6 @@
 
 cd `dirname $0`
 
-if [ -d /System/Library/Frameworks/JavaVM.framework/Headers ]; then
-	export CFLAGS_JAVA_VM="-I /System/Library/Frameworks/JavaVM.framework/Headers"
-else
-	export CFLAGS_JAVA_VM="-I $(/usr/libexec/java_home)/include -I $(/usr/libexec/java_home)/include/darwin"
-fi
-
 if [ "x${MODEL}" = "xx86_64" ]; then
 	export ARCHS="-arch x86_64"
 	if [ "x${OUTPUT_DIR}" = "x" ]; then

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/cocoa/library/build.sh
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/cocoa/library/build.sh
@@ -13,6 +13,8 @@
 #     IBM Corporation - initial API and implementation
 #*******************************************************************************
 
+sw_vers -productVersion
+
 cd `dirname $0`
 
 if [ "x${MODEL}" = "xx86_64" ]; then

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/cocoa/library/make_macosx.mak
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/cocoa/library/make_macosx.mak
@@ -14,6 +14,11 @@
 
 # Makefile for SWT libraries on Cocoa/Mac
 
+# assumes these variables are set in the environment from which make is run
+#	SWT_JAVA_HOME
+#	OUTPUT_DIR
+#	AWT_LIB_PATH (only if build jawt shall be build)
+
 include make_common.mak
 
 SWT_PREFIX=swt
@@ -32,7 +37,8 @@ AWT_OBJECTS   = swt_awt.o
 
 #SWT_DEBUG = -g
 CFLAGS = -c -xobjective-c -Wall $(ARCHS) -DSWT_VERSION=$(SWT_VERSION) $(NATIVE_STATS) $(SWT_DEBUG) -DUSE_ASSEMBLER -DCOCOA -DATOMIC \
-	$(CFLAGS_JAVA_VM) \
+	-I $(SWT_JAVA_HOME)/include \
+	-I $(SWT_JAVA_HOME)/include/darwin \
 	-I /System/Library/Frameworks/Cocoa.framework/Headers \
 	-I /System/Library/Frameworks/JavaScriptCore.framework/Headers
 LFLAGS = -bundle $(ARCHS) -framework Cocoa -framework WebKit -framework CoreServices -framework JavaScriptCore -framework Security -framework SecurityInterface

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/build.sh
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/build.sh
@@ -114,17 +114,6 @@ case $SWT_OS.$SWT_ARCH in
 		if [ "${CC}" = "" ]; then
 			export CC=gcc
 		fi
-		if [ "${JAVA_HOME}" = "" ]; then
-			# Cross-platform method of finding JAVA_HOME.
-			# Tested on Fedora 24 and Ubuntu 16
-			DYNAMIC_JAVA_HOME=`readlink -f /usr/bin/java | sed "s:jre/::" | sed "s:bin/java::"`
-			if [ -e "${DYNAMIC_JAVA_HOME}include/jni.h" ]; then
-				func_echo_plus "JAVA_HOME not set, but jni.h found, dynamically configured to $DYNAMIC_JAVA_HOME"
-				export JAVA_HOME="$DYNAMIC_JAVA_HOME"
-			else
-				func_echo_error "JAVA_HOME not set and jni.h could not be located. You might get a compile error about include 'jni.h'. You should install 'java-*-openjdk-devel' package or if you have it installed already, find jni.h and  set JAVA_HOME manually to base of 'include' folder"
-			fi
-		fi
 		if [ "${PKG_CONFIG_PATH}" = "" ]; then
 			export PKG_CONFIG_PATH="/usr/lib64/pkgconfig"
 		fi
@@ -133,9 +122,6 @@ case $SWT_OS.$SWT_ARCH in
 		if [ "${CC}" = "" ]; then
 			export CC=gcc
 		fi
-		if [ "${JAVA_HOME}" = "" ]; then
-			export JAVA_HOME=`readlink -f /usr/bin/java | sed "s:jre/::" | sed "s:bin/java::"`
-		fi
 		if [ "${PKG_CONFIG_PATH}" = "" ]; then
 			export PKG_CONFIG_PATH="/usr/lib64/pkgconfig/"
 		fi
@@ -143,9 +129,6 @@ case $SWT_OS.$SWT_ARCH in
 	"linux.loongarch64")
 		if [ "${CC}" = "" ]; then
 			export CC=gcc
-		fi
-		if [ "${JAVA_HOME}" = "" ]; then
-			export JAVA_HOME=`readlink -f /usr/bin/java | sed "s:jre/bin/java::"`
 		fi
 		if [ "${PKG_CONFIG_PATH}" = "" ]; then
 			export PKG_CONFIG_PATH="/usr/lib64/pkgconfig/"
@@ -177,6 +160,12 @@ else
 	func_echo_error "Cairo not found: Advanced graphics support using cairo will not be compiled."
 fi
 
+if [ -z ${SWT_JAVA_HOME} ] || [ ! -f "${SWT_JAVA_HOME}/include/jni.h" ]; then
+	func_echo_error "SWT_JAVA_HOME not set and jni.h could not be located. You might get a compile error about include 'jni.h'. You should install 'java-*-openjdk-devel' package or if you have it installed already, find jni.h and  set SWT_JAVA_HOME manually to base of 'include' folder"
+else
+	func_echo_plus "jni.h found"
+fi
+
 # Find AWT if available
 if [ ${SWT_OS} = 'win32' ]; then
 	AWT_LIB_EXPR="jawt.dll"
@@ -185,14 +174,14 @@ else
 fi
 
 if [ -z "${AWT_LIB_PATH}" ]; then
-	if [ -f ${JAVA_HOME}/jre/lib/${AWT_ARCH}/${AWT_LIB_EXPR} ]; then
-		AWT_LIB_PATH=${JAVA_HOME}/jre/lib/${AWT_ARCH}
+	if [ -f ${SWT_JAVA_HOME}/jre/lib/${AWT_ARCH}/${AWT_LIB_EXPR} ]; then
+		AWT_LIB_PATH=${SWT_JAVA_HOME}/jre/lib/${AWT_ARCH}
 		export AWT_LIB_PATH
-	elif [ -f ${JAVA_HOME}/lib/${AWT_LIB_EXPR} ]; then
-		AWT_LIB_PATH=${JAVA_HOME}/lib
+	elif [ -f ${SWT_JAVA_HOME}/lib/${AWT_LIB_EXPR} ]; then
+		AWT_LIB_PATH=${SWT_JAVA_HOME}/lib
 		export AWT_LIB_PATH
 	else
-		AWT_LIB_PATH=${JAVA_HOME}/jre/bin
+		AWT_LIB_PATH=${SWT_JAVA_HOME}/jre/bin
 		export AWT_LIB_PATH
 	fi
 fi

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/make_linux.mak
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/make_linux.mak
@@ -14,6 +14,10 @@
 
 # Makefile for creating SWT libraries for Linux GTK
 
+# assumes these variables are set in the environment from which make is run
+#	SWT_JAVA_HOME
+#	OUTPUT_DIR
+
 # SWT debug flags for various SWT components.
 #SWT_WEBKIT_DEBUG = -DWEBKIT_DEBUG
 
@@ -104,8 +108,8 @@ CFLAGS := $(CFLAGS) \
 		$(SWT_DEBUG) \
 		$(SWT_WEBKIT_DEBUG) \
 		-DLINUX -DGTK \
-		-I$(JAVA_HOME)/include \
-		-I$(JAVA_HOME)/include/linux \
+		-I$(SWT_JAVA_HOME)/include \
+		-I$(SWT_JAVA_HOME)/include/linux \
 		${SWT_PTR_CFLAGS}
 LFLAGS = -shared -fPIC ${SWT_LFLAGS}
 

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/win32/library/build.bat
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/win32/library/build.bat
@@ -48,21 +48,10 @@ IF NOT EXIST "%MSVC_HOME%" (
 	CALL :ECHO "MSVC_HOME: %MSVC_HOME%"
 )
 
-@rem Search for a usable JDK
-@rem -----------------------
-IF "%SWT_JAVA_HOME%"=="" CALL :ECHO "'SWT_JAVA_HOME' was not provided, auto-searching for JDK..."
-@rem Search for generic JDKs so that user can build with little configuration
-@rem Note that first found JDK wins, so sort them by order of preference.
-IF "%SWT_JAVA_HOME%"=="" CALL :TryToUseJdk "%ProgramFiles%\Java\jdk-11*"
-IF "%SWT_JAVA_HOME%"=="" CALL :TryToUseJdk "%ProgramFiles%\AdoptOpenJDK\jdk-11*"
-IF "%SWT_JAVA_HOME%"=="" CALL :TryToUseJdk "%ProgramFiles%\Java\jdk-17*"
-IF "%SWT_JAVA_HOME%"=="" CALL :TryToUseJdk "%ProgramFiles%\AdoptOpenJDK\jdk-17*"
-@rem Report
+@rem Check for a usable JDK
+IF "%SWT_JAVA_HOME%"=="" CALL :ECHO "'SWT_JAVA_HOME' was not provided"
 IF NOT EXIST "%SWT_JAVA_HOME%" (
-    CALL :ECHO "WARNING: x64 Java JDK not found. Please set SWT_JAVA_HOME to your JDK directory."
-    CALL :ECHO "         Refer steps for SWT Windows native setup: https://www.eclipse.org/swt/swt_win_native.php"
-) ELSE (
-    CALL :ECHO "SWT_JAVA_HOME x64: %SWT_JAVA_HOME%"
+    CALL :ECHO "WARNING: x64 Java JDK not found. Please set SWT_JAVA_HOME to the JDK directory containing the intended JDK native headers."
 )
 
 @rem -----------------------
@@ -150,25 +139,6 @@ GOTO :EOF
 	)
 	CALL :ECHO "-- VisualStudio '%TESTED_VS_PATH%' looks good, selecting it"
 	SET "MSVC_HOME=%TESTED_VS_PATH%"
-GOTO :EOF
-
-:TryToUseJdk
-	SET "TESTED_JDK_PATH_MASK=%~1"
-	@rem Loop over all directories matching mask.
-	@rem Note that directories are iterated in alphabetical order and *last* hit will
-	@rem be selected in hopes to select the highest available JDK version.
-	FOR /D %%I IN ("%TESTED_JDK_PATH_MASK%") DO (
-		IF NOT EXIST "%%~I" (
-			CALL :ECHO "-- JDK '%%~I' doesn't exist on disk"
-			GOTO :EOF
-		)
-		IF NOT EXIST "%%~I\include\jni.h" (
-			CALL :ECHO "-- JDK '%%~I' is bad: no jni.h"
-			GOTO :EOF
-		)
-		CALL :ECHO "-- JDK '%%~I' looks good, selecting it"
-		SET "SWT_JAVA_HOME=%%~I"
-	)
 GOTO :EOF
 
 @rem Regular ECHO has trouble with special characters such as ().

--- a/bundles/org.eclipse.swt/Readme.Linux.md
+++ b/bundles/org.eclipse.swt/Readme.Linux.md
@@ -25,7 +25,7 @@ You need to install the following on your system:
 * make
 * gcc
 * GTK+ development files (gtk3-devel)
-* Java 8 or 11 JDK
+* Java 17 JDK
 * (optional) Webkit for GTK development files (webkit2gtk3-devel)
 
 ### Building and Testing locally

--- a/bundles/org.eclipse.swt/buildSWT.xml
+++ b/bundles/org.eclipse.swt/buildSWT.xml
@@ -810,10 +810,13 @@
 
 	<target name="build_local">
 		<property name="gtk_version" value="3.0" />
+		<property name="SWT_JAVA_HOME" value="${java.home}"/><!-- Not overwritten if already set, e.g. as CLI argument -->
+		<echo>Compile SWT natives against headers and libraries from JDK: ${SWT_JAVA_HOME}</echo>
 		<exec dir="${build_dir}" executable="sh" failonerror="true">
 			<arg line="build.sh"/>
 			<env key="GTK_VERSION" value="${gtk_version}"/>
 			<env key="MODEL" value="${swt.arch}"/>
+			<env key="SWT_JAVA_HOME" value="${SWT_JAVA_HOME}"/>
 			<env key="OUTPUT_DIR" value="${output_dir}"/>
 			<arg line="${targets}"/>
 			<arg line="${clean}"/>
@@ -824,7 +827,10 @@
 		<pathconvert property="win_output_dir">
 			<path location="${output_dir}"></path>
 		</pathconvert>
+		<property name="SWT_JAVA_HOME" value="${java.home}"/><!-- Not overwritten if already set, e.g. as CLI argument -->
+		<echo>Compile SWT natives against headers and libraries from JDK: ${SWT_JAVA_HOME}</echo>
 		<exec dir="${build_dir}" executable="${build_dir}/build.bat" failonerror="true">
+			<env key="SWT_JAVA_HOME" value="${SWT_JAVA_HOME}"/>
 			<env key="OUTPUT_DIR" value="${win_output_dir}"/>
 			<arg line="${targets}"/>
 			<arg line="${clean}"/>


### PR DESCRIPTION
As described in https://github.com/eclipse-platform/eclipse.platform.swt/issues/626#issuecomment-1507719226 the SWT-natives are currently build against the JDK header files for different Java versions raging from 11 to 19. Because SWT now requires Java-17 (https://github.com/eclipse-platform/eclipse.platform.swt/issues/625), they all should be build against Java-17 headers.

This PR aims to achieve that and at the same time fixes the inconsistencies regarding the headers/libs in the natives build described in https://github.com/eclipse-platform/eclipse.platform.swt/issues/626#issuecomment-1507719226. 

- Use the C header files and shared native libraries from minimal JustJ JDKs when building the SWT native binaries on specialized build machines.
- Always specify the location of the JDK providing the headers/libs using the 'SWT_JAVA_HOME' environment variable. This allows to use another JDK as the one specified in the global JAVA_HOME variable.
- When building the natives for individual platforms via Maven (with the `build-individual-platform` profile active and `-Dnative=<platform>` specified) set the value of `SWT_JAVA_HOME` to the location of the running JDK (which must of course be present). If one wants to use a custom JDK to build the SWT natives against, one can set set for example the Maven CLI argument
`-DSWT_JAVA_HOME=<path-to-desired-JDK>`

Because in the CI and for Maven builds that build natives now always have a JDK specified the auto-search algorithms to find one is now obsolete and removed from the scripts.

Fixes https://github.com/eclipse-platform/eclipse.platform.swt/issues/626 (at least the part regarding the Java-11 headers). 