### PR TITLE
CTabFolder: Add 'showSelectedImage' property

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CTabFolder.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CTabFolder.java
@@ -196,6 +196,7 @@ public class CTabFolder extends Composite {
 	int[] gradientPercents;
 	boolean gradientVertical;
 	boolean showUnselectedImage = true;
+	boolean showSelectedImage = true;
 
 	// close, min/max and chevron buttons
 	boolean showClose = false;
@@ -1365,6 +1366,18 @@ public boolean getUnselectedCloseVisible() {
 public boolean getUnselectedImageVisible() {
 	checkWidget();
 	return showUnselectedImage;
+}
+/**
+ * Returns <code>true</code> if an image appears
+ * in selected tabs.
+ *
+ * @return <code>true</code> if an image appears in selected tabs
+ *
+ * @since 3.125
+ */
+public boolean getSelectedImageVisible() {
+	checkWidget();
+	return showSelectedImage;
 }
 /**
  * Return the index of the specified tab or -1 if the tab is not
@@ -3691,6 +3704,25 @@ public void setUnselectedImageVisible(boolean visible) {
 	if (showUnselectedImage == visible) return;
 	// display image on unselected items
 	showUnselectedImage = visible;
+	updateFolder(REDRAW);
+}
+/**
+ * Specify whether the image appears on selected tabs.
+ *
+ * @param visible <code>true</code> makes the image appear
+ *
+ * @exception SWTException <ul>
+ *    <li>ERROR_WIDGET_DISPOSED - if the receiver has been disposed</li>
+ *    <li>ERROR_THREAD_INVALID_ACCESS - if not called from the thread that created the receiver</li>
+ * </ul>
+ *
+ * @since 3.125
+ */
+public void setSelectedImageVisible(boolean visible) {
+	checkWidget();
+	if (showSelectedImage == visible) return;
+	// display image on selected items
+	showSelectedImage = visible;
 	updateFolder(REDRAW);
 }
 /**

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_custom_CTabFolder.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_custom_CTabFolder.java
@@ -468,6 +468,18 @@ public void test_iconWrappedOnNextLine() {
 	}
 }
 
+@Test
+public void test_selectedImageVisible() {
+	createTabFolder(null);
+
+	ctabFolder.setSelectedImageVisible(true);
+	assertTrue(ctabFolder.getSelectedImageVisible());
+
+	ctabFolder.setSelectedImageVisible(false);
+	assertFalse(ctabFolder.getSelectedImageVisible());
+
+}
+
 private void processEvents() {
 	Display display = shell.getDisplay();
 


### PR DESCRIPTION
- Added new property "showSelectedImage" to CTabFolder parallel to existing property "showUnselectedImage"

- Image rendering in drawSelected method updated in CTabFolderRenderer with handling the new property "showSelectedImage"

- Added standard padding for text of tabs when tab icon is either not available or is hidden (both for selected and unselected tabs)

- Pre-requisite for [issue](https://github.com/eclipse-platform/eclipse.platform.ui/issues/735) and pull request : https://github.com/eclipse-platform/eclipse.platform.ui/pull/1071
