### PR TITLE
Fix upside-down image in macOS Sonoma

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/graphics/GC.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/graphics/GC.java
@@ -331,7 +331,7 @@ long applierFunc(long info, long elementPtr) {
 NSAutoreleasePool checkGC (int mask) {
 	NSAutoreleasePool pool = null;
 	if (!NSThread.isMainThread()) pool = (NSAutoreleasePool) new NSAutoreleasePool().alloc().init();
-	if (data.flippedContext != null && !handle.isEqual(NSGraphicsContext.currentContext())) {
+	if (data.context != null && !handle.isEqual(NSGraphicsContext.currentContext())) {
 		data.restoreContext = true;
 		NSGraphicsContext.static_saveGraphicsState();
 		NSGraphicsContext.setCurrentContext(handle);
@@ -4166,7 +4166,7 @@ public String toString () {
 }
 
 void uncheckGC(NSAutoreleasePool pool) {
-	if (data.flippedContext != null && data.restoreContext) {
+	if (data.context != null && data.restoreContext) {
 		NSGraphicsContext.static_restoreGraphicsState();
 		data.restoreContext = false;
 	}

--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/graphics/GCData.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/graphics/GCData.java
@@ -64,6 +64,6 @@ public final class GCData {
 	public NSView view;
 	public NSSize size;
 	public Thread thread;
-	public NSGraphicsContext flippedContext;
+	public NSGraphicsContext context;
 	public boolean restoreContext;
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/graphics/Image.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/graphics/Image.java
@@ -1532,10 +1532,10 @@ public long internal_new_GC (GCData data) {
 			imageRep.setAlpha(false);
 			context = NSGraphicsContext.graphicsContextWithBitmapImageRep(imageRep);
 		}
-		NSGraphicsContext flippedContext = NSGraphicsContext.graphicsContextWithGraphicsPort(context.graphicsPort(), true);
-		context = flippedContext;
+		boolean flip = OS.VERSION < OS.VERSION(14, 0, 0); // https://github.com/eclipse-platform/eclipse.platform.swt/issues/772
+		context = NSGraphicsContext.graphicsContextWithGraphicsPort(context.graphicsPort(), flip);
 		context.retain();
-		if (data != null) data.flippedContext = flippedContext;
+		if (data != null) data.context = context;
 		NSGraphicsContext.static_saveGraphicsState();
 		NSGraphicsContext.setCurrentContext(context);
 		NSAffineTransform transform = NSAffineTransform.transform();

--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Composite.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Composite.java
@@ -336,12 +336,12 @@ public void drawBackground(GC gc, int x, int y, int width, int height, int offse
 		GCData data = gc.getGCData();
 		if (data.image != null) imgHeight =  data.image.getBounds().height;
 		NSGraphicsContext context = gc.handle;
-		if (data.flippedContext != null) {
+		if (data.context != null) {
 			NSGraphicsContext.static_saveGraphicsState();
 			NSGraphicsContext.setCurrentContext(context);
 		}
 		control.fillBackground (view, context, rect, imgHeight, data.view, offsetX, offsetY);
-		if (data.flippedContext != null) {
+		if (data.context != null) {
 			NSGraphicsContext.static_restoreGraphicsState();
 		}
 	} else {

--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Control.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Control.java
@@ -2199,10 +2199,10 @@ public long internal_new_GC (GCData data) {
 			graphicsContext = NSGraphicsContext.graphicsContextWithBitmapImageRep(rep);
 			rep.release();
 		}
-		NSGraphicsContext flippedContext = NSGraphicsContext.graphicsContextWithGraphicsPort(graphicsContext.graphicsPort(), true);
-		graphicsContext = flippedContext;
+		boolean flip = OS.VERSION < OS.VERSION(14, 0, 0); // https://github.com/eclipse-platform/eclipse.platform.swt/issues/772
+		graphicsContext = NSGraphicsContext.graphicsContextWithGraphicsPort(graphicsContext.graphicsPort(), flip);
 		if (data != null) {
-			data.flippedContext = flippedContext;
+			data.context = graphicsContext;
 			data.state &= ~VISIBLE_REGION;
 			data.visibleRgn = getVisibleRegion();
 			display.addContext (data);

--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Display.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Display.java
@@ -4380,8 +4380,8 @@ boolean runAWTInvokeLater() {
 boolean runContexts () {
 	if (contexts != null) {
 		for (int i = 0; i < contexts.length; i++) {
-			if (contexts[i] != null && contexts[i].flippedContext != null) {
-				contexts[i].flippedContext.flushGraphics();
+			if (contexts[i] != null && contexts[i].context != null) {
+				contexts[i].context.flushGraphics();
 			}
 		}
 	}


### PR DESCRIPTION
Image flipping was originally implemented back in 2008 [1,2]. Possibly as a workaround.

It appears something has changed with macOS Sonoma (14.0), and this is no longer necessary.

[1] https://bugs.eclipse.org/bugs/show_bug.cgi?id=254797
[2] ca92157b3c27b88421e1752a1072ed1fab69c0ce

Resolves #772.