### PR TITLE
Wayland qt paste copy fix r4.29

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/gtk/org/eclipse/swt/dnd/ClipboardProxy.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/gtk/org/eclipse/swt/dnd/ClipboardProxy.java
@@ -169,6 +169,9 @@ boolean setData(Clipboard owner, Object[] data, Transfer[] dataTypes, int clipbo
 				System.arraycopy(entries, 0, tmp, 0, entries.length);
 				tmp[entries.length] = entry;
 				entries = tmp;
+				TransferData tdata = new TransferData();
+				tdata.type = typeIds[j];
+				transfer.javaToNative(data[i], tdata);
 			}
 		}
 

--- a/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/gtk/org/eclipse/swt/dnd/ClipboardProxy.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/gtk/org/eclipse/swt/dnd/ClipboardProxy.java
@@ -169,9 +169,6 @@ boolean setData(Clipboard owner, Object[] data, Transfer[] dataTypes, int clipbo
 				System.arraycopy(entries, 0, tmp, 0, entries.length);
 				tmp[entries.length] = entry;
 				entries = tmp;
-				TransferData tdata = new TransferData();
-				tdata.type = typeIds[j];
-				transfer.javaToNative(data[i], tdata);
 			}
 		}
 

--- a/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/gtk/org/eclipse/swt/dnd/TextTransfer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/gtk/org/eclipse/swt/dnd/TextTransfer.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.swt.dnd;
 
+import java.nio.charset.*;
+
 import org.eclipse.swt.internal.*;
 import org.eclipse.swt.internal.gtk.*;
 
@@ -110,7 +112,28 @@ public void javaToNative (Object object, TransferData transferData) {
 		transferData.pValue = string_target;
 		transferData.result = 1;
 	}
+    if (transferData.type == TEXTPLAINUTF8_ID) {
+        // Convert the text into RFC-1341 format
+        byte[] rfc1341Data = encodeTextAsRFC1341(string);
+        transferData.format = 8; // Format for UTF-8
+        transferData.length = rfc1341Data.length;
+        transferData.pValue = OS.g_malloc(rfc1341Data.length);
+        if (transferData.pValue != 0) {
+            C.memmove(transferData.pValue, rfc1341Data, rfc1341Data.length);
+            transferData.result = 1;
+        }
+    }
 }
