### PR TITLE
Add  Maven launch-config to build native binaries of running platform

### DIFF
--- a/Build-SWT-native-binaries-for-running-platform.launch
+++ b/Build-SWT-native-binaries-for-running-platform.launch
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<launchConfiguration type="org.eclipse.m2e.Maven2LaunchConfigurationType">
+    <intAttribute key="M2_COLORS" value="0"/>
+    <booleanAttribute key="M2_DEBUG_OUTPUT" value="false"/>
+    <stringAttribute key="M2_GOALS" value="clean antrun:run@build-native-binaries"/>
+    <booleanAttribute key="M2_NON_RECURSIVE" value="false"/>
+    <booleanAttribute key="M2_OFFLINE" value="false"/>
+    <stringAttribute key="M2_PROFILES" value=""/>
+    <listAttribute key="M2_PROPERTIES">
+        <listEntry value="native=${target.ws}.${target.os}.${target.arch}"/>
+    </listAttribute>
+    <stringAttribute key="M2_RUNTIME" value="EMBEDDED"/>
+    <booleanAttribute key="M2_SKIP_TESTS" value="false"/>
+    <intAttribute key="M2_THREADS" value="1"/>
+    <booleanAttribute key="M2_UPDATE_SNAPSHOTS" value="false"/>
+    <stringAttribute key="M2_USER_SETTINGS" value=""/>
+    <booleanAttribute key="M2_WORKSPACE_RESOLUTION" value="false"/>
+    <booleanAttribute key="org.eclipse.debug.core.ATTR_FORCE_SYSTEM_CONSOLE_ENCODING" value="false"/>
+    <booleanAttribute key="org.eclipse.jdt.launching.ATTR_ATTR_USE_ARGFILE" value="false"/>
+    <booleanAttribute key="org.eclipse.jdt.launching.ATTR_SHOW_CODEDETAILS_IN_EXCEPTION_MESSAGES" value="true"/>
+    <booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_CLASSPATH_ONLY_JAR" value="false"/>
+    <stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17/"/>
+    <stringAttribute key="org.eclipse.jdt.launching.WORKING_DIRECTORY" value="${project_loc:eclipse.platform.swt}/binaries/org.eclipse.swt.${target.ws}.${target.os}.${target.arch}"/>
+</launchConfiguration>


### PR DESCRIPTION
In the SWT maven build local building of the native binaries can be activated by setting the system property `native` to `${ws}.${os}.${arch}`.
Consequently the full command for a complete Maven build of SWT that also builds the natives is (with the SWT-repo root as working directory):
`mvn clean verify -Dnative=${ws}.${os}.${arch}`

This full build takes a few minutes and if one skips the test execution, by appending `-DskipTests`, the complete build terminates earlier.

The fastest way to build the native binaries for a platform with Maven is to only run the execution of the `maven-antrun-plugin` that contains the local natives build. On the CLI this would be (with the SWT-repo root as working directory):
`mvn clean antrun:run@build-native-binaries -f binaries/org.eclipse.swt.${ws}.${os}.${arch} -Dnative=${ws}.${os}.${arch}`

This PR adds a Maven launch configuration (requires [Eclipse m2e](https://github.com/eclipse-m2e/m2e-core)) to the `org.eclipse.swt` project to perform such native binaries only build for the currently running platform. The launch-config uses the latter Maven command and infers the `${ws}`, `${os}` and `${arch}` placeholder using the launch variables `${target.ws}`, `${target.os}` and `${target.arch}`. With that one can just build the natives without further configuration after the necessary prerequisites are installed as described in the corresponding articles in https://www.eclipse.org/swt/docs.php.