### PR TITLE
Wait for SWT.Show event in Composite focus tests #616

### DIFF
--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/SwtTestUtil.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/SwtTestUtil.java
@@ -474,6 +474,22 @@ public static void waitShellActivate(Runnable trigger, Shell shell) {
 }
 
 /**
+ * Executes the given {@linkplain Runnable} and waits until the given shell
+ * becomes shown. To this end, the method asserts that the given
+ * {@linkplain Runnable} triggers the {@linkplain SWT#Show} event within a
+ * reasonable amount of time. Otherwise, the test calling this method will fail.
+ *
+ * @param trigger        code to executed that is expected to cause given shell
+ *                       to become shown
+ * @param shellToBeShown the shell to wait for being shown
+ */
+public static void waitForShellToBeShown(Runnable trigger, Shell shellToBeShown) {
+	final int timeoutInMsec = 3000;
+	boolean showEventReceived = waitEvent(trigger, shellToBeShown, SWT.Show, timeoutInMsec);
+	assertThat("SWT.Show event was not received", showEventReceived, is(true));
+}
+
+/**
  * Check if widget contains the given color.
  *
  * @param control       widget to check

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Composite.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Composite.java
@@ -14,6 +14,7 @@
 package org.eclipse.swt.tests.junit;
 
 
+import static org.eclipse.swt.tests.junit.SwtTestUtil.waitForShellToBeShown;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -130,7 +131,7 @@ public void test_setFocus_toChild_afterOpen() {
 		return;
 	}
 	Text focusChild = new Text(composite, SWT.NONE);
-	SwtTestUtil.waitShellActivate(shell::open, shell);
+	waitForShellToBeShown(shell::open, shell);
 	composite.setFocus();
 	assertTrue("First child widget should have focus", focusChild.isFocusControl());
 }
@@ -146,7 +147,7 @@ public void test_setFocus_toChild_beforeOpen() {
 	}
 	Text focusChild = new Text(composite, SWT.NONE);
 	composite.setFocus();
-	SwtTestUtil.waitShellActivate(shell::open, shell);
+	waitForShellToBeShown(shell::open, shell);
 	assertTrue("First child widget should have focus", focusChild.isFocusControl());
 }
 
@@ -161,7 +162,7 @@ public void test_setFocus_withInvisibleChild() {
 		}
 	};
 	invisibleChildWidget.setVisible(false);
-	SwtTestUtil.waitShellActivate(shell::open, shell);
+	waitForShellToBeShown(shell::open, shell);
 
 	composite.setFocus();
 	assertFalse("Composite should not try to set focus on invisible child", wasSetFocusCalledOnInvisibleChildWidget.get());
@@ -179,7 +180,7 @@ public void test_setFocus_withVisibleAndInvisibleChild() {
 	};
 	invisibleChildWidget.setVisible(false);
 	Composite visibleChildWidget = new Composite(composite, SWT.NONE);
-	SwtTestUtil.waitShellActivate(shell::open, shell);
+	waitForShellToBeShown(shell::open, shell);
 
 	composite.setFocus();
 	assertFalse("Composite should not try to set focus on invisible child", wasSetFocusCalledOnInvisibleChildWidget.get());


### PR DESCRIPTION
The tests for different focus settings of visible and invisible child controls added with #617 were implemented and refactored to wait for the shell to be activated after being opened.
Since the activation event cannot be reliably expected at least on MacOS and since activation is not even necessary for the tests, but having the shell shown is sufficient, this change adapts the awaited event to `SWT.Show`.

Contributes to https://github.com/eclipse-platform/eclipse.platform.swt/issues/616

This is based on the hint from @sratz in https://github.com/eclipse-platform/eclipse.platform.swt/issues/724#issuecomment-1625196057.