### PR TITLE
fix: #885 make R_29 builds succeed again.

### DIFF
--- a/bundles/org.eclipse.swt/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.swt/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.swt; singleton:=true
-Bundle-Version: 3.124.100.qualifier
+Bundle-Version: 3.124.101.qualifier
 Bundle-ManifestVersion: 2
 Bundle-Localization: plugin
 DynamicImport-Package: org.eclipse.swt.accessibility2


### PR DESCRIPTION
This PR is not to be merged.
It is a placeholder for solving https://github.com/eclipse-platform/eclipse.platform.swt/issues/888
The purpose is only for testing what can make the builder deliver build artifacts that then can be downloaded.
In this specific case for testing a bugfix by copying 3 produced binaries into a working Standard Eclipse PHP 2023-09
Which it what the R_29 maintenance branch works on.
The cherry picked version of this commit is after approval then supposed to be able to be merged onto R_29_Maintenance or any other Maintenance branch exactly when the branch is no longer required to deliver binaries
to the stream.