### PR TITLE
Correct order for triggering shell event and forcing active in test #724

### DIFF
--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/SwtTestUtil.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/SwtTestUtil.java
@@ -449,17 +449,16 @@ public static boolean waitEvent(Runnable trigger, Control control, int swtEvent,
  * @return <code>true</code> if Shell became active within timeout
  */
 public static void waitShellActivate(Runnable trigger, Shell shell) {
-	final int timeoutInMsec = 1000;
+	final int timeoutInMsec = 3000;
 
 	Runnable triggerWithEnforcedShellActivationOnMacOs = () -> {
+		trigger.run();
 		if (isCocoa) {
 			// Issue #731: if another app gains focus during entire JUnit session,
 			// newly opened Shells do not activate. The workaround is to activate
 			// explicitly.
 			shell.forceActive();
 		}
-
-		trigger.run();
 	};
 
 	// Issue #726: On GTK, 'Display.getActiveShell()' reports incorrect Shell.


### PR DESCRIPTION
The test utility to wait for a shell to activate introduced in #732 uses a workaround for MacOS to always enforce activation. The current behavior may have no effect because forcing activation before actually making the shell visible has no effect.

This change reorders the statements so that first the activation-triggering action is executed before enforcing activation for the situation that is does not work properly.

Contributes to https://github.com/eclipse-platform/eclipse.platform.swt/issues/724