### PR TITLE
Copy HTML line fragment without block levels. fixes #593

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/StyledText.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/StyledText.java
@@ -8629,7 +8629,7 @@ void setClipboardContent(int start, int length, int clipboardType) throws SWTErr
 		String rtfText = getPlatformDelimitedText(rtfWriter);
 
 		HTMLTransfer htmlTransfer = HTMLTransfer.getInstance();
-		HTMLWriter htmlWriter = new HTMLWriter(this, start, length);
+		HTMLWriter htmlWriter = new HTMLWriter(this, start, length, content);
 		String htmlText = getPlatformDelimitedText(htmlWriter);
 
 		data = new Object[]{rtfText, htmlText, plainText};


### PR DESCRIPTION
Does not add additional newline when pasting words to Teams/Word.