### PR TITLE
Remove P2Directory elements moved to Platform container from SWT-setup

### DIFF
--- a/bundles/org.eclipse.swt.tools/Oomph/platformSwt.setup
+++ b/bundles/org.eclipse.swt.tools/Oomph/platformSwt.setup
@@ -47,14 +47,6 @@
     <description>Platform SWT</description>
   </setupTask>
   <setupTask
-      xsi:type="setup:CompoundTask"
-      name="org.eclipse.egit.ui">
-    <setupTask
-        xsi:type="setup:PreferenceTask"
-        key="/instance/org.eclipse.egit.ui/auto_lfs_config"
-        value="true"/>
-  </setupTask>
-  <setupTask
       xsi:type="setup:ResourceCopyTask"
       excludedTriggers="BOOTSTRAP"
       filter="(osgi.ws=cocoa)"
@@ -164,17 +156,9 @@
   </setupTask>
   <setupTask
       xsi:type="setup.p2:P2Task"
-      label="SWT Tools and Git LFS">
+      label="SWT Tools">
     <requirement
         name="org.eclipse.swt.tools.feature.feature.group"/>
-    <requirement
-        name="org.eclipse.platform.feature.group"/>
-    <requirement
-        name="org.eclipse.jdt.feature.group"/>
-    <requirement
-        name="org.eclipse.pde.feature.group"/>
-    <requirement
-        name="org.eclipse.jgit.lfs"/>
     <repository
         url="${eclipse.latest.p2}"/>
   </setupTask>


### PR DESCRIPTION
With https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/1719 the required jgit.lfs Plug-in is now installed for all projects in the `Platform` container. Keeping it in the SWT setup is just a duplication.