### PR TITLE
Revert move of binaries-parent/build.xml into binaries directory

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -133,7 +133,7 @@ pipeline {
 								withAnt(installation: 'apache-ant-latest', jdk: 'openjdk-jdk11-latest') { // nashorn javascript-engine required in ant-scripts
 									sh '''
 										pfSpec=(${PLATFORM//"."/ })
-										ant -f build.xml copy_library_src_and_create_zip -Dws=${pfSpec[0]} -Dos=${pfSpec[1]} -Darch=${pfSpec[2]}
+										ant -f binaries-parent/build.xml copy_library_src_and_create_zip -Dws=${pfSpec[0]} -Dos=${pfSpec[1]} -Darch=${pfSpec[2]}
 									'''
 								}
 								dir("org.eclipse.swt.${PLATFORM}/tmpdir") {

--- a/binaries/binaries-parent/build.xml
+++ b/binaries/binaries-parent/build.xml
@@ -6,6 +6,6 @@
 	<property name="swt.arch" value="${arch}" />
 	
 	<property name="plugindir" value="../../bundles/org.eclipse.swt"/>
-	<import file="../bundles/org.eclipse.swt/buildFragment.xml"/>
-	<import file="../bundles/org.eclipse.swt/buildSWT.xml"/>
+	<import file="${plugindir}/buildFragment.xml"/>
+	<import file="${plugindir}/buildSWT.xml"/>
 </project>

--- a/binaries/pom.xml
+++ b/binaries/pom.xml
@@ -108,7 +108,7 @@
 								<configuration>
 									<target>
 										<property name="copy.src.dir" value="src" />
-										<ant antfile="../build.xml" target="copy.${ws}.src" />
+										<ant antfile="../binaries-parent/build.xml" target="copy.${ws}.src" />
 									</target>
 								</configuration>
 							</execution>
@@ -125,7 +125,7 @@
 										<if>
 											<equals arg1="${native}" arg2="${ws}.${os}.${arch}" />
 											<then>
-												<ant antfile="../build.xml" target="build_libraries" />
+												<ant antfile="../binaries-parent/build.xml" target="build_libraries" />
 											</then>
 										</if>
 									</target>
@@ -140,7 +140,7 @@
 								<configuration>
 									<target>
 										<property name="eclipse.version" value="${releaseNumberSDK}" />
-										<ant antfile="../build.xml" target="swtdownload" />
+										<ant antfile="../binaries-parent/build.xml" target="swtdownload" />
 									</target>
 								</configuration>
 							</execution>


### PR DESCRIPTION
Moving the binaries-parent/build.xml broke the native binaries build and fixing it would require the adjustments of many paths.

This reverts parts of commit 237811252b3f272fcc0dfca2d403b876a404ec64.