### PR TITLE
Enable PerformanceTests #882

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -77,6 +77,21 @@ jobs:
         -DfailIfNoTests=false
         clean install
        working-directory: eclipse.platform.swt
+    - name: Performance tests
+      if: contains(github.event.pull_request.labels.*.name, 'performance')
+      uses: coactions/setup-xvfb@b6b4fcfb9f5a895edadc3bc76318fae0ac17c8b3 # v1.0.1
+      with:
+       run: >-
+        mvn --batch-mode -V -U
+        -DforkCount=1
+        -Dcompare-version-with-baselines.skip=true
+        -Dmaven.compiler.failOnWarning=true
+        --fail-at-end
+        -DskipNativeTests=true
+        -DfailIfNoTests=true
+        -Dtest=PerformanceTests
+        integration-test
+       working-directory: eclipse.platform.swt/tests/org.eclipse.swt.tests
     - name: Upload Test Results for ${{ matrix.config.name }} / Java-${{ matrix.java }}
       if: always()
       uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3

--- a/tests/org.eclipse.swt.tests/.project
+++ b/tests/org.eclipse.swt.tests/.project
@@ -24,4 +24,15 @@
 	<natures>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1701266893922</id>
+			<name></name>
+			<type>10</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-true-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/performance/Test_situational.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/performance/Test_situational.java
@@ -18,6 +18,7 @@ import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.Font;
 import org.eclipse.swt.graphics.GC;
 import org.eclipse.swt.graphics.Image;
+import org.eclipse.swt.internal.Platform;
 import org.eclipse.swt.layout.FillLayout;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
@@ -39,6 +40,7 @@ import org.eclipse.swt.widgets.Tree;
 import org.eclipse.test.performance.Dimension;
 import org.eclipse.test.performance.Performance;
 import org.eclipse.test.performance.PerformanceMeter;
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -70,6 +72,7 @@ public void setUp() {
  */
 @Test
 public void test_createComposites() {
+	Assume.assumeFalse("https://github.com/eclipse-platform/eclipse.platform.swt/issues/912 Very slow on Mac OS", Platform.PLATFORM.equalsIgnoreCase("cocoa"));
 	PerformanceMeter meter = createMeter("Create composites");
 	int samples;
 


### PR DESCRIPTION
Enable PerformanceTests for Pull Requests labeled "performance".
See [discussion](https://github.com/eclipse-platform/eclipse.platform.swt/pull/903#discussion_r1405455957) on why tests can't be enabled on a permanent basis. 