### PR TITLE
Fixing the Item height for Table and Tree when the default font is set

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/List.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/List.java
@@ -50,6 +50,9 @@ public class List extends Scrollable {
 
 	static final int CELL_GAP = 1;
 
+	/* Vertical cell padding for list item */
+	static final int VERTICAL_CELL_PADDING= 8;
+
 /**
  * Constructs a new instance of this class given its parent
  * and a style value describing its behavior and appearance.
@@ -1179,7 +1182,7 @@ void setFont (NSFont font) {
 	super.setFont (font);
 	double ascent = font.ascender ();
 	double descent = -font.descender () + font.leading ();
-	((NSTableView)view).setRowHeight ((int)Math.ceil (ascent + descent) + 1);
+	((NSTableView)view).setRowHeight ((int)Math.ceil (ascent + descent) + VERTICAL_CELL_PADDING);
 	setScrollWidth();
 }
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Table.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Table.java
@@ -93,6 +93,9 @@ public class Table extends Composite {
 	static final int TEXT_GAP = 2;
 	static final int CELL_GAP = 1;
 
+	/* Vertical cell padding for table item */
+	static final int VERTICAL_CELL_PADDING= 8;
+
 /**
  * Constructs a new instance of this class given its parent
  * and a style value describing its behavior and appearance.
@@ -2822,7 +2825,7 @@ void setItemHeight (Image image, NSFont font, boolean set) {
 	if (font == null) font = getFont ().handle;
 	double ascent = font.ascender ();
 	double descent = -font.descender () + font.leading ();
-	int height = (int)Math.ceil (ascent + descent) + 1;
+	int height = (int)Math.ceil (ascent + descent) + VERTICAL_CELL_PADDING;
 	Rectangle bounds = image != null ? image.getBounds () : imageBounds;
 	if (bounds != null) {
 		imageBounds = bounds;

--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Tree.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Tree.java
@@ -109,6 +109,9 @@ public class Tree extends Composite {
 	static final int TEXT_GAP = 2;
 	static final int CELL_GAP = 1;
 
+	/* Vertical cell padding for tree item */
+	static final int VERTICAL_CELL_PADDING= 8;
+
 /**
  * Constructs a new instance of this class given its parent
  * and a style value describing its behavior and appearance.
@@ -3170,7 +3173,7 @@ void setItemHeight (Image image, NSFont font, boolean set) {
 	if (font == null) font = getFont ().handle;
 	double ascent = font.ascender ();
 	double descent = -font.descender () + font.leading ();
-	int height = (int)Math.ceil (ascent + descent) + 1;
+	int height = (int)Math.ceil (ascent + descent) + VERTICAL_CELL_PADDING;
 	Rectangle bounds = image != null ? image.getBounds () : imageBounds;
 	if (bounds != null) {
 		imageBounds = bounds;


### PR DESCRIPTION
Fixes: #677  

A new function named as `getInset()` is created in `Table.java`. This function calculates the inset value of a cell in a table for aarch64 architecture. The inset value of a row in a table is calculated by subtracting the height of a cell from a frame.This calculated inset value is added to the height in `setItemHeight()` function.

The inset value of 1 is retained for x86_64 architecture.

/cc @lshanmug 