### PR TITLE
Prefer libwebkit2gtk-4.1.so.0 over libwebkit2gtk-4.0.so.37

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT WebKit/gtk/library/webkitgtk.h
+++ b/bundles/org.eclipse.swt/Eclipse SWT WebKit/gtk/library/webkitgtk.h
@@ -45,9 +45,9 @@
 		if (gtk4 != NULL && strcmp(gtk4, "1") == 0) { \
 			handle = dlopen("libwebkit2gtk-5.0.so.0", LOAD_FLAGS); \
 		} else { \
-			handle = dlopen("libwebkit2gtk-4.0.so.37", LOAD_FLAGS); /* webkit2/libsoup2 */ \
+			handle = dlopen("libwebkit2gtk-4.1.so.0", LOAD_FLAGS); /* webkit2/libsoup3 */ \
 			if (!handle) { \
-				handle = dlopen("libwebkit2gtk-4.1.so.0", LOAD_FLAGS); /* webkit2/libsoup3 */ \
+				handle = dlopen("libwebkit2gtk-4.0.so.37", LOAD_FLAGS); /* webkit2/libsoup2 */ \
 			} \
 		} \
 		if (handle) { \


### PR DESCRIPTION
This will change something only in the case when both libs are installed on the machine to make the 4.1(aka compiled against libsoup3) be preferred.
If only one of the libs is installed nothing will change as it will dlopen one or the other no matter the order of trying them. This is an effort to mitigate
https://github.com/eclipse-platform/eclipse.platform.swt/issues/350 where people see crashes with the old version which btw is even scheduled for removal soon from Fedora
https://fedoraproject.org/wiki/Changes/Remove_webkit2gtk-4.0_API_Version .