### PR TITLE
Expose cancel state of FileDialog

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT PI/cocoa/org/eclipse/swt/internal/cocoa/OS.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/cocoa/org/eclipse/swt/internal/cocoa/OS.java
@@ -179,7 +179,7 @@ public class OS extends C {
 	 * Custom message that will be sent when setTheme is called for example from Platform UI code.
 	 */
 	public static final long sel_appAppearanceChanged = OS.sel_registerName("appAppearanceChanged");
-	
+
 	/**
 	 * Experimental API for dark theme.
 	 * <p>
@@ -194,7 +194,7 @@ public class OS extends C {
 	 * On GTK, behavior may be different as the boolean flag doesn't force dark
 	 * theme instead it specify that dark theme is preferred.
 	 * </p>
-	 * 
+	 *
 	 * @param isDarkTheme <code>true</code> for dark theme
 	 */
 	public static void setTheme(boolean isDarkTheme) {
@@ -2216,6 +2216,7 @@ public static final int NSEventTypeGesture = 29;
 public static final int NSEventTypeMagnify = 30;
 public static final int NSEventTypeRotate = 18;
 public static final int NSEventTypeSwipe = 31;
+public static final int NSFileHandlingPanelCancelButton = 0;
 public static final int NSFileHandlingPanelOKButton = 1;
 public static final int NSFlagsChanged = 12;
 public static final int NSFocusRingTypeNone = 1;

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/win32/org/eclipse/swt/internal/win32/OS.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/win32/org/eclipse/swt/internal/win32/OS.java
@@ -452,6 +452,7 @@ public class OS extends C {
 	public static final int EP_EDITTEXT = 1;
 	public static final int ERROR_FILE_NOT_FOUND = 0x2;
 	public static final int ERROR_NO_MORE_ITEMS = 0x103;
+	public static final int ERROR_CANCELED = 0x4C7;
 	public static final int ESB_DISABLE_BOTH = 0x3;
 	public static final int ESB_ENABLE_BOTH = 0x0;
 	public static final int ES_AUTOHSCROLL = 0x80;

--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/FileDialog.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/FileDialog.java
@@ -58,6 +58,7 @@ public class FileDialog extends Dialog {
 	long methodImpl_overwriteExistingFileCheck = 0;
 	long method_performKeyEquivalent = 0;
 	long methodImpl_performKeyEquivalent = 0;
+	boolean canceled;
 	static final char EXTENSION_SEPARATOR = ';';
 	private String selectedExtension;
 	boolean overwrite = (OS.VERSION >= OS.VERSION(10, 15, 0)) ? true : false;
@@ -333,6 +334,7 @@ void handleResponse (long response) {
 			}
 		}
 	}
+	canceled = response == OS.NSFileHandlingPanelCancelButton;
 	releaseHandles();
 }
 
@@ -444,6 +446,14 @@ public String open () {
 		handleResponse(response);
 	}
 	return fullPath;
+}
+
+/**
+ * {@return whether the dialog has been canceled when last opened or has not been opened at all}
+ * @since 3.125
+ */
+public boolean wasCanceled() {
+	return canceled;
 }
 
 long panel_shouldEnableURL (long id, long sel, long arg0, long arg1) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/FileDialog.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/FileDialog.java
@@ -53,6 +53,7 @@ public class FileDialog extends Dialog {
 	boolean overwrite = false;
 	boolean uriMode;
 	long handle;
+	boolean canceled;
 	static final char SEPARATOR = File.separatorChar;
 	static final char EXTENSION_SEPARATOR = ';';
 	static final char FILE_EXTENSION_SEPARATOR = '.';
@@ -374,6 +375,7 @@ String openNativeChooserDialog () {
 		display.externalEventLoop = false;
 		display.sendPostExternalEventDispatchEvent ();
 	}
+	canceled = response == GTK.GTK_RESPONSE_CANCEL;
 
 	if ((style & SWT.RIGHT_TO_LEFT) != 0) {
 		OS.g_signal_remove_emission_hook (signalId, hookId);
@@ -383,6 +385,14 @@ String openNativeChooserDialog () {
 	}
 	display.removeIdleProc ();
 	return answer;
+}
+
+/**
+ * {@return whether the dialog has been canceled when last opened or has not been opened at all}
+ * @since 3.125
+ */
+public boolean wasCanceled() {
+	return canceled;
 }
 
 void presetChooserDialog () {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/FileDialog.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/FileDialog.java
@@ -46,6 +46,7 @@ public class FileDialog extends Dialog {
 	String filterPath = "", fileName = "";
 	int filterIndex = 0;
 	boolean overwrite = false;
+	boolean canceled;
 	static final String DEFAULT_FILTER = "*.*";
 	static final String LONG_PATH_PREFIX = "\\\\?\\";
 
@@ -322,6 +323,7 @@ public String open () {
 	display.externalEventLoop = true;
 	display.sendPreExternalEventDispatchEvent();
 	hr = fileDialog.Show(parent.handle);
+	canceled = hr == OS.HRESULT_FROM_WIN32(OS.ERROR_CANCELED);
 	display.externalEventLoop = false;
 	display.sendPostExternalEventDispatchEvent();
 
@@ -387,6 +389,14 @@ public String open () {
 
 	/* Answer the full path or null */
 	return fullPath;
+}
+
+/**
+ * {@return whether the dialog has been canceled when last opened or has not been opened at all}
+ * @since 3.125
+ */
+public boolean wasCanceled() {
+	return canceled;
 }
 
 /**


### PR DESCRIPTION
The FileDialog implementations do currently not provide any way to identify that the dialog was canceled. The dialogs return a null string in case no file was selected, but is not possible to identify whether this was intended (via a cancel action) or if there was some unexpected error (such as too long file paths on Windows).

This change introduces a `wasCanceled()` method to the FileDialog implementations for all three operating systems. The dialogs evaluate the operating system's response code for the system's dialog control and store it to be retrieved by the added method.

A "better" solution would be to let the `open()` method somehow return a cancel operation as a its result, but such a solution would require an API change, while the proposed one only adds a method and thus keeps the API stable.

I have already tested the extension on all three operating system by both canceling and properly selecting a file in a dialog via the following simple snippet:
```java
public static void main(String[] args) {
	FileDialog dialog = new FileDialog(new Shell(new Display()));
	dialog.open();
	System.out.println(dialog.wasCanceled());
}
```