### PR TITLE
[Build] Use JDK in JAVA_HOME to run the Java source scripts

### DIFF
--- a/binaries/pom.xml
+++ b/binaries/pom.xml
@@ -120,7 +120,7 @@
 								</goals>
 								<configuration>
 									<target>
-										<exec executable="java" dir="${swtMainProject}" failonerror="true">
+										<exec executable="${java.home}/bin/java" dir="${swtMainProject}" failonerror="true">
 											<arg line="-Dws=${ws} -Darch=${arch} build-scripts/CollectSources.java -javaSources '${project.basedir}/src' "/>
 										</exec>
 									</target>
@@ -139,7 +139,7 @@
 										<if><equals arg1="${native}" arg2="${ws}.${os}.${arch}"/>
 											<then>
 												<property name="build_dir" value="${project.build.directory}/natives-build-temp"/>
-												<exec executable="java" dir="${swtMainProject}" failonerror="true">
+												<exec executable="${java.home}/bin/java" dir="${swtMainProject}" failonerror="true">
 													<arg line="-Dws=${ws} build-scripts/CollectSources.java -nativeSources '${build_dir}'"/>
 												</exec>
 												<property name="SWT_JAVA_HOME" value="${java.home}"/><!-- Not overwritten if already set, e.g. as CLI argument -->


### PR DESCRIPTION
This increases the probability that the same jvm running the maven build is used to run the java source scripts.
Maven's launch script by default uses the java executable referenced in $JAVA_HOME/bin first and only then searches the PATH environment variable.
Using the java exe at JAVA_HOME also simplifies to control which jvm is actually used. For example when launching a Maven build from the Eclipse IDE JAVA_HOME is set to the jvm running that build by Eclipse automatically, but PATH is not modified.

This would also have fixed https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1724.