### PR TITLE
Enable build-individual-bundles profile in maven.config

### DIFF
--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,1 @@
+-Pbuild-individual-bundles


### PR DESCRIPTION
Makes mvn calls work out of the box