### PR TITLE
Correct output specifications in build.properties

### DIFF
--- a/examples/org.eclipse.swt.examples.launcher/META-INF/MANIFEST.MF
+++ b/examples/org.eclipse.swt.examples.launcher/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %plugin.SWTLauncherExample.name
 Bundle-SymbolicName: org.eclipse.swt.examples.launcher; singleton:=true
-Bundle-Version: 3.108.200.qualifier
+Bundle-Version: 3.108.300.qualifier
 Bundle-Activator: org.eclipse.swt.examples.launcher.LauncherPlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/examples/org.eclipse.swt.examples.launcher/build.properties
+++ b/examples/org.eclipse.swt.examples.launcher/build.properties
@@ -24,6 +24,7 @@ bin.includes = doc/,\
 src.includes = about.html
 
 source.. = src/
+output.. = bin/
 
 pom.model.groupId = org.eclipse.swt
 tycho.pomless.parent = ../../local-build/local-build-parent

--- a/examples/org.eclipse.swt.examples.ole.win32/META-INF/MANIFEST.MF
+++ b/examples/org.eclipse.swt.examples.ole.win32/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %plugin.SWTOLEExample.name
 Bundle-SymbolicName: org.eclipse.swt.examples.ole.win32; singleton:=true
-Bundle-Version: 3.108.100.qualifier
+Bundle-Version: 3.108.200.qualifier
 Bundle-Activator: org.eclipse.swt.examples.ole.win32.OlePlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/examples/org.eclipse.swt.examples.ole.win32/build.properties
+++ b/examples/org.eclipse.swt.examples.ole.win32/build.properties
@@ -22,3 +22,5 @@ bin.includes = doc-html/,\
 src.includes = about.html
             
 source.. = src/
+
+output.. = bin/

--- a/examples/org.eclipse.swt.examples.ole.win32/pom.xml
+++ b/examples/org.eclipse.swt.examples.ole.win32/pom.xml
@@ -19,7 +19,7 @@
   </parent>
   <groupId>org.eclipse.swt</groupId>
   <artifactId>org.eclipse.swt.examples.ole.win32</artifactId>
-  <version>3.108.100-SNAPSHOT</version>
+  <version>3.108.200-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
   <build>

--- a/examples/org.eclipse.swt.examples.views/META-INF/MANIFEST.MF
+++ b/examples/org.eclipse.swt.examples.views/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %plugin.SWTPaintExample.name
 Bundle-SymbolicName: org.eclipse.swt.examples.views;singleton:=true
-Bundle-Version: 3.108.200.qualifier
+Bundle-Version: 3.108.300.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.core.runtime,

--- a/examples/org.eclipse.swt.examples.views/build.properties
+++ b/examples/org.eclipse.swt.examples.views/build.properties
@@ -22,6 +22,7 @@ bin.includes = doc-html/,\
 src.includes = about.html
 
 source.. = src/
+output.. = bin/
 
 pom.model.groupId = org.eclipse.swt
 tycho.pomless.parent = ../../local-build/local-build-parent

--- a/examples/org.eclipse.swt.examples/META-INF/MANIFEST.MF
+++ b/examples/org.eclipse.swt.examples/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %plugin.SWTStandaloneExampleSet.name
 Bundle-SymbolicName: org.eclipse.swt.examples; singleton:=true
-Bundle-Version: 3.108.200.qualifier
+Bundle-Version: 3.108.300.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/examples/org.eclipse.swt.examples/build.properties
+++ b/examples/org.eclipse.swt.examples/build.properties
@@ -22,6 +22,7 @@ src.includes = about.html,\
                doc-html/
                
 source.. = src/
+output.. = bin/
 
 pom.model.groupId = org.eclipse.swt
 tycho.pomless.parent = ../../local-build/local-build-parent

--- a/examples/org.eclipse.swt.snippets/META-INF/MANIFEST.MF
+++ b/examples/org.eclipse.swt.snippets/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.swt.snippets
-Bundle-Version: 3.4.0
+Bundle-Version: 3.4.100
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.swt

--- a/examples/org.eclipse.swt.snippets/build.properties
+++ b/examples/org.eclipse.swt.snippets/build.properties
@@ -11,4 +11,5 @@
 # Contributors:
 #     IBM Corporation - initial API and implementation
 ###############################################################################
-source..=src/
+source.. = src/
+output.. = bin/


### PR DESCRIPTION
Add missing output specifications in `build.properties`