### PR TITLE
backport Bug 579335: Fix crash on long styled lines on Windows

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/TextLayout.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/TextLayout.java
@@ -2877,10 +2877,12 @@ StyleItem[] merge (long items, int itemCount) {
 			}
 		}
 
+		boolean mayNeedSplit = true;
 		int styleLimit = translateOffset(styles[styleIndex + 1].start);
 		if (styleLimit <= itemLimit) {
 			int runLen = styleLimit - start;
 			if (runLen < MAX_RUN_LENGTH) {
+				mayNeedSplit = false;
 				styleIndex++;
 				start = styleLimit;
 				if (start < itemLimit && 0 < start && start < end) {
@@ -2894,7 +2896,7 @@ StyleItem[] merge (long items, int itemCount) {
 			}
 		}
 		int runLen = itemLimit - start;
-		if (runLen > MAX_RUN_LENGTH) {
+		if (mayNeedSplit && runLen > MAX_RUN_LENGTH) {
 			start += splitLongRun(item);
 		} else if (itemLimit <= styleLimit) {
 			itemIndex = nextItemIndex;

--- a/bundles/org.eclipse.swt/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.swt/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.swt; singleton:=true
-Bundle-Version: 3.119.2:200.qualifier
+Bundle-Version: 3.119.200.qualifier
 Bundle-ManifestVersion: 2
 Bundle-Localization: plugin
 DynamicImport-Package: org.eclipse.swt.accessibility2

--- a/bundles/org.eclipse.swt/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.swt/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.swt; singleton:=true
-Bundle-Version: 3.119.100.qualifier
+Bundle-Version: 3.119.2:200.qualifier
 Bundle-ManifestVersion: 2
 Bundle-Localization: plugin
 DynamicImport-Package: org.eclipse.swt.accessibility2

--- a/bundles/org.eclipse.swt/pom.xml
+++ b/bundles/org.eclipse.swt/pom.xml
@@ -21,7 +21,7 @@
     </parent>
     <groupId>org.eclipse.swt</groupId>
     <artifactId>org.eclipse.swt</artifactId>
-    <version>3.119.100-SNAPSHOT</version>
+    <version>3.119.200-SNAPSHOT</version>
     <packaging>eclipse-plugin</packaging>
 
     <properties>

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_TextLayout.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_TextLayout.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.fail;
 import java.util.Arrays;
 
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.Font;
 import org.eclipse.swt.graphics.GC;
 import org.eclipse.swt.graphics.Image;
@@ -1180,4 +1181,66 @@ public void test_bug23406_longLines() {
 	check(bestProgramInThai, 1000);
 }
 
+@Test
+public void test_Bug579335_win32_StyledText_LongLine() {
+	if (!SwtTestUtil.isWindows) {
+		// TODO This test was written for the platform specific parts of TextLayout and
+		// on Linux (and possibly mac)
+		// the size of images needed to run the tests causes failures.
+		if (SwtTestUtil.verbose) {
+			System.out.println(
+					"Excluded test_Bug579335_win32_StyledText_LongLine(org.eclipse.swt.tests.junit.Test_org_eclipse_swt_graphics_TextLayout).");
+		}
+		return;
+	}
+
+	Font font = null;
+	Image image = null;
+	TextLayout layout = null;
+
+	try {
+		font = new Font(display, SwtTestUtil.testFontName, 16, SWT.NORMAL);
+
+		layout = new TextLayout(display);
+		layout.setFont(font);
+		layout.setText("a".repeat(33000));
+		Color red = display.getSystemColor(SWT.COLOR_RED);
+		Color white = display.getSystemColor(SWT.COLOR_WHITE);
+		Color green = display.getSystemColor(SWT.COLOR_GREEN);
+		TextStyle redStyle = new TextStyle(font, red, white);
+		TextStyle greenStyle = new TextStyle(font, green, white);
+
+		image = draw(layout, SWT.DEFAULT);
+
+		layout.setStyle(redStyle, 7, 7);
+		layout.setStyle(greenStyle, 8, 8 + 32909 - 1);
+
+		image = draw(layout, SWT.DEFAULT);
+
+		// reset for next test
+		image.dispose();
+		layout.setStyle(null, 0, 33000 - 1);
+
+		layout.setStyle(greenStyle, 2, 2 + 16000 - 1);
+		image = draw(layout, SWT.DEFAULT);
+
+		// reset for next test
+		image.dispose();
+		layout.setStyle(null, 0, 33000 - 1);
+
+		layout.setStyle(redStyle, 0, 0 + 1 - 1);
+		layout.setStyle(greenStyle, 1, 1 + 32916 - 1);
+		image = draw(layout, SWT.DEFAULT);
+
+//		 SwtTestUtil.debugDisplayImage(image);
+	} finally {
+
+		if (layout != null)
+			layout.dispose();
+		if (image != null)
+			image.dispose();
+		if (font != null)
+			font.dispose();
+	}
+}
 }


### PR DESCRIPTION
The code had been mistakenly splitting even though the style had already split the run.

Adapted manual test case in the bug to a JUnit test.

triggerWinGerrit

Also-by: Alexandr Miloslavskiy <alexandr.miloslavskiy@syntevo.com>
Change-Id: I9fea7f0ac8e30fa38e486dedcdae26034f7f40d2
Reviewed-on: https://git.eclipse.org/r/c/platform/eclipse.platform.swt/+/192078
Tested-by: Platform Bot <platform-bot@eclipse.org>
Reviewed-by: Alexandr Miloslavskiy <alexandr.miloslavskiy@syntevo.com>
Reviewed-by: Jonah Graham <jonah@kichwacoders.com>


cc/ @lshanmug We have a user on 4.23 facing this bug.