### PR TITLE
Tree.java: correctly escape & in default Tooltip

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Tree.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Tree.java
@@ -5608,7 +5608,7 @@ String toolTipText (NMTTDISPINFO hdr) {
 			}
 			//TEMPORARY CODE
 			if (isCustomToolTip ()) text = " ";
-			if (text != null) return text;
+			if (text != null) return text.replace("&", "&&");
 		}
 	}
 	return super.toolTipText (hdr);


### PR DESCRIPTION
Fix for
https://github.com/eclipse-platform/eclipse.platform.ui/issues/238
https://github.com/eclipse-platform/eclipse.platform.ui/issues/1075

![grafik](https://github.com/eclipse-platform/eclipse.platform.swt/assets/16443184/2127695a-20cc-4c1d-889e-c46cdf076277)


When TreeColumn's are too small, a ToolTip is displayed on hover to reveal the whole Label of an Item (The WIN32-Docs call them [In-Place Tooltips](https://learn.microsoft.com/en-us/windows/win32/controls/using-tooltip-contro)).
These ToolTips pass through the Composite-ToolTipText-generator which escapes all & in a Text - allowing to reuse Text from Buttons as Tooltips. This is a well documented Feature of setToolTipText. Since TreeItem's Label does not have Mnemonics, we do not assume that the & should require escaping by the User.

This Commit Escapes all & in default Tooltips that are handled by the default mechanism.