### PR TITLE
Use large program icons on Windows

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT PI/win32/org/eclipse/swt/internal/win32/OS.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/win32/org/eclipse/swt/internal/win32/OS.java
@@ -1196,6 +1196,7 @@ public class OS extends C {
 	public static final int SET_FEATURE_ON_PROCESS = 0x2;
 	public static final int SHADEBLENDCAPS = 120;
 	public static final int SHGFI_ICON = 0x000000100;
+	public static final int SHGFI_LARGEICON= 0x0;
 	public static final int SHGFI_SMALLICON= 0x1;
 	public static final int SHGFI_USEFILEATTRIBUTES = 0x000000010;
 	public static final int SIGDN_FILESYSPATH = 0x80058000;


### PR DESCRIPTION
Icons for files associated with an external program area always loaded in small size using the Windows API. The API also provides an option to load large icons, which have twice the size of the small ones.

In order to improve the icon sharpness when retrieving the icon for (monitor) scale value of more than 100%, this change ensures that the higher resolution icon is used and scaled appropriately.

This is a follow-up to #409, in which proper scaling support for icons was first added. The missing retrieval of large icons has been identified there (https://github.com/eclipse-platform/eclipse.platform.swt/pull/409#issuecomment-1427958143) and deferred to follow-up work (https://github.com/eclipse-platform/eclipse.platform.swt/pull/409#issuecomment-1908437416).

Example at 150% scaling (`swt.autoScale=quarter`) before (left) and after (right) this PR.
![150](https://github.com/eclipse-platform/eclipse.platform.swt/assets/755472/57112617-8e2e-4f97-ad2a-28741228aaa3)

Example at 225% scaling (`swt.autoScale=quarter`) before (left) and after (right) this PR.
![225](https://github.com/eclipse-platform/eclipse.platform.swt/assets/755472/70f4b9b8-217d-4afc-a670-9cc4b1d43f77)