### PR TITLE
Fixing the spacing.width value to enable re-collapsing of table columns

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Table.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Table.java
@@ -651,6 +651,9 @@ void createItem (TableColumn column, int index) {
 	display.addWidget (headerCell, column);
 	column.nsColumn = nsColumn;
 	nsColumn.setWidth(0);
+	nsColumn.setMinWidth(2);
+	/* Maintaining the minimum width at the lowest value of 2, which guarantees the visibility of the drag cursor
+	and the possibility of table columns re-collapsing */
 	System.arraycopy (columns, index, columns, index + 1, columnCount++ - index);
 	columns [index] = column;
 	for (int i = 0; i < itemCount; i++) {


### PR DESCRIPTION
Fixes : https://github.com/eclipse-platform/eclipse.platform.swt/issues/662

The default intercell spacing value that is obtained from Cocoa for width is 17. This patch provides a change for `CELL_GAP` value. For width, `CELL_GAP` is replaced with `HCELL_GAP` with value 17 (default value obtained from Cocoa). For Height (existing value is retained which is 1) `CELL_GAP` is replaced with `VCELL_GAP` with value 1.