### PR TITLE
Move concurrent execution preventing test dependencies to build.props

### DIFF
--- a/tests/org.eclipse.swt.tests.cocoa/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.swt.tests.cocoa/META-INF/MANIFEST.MF
@@ -6,8 +6,7 @@ Bundle-Version: 3.108.100.qualifier
 Bundle-Vendor: Eclipse.org
 Bundle-Localization: plugin
 Require-Bundle: org.junit;bundle-version="4.12.0",
- org.eclipse.swt,
- org.eclipse.swt.tests
+ org.eclipse.swt
 Eclipse-BundleShape: dir
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Automatic-Module-Name: org.eclipse.swt.tests.cocoa

--- a/tests/org.eclipse.swt.tests.cocoa/build.properties
+++ b/tests/org.eclipse.swt.tests.cocoa/build.properties
@@ -16,6 +16,10 @@ source..=JUnit Tests/
 bin.includes = .,\
                META-INF/
 
+# The following dependency prevents parallel execution of this and the referenced test-project. 
+# Both use the same not-shareable resources and therefore cannot run in parallel. 
+additional.bundles = org.eclipse.swt.tests
+
 pom.model.groupId = org.eclipse.swt
 tycho.pomless.parent = ../../local-build/local-build-parent
 pom.model.packaging = eclipse-test-plugin

--- a/tests/org.eclipse.swt.tests.gtk/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.swt.tests.gtk/META-INF/MANIFEST.MF
@@ -5,8 +5,7 @@ Bundle-SymbolicName: org.eclipse.swt.tests.gtk
 Bundle-Version: 3.109.0.qualifier
 Bundle-Vendor: Eclipse.org
 Require-Bundle: org.junit;bundle-version="4.12.0",
- org.eclipse.swt,
- org.eclipse.swt.tests
+ org.eclipse.swt
 Eclipse-BundleShape: dir
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Automatic-Module-Name: org.eclipse.swt.tests.gtk

--- a/tests/org.eclipse.swt.tests.gtk/build.properties
+++ b/tests/org.eclipse.swt.tests.gtk/build.properties
@@ -16,6 +16,10 @@ source.. = JUnit Tests/,\
 bin.includes = .,\
                META-INF/
 
+# The following dependency prevents parallel execution of this and the referenced test-project. 
+# Both use the same not-shareable resources and therefore cannot run in parallel. 
+additional.bundles = org.eclipse.swt.tests
+
 pom.model.groupId = org.eclipse.swt
 tycho.pomless.parent = ../../local-build/local-build-parent
 pom.model.packaging = eclipse-test-plugin

--- a/tests/org.eclipse.swt.tests.win32/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.swt.tests.win32/META-INF/MANIFEST.MF
@@ -6,8 +6,7 @@ Bundle-Version: 3.108.100.qualifier
 Bundle-Vendor: Eclipse.org
 Bundle-Localization: plugin
 Require-Bundle: org.junit;bundle-version="4.12.0",
- org.eclipse.swt,
- org.eclipse.swt.tests
+ org.eclipse.swt
 Eclipse-BundleShape: dir
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Automatic-Module-Name: org.eclipse.swt.tests.win32

--- a/tests/org.eclipse.swt.tests.win32/build.properties
+++ b/tests/org.eclipse.swt.tests.win32/build.properties
@@ -16,6 +16,11 @@ source..=JUnit Tests/
 bin.includes = .,\
                META-INF/
 
+
+# The following dependency prevents parallel execution of this and the referenced test-project. 
+# Both use the same not-shareable resources and therefore cannot run in parallel. 
+additional.bundles = org.eclipse.swt.tests
+
 pom.model.groupId = org.eclipse.swt
 tycho.pomless.parent = ../../local-build/local-build-parent
 pom.model.packaging = eclipse-test-plugin


### PR DESCRIPTION
As discussed in https://github.com/eclipse-platform/eclipse.platform.swt/pull/1010#discussion_r1470690947:
In the build.properties we can add a proper comment to explain the purpose of these difficult to understand dependencies.
