### PR TITLE
Wayland qt kde clipboard fix

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/gtk/org/eclipse/swt/dnd/ClipboardProxy.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/gtk/org/eclipse/swt/dnd/ClipboardProxy.java
@@ -169,6 +169,9 @@ boolean setData(Clipboard owner, Object[] data, Transfer[] dataTypes, int clipbo
 				System.arraycopy(entries, 0, tmp, 0, entries.length);
 				tmp[entries.length] = entry;
 				entries = tmp;
+				TransferData tdata = new TransferData();
+				tdata.type = typeIds[j];
+				transfer.javaToNative(data[i], tdata);
 			}
 		}
 

--- a/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/gtk/org/eclipse/swt/dnd/TextTransfer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/gtk/org/eclipse/swt/dnd/TextTransfer.java
@@ -42,9 +42,11 @@ public class TextTransfer extends ByteArrayTransfer {
 	private static final String COMPOUND_TEXT = "COMPOUND_TEXT"; //$NON-NLS-1$
 	private static final String UTF8_STRING = "UTF8_STRING"; //$NON-NLS-1$
 	private static final String STRING = "STRING"; //$NON-NLS-1$
+	private static final String TEXT_PLAIN_UTF8 = "text/plain;charset=utf-8"; //RFC-1341
 	private static final int COMPOUND_TEXT_ID = GTK.GTK4 ? 0 : registerType(COMPOUND_TEXT);
 	private static final int UTF8_STRING_ID = GTK.GTK4 ? 0 : registerType(UTF8_STRING);
 	private static final int STRING_ID = GTK.GTK4 ? 0 : registerType(STRING);
+	private static final int TEXT_PLAIN_UTF8_ID = GTK.GTK4 ? 0 : registerType(TEXT_PLAIN_UTF8);
 
 private TextTransfer() {}
 
@@ -145,7 +147,7 @@ protected int[] getTypeIds() {
 	if(GTK.GTK4) {
 		return new int[] {(int) OS.G_TYPE_STRING()};
 	}
-	return new int[] {UTF8_STRING_ID, STRING_ID};
+	return new int[] {UTF8_STRING_ID, STRING_ID, TEXT_PLAIN_UTF8_ID};
 }
 
 @Override
@@ -157,7 +159,7 @@ protected String[] getTypeNames() {
 		return new String[] {"text/plain", STRING};
 	}
 
-	return new String[] {UTF8_STRING, STRING};
+	return new String[] {UTF8_STRING, STRING, TEXT_PLAIN_UTF8};
 }
 
 boolean checkText(Object object) {

--- a/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/gtk/org/eclipse/swt/dnd/TextTransfer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/gtk/org/eclipse/swt/dnd/TextTransfer.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.swt.dnd;
 
+import java.nio.charset.*;
+
 import org.eclipse.swt.internal.*;
 import org.eclipse.swt.internal.gtk.*;
 
@@ -109,7 +111,28 @@ public void javaToNative (Object object, TransferData transferData) {
 		transferData.pValue = string_target;
 		transferData.result = 1;
 	}
+    if (transferData.type == TEXT_PLAIN_UTF8_ID) {
+        // Convert the text into RFC-1341 format
+        byte[] rfc1341Data = encodeTextAsRFC1341(string);
+        transferData.format = 8; // Format for UTF-8
+        transferData.length = rfc1341Data.length;
+        transferData.pValue = OS.g_malloc(rfc1341Data.length);
+        if (transferData.pValue != 0) {
+            C.memmove(transferData.pValue, rfc1341Data, rfc1341Data.length);
+            transferData.result = 1;
+        }
+    }
 }
+
+// New method to encode text as RFC-1341
+private byte[] encodeTextAsRFC1341(String text) {
+    // Implement encoding logic here, e.g., adding MIME headers and encoding text
+    // This is a simplified example; actual encoding depends on RFC-1341 standards
+//    String rfc1341Text = "Content-Type: " + TEXTPLAINUTF8 + "\r\n\r\n" + text;
+    String rfc1341Text = text;
+    return rfc1341Text.getBytes(StandardCharsets.UTF_8);
+}
+
 
 /**
  * This implementation of <code>nativeToJava</code> converts a platform specific


### PR DESCRIPTION
I now know the buzzwords are:

> "Eclipse support for Wayland clipboard content types (RFC-1341  types)"

https://github.com/eclipse-platform/eclipse.platform.swt/issues/851#issuecomment-1794539321

However the main motivation here is:

` "Being able to use Eclipse comfortably with a LTS based linux distro in a wayland session in  2023"`

The first commit already has an open pr #861 the second has  been tested to work via this method #858
and then cherry picked from R_29_maintenance branch onto master without any issues.

 