### PR TITLE
[Build] Collect native sources in Jenkins pipeline with Java script

### DIFF
--- a/binaries/pom.xml
+++ b/binaries/pom.xml
@@ -48,6 +48,9 @@
 					<exists>META-INF/MANIFEST.MF</exists>
 				</file>
 			</activation>
+			<properties>
+				<swtMainProject>${project.basedir}/../../bundles/org.eclipse.swt</swtMainProject>
+			</properties>
 			<build>
 				<plugins>
 					<plugin>
@@ -104,7 +107,7 @@
 								</goals>
 								<configuration>
 									<target> <!-- Read git qualifier of 'org.eclipse.swt' project. -->
-										<loadfile property="swtBuildQualifier" srcFile="../../bundles/org.eclipse.swt/target/swtBuildQualifier.txt"/>
+										<loadfile property="swtBuildQualifier" srcFile="${swtMainProject}/target/swtBuildQualifier.txt"/>
 									</target>
 									<exportAntProperties>true</exportAntProperties>
 								</configuration>
@@ -123,7 +126,7 @@
 								</configuration>
 							</execution>
 							<execution>
-								<id>natives</id>
+								<id>build-native-binaries</id>
 								<phase>process-resources</phase>
 								<goals>
 									<goal>run</goal>
@@ -131,11 +134,37 @@
 								<configuration>
 									<target>
 										<!-- See https://stackoverflow.com/a/53227117 and http://ant-contrib.sourceforge.net/tasks/tasks/index.html -->
-										<taskdef resource="net/sf/antcontrib/antlib.xml" />
-										<if>
-											<equals arg1="${native}" arg2="${ws}.${os}.${arch}" />
+										<taskdef resource="net/sf/antcontrib/antlib.xml"/>
+										<if><equals arg1="${native}" arg2="${ws}.${os}.${arch}"/>
 											<then>
-												<ant antfile="../binaries-parent/build.xml" target="build_libraries" />
+												<property name="build_dir" value="${project.build.directory}/natives-build-temp"/>
+												<exec executable="java" dir="${swtMainProject}" failonerror="true">
+													<arg line="-Dws=${ws} build-scripts/CollectSources.java -nativeSources '${build_dir}'"/>
+												</exec>
+												<property name="SWT_JAVA_HOME" value="${java.home}"/><!-- Not overwritten if already set, e.g. as CLI argument -->
+												<echo>Compile SWT natives against headers and libraries from JDK: ${SWT_JAVA_HOME}</echo>
+												<if><equals arg1="${ws}" arg2="win32" />
+													<then>
+														<exec dir="${build_dir}" executable="${build_dir}/build.bat" failonerror="true">
+															<env key="SWT_JAVA_HOME" value="${SWT_JAVA_HOME}"/>
+															<env key="OUTPUT_DIR" value="${project.basedir}"/>
+															<arg line="${targets}"/>
+															<arg line="clean"/>
+														</exec>
+													</then>
+													<else>
+														<property name="gtk_version" value="3.0" />
+														<exec dir="${build_dir}" executable="sh" failonerror="true">
+															<arg line="build.sh"/>
+															<env key="SWT_JAVA_HOME" value="${SWT_JAVA_HOME}"/>
+															<env key="OUTPUT_DIR" value="${project.basedir}"/>
+															<env key="GTK_VERSION" value="${gtk_version}"/>
+															<env key="MODEL" value="${arch}"/>
+															<arg line="${targets}"/>
+															<arg line="clean"/>
+														</exec>
+													</else>
+												</if>
 											</then>
 										</if>
 									</target>
@@ -157,18 +186,8 @@
 						</executions>
 						<dependencies>
 							<dependency>
-								<groupId>org.mozilla</groupId>
-								<artifactId>rhino-runtime</artifactId>
-								<version>1.7.14</version>
-							</dependency>
-							<dependency>
 								<groupId>org.apache.ant</groupId>
 								<artifactId>ant</artifactId>
-								<version>1.10.14</version>
-							</dependency>
-							<dependency>
-								<groupId>org.apache.ant</groupId>
-								<artifactId>ant-apache-bsf</artifactId>
 								<version>1.10.14</version>
 							</dependency>
 							<dependency>

--- a/bundles/org.eclipse.swt/.classpath_cocoa_aarch64
+++ b/bundles/org.eclipse.swt/.classpath_cocoa_aarch64
@@ -29,5 +29,6 @@
     <classpathentry kind="src" path="Eclipse SWT WebKit/cocoa"/>
     <classpathentry kind="src" path="Eclipse SWT OpenGL/cocoa"/>
     <classpathentry kind="src" path="Eclipse SWT OpenGL/common"/>
