### PR TITLE
Fix wrong implementation of TEXT_PLAIN_UTF8 transfer feature

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/gtk/org/eclipse/swt/dnd/ClipboardProxy.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/gtk/org/eclipse/swt/dnd/ClipboardProxy.java
@@ -169,9 +169,6 @@ boolean setData(Clipboard owner, Object[] data, Transfer[] dataTypes, int clipbo
 				System.arraycopy(entries, 0, tmp, 0, entries.length);
 				tmp[entries.length] = entry;
 				entries = tmp;
-				TransferData tdata = new TransferData();
-				tdata.type = typeIds[j];
-				transfer.javaToNative(data[i], tdata);
 			}
 		}
 

--- a/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/gtk/org/eclipse/swt/dnd/TextTransfer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/gtk/org/eclipse/swt/dnd/TextTransfer.java
@@ -13,8 +13,6 @@
  *******************************************************************************/
 package org.eclipse.swt.dnd;
 
-import java.nio.charset.*;
-
 import org.eclipse.swt.internal.*;
 import org.eclipse.swt.internal.gtk.*;
 
@@ -92,11 +90,10 @@ public void javaToNative (Object object, TransferData transferData) {
 		transferData.pValue = ctext[0];
 		transferData.result = 1;
 	}
-	if (transferData.type == UTF8_STRING_ID) {
+	if (transferData.type == UTF8_STRING_ID || transferData.type == TEXT_PLAIN_UTF8_ID) {
 		long pValue = OS.g_malloc(utf8.length);
 		if (pValue ==  0) return;
 		C.memmove(pValue, utf8, utf8.length);
-		transferData.type = UTF8_STRING_ID;
 		transferData.format = 8;
 		transferData.length = utf8.length - 1;
 		transferData.pValue = pValue;
@@ -111,26 +108,6 @@ public void javaToNative (Object object, TransferData transferData) {
 		transferData.pValue = string_target;
 		transferData.result = 1;
 	}
-    if (transferData.type == TEXT_PLAIN_UTF8_ID) {
-        // Convert the text into RFC-1341 format
-        byte[] rfc1341Data = encodeTextAsRFC1341(string);
-        transferData.format = 8; // Format for UTF-8
-        transferData.length = rfc1341Data.length;
-        transferData.pValue = OS.g_malloc(rfc1341Data.length);
-        if (transferData.pValue != 0) {
-            C.memmove(transferData.pValue, rfc1341Data, rfc1341Data.length);
-            transferData.result = 1;
-        }
-    }
-}
-
-// New method to encode text as RFC-1341
-private byte[] encodeTextAsRFC1341(String text) {
-    // Implement encoding logic here, e.g., adding MIME headers and encoding text
-    // This is a simplified example; actual encoding depends on RFC-1341 standards
-//    String rfc1341Text = "Content-Type: " + TEXTPLAINUTF8 + "\r\n\r\n" + text;
-    String rfc1341Text = text;
-    return rfc1341Text.getBytes(StandardCharsets.UTF_8);
 }
 
 


### PR DESCRIPTION
1) The utf-8 content should be same as in UTF8_STRING, it just should use different label/type id.
2) The change in ClipboardProxy.setData() was non functional and makes no sense, it only leaks memory/wastes time

See https://github.com/eclipse-platform/eclipse.platform.swt/pull/863 See https://github.com/eclipse-platform/eclipse.platform.swt/issues/851