### PR TITLE
[Build] Disable p2-baseline-replacement for GH workflows

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -51,14 +51,15 @@ jobs:
     - name: Set up Maven
       uses: stCarolas/setup-maven@v4.5
       with:
-        maven-version: 3.9.2
+        maven-version: 3.9.6
     - name: Build with Maven
       uses: coactions/setup-xvfb@b6b4fcfb9f5a895edadc3bc76318fae0ac17c8b3 # v1.0.1
       with:
        run: >-
         mvn --batch-mode -V -U
         -DforkCount=1
-        -Dcompare-version-with-baselines.skip=false
+        -Dcompare-version-with-baselines.skip=true
+        -Dtycho.baseline.replace=none
         -Dmaven.compiler.failOnWarning=true
         --fail-at-end
         -DskipNativeTests=false

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -347,6 +347,7 @@ pipeline {
 							mvn clean verify \
 								--batch-mode -DforkCount=0 \
 								-Dcompare-version-with-baselines.skip=false -Dmaven.compiler.failOnWarning=true \
+								-Dorg.eclipse.swt.tests.junit.disable.test_isLocal=true \
 								-Dmaven.test.failure.ignore=true -Dmaven.test.error.ignore=true
 						'''
 					}

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_SWT.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_SWT.java
@@ -19,17 +19,18 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-import org.eclipse.swt.SWT;
-import org.eclipse.swt.SWTError;
-import org.eclipse.swt.SWTException;
-import org.junit.Test;
-
 import java.nio.file.Paths;
 import java.security.CodeSigner;
 import java.security.cert.Certificate;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.List;
+
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.SWTError;
+import org.eclipse.swt.SWTException;
+import org.junit.Assume;
+import org.junit.Test;
 
 /**
  * Automated Test Suite for class org.eclipse.swt.SWT
@@ -166,9 +167,7 @@ private List<String> signersFromClass(Class<?> classValue) {
 @Test
 public void test_isLocal() {
 	// If you change default to NO, make sure that this test runs on GitHub
-	if (Boolean.getBoolean("org.eclipse.swt.tests.junit.disable.test_isLocal")) {
-		return;
-	}
+	Assume.assumeFalse(Boolean.getBoolean("org.eclipse.swt.tests.junit.disable.test_isLocal"));
 
 	String swtPath = pathFromClass(SWT.class);
 	String tstPath = pathFromClass(Test_org_eclipse_swt_SWT.class);


### PR DESCRIPTION
and disable the Test_org_eclipse_swt_SWT.test_isLocal() test within the Jenkins pipeline.

And use assumeFalse() to not run said test if the 'disable.test_isLocal' property is set.

Fixes https://github.com/eclipse-platform/eclipse.platform.swt/issues/983