### PR TITLE
[GTK] Optimize TreeItem.getItem(int) by caching TreeItem.getItems() #882

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Tree.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Tree.java
@@ -181,6 +181,7 @@ void _addListener (int eventType, Listener listener) {
 }
 
 TreeItem _getItem (long iter) {
+	if (iter == 0) return null;
 	int id = getId (iter, true);
 	if (items [id] != null) return items [id];
 	long path = GTK.gtk_tree_model_get_path (modelHandle, iter);
@@ -193,7 +194,7 @@ TreeItem _getItem (long iter) {
 		parentIter = OS.g_malloc (GTK.GtkTreeIter_sizeof ());
 		GTK.gtk_tree_model_get_iter (modelHandle, parentIter, path);
 	}
-	items [id] = new TreeItem (this, parentIter, SWT.NONE, indices [indices.length -1], iter);
+	items [id] = new TreeItem (this, _getItem(parentIter), SWT.NONE, indices [indices.length -1], iter);
 	GTK.gtk_tree_path_free (path);
 	if (parentIter != 0) OS.g_free (parentIter);
 	return items [id];
@@ -202,7 +203,7 @@ TreeItem _getItem (long iter) {
 TreeItem _getItem (long parentIter, long iter, int index) {
 	int id = getId (iter, true);
 	if (items [id] != null) return items [id];
-	return items [id] = new TreeItem (this, parentIter, SWT.NONE, index, iter);
+	return items [id] = new TreeItem (this, _getItem(parentIter), SWT.NONE, index, iter);
 }
 
 void reallocateIds(int newSize) {
@@ -3524,7 +3525,7 @@ void setItemCount (long parentIter, int count) {
 		OS.g_free (iters);
 	} else {
 		for (int i=itemCount; i<count; i++) {
-			new TreeItem (this, parentIter, SWT.NONE, itemCount, 0);
+			new TreeItem (this, _getItem(parentIter), SWT.NONE, itemCount, 0);
 		}
 	}
 	if (!isVirtual) setRedraw (true);

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Tree.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Tree.java
@@ -191,7 +191,7 @@ TreeItem _getItem (long iter) {
 		parentIter = OS.g_malloc (GTK.GtkTreeIter_sizeof ());
 		GTK.gtk_tree_model_get_iter (modelHandle, parentIter, path);
 	}
-	items [id] = new TreeItem (this, parentIter, SWT.NONE, indices [indices.length -1], false);
+	items [id] = new TreeItem (this, parentIter, SWT.NONE, indices [indices.length -1], iter);
 	GTK.gtk_tree_path_free (path);
 	if (parentIter != 0) OS.g_free (parentIter);
 	return items [id];
@@ -199,11 +199,14 @@ TreeItem _getItem (long iter) {
 
 TreeItem _getItem (long parentIter, int index) {
 	long iter = OS.g_malloc (GTK.GtkTreeIter_sizeof ());
-	GTK.gtk_tree_model_iter_nth_child(modelHandle, iter, parentIter, index);
-	int id = getId (iter, true);
-	OS.g_free (iter);
-	if (items [id] != null) return items [id];
-	return items [id] = new TreeItem (this, parentIter, SWT.NONE, index, false);
+	try {
+		GTK.gtk_tree_model_iter_nth_child (modelHandle, iter, parentIter, index);
+		int id = getId (iter, true);
+		if (items [id] != null) return items [id];
+		return items [id] = new TreeItem (this, parentIter, SWT.NONE, index, iter);
+	} finally {
+		OS.g_free (iter);
+	}
 }
 
 void reallocateIds(int newSize) {
@@ -3532,7 +3535,7 @@ void setItemCount (long parentIter, int count) {
 		OS.g_free (iters);
 	} else {
 		for (int i=itemCount; i<count; i++) {
-			new TreeItem (this, parentIter, SWT.NONE, itemCount, true);
+			new TreeItem (this, parentIter, SWT.NONE, itemCount, 0);
 		}
 	}
 	if (!isVirtual) setRedraw (true);

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Tree.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Tree.java
@@ -14,6 +14,8 @@
 package org.eclipse.swt.widgets;
 
 
+import java.util.*;
+
 import org.eclipse.swt.*;
 import org.eclipse.swt.events.*;
 import org.eclipse.swt.graphics.*;
@@ -197,16 +199,10 @@ TreeItem _getItem (long iter) {
 	return items [id];
 }
 
-TreeItem _getItem (long parentIter, int index) {
-	long iter = OS.g_malloc (GTK.GtkTreeIter_sizeof ());
-	try {
-		GTK.gtk_tree_model_iter_nth_child (modelHandle, iter, parentIter, index);
-		int id = getId (iter, true);
-		if (items [id] != null) return items [id];
-		return items [id] = new TreeItem (this, parentIter, SWT.NONE, index, iter);
-	} finally {
-		OS.g_free (iter);
-	}
+TreeItem _getItem (long parentIter, long iter, int index) {
+	int id = getId (iter, true);
+	if (items [id] != null) return items [id];
+	return items [id] = new TreeItem (this, parentIter, SWT.NONE, index, iter);
 }
 
 void reallocateIds(int newSize) {
@@ -1748,10 +1744,14 @@ public boolean getHeaderVisible () {
  */
 public TreeItem getItem (int index) {
 	checkWidget();
-	if (!(0 <= index && index < GTK.gtk_tree_model_iter_n_children (modelHandle, 0)))  {
-		error (SWT.ERROR_INVALID_RANGE);
+	if (index < 0) error (SWT.ERROR_INVALID_RANGE);
+	long iter = OS.g_malloc (GTK.GtkTreeIter_sizeof ());
+	try {
+		if (!GTK.gtk_tree_model_iter_nth_child (modelHandle, iter, 0, index)) error (SWT.ERROR_INVALID_RANGE);
+		return _getItem (0, iter, index);
+	} finally {
+		OS.g_free (iter);
 	}
-	return _getItem (0, index);
 }
 
 /**
@@ -1927,26 +1927,15 @@ public TreeItem [] getItems () {
 }
 
 TreeItem [] getItems (long parent) {
-	int length = GTK.gtk_tree_model_iter_n_children (modelHandle, parent);
-	TreeItem[] result = new TreeItem [length];
-	if (length == 0) return result;
-	if ((style & SWT.VIRTUAL) != 0) {
-		for (int i=0; i<length; i++) {
-			result [i] = _getItem (parent, i);
-		}
-	} else {
-		int i = 0;
-		int[] index = new int [1];
-		long iter = OS.g_malloc (GTK.GtkTreeIter_sizeof ());
-		boolean valid = GTK.gtk_tree_model_iter_children (modelHandle, iter, parent);
-		while (valid) {
-			GTK.gtk_tree_model_get (modelHandle, iter, ID_COLUMN, index, -1);
-			result [i++] = items [index [0]];
-			valid = GTK.gtk_tree_model_iter_next (modelHandle, iter);
-		}
-		OS.g_free (iter);
+	ArrayList<TreeItem> result = new ArrayList<>();
+	long iter = OS.g_malloc (GTK.GtkTreeIter_sizeof ());
+	boolean valid = GTK.gtk_tree_model_iter_children (modelHandle, iter, parent);
+	while (valid) {
+		result.add (_getItem (parent, iter, result.size ()));
+		valid = GTK.gtk_tree_model_iter_next (modelHandle, iter);
 	}
-	return result;
+	OS.g_free (iter);
+	return result.toArray (new TreeItem [result.size()]);
 }
 
 /**

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/TreeItem.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/TreeItem.java
@@ -70,7 +70,7 @@ public class TreeItem extends Item {
  * @see Widget#getStyle
  */
 public TreeItem (Tree parent, int style) {
-	this (checkNull (parent), 0, style, -1, true);
+	this (checkNull (parent), 0, style, -1, 0);
 }
 
 /**
@@ -103,7 +103,7 @@ public TreeItem (Tree parent, int style) {
  * @see Tree#setRedraw
  */
 public TreeItem (Tree parent, int style, int index) {
-	this (checkNull (parent), 0, style, checkIndex (index), true);
+	this (checkNull (parent), 0, style, checkIndex (index), 0);
 }
 
 /**
@@ -129,7 +129,7 @@ public TreeItem (Tree parent, int style, int index) {
  * @see Widget#getStyle
  */
 public TreeItem (TreeItem parentItem, int style) {
-	this (checkNull (parentItem).parent, parentItem.handle, style, -1, true);
+	this (checkNull (parentItem).parent, parentItem.handle, style, -1, 0);
 }
 
 /**
@@ -158,17 +158,19 @@ public TreeItem (TreeItem parentItem, int style) {
  * @see Tree#setRedraw
  */
 public TreeItem (TreeItem parentItem, int style, int index) {
-	this (checkNull (parentItem).parent, parentItem.handle, style, checkIndex (index), true);
+	this (checkNull (parentItem).parent, parentItem.handle, style, checkIndex (index), 0);
 }
 
-TreeItem (Tree parent, long parentIter, int style, int index, boolean create) {
+TreeItem (Tree parent, long parentIter, int style, int index, long iter) {
 	super (parent, style);
 	this.parent = parent;
-	if (create) {
+	if (iter == 0) {
 		parent.createItem (this, parentIter, index);
 	} else {
+		assert handle == 0;
 		handle = OS.g_malloc (GTK.GtkTreeIter_sizeof ());
-		GTK.gtk_tree_model_iter_nth_child (parent.modelHandle, handle, parentIter, index);
+		if (handle == 0) error(SWT.ERROR_NO_HANDLES);
+		C.memmove(handle, iter, GTK.GtkTreeIter_sizeof ());
 	}
 }
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/TreeItem.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/TreeItem.java
@@ -794,9 +794,14 @@ public TreeItem getItem (int index) {
 	checkWidget();
 	if (index < 0) error (SWT.ERROR_INVALID_RANGE);
 	if (!parent.checkData (this)) error (SWT.ERROR_WIDGET_DISPOSED);
-	int itemCount = GTK.gtk_tree_model_iter_n_children (parent.modelHandle, handle);
-	if (index >= itemCount)  error (SWT.ERROR_INVALID_RANGE);
-	return  parent._getItem (handle, index);
+
+	long iter = OS.g_malloc (GTK.GtkTreeIter_sizeof ());
+	try {
+		if (!GTK.gtk_tree_model_iter_nth_child (parent.modelHandle, iter, handle, index)) error (SWT.ERROR_INVALID_RANGE);
+		return parent._getItem (handle, iter, index);
+	} finally {
+		OS.g_free (iter);
+	}
 }
 
 /**

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_TreeItem.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_TreeItem.java
@@ -1174,6 +1174,15 @@ public void test_setTextILjava_lang_String(){
 
 }
 
+@Test
+public void test_removeAll() {
+	TreeItem item = new TreeItem(treeItem, SWT.NONE);
+	assertEquals(1, treeItem.getItemCount());
+	treeItem.removeAll();
+	assertEquals(0, treeItem.getItemCount());
+	assertTrue(item.isDisposed());
+}
+
 /* custom */
 TreeItem treeItem;
 Tree tree;

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/performance/Test_org_eclipse_swt_widgets_Tree.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/performance/Test_org_eclipse_swt_widgets_Tree.java
@@ -1,0 +1,359 @@
+/*******************************************************************************
+ * Copyright (c) 2023, 2023 IBM Corporation and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Vasili Gulevich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.swt.tests.junit.performance;
+
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Deque;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Consumer;
+import java.util.function.IntFunction;
+
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.graphics.Color;
+import org.eclipse.swt.graphics.Font;
+import org.eclipse.swt.layout.FillLayout;
+import org.eclipse.swt.tests.junit.SwtTestUtil;
+import org.eclipse.swt.widgets.Control;
+import org.eclipse.swt.widgets.Shell;
+import org.eclipse.swt.widgets.Tree;
+import org.eclipse.swt.widgets.TreeItem;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+@RunWith(Parameterized.class)
+public class Test_org_eclipse_swt_widgets_Tree {
+	enum Shape {
+		BINARY {
+			@Override
+			void buildTree(Tree tree, int size, Consumer<TreeItem> initializeItem) {
+				tree.setItemCount(2);
+				{
+					int leftChildCount = size / 2;
+					tree.getItem(0).setData("childCount", leftChildCount - 1);
+					tree.getItem(1).setData("childCount", size - leftChildCount - 1);
+				}
+				boolean virtual = (tree.getStyle() & SWT.VIRTUAL) != 0;
+				if (virtual) {
+					tree.addListener(SWT.SetData, event -> {
+						TreeItem item = (TreeItem) event.item;
+						initializeItem.accept(item);
+						createBinaryChildren(item, initializeItem);
+					});
+				} else {
+					createBinaryBranch(tree.getItem(0), initializeItem);
+					createBinaryBranch(tree.getItem(1), initializeItem);
+				}
+			}
+
+			private void createBinaryBranch(TreeItem item, Consumer<TreeItem> initializeItem) {
+				initializeItem.accept(item);
+				for (TreeItem child : createBinaryChildren(item, initializeItem)) {
+					createBinaryBranch(child, initializeItem);
+				}
+			}
+
+			@Override
+			protected TreeItem lastItem(Tree tree) {
+				return lastItem(tree.getItem(1));
+			}
+
+			private List<TreeItem> createBinaryChildren(TreeItem item, Consumer<TreeItem> initializeItem) {
+				int childCount = (int) item.getData("childCount");
+				int leftChildCount = childCount / 2;
+				int rightChildCount = childCount - leftChildCount;
+				ArrayList<TreeItem> result = new ArrayList<>();
+				if (leftChildCount > 0) {
+					TreeItem left = new TreeItem(item, SWT.NONE);
+					left.setData("childCount", leftChildCount - 1);
+					result.add(left);
+				}
+				if (rightChildCount > 0) {
+					TreeItem right = new TreeItem(item, SWT.NONE);
+					right.setData("childCount", rightChildCount - 1);
+					result.add(right);
+				}
+				return result;
+			}
+
+			private TreeItem lastItem(TreeItem item) {
+				TreeItem[] children = item.getItems();
+				if (children.length == 0) {
+					return item;
+				} else {
+					return lastItem(children[children.length - 1]);
+				}
+			}
+
+		},
+		STAR {
+			@Override
+			void buildTree(Tree tree, int size, Consumer<TreeItem> initializeItem) {
+				if ((tree.getStyle() & SWT.VIRTUAL) != 0) {
+					tree.addListener(SWT.SetData, event -> {
+						TreeItem item = (TreeItem) event.item;
+						initializeItem.accept(item);
+						if (item.getParentItem() == null)
+							item.setItemCount(size - 1);
+					});
+					tree.setItemCount(1);
+				} else {
+					tree.setItemCount(1);
+					TreeItem root = tree.getItem(0);
+					initializeItem.accept(root);
+					root.setItemCount(size - 1);
+					for (TreeItem item : root.getItems()) {
+						initializeItem.accept(item);
+					}
+				}
+			}
+
+			@Override
+			protected TreeItem lastItem(Tree tree) {
+				TreeItem root = tree.getItem(0);
+				return root.getItem(tree.getItemCount() - 1);
+			}
+		};
+
+		abstract void buildTree(Tree parent, int size, Consumer<TreeItem> initializeItem);
+
+		protected abstract TreeItem lastItem(Tree tree);
+	}
+
+	@Rule
+	public final TestName name = new TestName();
+	private final boolean virtual;
+	private final Shape shape;
+	private final Shell shell = new Shell();
+	private final Font font = new Font(shell.getDisplay(), "Arial", 5, 5);
+	private final Color foreground = shell.getDisplay().getSystemColor(SWT.COLOR_GREEN);
+	private final Color background = shell.getDisplay().getSystemColor(SWT.COLOR_BLACK);
+
+	@Parameters(name = "Shape: {0}, virtual: {1}")
+	public static Iterable<Object[]> data() {
+		return Arrays.asList(new Object[][] { { Shape.STAR, false }, { Shape.STAR, true }, { Shape.BINARY, false },
+				{ Shape.BINARY, true }, });
+	}
+
+	public Test_org_eclipse_swt_widgets_Tree(Shape shape, boolean virtual) {
+		this.shape = Objects.requireNonNull(shape);
+		this.virtual = virtual;
+	}
+
+	@Before
+	public void setUp() {
+		shell.setSize(500, 500);
+		shell.setLayout(new FillLayout());
+		// Make tree visible to make GTK request updates
+		SwtTestUtil.openShell(shell);
+	}
+
+	@After
+	public void teardown() {
+		font.dispose();
+		shell.dispose();
+	}
+
+	@Test
+	public void build() {
+		assertMaximumDegree(1.1, n -> {
+			return measureNanos(() -> buildSubject(n, this::initializeItem));
+		});
+	}
+
+	@Test
+	public void traverse() {
+		assertMaximumDegree(2.1, n -> {
+			Tree tree = buildSubject(n, this::initializeItem);
+			return measureNanos(() -> {
+				int[] count = new int[] { 0 };
+				breadthFirstTraverse(tree, item -> count[0]++);
+				Assert.assertEquals(n, count[0]);
+			});
+		});
+	}
+
+	@Test
+	public void secondTraverse() {
+		assertMaximumDegree(1.2, n -> {
+			Tree tree = buildSubject(n, this::initializeItem);
+			breadthFirstTraverse(tree, item -> {
+				item.setExpanded(true);
+			});
+			return measureNanos(() -> {
+				breadthFirstTraverse(tree, item -> {
+				});
+			});
+		});
+	}
+
+	@Test
+	public void getForeground() {
+		assertMaximumDegree(1.2, n -> {
+			Tree tree = buildSubject(n, this::initializeItem);
+			breadthFirstTraverse(tree, item -> {
+				item.setExpanded(true);
+			});
+			return measureNanos(() -> {
+				breadthFirstTraverse(tree, TreeItem::getForeground);
+			});
+		});
+	}
+
+	@Test
+	public void setForeground() {
+		assertMaximumDegree(1.3, n -> {
+			Tree tree = buildSubject(n, this::initializeItem);
+			breadthFirstTraverse(tree, item -> {
+				item.setExpanded(true);
+			});
+			Color cyan = shell.getDisplay().getSystemColor(SWT.COLOR_CYAN);
+			return measureNanos(() -> {
+				breadthFirstTraverse(tree, item -> item.setForeground(cyan));
+			});
+		});
+	}
+
+	@Test
+	public void setText() {
+		assertMaximumDegree(1.3, n -> {
+			Tree tree = buildSubject(n, this::initializeItem);
+			breadthFirstTraverse(tree, item -> {
+				item.setExpanded(true);
+			});
+			return measureNanos(() -> {
+				breadthFirstTraverse(tree, item -> item.setText("test"));
+			});
+		});
+	}
+
+	@Test
+	public void showItem() {
+		assertMaximumDegree(virtual ? 1.2 : 1.9, n -> {
+			Tree tree = buildSubject(n, this::initializeItem);
+			return measureNanos(() -> tree.showItem(shape.lastItem(tree)));
+		});
+	}
+
+	@Test
+	public void jfaceReveal() {
+		// Still demonstrates different characteristics
+		assertMaximumDegree(virtual ? 1.1 : 2, n -> {
+			Tree tree = buildSubject(n, this::initializeItem);
+			return measureNanos(() -> {
+				// JFace creates all children and updates each by its index
+
+				TreeItem item = tree.getItem(tree.getItemCount() - 1);
+
+				for (;;) {
+					item.setExpanded(true);
+					int count = item.getItemCount();
+					if (virtual) {
+						item.getItems();
+						for (int i = 0; i < count; i++) {
+							item.getItem(i); // JFace updates children using their indices
+						}
+					}
+					if (count <= 0) {
+						tree.showItem(item);
+						break;
+					}
+					item = item.getItem(count - 1);
+				}
+			});
+		});
+	}
+
+	private Tree buildSubject(int size, Consumer<TreeItem> initialize) {
+		Tree result = new Tree(shell, virtual ? SWT.VIRTUAL : SWT.NONE);
+		shell.layout();
+		result.setRedraw(false);
+		shape.buildTree(result, size, initialize);
+		result.setRedraw(true);
+		return result;
+	}
+
+	/** Ensure that given function grows within acceptable polynomial degree */
+	private void assertMaximumDegree(double maximumDegree, IntFunction<Double> function) {
+		shell.setText(name.getMethodName());
+		clearShell();
+		int elementCount[] = new int[] { 10000, 100000 };
+		function.apply(elementCount[0]); // warmup
+		clearShell();
+		double elapsed[] = new double[] { function.apply(elementCount[0]), 0 };
+		clearShell();
+		elapsed[1] = function.apply(elementCount[1]);
+		double ratio = elapsed[1] / elementCount[1] / elapsed[0] * elementCount[0];
+		double degree = Math.log(elapsed[1] / elapsed[0]) / Math.log(elementCount[1] / elementCount[0]);
+		String error = String.format(
+				"Execution time should grow as %f degree polynom. \nTime for %d elements: %f ns\nTime for %d elements: %f ns\nRatio: %f\nDegree: %f\n",
+				maximumDegree, elementCount[0], elapsed[0], elementCount[1], elapsed[1], ratio, degree);
+		System.out.println(name.getMethodName() + "\n" + error);
+		assertTrue(error, (elapsed[1] <= 100 && elapsed[0] <= 100) || degree < maximumDegree);
+	}
+
+	private double measureNanos(Runnable runnable) {
+		SwtTestUtil.processEvents();
+		long start = System.nanoTime();
+		runnable.run();
+		SwtTestUtil.processEvents();
+		long stop = System.nanoTime();
+		return stop - start;
+	}
+
+	private final AtomicLong itemCount = new AtomicLong(0);
+
+	private void initializeItem(TreeItem item) {
+		item.setText(itemCount.getAndIncrement() + "");
+		item.setForeground(foreground);
+		item.setBackground(background);
+		item.setFont(font);
+	}
+
+	private void clearShell() {
+		for (Control child : shell.getChildren()) {
+			child.dispose();
+		}
+		assert shell.getChildren().length == 0;
+		itemCount.set(0);
+		SwtTestUtil.processEvents();
+	}
+
+	private void breadthFirstTraverse(Tree tree, Consumer<TreeItem> visitor) {
+		tree.setRedraw(false);
+		try {
+			Deque<TreeItem> queue = new LinkedList<>();
+			queue.addAll(Arrays.asList(tree.getItems()));
+			while (!queue.isEmpty()) {
+				TreeItem parent = queue.removeFirst();
+				visitor.accept(parent);
+				queue.addAll(Arrays.asList(parent.getItems()));
+			}
+		} finally {
+			tree.setRedraw(true);
+		}
+	}
+}

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/performance/Test_org_eclipse_swt_widgets_Tree.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/performance/Test_org_eclipse_swt_widgets_Tree.java
@@ -211,6 +211,18 @@ public class Test_org_eclipse_swt_widgets_Tree {
 	}
 
 	@Test
+	public void dispose() {
+		assertMaximumDegree(1.2, n -> {
+			Tree tree = buildSubject(n, this::initializeItem);
+			breadthFirstTraverse(tree, item -> {
+				item.setExpanded(true);
+			});
+			return measureNanos(() -> tree.dispose());
+		});
+	}
+
+
+	@Test
 	public void getForeground() {
 		assertMaximumDegree(1.2, n -> {
 			Tree tree = buildSubject(n, this::initializeItem);


### PR DESCRIPTION
DO NOT MERGE - this is a demonstration, not an actual solution. See below.

This is a follow up to #903 and #904.

This PR eliminates explicit iterations over `Tree` from execution profile when `TreeItem.getItems()` is called before `TreeItem.getItem(int)`. This is the case for JFace lazy TreeViewer. 

Performance improvement is proven by running relevant tests from
org.eclipse.swt.tests.junit.performance.Test_org_eclipse_swt_widgets_Tree:

In test jfaceReveal[Shape: STAR, virtual: true]:
10_000 elements:  218_583_468ns -> 141_061_117ns
100_000 elements: 20_872_245_796ns ->  10_761_449_641ns (-48%)
In test dispose[Shape: STAR, virtual: true]:
10_000 elements: 5_637_088ns -> 6_222_363ns
100_000 elements: 62_422_153ns -> 56_442_156ns

Profile before the change:
<img width="1082" alt="Screenshot 2023-11-26 at 21 22 34" src="https://github.com/eclipse-platform/eclipse.platform.swt/assets/650857/7bcc61e2-3331-46c6-8c5b-32c5641202c5">
Profile after the change:
<img width="1174" alt="Screenshot 2023-11-27 at 14 09 00" src="https://github.com/eclipse-platform/eclipse.platform.swt/assets/650857/1d4ab959-1a41-4212-8a0b-0f8bb19fd9f3">

The solution here is ideologically incorrect, as it targets a particular way of tree traversal, specific to JFAce lazy tree. However, a more general and self-consistent approach, that moves ownership of a TreeItem from a Tree to a parent item, prototyped in https://github.com/eclipse-platform/eclipse.platform.swt/compare/master...basilevs:eclipse.platform.swt:issue_882_gtk_direct_access is a much larger change. I suggest not to merge this PR and just use it as a starting point for discussion on removal of ID system from SWT GTK Tree.
The removal itself is done in #918 