### PR TITLE
Revert "Enabling default value to spacing to avoid table collapsing in Mac."

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Table.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Table.java
@@ -548,9 +548,8 @@ void createHandle () {
 	widget.setDataSource(widget);
 	widget.setDelegate(widget);
 	widget.setColumnAutoresizingStyle (OS.NSTableViewNoColumnAutoresizing);
-	NSSize spacing = widget.intercellSpacing();
-	spacing.height = CELL_GAP;
-	//spacing.width = CELL_GAP;  //spacing.width value is too small;so retaining the default value back.
+	NSSize spacing = new NSSize();
+	spacing.width = spacing.height = CELL_GAP;
 	widget.setIntercellSpacing(spacing);
 	widget.setDoubleAction(OS.sel_sendDoubleSelection);
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Tree.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Tree.java
@@ -588,9 +588,8 @@ void createHandle () {
 	widget.setDataSource (widget);
 	widget.setDelegate (widget);
 	widget.setColumnAutoresizingStyle (OS.NSTableViewNoColumnAutoresizing);
-	NSSize spacing = widget.intercellSpacing();
-	spacing.height = CELL_GAP;
-	//spacing.width = CELL_GAP;  //spacing.width value is too small;so retaining the default value back.
+	NSSize spacing = new NSSize();
+	spacing.width = spacing.height = CELL_GAP;
 	widget.setIntercellSpacing(spacing);
 	widget.setDoubleAction (OS.sel_sendDoubleSelection);
 


### PR DESCRIPTION
Reverts eclipse-platform/eclipse.platform.swt#760

Fixes https://github.com/eclipse-platform/eclipse.platform.swt/issues/777