### PR TITLE
Change the message of the Exception in ResourceTracker

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/Resource.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/Resource.java
@@ -168,8 +168,16 @@ void initNonDisposeTracking() {
 	// Avoid performance costs of having '.finalize()' when not tracking.
 	if (nonDisposedReporter == null) return;
 
-	// Capture a stack trace to help investigating the leak
-	Error error = new Error("SWT Resource was not properly disposed"); //$NON-NLS-1$
+	// Capture a stack trace to help investigating the possible memory leak.
+	// NOTICE: this Error will also be shown if an SWTException/SWTError occurs during
+	// the initialization of the resource (i.e. in the constructor or in an
+	// init-method), but in such cases it is not necessarily a memory leak.
+	// The reason for this is that the ResourceTracker is initialized in the constructor
+	// and if an error occurs in the constructor of a subclass then the object will be
+	// eligible for garbage collection without ever having been disposed (because it
+	// was never fully initialized in the first place).
+	Error error = new Error("SWT Resource was not properly disposed. If no Exception/Error "
+			+ "was thrown during the initialization of the resource then this MIGHT be a memory leak.");
 
 	// Allocate a helper class with '.finalize()' in it, it will do the actual
 	// work of detecting and reporting errors. This works because Resource


### PR DESCRIPTION
See https://github.com/eclipse-platform/eclipse.platform/issues/528#issuecomment-1678484049

Change the error message in the `ResourceTracker` to inform about possible false-positives _i.e._ cases where it is **not** a leak. 

Contributes to https://github.com/eclipse-platform/eclipse.platform/issues/528

## How to reproduce the error
Randomly throw an Exception right after the tracker is initialized (at the bottom of `initNonDisposeTracking`)

```java
void initNonDisposeTracking() {
	...
	// throw an exception every once in a while
	if (Math.random() > 0.99) SWT.error(SWT.ERROR_UNSPECIFIED);	
}
```

And you will see some exceptions saying: `SWT Resource was not properly disposed`.