### PR TITLE
[Build] Build commits from releng-bot if natives build is enforced

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -53,7 +53,7 @@ pipeline {
 		PR_VALIDATION_BUILD = "true"
 	}
 	parameters {
-		booleanParam(name: 'forceNativeBuilds', defaultValue: false, description: 'Forces to run the native builds of swt\'s binaries. Useful in debugging.')
+		booleanParam(name: 'forceNativeBuilds', defaultValue: false, description: 'Forces to run the native builds of swt\'s binaries. Will push the built binaries to the master branch, unless \'skipCommit\' is set. Useful in debugging.')
 		booleanParam(name: 'skipCommit', defaultValue: false, description: 'Stops committing to swt and swt binaries repo at the end. Useful in debugging.')
 	}
 	stages {
@@ -64,7 +64,7 @@ pipeline {
 					script {
 						def authorMail = sh(script: 'git log -1 --pretty=format:"%ce" HEAD', returnStdout: true)
 						echo 'HEAD commit author: ' + authorMail
-						if ('eclipse-releng-bot@eclipse.org'.equals(authorMail)) {
+						if ('eclipse-releng-bot@eclipse.org'.equals(authorMail) && !params.forceNativeBuilds) {
 							// Prevent endless build-loops due to self triggering because of a previous automated build of SWT-natives and the associated updates.
 							currentBuild.result = 'ABORTED'
 							error('Abort build only triggered by automated SWT-natives update.')


### PR DESCRIPTION
And add a not to the description of 'forceNativeBuilds' parameter that if enabled and 'skipCommit' is not set, the then build binaries will be pushed to the master branch.

FYI @akurtakov and @iloveeclipse

Requested in https://github.com/eclipse-platform/eclipse.platform.swt/pull/919#issuecomment-1833269324.