### PR TITLE
SWT TableEditor: Caret is not shown for StyledText Control

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Canvas.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Canvas.java
@@ -172,6 +172,11 @@ long gtk_commit (long imcontext, long text) {
 long gtk_draw (long widget, long cairo) {
 	if ((state & OBSCURED) != 0) return 0;
 	long result = super.gtk_draw (widget, cairo);
+	drawCaretInFocus(widget, cairo);
+	return result;
+}
+
+void drawCaretInFocus(long widget, long cairo) {
 	/*
 	 *  blink is needed to be checked as gtk_draw() signals sent from other parts of the canvas
 	 *  can interfere with the blinking state. This will ensure that we are only draw/redrawing the
@@ -183,7 +188,6 @@ long gtk_draw (long widget, long cairo) {
 		drawCaret(widget,cairo);
 		blink = false;
 	}
-	return result;
 }
 
 private void drawCaret(long widget, long cairo) {
@@ -223,7 +227,9 @@ private void drawCaret(long widget, long cairo) {
 
 		Cairo.cairo_fill(cairo);
 		Cairo.cairo_restore(cairo);
-		drawFlag = false;
+		if (caret.embeddedInto == null) {
+			drawFlag = false;
+		}
 	} else {
 		drawFlag = true;
 	}

--- a/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet126.java
+++ b/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet126.java
@@ -32,7 +32,7 @@ public static void main(String[] args) {
 	shell.setLayout (new FillLayout ());
 	Table table = new Table (shell, SWT.BORDER | SWT.MULTI);
 	table.setLinesVisible (true);
-	for (int i=0; i<3; i++) {
+	for (int i=0; i < 4; i++) {
 		TableColumn column = new TableColumn(table, SWT.NONE);
 		column.setWidth (100);
 	}
@@ -48,17 +48,25 @@ public static void main(String[] args) {
 		combo.add("item 2");
 		editor.grabHorizontal = true;
 		editor.setEditor(combo, item, 0);
+
 		editor = new TableEditor (table);
 		Text text = new Text (table, SWT.NONE);
 		text.setText("Text");
 		editor.grabHorizontal = true;
 		editor.setEditor(text, item, 1);
+
+		editor = new TableEditor (table);
+		StyledText stext = new StyledText (table, SWT.NONE);
+		stext.setText("StyledText");
+		editor.grabHorizontal = true;
+		editor.setEditor(stext, item, 2);
+
 		editor = new TableEditor (table);
 		Button button = new Button (table, SWT.CHECK);
 		button.pack ();
 		editor.minimumWidth = button.getSize ().x;
 		editor.horizontalAlignment = SWT.LEFT;
-		editor.setEditor (button, item, 2);
+		editor.setEditor (button, item, 3);
 	}
 	shell.pack ();
 	shell.open ();

--- a/tests/org.eclipse.swt.tests.gtk/ManualTests/org/eclipse/swt/tests/gtk/snippets/Issue644_TableEditorWithCanvas.java
+++ b/tests/org.eclipse.swt.tests.gtk/ManualTests/org/eclipse/swt/tests/gtk/snippets/Issue644_TableEditorWithCanvas.java
@@ -19,6 +19,7 @@ import org.eclipse.swt.graphics.Rectangle;
 import org.eclipse.swt.layout.FillLayout;
 import org.eclipse.swt.widgets.Canvas;
 import org.eclipse.swt.widgets.Caret;
+import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.Table;
@@ -44,10 +45,8 @@ public class Issue644_TableEditorWithCanvas {
 
 		Table table = new Table(shell, SWT.BORDER | SWT.MULTI);
 		table.setLinesVisible(true);
-		table.setHeaderVisible(true);
 		for (int i = 0; i < 1; i++) {
 			TableColumn column = new TableColumn(table, SWT.NONE);
-			column.setText("Column : " + i);
 			column.setWidth(200);
 		}
 
@@ -60,24 +59,13 @@ public class Issue644_TableEditorWithCanvas {
 		for (int i = 0; i < items.length; i++) {
 			// canvas
 			TableEditor editor = new TableEditor(table);
-			Canvas canvas = new Canvas(table, SWT.NONE);
-			Rectangle parentBounds = canvas.getBounds();
-			Rectangle caretBound = new Rectangle(parentBounds.x + 20, parentBounds.y, 5, 17);
-			Caret caret = new Caret(canvas, SWT.NONE);
-			caret.setBounds(caretBound);
-			canvas.setCaret(caret);
-			canvas.addListener(SWT.MouseDown, event -> {
-				canvas.setFocus();
-			});
+			Canvas canvas = createCanvas(table, "Canvas inside table");
 			editor.grabHorizontal = true;
 			editor.setEditor(canvas, items[i], 0);
 			// Create a paint handler for the canvas
-			canvas.addPaintListener(e -> {
-				e.gc.setForeground(e.display.getSystemColor(SWT.COLOR_RED));
-				e.gc.drawText("Drawn content", 10, 1);
-			});
 		}
 
+		createCanvas(shell, "Canvas outside table");
 		shell.pack();
 		shell.open();
 		while (!shell.isDisposed()) {
@@ -85,5 +73,22 @@ public class Issue644_TableEditorWithCanvas {
 				display.sleep();
 		}
 		display.dispose();
+	}
+
+	private static Canvas createCanvas(Composite table, String text) {
+		Canvas canvas = new Canvas(table, SWT.NONE);
+		Rectangle parentBounds = canvas.getBounds();
+		Rectangle caretBound = new Rectangle(parentBounds.x + 20, parentBounds.y, 5, 17);
+		Caret caret = new Caret(canvas, SWT.NONE);
+		caret.setBounds(caretBound);
+		canvas.setCaret(caret);
+		canvas.addListener(SWT.MouseDown, event -> {
+			canvas.setFocus();
+		});
+		canvas.addPaintListener(e -> {
+			e.gc.setForeground(e.display.getSystemColor(SWT.COLOR_RED));
+			e.gc.drawText(text, 10, 1);
+		});
+		return canvas;
 	}
 }


### PR DESCRIPTION
Add missing repaints for Caret that is created for an embedded Canvas.

Fixes https://github.com/eclipse-platform/eclipse.platform.swt/issues/644