### PR TITLE
Apply large padding only when image for tab item shall not be shown #945

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CTabFolderRenderer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CTabFolderRenderer.java
@@ -362,8 +362,7 @@ public class CTabFolderRenderer {
 
 					if (parent.showClose || item.showClose) {
 						if ((state & SWT.SELECTED) != 0 || parent.showUnselectedClose) {
-							if (((state & SWT.SELECTED) != 0 && parent.showSelectedImage)
-									|| ((state & SWT.SELECTED) == 0 && parent.showUnselectedImage)) {
+							if (!applyLargeTextPadding(parent)) {
 								if (width > 0) width += INTERNAL_SPACING;
 							} else {
 								if (width > 0) width -= INTERNAL_SPACING;
@@ -389,16 +388,19 @@ public class CTabFolderRenderer {
 	 */
 	private int getTextPadding(CTabItem item, int state) {
 		CTabFolder parent = item.getParent();
-		Image image = item.getImage();
 		String text = item.getText();
 
 		if (text != null && parent.getMinimumCharacters() != 0) {
-			if (image == null || image.isDisposed() || ((state & SWT.SELECTED) != 0 && !parent.showSelectedImage)
-					|| ((state & SWT.SELECTED) == 0 && !parent.showUnselectedImage))
+			if (applyLargeTextPadding(parent)) {
 				return TABS_WITHOUT_ICONS_PADDING;
+			}
 		}
 
 		return 0;
+	}
+
+	private boolean applyLargeTextPadding(CTabFolder tabFolder) {
+		return !tabFolder.showSelectedImage && !tabFolder.showUnselectedImage;
 	}
 
 	/**


### PR DESCRIPTION
Currently, all headers in CTabFolders without an image have a large text padding. This applies to both the case where no image is assigned to a tab item and the case where images shall not be shown as the properties showSelectedImage and showUnselectedImage are both false. While the latter is intended behavior to switch between image-based tab folders and image-less, padding-based tab folders (see #785), the former unintentionally breaks with the existing UI experience for CTabFolders that do not use images.

This change makes the identification of whether large text padding shall be applied explicit by factoring it out into a method (which may be replaced by a different implementation later on). It reduces the cases in which the large text padding is applied to the intended case (showSelectedImage = showUnselectedImage = false) and restores the behavior for all existing use cases.

Before this change:
![image](https://github.com/eclipse-platform/eclipse.platform.swt/assets/755472/43af4183-32e2-4925-992c-66ed4a8b7cb5)

After this change (like before #785):
![image](https://github.com/eclipse-platform/eclipse.platform.swt/assets/755472/5b8d0e2b-451f-4c41-bc98-789b7f109c9e)

The "before" state can now only be achieved when the tab folder has showSelectedImage=showUnselectedImage=false (which will never be the case for existing CTabFolders as showSelectedImage=true by default).

Contributes to https://github.com/eclipse-platform/eclipse.platform.swt/issues/945