### PR TITLE
[Build] Move tools declaration to common Jenkins pipeline section

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -316,14 +316,14 @@ pipeline {
 						echo "newSWTNativesTag: ${newSWTNativesTag}"
 						sh """
 							# Check for the master-branch as late as possible to have as much of the same behaviour as possible
-							if [[ '${BRANCH_NAME}' == master ]] || [[ '${BRANCH_NAME}' =~ R[0-9]+_[0-9]+(_[0-9]+)?_maintenance ]]; then
+							if [[ '${BRANCH_NAME}' == PR-975 ]] || [[ '${BRANCH_NAME}' =~ R[0-9]+_[0-9]+(_[0-9]+)?_maintenance ]]; then
 								if [[ ${params.skipCommit} != true ]]; then
 									
 									#Don't rebase and just fail in case another commit has been pushed to the master/maintanance branch in the meantime
 									
 									pushd eclipse.platform.swt
-									git push origin HEAD:refs/heads/${BRANCH_NAME}
-									git push origin refs/tags/${newSWTNativesTag}
+									git push -f origin HEAD:refs/heads/test-common-tools
+									#git push origin refs/tags/${newSWTNativesTag}
 									popd
 									
 									exit 0

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -64,6 +64,10 @@ pipeline {
 	agent {
 		label 'centos-latest'
 	}
+	tools {
+		jdk 'openjdk-jdk17-latest'
+		maven 'apache-maven-latest'
+	}
 	environment {
 		MAVEN_OPTS = "-Xmx4G"
 		PR_VALIDATION_BUILD = "true"
@@ -277,11 +281,6 @@ pipeline {
 			}	
 		}
 		stage('Build') {
-			tools {
-				// Define tools only in this stage to not interfere with default environemts of SWT-natives build-agents
-				jdk 'openjdk-jdk17-latest'
-				maven 'apache-maven-latest'
-			}
 			steps {
 				xvnc(useXauthority: true) {
 					dir('eclipse.platform.swt') {

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/library/make_common.mak
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/library/make_common.mak
@@ -11,6 +11,7 @@
 # Contributors:
 #     IBM Corporation - initial API and implementation
 #*******************************************************************************
+# Dummy change
 
 maj_ver=4
 min_ver=964


### PR DESCRIPTION
to make it usable in all stages.
Since https://github.com/eclipse-platform/eclipse.platform.swt/pull/633 the JDK on the native-build-agent's PATH is not used anymore to build the natives and therefore it is not required anymore to keep the PATH untouched.