+
+// New method to encode text as RFC-1341
+private byte[] encodeTextAsRFC1341(String text) {
+    // Implement encoding logic here, e.g., adding MIME headers and encoding text
+    // This is a simplified example; actual encoding depends on RFC-1341 standards
+//    String rfc1341Text = "Content-Type: " + TEXTPLAINUTF8 + "\r\n\r\n" + text;
+    String rfc1341Text = text;
+    return rfc1341Text.getBytes(StandardCharsets.UTF_8);
+}
+
 
 /**
  * This implementation of <code>nativeToJava</code> converts a platform specific

--- a/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/gtk/org/eclipse/swt/dnd/TextTransfer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/gtk/org/eclipse/swt/dnd/TextTransfer.java
@@ -35,6 +35,7 @@ import org.eclipse.swt.internal.gtk.*;
  * </p>
  *
  * @see Transfer
+ * @since 3.124
  */
 public class TextTransfer extends ByteArrayTransfer {
 
@@ -42,9 +43,11 @@ public class TextTransfer extends ByteArrayTransfer {
 	private static final String COMPOUND_TEXT = "COMPOUND_TEXT"; //$NON-NLS-1$
 	private static final String UTF8_STRING = "UTF8_STRING"; //$NON-NLS-1$
 	private static final String STRING = "STRING"; //$NON-NLS-1$
+	private static final String TEXT_PLAIN_UTF8 = "text/plain;charset=utf-8";
 	private static final int COMPOUND_TEXT_ID = GTK.GTK4 ? 0 : registerType(COMPOUND_TEXT);
 	private static final int UTF8_STRING_ID = GTK.GTK4 ? 0 : registerType(UTF8_STRING);
 	private static final int STRING_ID = GTK.GTK4 ? 0 : registerType(STRING);
+	private static final int TEXT_PLAIN_UTF8_ID = GTK.GTK4 ? 0 : registerType(TEXT_PLAIN_UTF8);
 
 private TextTransfer() {}
 
@@ -145,7 +148,7 @@ protected int[] getTypeIds() {
 	if(GTK.GTK4) {
 		return new int[] {(int) OS.G_TYPE_STRING()};
 	}
-	return new int[] {UTF8_STRING_ID, STRING_ID};
+	return new int[] {UTF8_STRING_ID, STRING_ID, TEXT_PLAIN_UTF8_ID};
 }
 
 @Override
@@ -157,7 +160,7 @@ protected String[] getTypeNames() {
 		return new String[] {"text/plain", STRING};
 	}
 
-	return new String[] {UTF8_STRING, STRING};
+	return new String[] {UTF8_STRING, STRING, TEXT_PLAIN_UTF8};
 }
 
 boolean checkText(Object object) {

--- a/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/gtk/org/eclipse/swt/dnd/TextTransfer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/gtk/org/eclipse/swt/dnd/TextTransfer.java
@@ -13,8 +13,6 @@
  *******************************************************************************/
 package org.eclipse.swt.dnd;
 
-import java.nio.charset.*;
-
 import org.eclipse.swt.internal.*;
 import org.eclipse.swt.internal.gtk.*;
 
@@ -93,11 +91,10 @@ public void javaToNative (Object object, TransferData transferData) {
 		transferData.pValue = ctext[0];
 		transferData.result = 1;
 	}
-	if (transferData.type == UTF8_STRING_ID) {
+	if (transferData.type == UTF8_STRING_ID || transferData.type == TEXT_PLAIN_UTF8_ID) {
 		long pValue = OS.g_malloc(utf8.length);
 		if (pValue ==  0) return;
 		C.memmove(pValue, utf8, utf8.length);
-		transferData.type = UTF8_STRING_ID;
 		transferData.format = 8;
 		transferData.length = utf8.length - 1;
 		transferData.pValue = pValue;
@@ -112,26 +109,6 @@ public void javaToNative (Object object, TransferData transferData) {
 		transferData.pValue = string_target;
 		transferData.result = 1;
 	}
-    if (transferData.type == TEXTPLAINUTF8_ID) {
-        // Convert the text into RFC-1341 format
-        byte[] rfc1341Data = encodeTextAsRFC1341(string);
-        transferData.format = 8; // Format for UTF-8
-        transferData.length = rfc1341Data.length;
-        transferData.pValue = OS.g_malloc(rfc1341Data.length);
-        if (transferData.pValue != 0) {
-            C.memmove(transferData.pValue, rfc1341Data, rfc1341Data.length);
-            transferData.result = 1;
-        }
-    }
-}
-
-// New method to encode text as RFC-1341
-private byte[] encodeTextAsRFC1341(String text) {
-    // Implement encoding logic here, e.g., adding MIME headers and encoding text
-    // This is a simplified example; actual encoding depends on RFC-1341 standards
-//    String rfc1341Text = "Content-Type: " + TEXTPLAINUTF8 + "\r\n\r\n" + text;
-    String rfc1341Text = text;
-    return rfc1341Text.getBytes(StandardCharsets.UTF_8);
 }
 
 


### PR DESCRIPTION
Update
This PR is superseded by #890 

This is also for seeing if a build here could replace the https://github.com/eclipse-platform/eclipse.platform.swt/discussions/858 method.

Just for final testing of build errors. and because I have something wrong with all my SWT Eclipse build setups.
To see If They show virtual errors and warnings.
Update: the problems could be removed by deleting the unrelated projects including them.
...
Afterthought:
Hmmm this seems non conclusive how can I see if the binaries got built ?
This seems to be the culprit:

    [ERROR] Failed to execute goal org.eclipse.tycho.extras:tycho-p2-extras-plugin:4.0.2:compare-version-with-baselines
    (compare-attached-artifacts-with-release) on project org.eclipse.swt: Only qualifier changed for 
    (org.eclipse.swt/3.124.100.v20231111-0040). Expected to have bigger x.y.z than what is available in baseline 
    (3.124.100.v20230825-1346)

Seems like something like the dependa-bot commit here is needed:
https://github.com/the-snowwhite/eclipse.platform.swt/commit/4daf005a457fb50b929719cb5b3616e55cc2e5c4
To at least get this build to succeed  ?
