### PR TITLE
[Build] Run SWT native binary build in GH workflows

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -38,10 +38,16 @@ jobs:
       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       with:
        fetch-depth: 0 # required for jgit timestamp provider to work
-       lfs: true
+       lfs: false # lfs-pull is not necessary, the natives are re-build in each run
     - name: Install Linux requirements
-      run: sudo apt-get update -qq && sudo apt-get install -qq -y webkit2gtk-driver
+      run: |
+        sudo apt-get update -qq 
+        sudo apt-get install -qq -y libgtk-3-dev freeglut3-dev webkit2gtk-driver
       if: ${{ matrix.config.native == 'gtk.linux.x86_64'}}
+    - name: Pull large static Windows binaries
+      run: |
+        git lfs pull --include='/binaries/org.eclipse.swt.win32.win32.x86_64/WebView2Loader.dll'
+      if: ${{ matrix.config.native == 'win32.win32.x86_64'}}
     - name: Set up Java ${{ matrix.java }}
       uses: actions/setup-java@387ac29b308b003ca37ba93a6cab5eb57c8f5f93 # v4.0.0
       with:
@@ -58,6 +64,7 @@ jobs:
        run: >-
         mvn --batch-mode -V -U
         -DforkCount=1
+        -Dnative=${{ matrix.config.native }}
         -Dcompare-version-with-baselines.skip=true
         -Dtycho.baseline.replace=none
         -Dmaven.compiler.failOnWarning=true

--- a/binaries/org.eclipse.swt.cocoa.macosx.aarch64/build.properties
+++ b/binaries/org.eclipse.swt.cocoa.macosx.aarch64/build.properties
@@ -19,4 +19,4 @@ src.includes = about.html,about_files/
 pom.model.property.os=macosx
 pom.model.property.ws=cocoa
 pom.model.property.arch=aarch64
-pom.model.property.targets=
+pom.model.property.targets=install

--- a/binaries/org.eclipse.swt.cocoa.macosx.x86_64/build.properties
+++ b/binaries/org.eclipse.swt.cocoa.macosx.x86_64/build.properties
@@ -19,4 +19,4 @@ src.includes = about.html,about_files/
 pom.model.property.os=macosx
 pom.model.property.ws=cocoa
 pom.model.property.arch=x86_64
-pom.model.property.targets=
+pom.model.property.targets=install

--- a/binaries/pom.xml
+++ b/binaries/pom.xml
@@ -140,7 +140,7 @@
 											<then>
 												<property name="build_dir" value="${project.build.directory}/natives-build-temp"/>
 												<exec executable="${java.home}/bin/java" dir="${swtMainProject}" failonerror="true">
-													<arg line="-Dws=${ws} build-scripts/CollectSources.java -nativeSources '${build_dir}'"/>
+													<arg line="-Dws=${ws} -Darch=${arch} build-scripts/CollectSources.java -nativeSources '${build_dir}'"/>
 												</exec>
 												<property name="SWT_JAVA_HOME" value="${java.home}"/><!-- Not overwritten if already set, e.g. as CLI argument -->
 												<echo>Compile SWT natives against headers and libraries from JDK: ${SWT_JAVA_HOME}</echo>

--- a/bundles/org.eclipse.swt/build-scripts/CollectSources.java
+++ b/bundles/org.eclipse.swt/build-scripts/CollectSources.java
@@ -68,7 +68,7 @@ public class CollectSources {
 		String commonSources = sources.get("src_common");
 		String nativeSources = sources.get("src_" + env.ws);
 		List<String> allSources = Arrays.asList((commonSources + "," + nativeSources).split(","));
-		System.out.println("Copy " + allSources.size() + " java source folders for " + env.ws + "." + env.arch);
+		System.out.println("Copy " + allSources.size() + " native source folders for " + env.ws + "." + env.arch);
 		copySubDirectories(env.swtProjectRoot, allSources, env.targetDirectory, Set.of());
 	}
 
@@ -88,7 +88,7 @@ public class CollectSources {
 		}
 		Set<String> srcClassPaths = readNativeJavaSourcesFromClasspath(classpathFile);
 		Set<String> excludedExtensions = Set.of("_properties", "extras", "bridgesupport");
-		System.out.println("Copy " + srcClassPaths.size() + " native source folders for" + env.ws + "." + env.arch);
+		System.out.println("Copy " + srcClassPaths.size() + " java source folders for" + env.ws + "." + env.arch);
 		copySubDirectories(env.swtProjectRoot, srcClassPaths, env.targetDirectory, excludedExtensions);
 	}
 


### PR DESCRIPTION
This allows to test changes in the natives in verification builds on all platforms and not only on Linux because Jenkins re-builds the binaries.