### PR TITLE
Use the ECJ generated compiler logs to parse compiler problems

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -290,7 +290,7 @@ pipeline {
 					junit 'eclipse.platform.swt/tests/*.test*/target/surefire-reports/*.xml'
 					archiveArtifacts artifacts: '**/*.log,**/*.html,**/target/*.jar,**/target/*.zip'
 					discoverGitReferenceBuild referenceJob: 'eclipse.platform.swt/master'
-					recordIssues publishAllIssues: true, tools: [java(), mavenConsole(), javaDoc()]
+					recordIssues publishAllIssues: true, tools: [eclipse(pattern: '**/target/compilelogs/*.xml'), mavenConsole(), javaDoc()]
 				}
 			}
 		}


### PR DESCRIPTION
Reading a structured XML is more reliable than parsing the logfiles.

For SWT we need to make sure that the logs are actually produced and located at the given location, so this is just a first try.