### PR TITLE
Distinguish Edge instantiation error due to invalid thread access #1013

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Browser/win32/org/eclipse/swt/browser/Edge.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Browser/win32/org/eclipse/swt/browser/Edge.java
@@ -359,7 +359,15 @@ public void create(Composite parent, int style) {
 	if (hr == COM.S_OK) environment2 = new ICoreWebView2Environment2(ppv[0]);
 
 	hr = callAndWait(ppv, completion -> environment.CreateCoreWebView2Controller(browser.handle, completion));
-	if (hr != COM.S_OK) error(SWT.ERROR_NO_HANDLES, hr);
+	switch (hr) {
+	case COM.S_OK:
+		break;
+	case COM.E_WRONG_THREAD:
+		error(SWT.ERROR_THREAD_INVALID_ACCESS, hr);
+		break;
+	default:
+		error(SWT.ERROR_NO_HANDLES, hr);
+	}
 	controller = new ICoreWebView2Controller(ppv[0]);
 
 	controller.get_CoreWebView2(ppv);

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/win32/org/eclipse/swt/internal/ole/win32/COM.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/win32/org/eclipse/swt/internal/ole/win32/COM.java
@@ -186,6 +186,7 @@ public class COM extends OS {
 	public static final int E_NOTIMPL = -2147467263;
 	public static final int E_NOTSUPPORTED = 0x80040100;
 	public static final int E_OUTOFMEMORY = -2147024882;
+	public static final int E_WRONG_THREAD = 0x802a000c;
 	public static final int GMEM_FIXED = 0;
 	public static final int GMEM_ZEROINIT = 64;
 	public static final int GUIDKIND_DEFAULT_SOURCE_DISP_IID = 1;


### PR DESCRIPTION
Instead of always showing a "no more handles" error, with this change an error due to invalid thread access is explicitly logged as such.

Contributes to https://github.com/eclipse-platform/eclipse.platform.swt/issues/1013