+    <classpathentry kind="src" output="bin_build" path="build-scripts"/>
     <classpathentry kind="output" path="bin"/>
 </classpath>

--- a/bundles/org.eclipse.swt/.classpath_cocoa_x86_64
+++ b/bundles/org.eclipse.swt/.classpath_cocoa_x86_64
@@ -29,5 +29,6 @@
     <classpathentry kind="src" path="Eclipse SWT WebKit/cocoa"/>
     <classpathentry kind="src" path="Eclipse SWT OpenGL/cocoa"/>
     <classpathentry kind="src" path="Eclipse SWT OpenGL/common"/>
+    <classpathentry kind="src" output="bin_build" path="build-scripts"/>
     <classpathentry kind="output" path="bin"/>
 </classpath>

--- a/bundles/org.eclipse.swt/.classpath_gtk
+++ b/bundles/org.eclipse.swt/.classpath_gtk
@@ -31,5 +31,6 @@
 	<classpathentry kind="src" path="Eclipse SWT OpenGL/glx"/>
 	<classpathentry kind="src" path="Eclipse SWT OpenGL/common"/>
 	<classpathentry kind="src" path="Eclipse SWT WebKit/gtk"/>
+	<classpathentry kind="src" output="bin_build" path="build-scripts"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/bundles/org.eclipse.swt/.classpath_win32
+++ b/bundles/org.eclipse.swt/.classpath_win32
@@ -25,5 +25,6 @@
 	<classpathentry kind="src" path="Eclipse SWT Browser/win32"/>
 	<classpathentry kind="src" path="Eclipse SWT OpenGL/win32"/>
 	<classpathentry kind="src" path="Eclipse SWT OpenGL/common"/>
+	<classpathentry kind="src" output="bin_build" path="build-scripts"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/bundles/org.eclipse.swt/.gitignore
+++ b/bundles/org.eclipse.swt/.gitignore
@@ -2,3 +2,4 @@
 ws/
 .build64/
 .buildas/
+/bin_build/

--- a/bundles/org.eclipse.swt/build-scripts/CollectSources.java
+++ b/bundles/org.eclipse.swt/build-scripts/CollectSources.java
@@ -1,0 +1,87 @@
+/*******************************************************************************
+ * Copyright (c) 2024, 2024 Hannes Wellmann and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Hannes Wellmann - initial API and implementation
+ *******************************************************************************/
+import java.io.*;
+import java.nio.file.*;
+import java.util.*;
+
+/**
+ * Script to collect the SWT native sources for the specified native fragment.
+ * <p>
+ * In order to be able to launch this directly as source script <b>only
+ * reference standard java classes!</b>
+ * </p>
+ */
+public class CollectSources {
+
+	private record ScriptEnvironment(Path swtProjectRoot, Path targetDirectory, String ws, String arch) {
+		private static ScriptEnvironment read(String[] args) {
+			if (args.length != 2) {
+				throw new IllegalArgumentException("task and target directory must be defined as only argument");
+			}
+			Path swtProjectRoot = Path.of("").toAbsolutePath();
+			if (!swtProjectRoot.endsWith(Path.of("bundles/org.eclipse.swt"))) { // Consistency check
+				throw new IllegalStateException("Sript must be excuted from org.eclipse.swt project");
+			}
+			Path targetDirectory = Path.of(args[1]);
+			String ws = System.getProperty("ws");
+			String arch = System.getProperty("arch");
+			return new ScriptEnvironment(swtProjectRoot, targetDirectory, ws, arch);
+		}
+	}
+
+	public static void main(String[] args) throws Exception {
+		ScriptEnvironment env = ScriptEnvironment.read(args);
+		switch (args[0]) {
+		case "-nativeSources":
+			collectNativeSources(env);
+			break;
+		default:
+			throw new IllegalArgumentException("Unexpected value: " + args[0]);
+		}
+	}
+
+	private static void collectNativeSources(ScriptEnvironment env) throws IOException {
+		Path props = env.swtProjectRoot.resolve("nativeSourceFolders.properties");
+		Map<String, String> sources = loadProperty(props);
+
+		String commonSources = sources.get("src_common");
+		String nativeSources = sources.get("src_" + env.ws);
+		List<String> allSources = Arrays.asList((commonSources + "," + nativeSources).split(","));
+		System.out.println("Copy " + allSources.size() + " java source folders for " + env.ws + "." + env.arch);
+		copySubDirectories(env.swtProjectRoot, allSources, env.targetDirectory);
+	}
+
+	@SuppressWarnings({ "unchecked", "rawtypes" })
+	private static Map<String, String> loadProperty(Path path) throws IOException {
+		try (InputStream in = Files.newInputStream(path)) {
+			Properties props = new Properties();
+			props.load(in);
+			return (Map) props;
+		}
+	}
+
+	private static void copySubDirectories(Path root, Collection<String> allSources, Path target) throws IOException {
+		System.out.println("from " + root + "\nto " + target);
+		for (String srcPath : allSources) {
+			Path srcFolder = root.resolve(srcPath);
+			try (var files = Files.walk(srcFolder).filter(Files::isRegularFile)) {
+				for (Path sourceFile : (Iterable<Path>) files::iterator) {
+					Path targetFile = target.resolve(srcFolder.relativize(sourceFile));
+					Files.createDirectories(targetFile.getParent());
+					Files.copy(sourceFile, targetFile, StandardCopyOption.REPLACE_EXISTING);
+				}
+			}
+		}
+	}
+}

