### PR TITLE
Remove now unnecessary references of 'build-individual-bundles' profile and migrate to 'coactions/setup-xvfb'

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -69,7 +69,6 @@ jobs:
       with:
        run: >- 
         mvn --batch-mode -V -U
-        -Pbuild-individual-bundles
         -Pbuild-individual-platform
         -Dswt.build.platform_cp=${{ matrix.config.cp }}
         -DforkCount=1

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -65,7 +65,7 @@ jobs:
         -Dcompare-version-with-baselines.skip=true -Dmaven.compiler.failOnWarning=true install
        working-directory: eclipse.platform.swt.binaries
     - name: Build with Maven
-      uses: GabrielBB/xvfb-action@v1
+      uses: coactions/setup-xvfb@v1
       with:
        run: >- 
         mvn --batch-mode -V -U

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -294,7 +294,7 @@ pipeline {
 					dir ('eclipse.platform.swt') {
 						sh '''
 							mvn clean verify \
-								--batch-mode -Pbuild-individual-bundles -DcheckAllWS=true -DforkCount=0 \
+								--batch-mode -DcheckAllWS=true -DforkCount=0 \
 								-Dcompare-version-with-baselines.skip=false -Dmaven.compiler.failOnWarning=true \
 								-Dmaven.test.failure.ignore=true -Dmaven.test.error.ignore=true
 						'''


### PR DESCRIPTION
With commit 34af5497383d3f77357c03de6a77d36f681af066 respectively PR https://github.com/eclipse-platform/eclipse.platform.swt/pull/638

The 'build-individual-bundles' profile is activated in the `maven.config` and does not have to be activated explicitly anymore.
