### PR TITLE
Explicitly activate shell after openining in setFocus tests #616

### DIFF
--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/SwtTestUtil.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/SwtTestUtil.java
@@ -474,6 +474,19 @@ public static void waitShellActivate(Runnable trigger, Shell shell) {
 }
 
 /**
+ * Opens the given shell and sets it active. Asserts that the shell is active
+ * afterwards. I.e., the test calling this method will fail otherwise.
+ *
+ * @param shell the shell to open and activate
+ */
+public static void openAndActivate(Shell shell) {
+	shell.open();
+	assertThat("Shell has not become visible while opening", shell.isVisible(), is(true));
+	shell.setActive();
+	assertThat("Shell has not become active", shell.getDisplay().getActiveShell(), is(shell));
+}
+
+/**
  * Check if widget contains the given color.
  *
  * @param control       widget to check

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Composite.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Composite.java
@@ -14,6 +14,7 @@
 package org.eclipse.swt.tests.junit;
 
 
+import static org.eclipse.swt.tests.junit.SwtTestUtil.openAndActivate;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -130,7 +131,7 @@ public void test_setFocus_toChild_afterOpen() {
 		return;
 	}
 	Text focusChild = new Text(composite, SWT.NONE);
-	SwtTestUtil.waitShellActivate(shell::open, shell);
+	openAndActivate(shell);
 	composite.setFocus();
 	assertTrue("First child widget should have focus", focusChild.isFocusControl());
 }
@@ -146,7 +147,7 @@ public void test_setFocus_toChild_beforeOpen() {
 	}
 	Text focusChild = new Text(composite, SWT.NONE);
 	composite.setFocus();
-	SwtTestUtil.waitShellActivate(shell::open, shell);
+	openAndActivate(shell);
 	assertTrue("First child widget should have focus", focusChild.isFocusControl());
 }
 
@@ -161,7 +162,7 @@ public void test_setFocus_withInvisibleChild() {
 		}
 	};
 	invisibleChildWidget.setVisible(false);
-	SwtTestUtil.waitShellActivate(shell::open, shell);
+	openAndActivate(shell);
 
 	composite.setFocus();
 	assertFalse("Composite should not try to set focus on invisible child", wasSetFocusCalledOnInvisibleChildWidget.get());
@@ -179,7 +180,7 @@ public void test_setFocus_withVisibleAndInvisibleChild() {
 	};
 	invisibleChildWidget.setVisible(false);
 	Composite visibleChildWidget = new Composite(composite, SWT.NONE);
-	SwtTestUtil.waitShellActivate(shell::open, shell);
+	openAndActivate(shell);
 
 	composite.setFocus();
 	assertFalse("Composite should not try to set focus on invisible child", wasSetFocusCalledOnInvisibleChildWidget.get());

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Control.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Control.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.swt.tests.junit;
 
+import static org.eclipse.swt.tests.junit.SwtTestUtil.openAndActivate;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -532,8 +533,7 @@ public void test_isFocusControl() {
 	}
 
 	assertFalse(control.isFocusControl());
-	SwtTestUtil.waitShellActivate(shell::open, shell);
-	assertEquals(shell, shell.getDisplay().getActiveShell());
+	openAndActivate(shell);
 	assertEquals("Unexpected focus", control.forceFocus(), control.isFocusControl());
 }
 @Test


### PR DESCRIPTION
The tests for different focus settings of visible and invisible child controls added with #617 were implemented and refactored to wait for the shell to be activated after being opened.
Since the activation event cannot be reliably expected at least on MacOS and since expecting activation by `Shell.open()` is nothing the test is supposed to cover, this change makes the tests explicitly activate the shell after opening it to avoid unrelated test failures.

Contributes to https://github.com/eclipse-platform/eclipse.platform.swt/issues/616