### PR TITLE
Enabling default value to spacing to avoid table collapsing in Mac.

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Table.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Table.java
@@ -548,8 +548,9 @@ void createHandle () {
 	widget.setDataSource(widget);
 	widget.setDelegate(widget);
 	widget.setColumnAutoresizingStyle (OS.NSTableViewNoColumnAutoresizing);
-	NSSize spacing = new NSSize();
-	spacing.width = spacing.height = CELL_GAP;
+	NSSize spacing = widget.intercellSpacing();
+	spacing.height = CELL_GAP;
+	//spacing.width = CELL_GAP;  //spacing.width value is too small;so retaining the default value back.
 	widget.setIntercellSpacing(spacing);
 	widget.setDoubleAction(OS.sel_sendDoubleSelection);
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Tree.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Tree.java
@@ -588,8 +588,9 @@ void createHandle () {
 	widget.setDataSource (widget);
 	widget.setDelegate (widget);
 	widget.setColumnAutoresizingStyle (OS.NSTableViewNoColumnAutoresizing);
-	NSSize spacing = new NSSize();
-	spacing.width = spacing.height = CELL_GAP;
+	NSSize spacing = widget.intercellSpacing();
+	spacing.height = CELL_GAP;
+	//spacing.width = CELL_GAP;  //spacing.width value is too small;so retaining the default value back.
 	widget.setIntercellSpacing(spacing);
 	widget.setDoubleAction (OS.sel_sendDoubleSelection);
 


### PR DESCRIPTION
Fixes :https://github.com/eclipse-platform/eclipse.platform.swt/issues/662

The table columns once collapsed one over the other, doesn't  reexpand to bring back to the original form.This is due to the very small spacing.width value of intercell spacing.This is a fix inorder to bring back the default spacing.width value (17.0) to avoid the collapsing problem.

cc/ @lshanmug
