### PR TITLE
Cosmetic change only Fix indentation problem introduced in c7549d9

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/gtk/org/eclipse/swt/dnd/TextTransfer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/gtk/org/eclipse/swt/dnd/TextTransfer.java
@@ -111,26 +111,24 @@ public void javaToNative (Object object, TransferData transferData) {
 		transferData.pValue = string_target;
 		transferData.result = 1;
 	}
-    if (transferData.type == TEXT_PLAIN_UTF8_ID) {
-        // Convert the text into RFC-1341 format
-        byte[] rfc1341Data = encodeTextAsRFC1341(string);
-        transferData.format = 8; // Format for UTF-8
-        transferData.length = rfc1341Data.length;
-        transferData.pValue = OS.g_malloc(rfc1341Data.length);
-        if (transferData.pValue != 0) {
-            C.memmove(transferData.pValue, rfc1341Data, rfc1341Data.length);
-            transferData.result = 1;
-        }
-    }
+	if (transferData.type == TEXT_PLAIN_UTF8_ID) {
+		// Convert the text into RFC-1341 format
+		byte[] rfc1341Data = encodeTextAsRFC1341(string);
+		transferData.format = 8; // Format for UTF-8
+		transferData.length = rfc1341Data.length;
+		transferData.pValue = OS.g_malloc(rfc1341Data.length);
+		if (transferData.pValue != 0) {
+			C.memmove(transferData.pValue, rfc1341Data, rfc1341Data.length);
+			transferData.result = 1;
+		}
+	}
 }
 
 // New method to encode text as RFC-1341
 private byte[] encodeTextAsRFC1341(String text) {
-    // Implement encoding logic here, e.g., adding MIME headers and encoding text
-    // This is a simplified example; actual encoding depends on RFC-1341 standards
-//    String rfc1341Text = "Content-Type: " + TEXTPLAINUTF8 + "\r\n\r\n" + text;
-    String rfc1341Text = text;
-    return rfc1341Text.getBytes(StandardCharsets.UTF_8);
+	// Implement encoding logic here, e.g., encoding text
+	// This is a simplified example; actual encoding depends on RFC-1341 standards
+	return text.getBytes(StandardCharsets.UTF_8);
 }
 
 


### PR DESCRIPTION
This perhaps seems like a small detail but when looking through the source code from the recent I20231109-0710 build:
https://github.com/eclipse-platform/eclipse.platform.swt/releases/tag/I20231109-0710

I could see the the code I had added in commit:
https://github.com/eclipse-platform/eclipse.platform.swt/commit/c7549d957953bb94df337ce802548ac19c13f4a5
had spaces instead of tabs in the indentationm.

This is something not easy to see in the github source viewer or Eclipse, however it can lead to all sorts of view
problems elsewhere.
And the issue stands out in Kate or Kwrite:
![Kate_indention_prob](https://github.com/eclipse-platform/eclipse.platform.swt/assets/11050908/0bf08aab-50eb-498d-9f68-5972d63511b7)

