### PR TITLE
Remove blank Javadoc

### DIFF
--- a/bundles/org.eclipse.swt.tools.spies/src/org/eclipse/swt/tools/internal/Sleak.java
+++ b/bundles/org.eclipse.swt.tools.spies/src/org/eclipse/swt/tools/internal/Sleak.java
@@ -31,7 +31,6 @@ import org.eclipse.swt.widgets.List;
  *
  * Modify the main method below to launch your application.
  * Run Sleak.
- *
  */
 public class Sleak {
 	List list;

--- a/bundles/org.eclipse.swt.tools.spies/src/org/eclipse/swt/tools/internal/SpiesConstants.java
+++ b/bundles/org.eclipse.swt.tools.spies/src/org/eclipse/swt/tools/internal/SpiesConstants.java
@@ -13,7 +13,6 @@ package org.eclipse.swt.tools.internal;
 
 /**
  * Interface containing constants for the Spies plug-in.
- * 
  */
 
 public interface SpiesConstants {

--- a/bundles/org.eclipse.swt.tools/Icon Exe/org/eclipse/swt/tools/internal/IconExe.java
+++ b/bundles/org.eclipse.swt.tools/Icon Exe/org/eclipse/swt/tools/internal/IconExe.java
@@ -1101,7 +1101,6 @@ static class ImageLoader {
 	 * the background pixel for the logical screen (this 
 	 * corresponds to the GIF89a Background Color Index value).
 	 * The default is -1 which means 'unspecified background'
-	 * 
 	 */
 	public int backgroundPixel;
 

--- a/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CBanner.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CBanner.java
@@ -100,7 +100,6 @@ public class CBanner extends Composite {
  * @exception SWTException <ul>
  *    <li>ERROR_THREAD_INVALID_ACCESS - if not called from the thread that created the parent</li>
  * </ul>
- *
  */
 public CBanner(Composite parent, int style) {
 	super(parent, checkStyle(style));

--- a/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CTabFolder.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CTabFolder.java
@@ -872,7 +872,6 @@ ToolBar getChevron() {
  *    <li>ERROR_WIDGET_DISPOSED - if the receiver has been disposed</li>
  *    <li>ERROR_THREAD_INVALID_ACCESS - if not called from the thread that created the receiver</li>
  * </ul>
- *
  */
 /*public*/ boolean getChevronVisible() {
 	checkWidget();
@@ -4176,7 +4175,6 @@ int getWrappedHeight (Point size) {
  *    <li>ERROR_THREAD_INVALID_ACCESS when called from the wrong thread</li>
  *    <li>ERROR_WIDGET_DISPOSED when the widget has been disposed</li>
  * </ul>
- *
  */
 /*public*/ void setChevronVisible(boolean visible) {
 	checkWidget();

--- a/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CTabFolderRenderer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CTabFolderRenderer.java
@@ -755,9 +755,6 @@ public class CTabFolderRenderer {
 
 	/*
 	 * Draw the border of the tab
-	 *
-	 * @param gc
-	 * @param shape
 	 */
 	void drawBorder(GC gc, int[] shape) {
 
@@ -1045,8 +1042,6 @@ public class CTabFolderRenderer {
 
 	/*
 	 * Draw the unselected border for the receiver on the left.
-	 *
-	 * @param gc
 	 */
 	void drawLeftUnselectedBorder(GC gc, Rectangle bounds, int state) {
 		int x = bounds.x;
@@ -1184,8 +1179,6 @@ public class CTabFolderRenderer {
 
 	/*
 	 * Draw the unselected border for the receiver on the right.
-	 *
-	 * @param gc
 	 */
 	void drawRightUnselectedBorder(GC gc, Rectangle bounds, int state) {
 		int x = bounds.x;

--- a/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/ControlEditor.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/ControlEditor.java
@@ -118,7 +118,6 @@ public class ControlEditor {
 * Creates a ControlEditor for the specified Composite.
 *
 * @param parent the Composite above which this editor will be displayed
-*
 */
 public ControlEditor (Composite parent) {
 	this.parent = parent;

--- a/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/StyledText.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/StyledText.java
@@ -10235,10 +10235,7 @@ void setStyleRanges(int start, int length, int[] ranges, StyleRange[] styles, bo
 /**
  *
  * @param referenceRanges former ranges, sorted by order and without overlapping, typically returned {@link #getRanges(int, int)}
- * @param referenceStyles
  * @param newRanges former ranges, sorted by order and without overlapping
- * @param newStyles
- * @return
  */
 private SortedSet<Integer> computeModifiedLines(int[] referenceRanges, StyleRange[] referenceStyles, int[] newRanges, StyleRange[] newStyles) {
 	if (referenceStyles == null) {
@@ -10329,9 +10326,6 @@ private boolean isInRange(int[] ranges, int styleIndex, int offset) {
 
 /**
  * The offset on which the range ends (excluded)
- * @param ranges
- * @param styleIndex
- * @return
  */
 private int endRangeOffset(int[] ranges, int styleIndex) {
 	if (styleIndex < 0 || 2 * styleIndex > ranges.length) {

--- a/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/StyledTextEvent.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/StyledTextEvent.java
@@ -16,9 +16,6 @@ package org.eclipse.swt.custom;
 import org.eclipse.swt.graphics.*;
 import org.eclipse.swt.widgets.*;
 
-/**
- *
- */
 class StyledTextEvent extends Event {
 	// used by LineStyleEvent
 	int[] ranges;

--- a/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/StyledTextListener.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/StyledTextListener.java
@@ -18,8 +18,6 @@ import org.eclipse.swt.internal.*;
 import org.eclipse.swt.widgets.*;
 
 class StyledTextListener extends TypedListener {
-/**
- */
 StyledTextListener(SWTEventListener listener) {
 	super(listener);
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/TableCursor.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/TableCursor.java
@@ -195,7 +195,6 @@ public TableCursor(Table parent, int style) {
  * @see SelectionListener
  * @see SelectionEvent
  * @see #removeSelectionListener(SelectionListener)
- *
  */
 public void addSelectionListener(SelectionListener listener) {
 	checkWidget();
@@ -626,7 +625,6 @@ public void setForeground (Color color) {
  *    <li>ERROR_WIDGET_DISPOSED - if the receiver has been disposed</li>
  *    <li>ERROR_THREAD_INVALID_ACCESS - if not called from the thread that created the receiver</li>
  * </ul>
- *
  */
 public void setSelection(int row, int column) {
 	checkWidget();
@@ -649,7 +647,6 @@ public void setSelection(int row, int column) {
  *    <li>ERROR_WIDGET_DISPOSED - if the receiver has been disposed</li>
  *    <li>ERROR_THREAD_INVALID_ACCESS - if not called from the thread that created the receiver</li>
  * </ul>
- *
  */
 public void setSelection(TableItem row, int column) {
 	checkWidget();

--- a/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/TableEditor.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/TableEditor.java
@@ -87,7 +87,6 @@ public class TableEditor extends ControlEditor {
 * Creates a TableEditor for the specified Table.
 *
 * @param table the Table Control above which this editor will be displayed
-*
 */
 public TableEditor (Table table) {
 	super(table);

--- a/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/TreeEditor.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/TreeEditor.java
@@ -87,7 +87,6 @@ public class TreeEditor extends ControlEditor {
 * Creates a TreeEditor for the specified Tree.
 *
 * @param tree the Tree Control above which this editor will be displayed
-*
 */
 public TreeEditor (Tree tree) {
 	super(tree);

--- a/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/common/org/eclipse/swt/dnd/DragSourceListener.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/common/org/eclipse/swt/dnd/DragSourceListener.java
@@ -25,7 +25,6 @@ import org.eclipse.swt.internal.*;
  * <p>After the drop has completed successfully or has been aborted, the application which defines the
  * <code>DragSource</code> is required to take the appropriate cleanup action.  In the case of a successful
  * <b>move</b> operation, the application must remove the data that was transferred.</p>
- *
  */
 public interface DragSourceListener extends SWTEventListener {
 

--- a/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/common/org/eclipse/swt/dnd/DropTargetListener.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/common/org/eclipse/swt/dnd/DropTargetListener.java
@@ -34,7 +34,6 @@ import org.eclipse.swt.internal.*;
  * operation that is performed but the data type is fixed.</p>
  *
  * @see DropTargetEvent
- *
  */
 public interface DropTargetListener extends SWTEventListener {
 

--- a/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/gtk/org/eclipse/swt/internal/dnd/gtk/ListDragSourceEffect.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/gtk/org/eclipse/swt/internal/dnd/gtk/ListDragSourceEffect.java
@@ -35,7 +35,6 @@ import org.eclipse.swt.widgets.*;
  * @see DragSourceEffect
  * @see DragSourceEvent
  * @see <a href="http://www.eclipse.org/swt/">Sample code and further information</a>
- *
  */
 public class ListDragSourceEffect extends DragSourceEffect {
 	Image dragSourceImage = null;

--- a/bundles/org.eclipse.swt/Eclipse SWT OLE Win32/win32/org/eclipse/swt/ole/win32/OLE.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT OLE Win32/win32/org/eclipse/swt/ole/win32/OLE.java
@@ -25,7 +25,6 @@ import org.eclipse.swt.internal.win32.*;
  * OLE contains all the constants used to create an ActiveX Control or an OLE Document.
  *
  * <p>Definitions for these constants can be found in MSDN.
- *
  */
 public class OLE extends SWT {
 

--- a/bundles/org.eclipse.swt/Eclipse SWT OLE Win32/win32/org/eclipse/swt/ole/win32/OleClientSite.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT OLE Win32/win32/org/eclipse/swt/ole/win32/OleClientSite.java
@@ -660,7 +660,6 @@ public int doVerb(int verb) {
  * @param out the return value of the command
  *
  * @return an HRESULT value; OLE.S_OK is returned if successful
- *
  */
 public int exec(int cmdID, int options, Variant in, Variant out) {
 

--- a/bundles/org.eclipse.swt/Eclipse SWT OLE Win32/win32/org/eclipse/swt/ole/win32/OleEventTable.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT OLE Win32/win32/org/eclipse/swt/ole/win32/OleEventTable.java
@@ -19,7 +19,6 @@ package org.eclipse.swt.ole.win32;
 * look up mechanism that maps an event type
 * to a listener.  Multiple listeners for the
 * same event type are supported.
-*
 */
 
 class OleEventTable {

--- a/bundles/org.eclipse.swt/Eclipse SWT OLE Win32/win32/org/eclipse/swt/ole/win32/OleFrame.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT OLE Win32/win32/org/eclipse/swt/ole/win32/OleFrame.java
@@ -89,7 +89,6 @@ final public class OleFrame extends Composite
  * @exception SWTException <ul>
  *     <li>ERROR_THREAD_INVALID_ACCESS when called from the wrong thread
  * </ul>
- *
  */
 public OleFrame(Composite parent, int style) {
 	super(parent, style);
@@ -382,7 +381,6 @@ private int GetBorder(long lprectBorder) {
  *
  * @return the application menu items that will appear in the Container location when an OLE Document
  *         is in-place activated.
- *
  */
 public MenuItem[] getContainerMenus(){
 	return containerMenuItems;
@@ -400,7 +398,6 @@ public MenuItem[] getContainerMenus(){
  *
  * @return the application menu items that will appear in the File location when an OLE Document
  *         is in-place activated.
- *
  */
 public MenuItem[] getFileMenus(){
 	return fileMenuItems;
@@ -440,7 +437,6 @@ private int GetWindow(long phwnd) {
  *
  * @return the application menu items that will appear in the Window location when an OLE Document
  *         is in-place activated.
- *
  */
 public MenuItem[] getWindowMenus(){
 	return windowMenuItems;

--- a/bundles/org.eclipse.swt/Eclipse SWT OLE Win32/win32/org/eclipse/swt/ole/win32/Variant.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT OLE Win32/win32/org/eclipse/swt/ole/win32/Variant.java
@@ -23,7 +23,6 @@ import org.eclipse.swt.internal.win32.*;
  *
  * <p>It is used within the OleAutomation object for getting a property, setting a property or invoking
  * a method on an OLE Control or OLE Document.
- *
  */
 public final class Variant {
 	/**
@@ -115,7 +114,6 @@ public Variant() {
  * Create a Variant object which represents a Java float as a VT_R4.
  *
  * @param val the Java float value that this Variant represents
- *
  */
 public Variant(float val) {
 	type = COM.VT_R4;
@@ -136,7 +134,6 @@ public Variant(double val) {
  * Create a Variant object which represents a Java int as a VT_I4.
  *
  * @param val the Java int value that this Variant represents
- *
  */
  public Variant(int val) {
 	type = COM.VT_I4;
@@ -152,7 +149,6 @@ public Variant(double val) {
  *
  * @param ptr a pointer to the data being transferred.
  * @param byRefType the type of the data being transferred such as OLE.VT_BSTR | OLE.VT_BYREF
- *
  */
 public Variant(long ptr, short byRefType) {
 	type = byRefType;
@@ -162,7 +158,6 @@ public Variant(long ptr, short byRefType) {
  * Create a Variant object which represents an IDispatch interface as a VT_Dispatch.
  *
  * @param automation the OleAutomation object that this Variant represents
- *
  */
 public Variant(OleAutomation automation) {
 	type = COM.VT_DISPATCH;
@@ -176,7 +171,6 @@ public Variant(OleAutomation automation) {
  * @since 2.0
  *
  * @param idispatch the IDispatch object that this Variant represents
- *
  */
 public Variant(IDispatch idispatch) {
 	type = COM.VT_DISPATCH;
@@ -189,7 +183,6 @@ public Variant(IDispatch idispatch) {
  * this Variant.
  *
  * @param unknown the IUnknown object that this Variant represents
- *
  */
 public Variant(IUnknown unknown) {
 	type = COM.VT_UNKNOWN;
@@ -210,7 +203,6 @@ public Variant(IUnknown unknown) {
  * Create a Variant object which represents a Java String as a VT_BSTR.
  *
  * @param string the Java String value that this Variant represents
- *
  */
 public Variant(String string) {
 	type = COM.VT_BSTR;
@@ -220,7 +212,6 @@ public Variant(String string) {
  * Create a Variant object which represents a Java short as a VT_I2.
  *
  * @param val the Java short value that this Variant represents
- *
  */
 public Variant(short val) {
 	type = COM.VT_I2;
@@ -230,7 +221,6 @@ public Variant(short val) {
  * Create a Variant object which represents a Java boolean as a VT_BOOL.
  *
  * @param val the Java boolean value that this Variant represents
- *
  */
 public Variant(boolean val) {
 	type = COM.VT_BOOL;
@@ -355,7 +345,6 @@ public IDispatch getDispatch() {
  * @exception SWTException <ul>
  *     <li>ERROR_CANNOT_CHANGE_VARIANT_TYPE when type of Variant can not be coerced into a boolean</li>
  * </ul>
- *
  */
 public boolean getBoolean() {
 	if (type == COM.VT_EMPTY) {
@@ -389,7 +378,6 @@ public boolean getBoolean() {
  * <p>If this Variant does not contain a reference to data, zero is returned.
  *
  * @return a pointer to the referenced data represented by this Variant or 0
- *
  */
 public long getByRef() {
 	if (type == COM.VT_EMPTY) {

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/common/org/eclipse/swt/internal/Library.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/common/org/eclipse/swt/internal/Library.java
@@ -116,9 +116,6 @@ static int parseVersion(String version) {
 /**
  * Returns the Java version number as an integer.
  *
- * @param major
- * @param minor
- * @param micro
  * @return the version
  */
 public static int JAVA_VERSION (int major, int minor, int micro) {
@@ -128,8 +125,6 @@ public static int JAVA_VERSION (int major, int minor, int micro) {
 /**
  * Returns the SWT version number as an integer.
  *
- * @param major
- * @param minor
  * @return the version
  */
 public static int SWT_VERSION (int major, int minor) {

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/org/eclipse/swt/internal/gtk/GTK.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/org/eclipse/swt/internal/gtk/GTK.java
@@ -944,13 +944,11 @@ public class GTK extends OS {
 	/**
 	 * @param label cast=(GtkLabel *)
 	 * @param xalign cast=(gfloat)
-	 *
 	 */
 	public static final native void gtk_label_set_xalign(long label, float xalign);
 	/**
 	* @param label cast=(GtkLabel *)
 	* @param yalign cast=(gfloat)
-	*
 	*/
 	public static final native void gtk_label_set_yalign(long label, float yalign);
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/graphics/ImageLoader.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/graphics/ImageLoader.java
@@ -78,7 +78,6 @@ public class ImageLoader {
 	 * the background pixel for the logical screen (this
 	 * corresponds to the GIF89a Background Color Index value).
 	 * The default is -1 which means 'unspecified background'
-	 *
 	 */
 	public int backgroundPixel;
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/graphics/Region.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/graphics/Region.java
@@ -207,7 +207,6 @@ static long polyRgn(int[] pointArray, int count) {
  * </ul>
  *
  * @since 3.0
- *
  */
 public void add (int[] pointArray) {
 	if (isDisposed()) SWT.error(SWT.ERROR_GRAPHIC_DISPOSED);

--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/internal/graphics/ImageUtil.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/internal/graphics/ImageUtil.java
@@ -22,7 +22,6 @@ import org.eclipse.swt.internal.cocoa.*;
  * Not used on other platforms
  *
  * @since 3.110
- *
  */
 public class ImageUtil {
 	/**

--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Display.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Display.java
@@ -3506,7 +3506,6 @@ static long getCurrentKeyLayout () {
  * </ul>
  *
  * @since 3.0
- *
  */
 public boolean post(Event event) {
 	synchronized (Device.class) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Shell.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Shell.java
@@ -1163,7 +1163,6 @@ public Point getMinimumSize () {
  * </ul>
  *
  * @since 3.0
- *
  */
 @Override
 public Region getRegion () {

--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/TabItem.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/TabItem.java
@@ -392,7 +392,6 @@ public void setImage (Image image) {
  *    <li>ERROR_WIDGET_DISPOSED - if the receiver has been disposed</li>
  *    <li>ERROR_THREAD_INVALID_ACCESS - if not called from the thread that created the receiver</li>
  * </ul>
- *
  */
 @Override
 public void setText (String string) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/TableColumn.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/TableColumn.java
@@ -521,7 +521,6 @@ public int getWidth () {
  *    <li>ERROR_WIDGET_DISPOSED - if the receiver has been disposed</li>
  *    <li>ERROR_THREAD_INVALID_ACCESS - if not called from the thread that created the receiver</li>
  * </ul>
- *
  */
 public void pack () {
 	checkWidget ();

--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/TaskItem.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/TaskItem.java
@@ -159,7 +159,6 @@ public String getOverlayText () {
  *    <li>ERROR_WIDGET_DISPOSED - if the receiver has been disposed</li>
  *    <li>ERROR_THREAD_INVALID_ACCESS - if not called from the thread that created the receiver</li>
  * </ul>
- *
  */
 public TaskBar getParent () {
 	checkWidget ();

--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/TreeColumn.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/TreeColumn.java
@@ -523,7 +523,6 @@ public int getWidth () {
  *    <li>ERROR_WIDGET_DISPOSED - if the receiver has been disposed</li>
  *    <li>ERROR_THREAD_INVALID_ACCESS - if not called from the thread that created the receiver</li>
  * </ul>
- *
  */
 public void pack () {
 	checkWidget ();

--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/TreeItem.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/TreeItem.java
@@ -392,7 +392,6 @@ void destroyWidget () {
  * </ul>
  *
  * @since 2.0
- *
  */
 public Color getBackground () {
 	checkWidget ();
@@ -597,7 +596,6 @@ public Font getFont (int index) {
  * </ul>
  *
  * @since 2.0
- *
  */
 public Color getForeground () {
 	checkWidget ();
@@ -1055,7 +1053,6 @@ void sendExpand (boolean expand, boolean recurse) {
  * </ul>
  *
  * @since 2.0
- *
  */
 public void setBackground (Color color) {
 	checkWidget ();
@@ -1087,7 +1084,6 @@ public void setBackground (Color color) {
  * </ul>
  *
  * @since 3.1
- *
  */
 public void setBackground (int index, Color color) {
 	checkWidget ();
@@ -1244,7 +1240,6 @@ public void setFont (int index, Font font) {
  * </ul>
  *
  * @since 2.0
- *
  */
 public void setForeground (Color color) {
 	checkWidget ();
@@ -1276,7 +1271,6 @@ public void setForeground (Color color) {
  * </ul>
  *
  * @since 3.1
- *
  */
 public void setForeground (int index, Color color){
 	checkWidget ();

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/SwtRunnable.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/SwtRunnable.java
@@ -17,7 +17,6 @@ package org.eclipse.swt;
  * A method that returns no result and may throw a checked exception of the given
  * type.
  * @since 3.123
- *
  */
 @FunctionalInterface
 public interface SwtRunnable<E extends Exception> {

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/RGBA.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/RGBA.java
@@ -89,7 +89,6 @@ public RGBA(int red, int green, int blue, int alpha) {
 *    the saturation or brightness is not between 0 and 1 or if the alpha
 *    is not between 0 and 255</li>
 * </ul>
-*
 */
 public RGBA(float hue, float saturation, float brightness, float alpha) {
 	if ((alpha > 255) || (alpha < 0)) SWT.error(SWT.ERROR_INVALID_ARGUMENT);

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/image/FileFormat.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/image/FileFormat.java
@@ -22,7 +22,6 @@ import org.eclipse.swt.graphics.*;
 /**
  * Abstract factory class for loading/unloading images from files or streams
  * in various image file formats.
- *
  */
 public abstract class FileFormat {
 	static final String FORMAT_PACKAGE = "org.eclipse.swt.internal.image"; //$NON-NLS-1$

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/layout/BorderLayout.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/layout/BorderLayout.java
@@ -84,7 +84,6 @@ public class BorderLayout extends Layout {
 	 * placed along the left and right edges of the layout.
 	 *
 	 * The default value is 0.
-	 *
 	 */
 	public int marginWidth = 0;
 	/**
@@ -92,7 +91,6 @@ public class BorderLayout extends Layout {
 	 * placed along the top and bottom edges of the layout.
 	 *
 	 * The default value is 0.
-	 *
 	 */
 	public int marginHeight = 0;
 	/**
@@ -100,7 +98,6 @@ public class BorderLayout extends Layout {
 	 * neighboring regions.
 	 *
 	 * The default value is 0.
-	 *
 	 */
 	public int spacing = 0;
 	/**
@@ -108,7 +105,6 @@ public class BorderLayout extends Layout {
 	 * and its neighboring control inside a region.
 	 *
 	 * The default value is 0.
-	 *
 	 */
 	public int controlSpacing = 0;
 	/**
@@ -125,7 +121,6 @@ public class BorderLayout extends Layout {
 	 * controls, valid values range between [0 ... 1]
 	 *
 	 * The default value is 0.5 (equal distribution of available space)
-	 *
 	 */
 	public double heightDistributionFactor = 0.5;
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/Monitor.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/Monitor.java
@@ -108,7 +108,6 @@ void setClientArea (Rectangle rect) {
  * @return the receiver's hash
  *
  * @see #equals(Object)
- *
  */
 @Override
 public int hashCode () {

--- a/bundles/org.eclipse.swt/Eclipse SWT/emulated/bidi/org/eclipse/swt/internal/BidiUtil.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/emulated/bidi/org/eclipse/swt/internal/BidiUtil.java
@@ -52,13 +52,11 @@ public static void addLanguageListener (Control control, Runnable runnable) {
 }
 /*
  * Not implemented.
- *
  */
 public static void drawGlyphs(GC gc, char[] renderBuffer, int[] renderDx, int x, int y) {
 }
 /*
  * Bidi not supported on emulated platforms.
- *
  */
 public static boolean isBidiPlatform() {
 	return false;
@@ -77,13 +75,11 @@ public static int getFontBidiAttributes(GC gc) {
 }
 /*
  *  Not implemented.
- *
  */
 public static void getOrderInfo(GC gc, String text, int[] order, byte[] classBuffer, int flags, int [] offsets) {
 }
 /*
  *  Not implemented. Returns null.
- *
  */
 public static char[] getRenderInfo(GC gc, String text, int[] order, byte[] classBuffer, int[] dx, int flags, int[] offsets) {
 	return null;

--- a/bundles/org.eclipse.swt/Eclipse SWT/emulated/taskbar/org/eclipse/swt/widgets/TaskItem.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/emulated/taskbar/org/eclipse/swt/widgets/TaskItem.java
@@ -146,7 +146,6 @@ public String getOverlayText () {
  *    <li>ERROR_WIDGET_DISPOSED - if the receiver has been disposed</li>
  *    <li>ERROR_THREAD_INVALID_ACCESS - if not called from the thread that created the receiver</li>
  * </ul>
- *
  */
 public TaskBar getParent () {
 	checkWidget ();

--- a/bundles/org.eclipse.swt/Eclipse SWT/emulated/tooltip/org/eclipse/swt/widgets/ToolTip.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/emulated/tooltip/org/eclipse/swt/widgets/ToolTip.java
@@ -263,7 +263,6 @@ void configure () {
  *    <li>ERROR_WIDGET_DISPOSED - if the receiver has been disposed</li>
  *    <li>ERROR_THREAD_INVALID_ACCESS - if not called from the thread that created the receiver</li>
  * </ul>
- *
  */
 public boolean getAutoHide () {
 	checkWidget ();

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/graphics/ImageLoader.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/graphics/ImageLoader.java
@@ -83,7 +83,6 @@ public class ImageLoader {
 	 * the background pixel for the logical screen (this
 	 * corresponds to the GIF89a Background Color Index value).
 	 * The default is -1 which means 'unspecified background'
-	 *
 	 */
 	public int backgroundPixel;
 
@@ -170,7 +169,6 @@ public ImageData[] load(InputStream stream) {
 /**
  * Return true if the image is an interlaced PNG file.
  * This is used to check whether ImageLoaderEvent should be fired when loading images.
- * @param imageAsByteArray
  * @return true iff 29th byte of PNG files is not zero
  */
 boolean isInterlacedPNG(byte [] imageAsByteArray) {
@@ -315,8 +313,6 @@ public ImageData[] load(String filename) {
 /**
  * Load GdkPixbuf directly using gdk_pixbuf_new_from_file,
  * without FileInputStream.
- * @param filename
- * @return
  */
 ImageData[] loadFromFile(String filename) {
 	long pixbuf = gdk_pixbuf_new_from_file(filename);
@@ -363,7 +359,6 @@ int getImageFormat(long loader) {
 
 /**
  * Convert GdkPixbuf pointer to Java object ImageData
- * @param pixbuf
  * @return ImageData with pixbuf data
  */
 static ImageData pixbufToImageData(long pixbuf) {
@@ -426,8 +421,6 @@ static ImageData pixbufToImageData(long pixbuf) {
 
 /**
  * Returns GdkPixbuf pointer by loading an image from filename (Java string)
- * @param filename
- * @return
  */
 static long gdk_pixbuf_new_from_file(String filename) {
 	int length = filename.length ();

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/graphics/Region.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/graphics/Region.java
@@ -152,7 +152,6 @@ static void cairo_region_get_rectangles(long region, long [] rectangles, int[] n
  * </ul>
  *
  * @since 3.0
- *
  */
 public void add (int[] pointArray) {
 	if (isDisposed()) SWT.error(SWT.ERROR_GRAPHIC_DISPOSED);

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/internal/GDBus.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/internal/GDBus.java
@@ -99,7 +99,6 @@ public class GDBus {
 		 *		(args) -> {
 		 *			return new Object[] {true}; // You should 'g_variant_unref(result)' on client side.
 		 *		})
-		 *
 		 */
 		public GDBusMethod(String name, String [][] inputArgs, String [][] outputArgs, Function<Object[], Object[]> userFunction) {
 			this.name = name;
@@ -292,7 +291,6 @@ public class GDBus {
 	 * @param gvar_parameters	 GVariant
 	 * @param invocation     GDBusMethodInvocation
 	 * @param user_data      gpointer
-	 * @return
 	 */
 	@SuppressWarnings("unused") // Callback only called directly by JNI.
 	private static long handleMethod (

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Control.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Control.java
@@ -293,7 +293,6 @@ long eventSurface () {
 /**
  * GdkEventType constants different on GTK4 and GTK3.
  * This checks for GTK versions and return the correct constants defined in GDK.java
- * @param eventType
  * @return constant defined
  */
 static int fixGdkEventTypeValues(int eventType) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/DateTime.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/DateTime.java
@@ -269,9 +269,6 @@ protected void checkSubclass () {
  * is at the longest length possible. i.e. Assume DATE/HOUR field to be double digit,
  * MONTH field for SWT.DATE | SWT.LONG is the longest text.
  *
- * @param wHint
- * @param hHint
- * @param changed
  * @return text entry size to hold the longest possible formatted text.
  */
 Point computeMaxTextSize (int wHint, int hHint, boolean changed) {
@@ -1322,8 +1319,6 @@ public void removeSelectionListener (SelectionListener listener) {
 
 /**
  * selects the first occurrence of the given field
- *
- * @param field
  */
 void selectField(Field field) {
 	AttributedCharacterIterator iterator = dateFormat.formatToCharacterIterator(calendar.getTime());
@@ -1340,10 +1335,6 @@ void selectField(Field field) {
 
 /**
  * Selects the given field at the given start/end coordinates
- *
- * @param field
- * @param start
- * @param end
  */
 void selectField(FieldPosition fieldPosition) {
 	boolean sameField = isSameField(fieldPosition, currentField);
@@ -2352,9 +2343,6 @@ void releaseWidget () {
 
 /**
  * Returns a field with updated positionla data
- *
- * @param field
- * @return
  */
 private FieldPosition updateField(FieldPosition field) {
 	AttributedCharacterIterator iterator = dateFormat.formatToCharacterIterator(calendar.getTime());
@@ -2400,7 +2388,6 @@ private FieldPosition getNextField(FieldPosition field) {
 
 /**
  *
- * @param field
  * @return the next field of the given one
  */
 private FieldPosition getPreviousField(FieldPosition field) {
@@ -2488,7 +2475,6 @@ private static boolean isSameField(FieldPosition p1, FieldPosition p2) {
 /**
  * Extracts the calendarfield for the given fieldposition
  *
- * @param fieldPosition
  * @return the {@link Calendar} field or -1 if this is not a valid Fieldposition
  */
 private static int getCalendarField(FieldPosition fieldPosition) {
@@ -2502,7 +2488,6 @@ private static int getCalendarField(FieldPosition fieldPosition) {
 /**
  * Extracts the calendarfield transforming HOUR1 types to HOUR0
  *
- * @param field
  * @return the calendarfield coresponding to the {@link Field}
  */
 private static int getCalendarField(Field field) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Display.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Display.java
@@ -4272,7 +4272,6 @@ long findFocusedWindow() {
  * </ul>
  *
  * @since 3.0
- *
  */
 public boolean post (Event event) {
 	/*

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Shell.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Shell.java
@@ -1393,7 +1393,6 @@ public boolean getVisible () {
  * </ul>
  *
  * @since 3.0
- *
  */
 @Override
 public Region getRegion () {

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/TabItem.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/TabItem.java
@@ -463,7 +463,6 @@ void setOrientation (boolean create) {
  *    <li>ERROR_WIDGET_DISPOSED - if the receiver has been disposed</li>
  *    <li>ERROR_THREAD_INVALID_ACCESS - if not called from the thread that created the receiver</li>
  * </ul>
- *
  */
 @Override
 public void setText (String string) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/TableColumn.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/TableColumn.java
@@ -469,7 +469,6 @@ void hookEvents () {
  *    <li>ERROR_WIDGET_DISPOSED - if the receiver has been disposed</li>
  *    <li>ERROR_THREAD_INVALID_ACCESS - if not called from the thread that created the receiver</li>
  * </ul>
- *
  */
 public void pack () {
 	checkWidget();

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Text.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Text.java
@@ -2059,7 +2059,6 @@ public void insert (String string) {
  * @param iter the GtkTextIter representing the insertion/selection point
  * @param scrollTo the GtkTextIter representing the point to be scrolled to (can be null)
  * @param insert true if insertion is being performed, false if selection
- *
  */
 private void scrollIfNotVisible(byte [] iter, byte [] scrollTo, boolean insert) {
 	GdkRectangle rect = new GdkRectangle ();

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/ToolTip.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/ToolTip.java
@@ -366,7 +366,6 @@ void destroyWidget () {
  *    <li>ERROR_WIDGET_DISPOSED - if the receiver has been disposed</li>
  *    <li>ERROR_THREAD_INVALID_ACCESS - if not called from the thread that created the receiver</li>
  * </ul>
- *
  */
 public boolean getAutoHide () {
 	checkWidget ();

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Tracker.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Tracker.java
@@ -337,8 +337,6 @@ Rectangle [] computeProportions (Rectangle [] rects) {
  * - Rectangles can have absolute coords [Tracker(Display)] or relative to parent [Tracker(Composite)]
  * - This method is called a lot, optimize your code.
  * - Note, region != rectangle. A region can have a non-squared form, e.g an 'L' shape.
- *
- * @param rects
  */
 void drawRectangles (Rectangle [] rects) {
 	long gdkResource = 0;

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/TreeColumn.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/TreeColumn.java
@@ -461,7 +461,6 @@ void hookEvents () {
  *    <li>ERROR_WIDGET_DISPOSED - if the receiver has been disposed</li>
  *    <li>ERROR_THREAD_INVALID_ACCESS - if not called from the thread that created the receiver</li>
  * </ul>
- *
  */
 public void pack () {
 	checkWidget();

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/TreeItem.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/TreeItem.java
@@ -363,7 +363,6 @@ void destroyWidget () {
  * </ul>
  *
  * @since 2.0
- *
  */
 public Color getBackground () {
 	checkWidget ();
@@ -603,7 +602,6 @@ public Font getFont (int index) {
  * </ul>
  *
  * @since 2.0
- *
  */
 public Color getForeground () {
 	checkWidget ();
@@ -1138,7 +1136,6 @@ public void removeAll () {
  * </ul>
  *
  * @since 2.0
- *
  */
 public void setBackground (Color color) {
 	checkWidget ();
@@ -1168,7 +1165,6 @@ public void setBackground (Color color) {
  * </ul>
  *
  * @since 3.1
- *
  */
 public void setBackground (int index, Color color) {
 	checkWidget ();
@@ -1377,7 +1373,6 @@ public void setFont (int index, Font font) {
  * </ul>
  *
  * @since 2.0
- *
  */
 public void setForeground (Color color){
 	checkWidget ();
@@ -1407,7 +1402,6 @@ public void setForeground (Color color){
  * </ul>
  *
  * @since 3.1
- *
  */
 public void setForeground (int index, Color color){
 	checkWidget ();

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Widget.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Widget.java
@@ -2570,7 +2570,6 @@ void gtk_widget_get_preferred_size (long widget, GtkRequisition requisition){
  * Retrieves the amount of space around the outside of the container.
  * On GTK3: this is done using gtk_container_get_border_width.
  * On GTK4: this is done by returning the max margin on any side.
- * @param handle
  * @return amount of space around the outside of the container.
  */
 int gtk_container_get_border_width_or_margin (long handle) {
@@ -2586,8 +2585,6 @@ int gtk_container_get_border_width_or_margin (long handle) {
 }
 /**
  * Sets the border width of the container to all sides of the container.
- * @param handle
- * @param border_width
  */
 void gtk_container_set_border_width (long handle, int border_width) {
 	if (GTK.GTK4) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/GC.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/GC.java
@@ -604,7 +604,6 @@ static long createGdipFont(long hDC, long hFont, long graphics, long fontCollect
  * The returned brush has to be disposed by the caller.
  *
  * @param brush Brush with pattern
- * @param alpha
  * @return new brush with transparency
  * @exception SWTError <ul>
  *    <li>ERROR_CANNOT_BE_ZERO - if the image in the brush is null</li>

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/ImageLoader.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/ImageLoader.java
@@ -78,7 +78,6 @@ public class ImageLoader {
 	 * the background pixel for the logical screen (this
 	 * corresponds to the GIF89a Background Color Index value).
 	 * The default is -1 which means 'unspecified background'
-	 *
 	 */
 	public int backgroundPixel;
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Region.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Region.java
@@ -114,7 +114,6 @@ Region(Device device, int handle) {
  * </ul>
  *
  * @since 3.0
- *
  */
 public void add (int[] pointArray) {
 	if (isDisposed()) SWT.error(SWT.ERROR_GRAPHIC_DISPOSED);

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Display.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Display.java
@@ -3486,7 +3486,6 @@ int numpadKey (int key) {
  * </ul>
  *
  * @since 3.0
- *
  */
 public boolean post (Event event) {
 	synchronized (Device.class) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Shell.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Shell.java
@@ -1141,7 +1141,6 @@ public boolean getModified () {
  * </ul>
  *
  * @since 3.0
- *
  */
 @Override
 public Region getRegion () {
@@ -2323,7 +2322,6 @@ int widgetStyle () {
 	*
 	* 	WS_OVERLAPPED = 0
 	* 	WS_CAPTION = WS_BORDER | WS_DLGFRAME
-	*
 	*/
 	return bits | OS.WS_OVERLAPPED | OS.WS_CAPTION;
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TabItem.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TabItem.java
@@ -343,7 +343,6 @@ public void setImage (Image image) {
  *    <li>ERROR_WIDGET_DISPOSED - if the receiver has been disposed</li>
  *    <li>ERROR_THREAD_INVALID_ACCESS - if not called from the thread that created the receiver</li>
  * </ul>
- *
  */
 @Override
 public void setText (String string) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Table.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Table.java
@@ -4604,7 +4604,6 @@ void setItemHeight (boolean fixScroll) {
 	* visible and are shown afterwards.  The fix is to
 	* save the top index, scroll to the top of the table
 	* and then restore the original top index.
-	*
 	*/
 	int topIndex = getTopIndex ();
 	if (fixScroll && topIndex != 0) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TableColumn.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TableColumn.java
@@ -401,7 +401,6 @@ private int calcAutoWidth(int index, boolean withHeader) {
  *    <li>ERROR_WIDGET_DISPOSED - if the receiver has been disposed</li>
  *    <li>ERROR_THREAD_INVALID_ACCESS - if not called from the thread that created the receiver</li>
  * </ul>
- *
  */
 public void pack () {
 	checkWidget ();

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TaskItem.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TaskItem.java
@@ -174,7 +174,6 @@ public String getOverlayText () {
  *    <li>ERROR_WIDGET_DISPOSED - if the receiver has been disposed</li>
  *    <li>ERROR_THREAD_INVALID_ACCESS - if not called from the thread that created the receiver</li>
  * </ul>
- *
  */
 public TaskBar getParent () {
 	checkWidget ();

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ToolTip.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ToolTip.java
@@ -143,7 +143,6 @@ void destroyWidget () {
  *    <li>ERROR_WIDGET_DISPOSED - if the receiver has been disposed</li>
  *    <li>ERROR_THREAD_INVALID_ACCESS - if not called from the thread that created the receiver</li>
  * </ul>
- *
  */
 public boolean getAutoHide () {
 	checkWidget();

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TreeColumn.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TreeColumn.java
@@ -338,7 +338,6 @@ int getWidthInPixels () {
  *    <li>ERROR_WIDGET_DISPOSED - if the receiver has been disposed</li>
  *    <li>ERROR_THREAD_INVALID_ACCESS - if not called from the thread that created the receiver</li>
  * </ul>
- *
  */
 public void pack () {
 	checkWidget ();

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TreeItem.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TreeItem.java
@@ -328,7 +328,6 @@ long fontHandle (int index) {
  * </ul>
  *
  * @since 2.0
- *
  */
 public Color getBackground () {
 	checkWidget ();
@@ -636,7 +635,6 @@ public Font getFont (int index) {
  * </ul>
  *
  * @since 2.0
- *
  */
 public Color getForeground () {
 	checkWidget ();
@@ -1070,7 +1068,6 @@ public void removeAll () {
  * </ul>
  *
  * @since 2.0
- *
  */
 public void setBackground (Color color) {
 	checkWidget ();
@@ -1105,7 +1102,6 @@ public void setBackground (Color color) {
  * </ul>
  *
  * @since 3.1
- *
  */
 public void setBackground (int index, Color color) {
 	checkWidget ();
@@ -1484,7 +1480,6 @@ public void setFont (int index, Font font) {
  * </ul>
  *
  * @since 2.0
- *
  */
 public void setForeground (Color color) {
 	checkWidget ();
@@ -1519,7 +1514,6 @@ public void setForeground (Color color) {
  * </ul>
  *
  * @since 3.1
- *
  */
 public void setForeground (int index, Color color){
 	checkWidget ();

--- a/examples/org.eclipse.swt.examples/src/org/eclipse/swt/examples/accessibility/CTableColumn.java
+++ b/examples/org.eclipse.swt.examples/src/org/eclipse/swt/examples/accessibility/CTableColumn.java
@@ -473,7 +473,6 @@ int getX () {
  *    <li>ERROR_WIDGET_DISPOSED - if the receiver has been disposed</li>
  *    <li>ERROR_THREAD_INVALID_ACCESS - if not called from the thread that created the receiver</li>
  * </ul>
- *
  */
 public void pack () {
 	checkWidget ();

--- a/examples/org.eclipse.swt.examples/src/org/eclipse/swt/examples/controlexample/CanvasTab.java
+++ b/examples/org.eclipse.swt.examples/src/org/eclipse/swt/examples/controlexample/CanvasTab.java
@@ -251,8 +251,6 @@ class CanvasTab extends Tab {
 
 	/**
 	 * Scrolls the canvas horizontally.
-	 *
-	 * @param scrollBar
 	 */
 	void scrollHorizontal (ScrollBar scrollBar) {
 		Rectangle bounds = canvas.getClientArea();
@@ -266,8 +264,6 @@ class CanvasTab extends Tab {
 
 	/**
 	 * Scrolls the canvas vertically.
-	 *
-	 * @param scrollBar
 	 */
 	void scrollVertical (ScrollBar scrollBar) {
 		Rectangle bounds = canvas.getClientArea();

--- a/examples/org.eclipse.swt.examples/src/org/eclipse/swt/examples/graphics/GradientDialog.java
+++ b/examples/org.eclipse.swt.examples/src/org/eclipse/swt/examples/graphics/GradientDialog.java
@@ -248,7 +248,6 @@ public class GradientDialog extends Dialog {
 
 	/**
 	 * Sets the first RGB.
-	 * @param rgb
 	 */
 	public void setFirstRGB(RGB rgb) {
 		this.rgb1 = rgb;
@@ -263,7 +262,6 @@ public class GradientDialog extends Dialog {
 
 	/**
 	 * Sets the second RGB.
-	 * @param rgb
 	 */
 	public void setSecondRGB(RGB rgb) {
 		this.rgb2 = rgb;

--- a/examples/org.eclipse.swt.examples/src/org/eclipse/swt/examples/graphics/GraphicsExample.java
+++ b/examples/org.eclipse.swt.examples/src/org/eclipse/swt/examples/graphics/GraphicsExample.java
@@ -241,7 +241,6 @@ void recreateCanvas() {
 
 /**
  * Creates the control panel
- * @param parent
  */
 void createControlPanel(Composite parent) {
 	Group group;

--- a/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet174.java
+++ b/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet174.java
@@ -39,7 +39,6 @@ import org.eclipse.swt.widgets.*;
  * @deprecated 
  * This snippet is being deprecated as the org.eclipse.swt.opengl plugin it needs
  * is not available anymore.
- *
  */
 @Deprecated
 public class Snippet174 {

--- a/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet325.java
+++ b/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet325.java
@@ -18,7 +18,6 @@ package org.eclipse.swt.snippets;
  *
  * For a list of all SWT example snippets see
  * http://www.eclipse.org/swt/snippets/
- *
  */
 import org.eclipse.swt.*;
 import org.eclipse.swt.custom.*;

--- a/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet328.java
+++ b/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet328.java
@@ -18,7 +18,6 @@ package org.eclipse.swt.snippets;
  *
  * For a list of all SWT example snippets see
  * http://www.eclipse.org/swt/snippets/
- *
  */
 import org.eclipse.swt.*;
 import org.eclipse.swt.custom.*;

--- a/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet380.java
+++ b/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet380.java
@@ -23,7 +23,6 @@ import org.eclipse.swt.widgets.*;
 
 /**
  * This shows the usage of the display in the executor framework in conjunction with a CompletableFuture
- *
  */
 public class Snippet380 {
 	public static void main(String[] args) {

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_ImageData.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_ImageData.java
@@ -60,11 +60,6 @@ public void setUp() {
 /**
  * Tests {@link ImageData#blit}:
  * creates a random image and tests over all combinations of depth,format,scale
- * @throws InvocationTargetException
- * @throws IllegalArgumentException
- * @throws IllegalAccessException
- * @throws SecurityException
- * @throws NoSuchMethodException
  */
 @Test
 public void test_blit() throws NoSuchMethodException, SecurityException, IllegalAccessException, IllegalArgumentException, InvocationTargetException {
@@ -122,11 +117,6 @@ public void test_blit() throws NoSuchMethodException, SecurityException, Illegal
 /**
  * Tests {@link ImageData#blit}:
  * Ensures that (MSB_FIRST, LSB_FIRST) round trip produces original.
- * @throws InvocationTargetException
- * @throws IllegalArgumentException
- * @throws IllegalAccessException
- * @throws SecurityException
- * @throws NoSuchMethodException
  */
 @Test
 public void test_blit_MsbLsb() throws NoSuchMethodException, SecurityException, IllegalAccessException, IllegalArgumentException, InvocationTargetException {

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_layout_BorderLayout.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_layout_BorderLayout.java
@@ -30,7 +30,6 @@ import org.junit.Test;
 
 /**
  * Automated Test Suite for class {@link BorderLayout}
- *
  */
 public class Test_org_eclipse_swt_layout_BorderLayout {
 

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Widget.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Widget.java
@@ -240,7 +240,6 @@ protected String getClassName() {
  * called for headless tests!
  * @param shell The shell to render.
  * @param durationMs duration in milliseconds. Method exits after duration.
- * @throws InterruptedException
  */
 protected void render(Shell shell, int durationMs) throws InterruptedException {
 	long timestamp = System.currentTimeMillis();

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/performance/BenchmarkSwtMultithreading.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/performance/BenchmarkSwtMultithreading.java
@@ -30,7 +30,6 @@ public class BenchmarkSwtMultithreading {
 	 * see https://github.com/eclipse-platform/eclipse.platform.swt/issues/74
 	 *
 	 * @param args ignored
-	 * @throws InterruptedException
 	 */
 	public static void main(String[] args) throws InterruptedException {
 		final Display display = new Display();


### PR DESCRIPTION
This commit cleans up Javadoc that does not add information. It resolves ecj warnings:
 `Javadoc: Description expected after ...`
It helps to prevent future empty javadoc by disabling missingJavaDoc warnings. This resolves
 `Javadoc: Missing ...`

The modification is a result of regular expression search&replace:

in files `*.java`
 `^[\s]*\*[\s]*(@return|@param[\s]*[^\s]+|@throws[\s]*[^\s]+)\R([\s]*\*[\s]*@|[\s]*\*/\R)`
 ->`$2`
 `^([\s]*\*[\s]*\R)([\s]*\*/\R)`
 ->`$2`
 `^[\S\t ]*/\*\*\R[\s]*\*/\R`
 ->``

in files `org.eclipse.jdt.core.prefs`
 `org\.eclipse\.jdt\.core\.compiler\.problem\.missingJavadoc(Comments|Tags)\=[^\s]*`
 ->`org\.eclipse\.jdt\.core\.compiler\.problem\.missingJavadoc$1\=ignore`