--- a/bundles/org.eclipse.swt/buildSWT.xml
+++ b/bundles/org.eclipse.swt/buildSWT.xml
@@ -25,8 +25,6 @@
 		revision in the swp.map.
 		for Example: ant -f buildSWT.xml increment_version -Dnatives_changed=true
 
-	To build the libraries of a fragment, run
-		ant -f <fragment dir>/build.xml build_libraries
  -->
 
 <project name="swtbuild" basedir=".">
@@ -213,25 +211,6 @@
 		</exec>
 	</target>
 
-	<target name="init_fragment">
-		<condition property="m_fail">
-			<not><and>
-				<isset property="swt.ws"/>
-				<isset property="swt.os"/>
-			</and></not>
-		</condition>
-		<fail if="m_fail" message="Failed: ${swt.ws} and ${swt.os} not set"/>
-		<condition property="fragment" value="org.eclipse.swt.${swt.ws}.${swt.os}.${swt.arch}" else="org.eclipse.swt.${swt.ws}.${swt.os}">
-			<isset property="swt.arch"/>
-		</condition>
-		<property name="fragment_dir" value="${repo.bin}/binaries/${fragment}"/>
-		<script language="javascript">
-			<![CDATA[
-				project.setProperty("library_src", project.getProperty("src_" + project.getProperty("swt.ws")));
-			]]>
-		</script>
-	</target>
-	
 	<!-- Params: fragment, swt_version -->
 	<target name="commit_binaries" depends="get_version">
 		<!-- Get libraries to remove from repo -->
@@ -297,87 +276,6 @@
 		</exec>
 	</target>
 
-	<target name="init_build" if="eclipse.running">
-		<eclipse.refreshLocal resource="org.eclipse.swt" depth="infinite"/>
-		<eclipse.incrementalBuild project="org.eclipse.swt" kind="incr"/>
-	</target>
-
-	<target name="refresh_fragment" if="eclipse.running">
-		<echo>refreshing ${fragment}</echo>
-		<eclipse.refreshLocal resource="${fragment}" depth="infinite"/>
-	</target>
-
-	<target name="copy.library.src">
-		<script language="javascript">
-			<![CDATA[
-				var File = java.io.File;
-				var StreamTokenizer = java.io.StreamTokenizer;
-				var StringReader = java.io.StringReader;
-				task = project.createTask("copy");
-				projectDir = project.getProperty("project_dir");
-				task.setTodir(new File(project.getProperty("build_dir")));
-				tk = new StreamTokenizer(new StringReader(project.getProperty("library_src")));
-				while ((token = tk.nextToken()) != StreamTokenizer.TT_EOF) {
-					fileset = project.createDataType("fileset");
-					fileset.setDir(new File(projectDir + "/" + tk.sval + "/"));
-					task.addFileset(fileset);
-				}
-				task.execute();
-			]]>
-		</script>
-	</target>
-
-	<!-- Params: swt.ws, swt.os, swt.arch -->
-	<target name="build_libraries" depends="init_fragment,get_version">
-		<property name="swt.arch" value=""/>
-		<property name="clean" value="clean"/>
-		<property name="targets" value="install"/>
-		<property name="project_dir" value="${basedir}/${repo.src}"/>
-		<property name="output_dir" value="${basedir}/${fragment_dir}"/>
-		<property name="build_dir" value="${basedir}/${fragment_dir}/tmpdir"/>
-		<delete dir="${build_dir}" quiet="true"/>
-		<antcall target="copy.library.src"/>
-		<condition property="build_task" value="build_local_win" else="build_local">
-			<equals arg1="${swt.ws}" arg2="win32"/>
-		</condition>
-		<antcall target="init_build"/>
-		<antcall target="${build_task}">
-			<param name="build_targets" value="${targets}"/>
-			<param name="build_machine" value="${machine}"/>
-		</antcall>
-		<delete dir="${build_dir}" quiet="true"/>
-		<antcall target="refresh_fragment"/>
-	</target>
-
-	<target name="build_local">
-		<property name="gtk_version" value="3.0" />
-		<property name="SWT_JAVA_HOME" value="${java.home}"/><!-- Not overwritten if already set, e.g. as CLI argument -->
-		<echo>Compile SWT natives against headers and libraries from JDK: ${SWT_JAVA_HOME}</echo>
-		<exec dir="${build_dir}" executable="sh" failonerror="true">
-			<arg line="build.sh"/>
-			<env key="GTK_VERSION" value="${gtk_version}"/>
-			<env key="MODEL" value="${swt.arch}"/>
-			<env key="SWT_JAVA_HOME" value="${SWT_JAVA_HOME}"/>
-			<env key="OUTPUT_DIR" value="${output_dir}"/>
-			<arg line="${targets}"/>
-			<arg line="${clean}"/>
-		</exec>
-	</target>
-
-	<target name="build_local_win">
-		<pathconvert property="win_output_dir">
-			<path location="${output_dir}"></path>
-		</pathconvert>
-		<property name="SWT_JAVA_HOME" value="${java.home}"/><!-- Not overwritten if already set, e.g. as CLI argument -->
-		<echo>Compile SWT natives against headers and libraries from JDK: ${SWT_JAVA_HOME}</echo>
-		<exec dir="${build_dir}" executable="${build_dir}/build.bat" failonerror="true">
-			<env key="SWT_JAVA_HOME" value="${SWT_JAVA_HOME}"/>
-			<env key="OUTPUT_DIR" value="${win_output_dir}"/>
-			<arg line="${targets}"/>
-			<arg line="${clean}"/>
-		</exec>
-	</target>
-
 	<!-- ******************************************************************************** -->
 	<!-- targets to run the builds on the Eclipse Foundation Hudson in master-slave setup -->
 	<!-- ******************************************************************************** -->
