### PR TITLE
[GTK] Don't use deprecated gtk_style_context_invalidate()

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/gtk3.c
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/gtk3.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2022 IBM Corporation and others.
+ * Copyright (c) 2000, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -1734,18 +1734,6 @@ JNIEXPORT jlong JNICALL GTK3_NATIVE(gtk_1style_1context_1get_1parent)
 	GTK3_NATIVE_EXIT(env, that, gtk_1style_1context_1get_1parent_FUNC);
 	return rc;
 }
-#endif
-
-#ifndef NO_gtk_1style_1context_1invalidate
-G_GNUC_BEGIN_IGNORE_DEPRECATIONS
-JNIEXPORT void JNICALL GTK3_NATIVE(gtk_1style_1context_1invalidate)
-	(JNIEnv *env, jclass that, jlong arg0)
-{
-	GTK3_NATIVE_ENTER(env, that, gtk_1style_1context_1invalidate_FUNC);
-	gtk_style_context_invalidate((GtkStyleContext *)arg0);
-	GTK3_NATIVE_EXIT(env, that, gtk_1style_1context_1invalidate_FUNC);
-}
-G_GNUC_END_IGNORE_DEPRECATIONS
 #endif
 
 #ifndef NO_gtk_1target_1list_1new

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/gtk3_stats.h
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/gtk3_stats.h
@@ -165,7 +165,6 @@ typedef enum {
 	gtk_1style_1context_1get_1font_FUNC,
 	gtk_1style_1context_1get_1padding_FUNC,
 	gtk_1style_1context_1get_1parent_FUNC,
-	gtk_1style_1context_1invalidate_FUNC,
 	gtk_1target_1list_1new_FUNC,
 	gtk_1target_1list_1unref_FUNC,
 	gtk_1text_1view_1get_1window_FUNC,

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/org/eclipse/swt/internal/gtk3/GTK3.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/org/eclipse/swt/internal/gtk3/GTK3.java
@@ -917,11 +917,6 @@ public class GTK3 {
 
 	/* GtkStyleContext */
 	/**
-	 * @method flags=ignore_deprecations
-	 * @param context cast=(GtkStyleContext *)
-	 */
-	public static final native void gtk_style_context_invalidate(long context);
-	/**
 	 * @param screen cast=(GdkScreen *)
 	 * @param provider cast=(GtkStyleProvider *)
 	 * @param priority cast=(guint)

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Control.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Control.java
@@ -5307,7 +5307,6 @@ void setBackgroundGdkRGBA (long handle, GdkRGBA rgba) {
 
 	long context = GTK.gtk_widget_get_style_context(handle);
 	setBackgroundGdkRGBA(context, handle, rgba);
-	if (!GTK.GTK4) GTK3.gtk_style_context_invalidate(context);
 }
 /**
  * Sets the receiver's background image to the image specified

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Display.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Display.java
@@ -3220,7 +3220,6 @@ void initializeSystemColorsList(long shellContext) {
 	GTK.gtk_style_context_save (shellContext);
 	GTK.gtk_style_context_add_class(shellContext, GTK.GTK_STYLE_CLASS_VIEW);
 	GTK.gtk_style_context_add_class(shellContext, GTK.GTK_STYLE_CLASS_CELL);
-	if (!GTK.GTK4) GTK3.gtk_style_context_invalidate(shellContext);
 
 	COLOR_LIST_FOREGROUND_RGBA = styleContextGetColor (shellContext, GTK.GTK_STATE_FLAG_NORMAL);
 	COLOR_LIST_BACKGROUND_RGBA = styleContextEstimateBackgroundColor(shellContext, GTK.GTK_STATE_FLAG_NORMAL);

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Text.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Text.java
@@ -259,7 +259,6 @@ void createHandle (int index) {
 			long context = GTK.gtk_widget_get_style_context(handle);
 			String background = display.gtk_rgba_to_css_string(display.COLOR_LIST_BACKGROUND_RGBA);
 			gtk_css_provider_load_from_css(context, "entry {border: solid; background: " + background + ";}");
-			if (!GTK.GTK4) GTK3.gtk_style_context_invalidate(context);
 		}
 
 		float alignment = 0.0f;

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/ToolTip.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/ToolTip.java
@@ -308,7 +308,6 @@ void createHandle (int index) {
 			GdkRGBA bgRGBA = background.handle;
 			String css = "window {background-color: " + display.gtk_rgba_to_css_string(bgRGBA) + ";}";
 			gtk_css_provider_load_from_css (context, css);
-			GTK3.gtk_style_context_invalidate (context);
 			GTK3.gtk_window_set_type_hint (handle, GDK.GDK_WINDOW_TYPE_HINT_TOOLTIP);
 		}
 	}

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Tracker.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Tracker.java
@@ -917,7 +917,6 @@ private void setTrackerBackground(boolean opaque) {
 		GTK4.gtk_css_provider_load_from_data (provider, Converter.wcsToMbcs (css, true), -1);
 	} else {
 		GTK3.gtk_css_provider_load_from_data (provider, Converter.wcsToMbcs (css, true), -1, null);
-		GTK3.gtk_style_context_invalidate (context);
 	}
 
 	long region = Cairo.cairo_region_create ();

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Widget.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Widget.java
@@ -1851,8 +1851,6 @@ void setFontDescription(long widget, long fontDescription) {
 		// gtk_widget_override_font() copies the fields from 'fontDescription'
 		// and does not remember the pointer passed to it.
 		GTK3.gtk_widget_override_font(widget, fontDescription);
-		long context = GTK.gtk_widget_get_style_context(widget);
-		GTK3.gtk_style_context_invalidate(context);
 	}
 }
 


### PR DESCRIPTION
GTK sources say:
  Deprecated: 3.12: Style contexts are invalidated automatically.

https://www.eclipse.org/swt/faq.php#gtkstartup says:
  Eclipse/SWT 4.16.x: GTK+ 3.20.0 and its dependencies
  Eclipse/SWT 4.15.x: GTK+ 3.14.0 and its dependencies

This means that it's been at least 3 years since SWT requires GTK 3.20. Sounds safe to stop using the deprecated function now.

Hopefully fixes https://github.com/eclipse-platform/eclipse.platform.swt/issues/697 I couldn't reproduce it in SWT snippet, so I didn't test this with SWT. But when I tested in native snippet, removing `gtk_style_context_invalidate()` changed things a bit and crash no longer occurred.