### PR TITLE
Execute browser tests for Edge #671

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Browser/win32/org/eclipse/swt/browser/Edge.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Browser/win32/org/eclipse/swt/browser/Edge.java
@@ -596,6 +596,7 @@ void setupBrowser(int hr, long pv) {
 		error(SWT.ERROR_THREAD_INVALID_ACCESS, hr);
 		break;
 	default:
+		System.err.println("WebView instantiation failed with result: " + hr);
 		containingEnvironment.instances().remove(this);
 		error(SWT.ERROR_NO_HANDLES, hr);
 	}


### PR DESCRIPTION
Browser tests were only executed for the default configuration of a system's browser using the `SWT.NONE` flag. Other configurations, such as using the Edge browser in Windows, were not tested.

This change parameterizes the browser tests to also execute them for the Edge browser on Windows. It also deactivates those tests for the Edge browser for which the implementation does (currently) not work. This allows to detect regressions when performing future changes to the Edge browser.

Fixes https://github.com/eclipse-platform/eclipse.platform.swt/issues/671