### PR TITLE
Fix app name not shown in main menu on macOS Sonoma

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Display.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Display.java
@@ -5748,6 +5748,7 @@ void applicationWillFinishLaunching (long id, long sel, long notification) {
 		NSString match = NSString.stringWith("%@");
 		appitem.setTitle(name);
 		NSMenu sm = appitem.submenu();
+		sm.setTitle(name);
 		NSArray ia = sm.itemArray();
 		for(int i = 0; i < ia.count(); i++) {
 			NSMenuItem ni = new NSMenuItem(ia.objectAtIndex(i));


### PR DESCRIPTION
- We need to set the sub-menu to the application name
- See https://github.com/eclipse-platform/eclipse.platform.swt/issues/779