### PR TITLE
[Build] Run Maven build in parallel and only up until the verify phase

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -63,6 +63,7 @@ jobs:
       with:
        run: >-
         mvn --batch-mode -V -U
+        --threads 1C
         -DforkCount=1
         -Dnative=${{ matrix.config.native }}
         -Dcompare-version-with-baselines.skip=true
@@ -71,7 +72,7 @@ jobs:
         --fail-at-end
         -DskipNativeTests=false
         -DfailIfNoTests=false
-        clean install
+        clean verify
     - name: Performance tests
       if: contains(github.event.pull_request.labels.*.name, 'performance')
       uses: coactions/setup-xvfb@b6b4fcfb9f5a895edadc3bc76318fae0ac17c8b3 # v1.0.1

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -299,7 +299,7 @@ pipeline {
 					dir('eclipse.platform.swt') {
 						sh '''
 							mvn clean verify \
-								--batch-mode -DforkCount=0 \
+								--batch-mode --threads 1C -DforkCount=0 \
 								-Dcompare-version-with-baselines.skip=false -Dmaven.compiler.failOnWarning=true \
 								-Dorg.eclipse.swt.tests.junit.disable.test_isLocal=true \
 								-Dmaven.test.failure.ignore=true -Dmaven.test.error.ignore=true

--- a/tests/org.eclipse.swt.tests.cocoa/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.swt.tests.cocoa/META-INF/MANIFEST.MF
@@ -6,7 +6,8 @@ Bundle-Version: 3.108.100.qualifier
 Bundle-Vendor: Eclipse.org
 Bundle-Localization: plugin
 Require-Bundle: org.junit;bundle-version="4.12.0",
- org.eclipse.swt
+ org.eclipse.swt,
+ org.eclipse.swt.tests
 Eclipse-BundleShape: dir
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Automatic-Module-Name: org.eclipse.swt.tests.cocoa

--- a/tests/org.eclipse.swt.tests.gtk/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.swt.tests.gtk/META-INF/MANIFEST.MF
@@ -5,7 +5,8 @@ Bundle-SymbolicName: org.eclipse.swt.tests.gtk
 Bundle-Version: 3.109.0.qualifier
 Bundle-Vendor: Eclipse.org
 Require-Bundle: org.junit;bundle-version="4.12.0",
- org.eclipse.swt
+ org.eclipse.swt,
+ org.eclipse.swt.tests
 Eclipse-BundleShape: dir
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Automatic-Module-Name: org.eclipse.swt.tests.gtk

--- a/tests/org.eclipse.swt.tests.win32/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.swt.tests.win32/META-INF/MANIFEST.MF
@@ -6,7 +6,8 @@ Bundle-Version: 3.108.100.qualifier
 Bundle-Vendor: Eclipse.org
 Bundle-Localization: plugin
 Require-Bundle: org.junit;bundle-version="4.12.0",
- org.eclipse.swt
+ org.eclipse.swt,
+ org.eclipse.swt.tests
 Eclipse-BundleShape: dir
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Automatic-Module-Name: org.eclipse.swt.tests.win32


### PR DESCRIPTION
All the fragments can build in parallel so this should speed-up the build.