@@ -400,21 +298,6 @@
 	<target name="create_file_if_property_exists" if="${property}">
 		<echo>"Creating file ${fileName}"</echo>
 		<echo file="${fileName}" append="false">true</echo>
-	</target>
-	
-	<target name="copy_library_src_and_create_zip" depends="init_fragment">
-		<property name="swt.arch" value=""/>
-		<property name="project_dir" value="${basedir}/${repo.src}"/>
-		<property name="output_dir" value="${basedir}/${fragment_dir}"/>
-		<property name="build_dir" value="${basedir}/${fragment_dir}/tmpdir"/>
-		<property name="zip_file" value="${fragment}.${TAG}.zip"/>
-		<delete dir="${build_dir}" quiet="true"/>
-		
-		<!-- copy the library source files -->
-		<antcall target="copy.library.src"/>
-		
-		<!-- create a zip of the native source files to be sent to the build machine -->
-		<zip destfile="${build_dir}/${zip_file}" basedir="${build_dir}" excludes="${zip_file}"/>
 	</target>
 
 </project>

--- a/bundles/org.eclipse.swt/nativeSourceFolders.properties
+++ b/bundles/org.eclipse.swt/nativeSourceFolders.properties
@@ -1,0 +1,4 @@
+src_common=Eclipse SWT/common/library,Eclipse SWT PI/common/library
+src_win32=Eclipse SWT PI/win32/library,Eclipse SWT AWT/win32/library,Eclipse SWT OpenGL/win32/library
+src_gtk=Eclipse SWT PI/gtk/library,Eclipse SWT AWT/gtk/library,Eclipse SWT OpenGL/glx/library,Eclipse SWT PI/cairo/library,Eclipse SWT WebKit/gtk/library
+src_cocoa=Eclipse SWT PI/cocoa/library,Eclipse SWT AWT/cocoa/library


### PR DESCRIPTION
in order to replace ANT tasks with JavaScript (which require Java-11) in Jenkins pipeline.
Stash native sources not-zipped to save the zip and unzip steps.

Additionally move all remaining ANT tasks to run a native build in a local Maven for the running platform completely to the
maven-antrun-plugin configuration.

Furthermore move declaration of tools to the common Jenkins pipeline section to make them usable in all stages.
Since https://github.com/eclipse-platform/eclipse.platform.swt/pull/633 the JDK on the native-build-agent's PATH is not used anymore when building the native binaries and thus it is not required anymore to keep the PATH untouched.

Part of
- https://github.com/eclipse-platform/eclipse.platform.swt/issues/513
- https://github.com/eclipse-platform/eclipse.platform.swt/issues/626