### PR TITLE
Button's setAlignment() is being considered and right margin value is recalculated depending on alignment set.

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Button.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Button.java
@@ -299,7 +299,15 @@ int computeLeftMargin () {
 		if (newFont != 0) OS.SelectObject (hDC, oldFont);
 		OS.ReleaseDC (handle, hDC);
 		OS.GetClientRect (handle, rect);
-		margin = Math.max (MARGIN, (rect.right - rect.left - margin) / 2);
+		if ((style & SWT.LEFT) != 0) {
+			margin = MARGIN;
+		}
+		else if ((style & SWT.RIGHT) != 0) {
+			margin = Math.max (MARGIN, (rect.right - rect.left - margin - MARGIN));
+		}
+		else {
+			margin = Math.max (MARGIN, (rect.right - rect.left - margin) / 2);
+		}
 	}
 	return margin;
 }

--- a/tests/org.eclipse.swt.tests/ManualTests/org/eclipse/swt/tests/manual/Issue0519_ButtonAlignmentExample.java
+++ b/tests/org.eclipse.swt.tests/ManualTests/org/eclipse/swt/tests/manual/Issue0519_ButtonAlignmentExample.java
@@ -1,0 +1,67 @@
+package org.eclipse.swt.tests.manual;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.graphics.Image;
+import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.layout.GridLayout;
+import org.eclipse.swt.widgets.Button;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Shell;
+
+public class Issue0519_ButtonAlignmentExample {
+
+	public static void main(String[] args) {
+		Display display = new Display();
+		Shell shell = new Shell(display);
+		shell.setText("Button Alignment Example for Issue0519");
+		shell.setLayout(new GridLayout(1, false));
+
+		// Load an image (you should replace "imagePath" with your image file path)
+		//Image image = ImageDescriptor.createFromFile(Snippet.class, "error_tsk.png").createImage();
+		Image image = new Image(display, "data/eclipse32.png");
+
+		// Create a button with text and image
+		Button button;
+		button = new Button(shell, SWT.PUSH);
+		button.setText("Right Text");
+		button.setImage(image);
+		button.setSize(200, 50);
+		button.setAlignment(SWT.RIGHT);
+		button.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
+
+		button = new Button(shell, SWT.PUSH);
+		button.setText("Left Text");
+		button.setImage(image);
+		button.setSize(200, 50);
+		button.setAlignment(SWT.LEFT);
+		button.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
+
+		button = new Button(shell, SWT.PUSH);
+		button.setText("Center Text");
+		button.setImage(image);
+		button.setSize(200, 50);
+		button.setAlignment(SWT.CENTER);
+
+		// Set layout data to take up the whole shell
+		button.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
+
+		button = new Button(shell, SWT.PUSH);
+		button.setText("No Alignment assumes CENTER");
+		button.setImage(image);
+		button.setSize(200, 50);
+		//button.setAlignment(SWT.CENTER);
+		button.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
+
+		shell.setSize(500, 300);
+		shell.open();
+		//shell.pack();
+		while (!shell.isDisposed()) {
+			if (!display.readAndDispatch()) {
+				display.sleep();
+			}
+		}
+
+		// Dispose of the image and resources
+		image.dispose();
+		display.dispose();
+	}
+}


### PR DESCRIPTION
Button's setAlignment() is calculating the right margin value now when text and image are set depending on the alignment of the button.

Fixes
https://github.com/eclipse-platform/eclipse.platform.swt/issues/519

@niraj-modi 
@sravanlakkimsetti 
Can anyone of you review the changes and let me know your comments please.