### PR TITLE
Ignore semicolons in validation of Browser.getText tests #103

### DIFF
--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_browser_Browser.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_browser_Browser.java
@@ -1586,7 +1586,13 @@ private void getText_helper(String testString, String expectedOutput) {
 			+ "Expected:"+testString+"\n"
 			+ "Actual:"+returnString.get()
 			: "Test timed out";
-	assertEquals(error_msg, expectedOutput.toLowerCase(Locale.ENGLISH), returnString.get().replace("\r", "").replace("\n", "").toLowerCase(Locale.ENGLISH));
+	assertEquals(error_msg, normalizeHtmlString(expectedOutput), normalizeHtmlString(returnString.get()));
+}
+
+private String normalizeHtmlString(String htmlString) {
+	return htmlString.replace("\r", "").replace("\n", "") // ignore OS-Specific newlines
+			.replace(";", "") // ignore semicolons potentially added on Windows when processing style properties
+			.toLowerCase(Locale.ENGLISH); // ignore capitalization
 }
 
 /**


### PR DESCRIPTION
The `org.eclipse.swt.tests.junitBrowser.Test_org_eclipse_swt_browser_Browser.test_getText*` tests expect the browser to return the same text as was set to it via `setText`, only ignoring formatting-related information such as capitalization and newline characters. In Windows tests, the browser returns a processed HTML document, which can also differ in other aspects while having the same semantics. One difference is the use of semicolons in style properties.

Since the tests only use basic HTML documents in which the semicolon has no meaning, the proposed change simply ignores semicolons when validating the expected result of Browser.getText.

A more sophisticated test could use the HTML DOM for comparison, but from my perspective the simple fix is sufficient as the comparison (1) is used only for very simple HTML documents right now and (2) should not be necessary in a more sophisticated way as SWT is not responsible for HTML processing of the browser but only for properly passing through API calls to the underlying browser.

Contributes to #103.