### PR TITLE
Fix size of tab items when large text padding is used

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CTabFolder.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CTabFolder.java
@@ -2972,19 +2972,17 @@ boolean setItemSize(GC gc) {
 	for (int i = 0; i < items.length; i++) {
 		CTabItem tab = items[i];
 		int width = widths[i];
-		if (tab.height != tabHeight || tab.width != width) {
-			changed = true;
-			tab.shortenedText = null;
-			tab.shortenedTextWidth = 0;
-			tab.height = tabHeight;
-			tab.width = width;
-			tab.closeRect.width = tab.closeRect.height = 0;
-			if (showClose || tab.showClose) {
-				if (i == selectedIndex || showUnselectedClose) {
-					Point closeSize = renderer.computeSize(CTabFolderRenderer.PART_CLOSE_BUTTON, SWT.NONE, gc, SWT.DEFAULT, SWT.DEFAULT);
-					tab.closeRect.width = closeSize.x;
-					tab.closeRect.height = closeSize.y;
-				}
+		changed = true;
+		tab.shortenedText = null;
+		tab.shortenedTextWidth = 0;
+		tab.height = tabHeight;
+		tab.width = width;
+		tab.closeRect.width = tab.closeRect.height = 0;
+		if (showClose || tab.showClose) {
+			if (i == selectedIndex || showUnselectedClose) {
+				Point closeSize = renderer.computeSize(CTabFolderRenderer.PART_CLOSE_BUTTON, SWT.NONE, gc, SWT.DEFAULT, SWT.DEFAULT);
+				tab.closeRect.width = closeSize.x;
+				tab.closeRect.height = closeSize.y;
 			}
 		}
 	}

--- a/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CTabFolderRenderer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CTabFolderRenderer.java
@@ -360,15 +360,13 @@ public class CTabFolderRenderer {
 
 					width += getTextPadding(item, state) * 2;
 
-					if (parent.showClose || item.showClose) {
-						if ((state & SWT.SELECTED) != 0 || parent.showUnselectedClose) {
-							if (!applyLargeTextPadding(parent)) {
-								if (width > 0) width += INTERNAL_SPACING;
-							} else {
-								if (width > 0) width -= INTERNAL_SPACING;
-							}
-							width += computeSize(PART_CLOSE_BUTTON, SWT.NONE, gc, SWT.DEFAULT, SWT.DEFAULT).x;
+					if (shouldDrawCloseIcon(item)) {
+						if (!applyLargeTextPadding(parent)) {
+							if (width > 0) width += INTERNAL_SPACING;
+						} else {
+							if (width > 0) width -= INTERNAL_SPACING;
 						}
+						width += computeSize(PART_CLOSE_BUTTON, SWT.NONE, gc, SWT.DEFAULT, SWT.DEFAULT).x;
 					}
 				}
 				break;
@@ -377,6 +375,13 @@ public class CTabFolderRenderer {
 		width = trim.width;
 		height = trim.height;
 		return new Point(width, height);
+	}
+
+	private boolean shouldDrawCloseIcon(CTabItem item) {
+		CTabFolder folder = item.getParent();
+		boolean showClose = folder.showClose || item.showClose;
+		boolean isSelectedOrShowCloseForUnselected = (item.state & SWT.SELECTED) != 0 || folder.showUnselectedClose;
+		return showClose && isSelectedOrShowCloseForUnselected;
 	}
 
 	/**
@@ -1416,7 +1421,7 @@ public class CTabFolderRenderer {
 			// draw Image
 			Rectangle trim = computeTrim(itemIndex, SWT.NONE, 0, 0, 0, 0);
 			int xDraw = x - trim.x;
-			if (parent.single && (parent.showClose || item.showClose)) xDraw += item.closeRect.width;
+			if (parent.single && shouldDrawCloseIcon(item)) xDraw += item.closeRect.width;
 			Image image = item.getImage();
 			if (image != null && !image.isDisposed() && parent.showSelectedImage) {
 				Rectangle imageBounds = image.getBounds();
@@ -1469,7 +1474,7 @@ public class CTabFolderRenderer {
 					gc.setBackground(orginalBackground);
 				}
 			}
-			if (parent.showClose || item.showClose) drawClose(gc, item.closeRect, item.closeImageState);
+			if (shouldDrawCloseIcon(item)) drawClose(gc, item.closeRect, item.closeImageState);
 		}
 	}
 
@@ -1631,7 +1636,7 @@ public class CTabFolderRenderer {
 				Rectangle imageBounds = image.getBounds();
 				// only draw image if it won't overlap with close button
 				int maxImageWidth = x + width - xDraw - (trim.width + trim.x);
-				if (parent.showUnselectedClose && (parent.showClose || item.showClose)) {
+				if (shouldDrawCloseIcon(item)) {
 					maxImageWidth -= item.closeRect.width + INTERNAL_SPACING;
 				}
 				if (imageBounds.width < maxImageWidth) {
@@ -1649,7 +1654,7 @@ public class CTabFolderRenderer {
 			// draw Text
 			xDraw += getTextPadding(item, state);
 			int textWidth = x + width - xDraw - (trim.width + trim.x);
-			if (parent.showUnselectedClose && (parent.showClose || item.showClose)) {
+			if (shouldDrawCloseIcon(item)) {
 				textWidth -= item.closeRect.width + INTERNAL_SPACING;
 			}
 			if (textWidth > 0) {
@@ -1667,7 +1672,7 @@ public class CTabFolderRenderer {
 				gc.setFont(gcFont);
 			}
 			// draw close
-			if (parent.showUnselectedClose && (parent.showClose || item.showClose)) drawClose(gc, item.closeRect, item.closeImageState);
+			if (shouldDrawCloseIcon(item)) drawClose(gc, item.closeRect, item.closeImageState);
 		}
 	}
 

--- a/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CTabFolderRenderer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CTabFolderRenderer.java
@@ -358,14 +358,10 @@ public class CTabFolderRenderer {
 						}
 					}
 
-					width += getTextPadding(item, state) * 2;
-
-					if (shouldDrawCloseIcon(item)) {
-						if (!applyLargeTextPadding(parent)) {
-							if (width > 0) width += INTERNAL_SPACING;
-						} else {
-							if (width > 0) width -= INTERNAL_SPACING;
-						}
+					if (shouldApplyLargeTextPadding(parent)) {
+						width += getLargeTextPadding(item) * 2;
+					} else if (shouldDrawCloseIcon(item)) {
+						if (width > 0) width += INTERNAL_SPACING;
 						width += computeSize(PART_CLOSE_BUTTON, SWT.NONE, gc, SWT.DEFAULT, SWT.DEFAULT).x;
 					}
 				}
@@ -385,26 +381,19 @@ public class CTabFolderRenderer {
 	}
 
 	/**
-	 * Returns padding for the text of a tab when image is not available or is hidden.
-	 *
-	 * @param item CTabItem
-	 * @param state current state
-	 *
+	 * Returns padding for the text of a tab item when showing images is disabled for the tab folder.
 	 */
-	private int getTextPadding(CTabItem item, int state) {
+	private int getLargeTextPadding(CTabItem item) {
 		CTabFolder parent = item.getParent();
 		String text = item.getText();
 
 		if (text != null && parent.getMinimumCharacters() != 0) {
-			if (applyLargeTextPadding(parent)) {
-				return TABS_WITHOUT_ICONS_PADDING;
-			}
+			return TABS_WITHOUT_ICONS_PADDING;
 		}
-
 		return 0;
 	}
 
-	private boolean applyLargeTextPadding(CTabFolder tabFolder) {
+	private boolean shouldApplyLargeTextPadding(CTabFolder tabFolder) {
 		return !tabFolder.showSelectedImage && !tabFolder.showUnselectedImage;
 	}
 
@@ -1438,7 +1427,7 @@ public class CTabFolderRenderer {
 			}
 
 			// draw Text
-			xDraw += getTextPadding(item, state);
+			xDraw += getLeftTextMargin(item);
 			int textWidth = rightEdge - xDraw - (trim.width + trim.x);
 			if (!parent.single && item.closeRect.width > 0) textWidth -= item.closeRect.width + INTERNAL_SPACING;
 			if (textWidth > 0) {
@@ -1476,6 +1465,17 @@ public class CTabFolderRenderer {
 			}
 			if (shouldDrawCloseIcon(item)) drawClose(gc, item.closeRect, item.closeImageState);
 		}
+	}
+
+	private int getLeftTextMargin(CTabItem item) {
+		int margin = 0;
+		if (shouldApplyLargeTextPadding(parent)) {
+			margin += getLargeTextPadding(item);
+			if (shouldDrawCloseIcon(item)) {
+				 margin -= item.closeRect.width / 2;
+			}
+		}
+		return margin;
 	}
 
 	void drawTabArea(GC gc, Rectangle bounds, int state) {
@@ -1652,7 +1652,7 @@ public class CTabFolderRenderer {
 				}
 			}
 			// draw Text
-			xDraw += getTextPadding(item, state);
+			xDraw += getLeftTextMargin(item);
 			int textWidth = x + width - xDraw - (trim.width + trim.x);
 			if (shouldDrawCloseIcon(item)) {
 				textWidth -= item.closeRect.width + INTERNAL_SPACING;


### PR DESCRIPTION
This is follow-up to #785, which introduced an iconless tab folder design that allows to disable tab item images and uses centered text a large padding within tab items as a separator instead. This visualization option for tab folders currently works as follows: A large padding is applied to the tab item as a separator with the text being centered within this padding. For tabs showing a close icon (which in particular is the currently selected on), this icon is added right at the right end of the tab item, such that the text is centered in between the left end of the tab item and the close button.

As discussed downstream in eclipse-platform/eclipse.platform.ui#1071, this does not look perfect and while the padding is necessary as a separator for tabs only containing a text, having close icons and, in case of the selected tab, also a different background is sufficient as a separator. @thomasritter, @sratz and I evaluated different options and came up with the concept for what is proposed in this PR.

This change adapts the appearance of tab items having a close icon when having images disabled. It uses the same size for the tab as if no close icon was drawn and then reduces the area in which the text is centered to the remaining space left to the close icon. This looks cleaner and has the effect that tabs within a tab folder have a fixed width, such that when changing the selection all tabs keep their size and positions. Only the texts within the tab items change their positions depending on whether the close icon is shown or not.

This is a standalone screenshot of how the padding will look like:
![image](https://github.com/eclipse-platform/eclipse.platform.swt/assets/755472/a28794c6-99ec-4ef0-aefb-7c1fd1266384)

This is how it looks now when switching from "Problems" to "Console" tab:
![image](https://github.com/eclipse-platform/eclipse.platform.swt/assets/755472/f767945e-a946-4bcc-acb1-634602dec5ed)

This is how it will look after this PR when switching from "Problems" to "Console" tab:
![image](https://github.com/eclipse-platform/eclipse.platform.swt/assets/755472/191adfed-df4f-465e-8371-99c0afc9658d)

Note that this also improves the appearance when a tab folder only has a single item, as it will not have a large padding at the left.
Here is how it looks before this PR:
![image](https://github.com/eclipse-platform/eclipse.platform.swt/assets/755472/d7e56864-a33e-468d-8451-a48d2f44d845)

Here is how it looks after this PR:
![image](https://github.com/eclipse-platform/eclipse.platform.swt/assets/755472/0aefab44-9db4-4d24-92d3-fa3dcbc8a95a)

@shubhamWaghmare-sap @praveen-skp FYI as original contributors of this functionality.


