### PR TITLE
Expose cancel state of FileDialog and DirectoryDialog

### DIFF
--- a/binaries/org.eclipse.swt.cocoa.macosx.aarch64/META-INF/MANIFEST.MF
+++ b/binaries/org.eclipse.swt.cocoa.macosx.aarch64/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Fragment-Host: org.eclipse.swt;bundle-version="[3.125.100,4.0.0)"
 Bundle-Name: %fragmentName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.swt.cocoa.macosx.aarch64; singleton:=true
-Bundle-Version: 3.125.100.qualifier
+Bundle-Version: 3.126.0.qualifier
 Bundle-ManifestVersion: 2
 Bundle-Localization: fragment
 Export-Package: 

--- a/binaries/org.eclipse.swt.cocoa.macosx.x86_64/META-INF/MANIFEST.MF
+++ b/binaries/org.eclipse.swt.cocoa.macosx.x86_64/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Fragment-Host: org.eclipse.swt;bundle-version="[3.125.100,4.0.0)"
 Bundle-Name: %fragmentName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.swt.cocoa.macosx.x86_64; singleton:=true
-Bundle-Version: 3.125.100.qualifier
+Bundle-Version: 3.126.0.qualifier
 Bundle-ManifestVersion: 2
 Bundle-Localization: fragment
 Export-Package: 

--- a/binaries/org.eclipse.swt.gtk.linux.aarch64/META-INF/MANIFEST.MF
+++ b/binaries/org.eclipse.swt.gtk.linux.aarch64/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Fragment-Host: org.eclipse.swt;bundle-version="[3.125.100,4.0.0)"
 Bundle-Name: %fragmentName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.swt.gtk.linux.aarch64; singleton:=true
-Bundle-Version: 3.125.100.qualifier
+Bundle-Version: 3.126.0.qualifier
 Bundle-ManifestVersion: 2
 Bundle-Localization: fragment
 Export-Package: 

--- a/binaries/org.eclipse.swt.gtk.linux.loongarch64/META-INF/MANIFEST.MF
+++ b/binaries/org.eclipse.swt.gtk.linux.loongarch64/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Fragment-Host: org.eclipse.swt;bundle-version="[3.125.100,4.0.0)"
 Bundle-Name: %fragmentName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.swt.gtk.linux.loongarch64; singleton:=true
-Bundle-Version: 3.125.100.qualifier
+Bundle-Version: 3.126.0.qualifier
 Bundle-ManifestVersion: 2
 Bundle-Localization: fragment
 Export-Package: 

--- a/binaries/org.eclipse.swt.gtk.linux.ppc64le/META-INF/MANIFEST.MF
+++ b/binaries/org.eclipse.swt.gtk.linux.ppc64le/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Fragment-Host: org.eclipse.swt;bundle-version="[3.125.100,4.0.0)"
 Bundle-Name: %fragmentName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.swt.gtk.linux.ppc64le;singleton:=true
-Bundle-Version: 3.125.100.qualifier
+Bundle-Version: 3.126.0.qualifier
 Bundle-ManifestVersion: 2
 Bundle-Localization: fragment
 Export-Package: 

--- a/binaries/org.eclipse.swt.gtk.linux.x86_64/META-INF/MANIFEST.MF
+++ b/binaries/org.eclipse.swt.gtk.linux.x86_64/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Fragment-Host: org.eclipse.swt;bundle-version="[3.125.100,4.0.0)"
 Bundle-Name: %fragmentName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.swt.gtk.linux.x86_64; singleton:=true
-Bundle-Version: 3.125.100.qualifier
+Bundle-Version: 3.126.0.qualifier
 Bundle-ManifestVersion: 2
 Bundle-Localization: fragment
 Export-Package: 

--- a/binaries/org.eclipse.swt.win32.win32.x86_64/META-INF/MANIFEST.MF
+++ b/binaries/org.eclipse.swt.win32.win32.x86_64/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Fragment-Host: org.eclipse.swt;bundle-version="[3.125.100,4.0.0)"
 Bundle-Name: %fragmentName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.swt.win32.win32.x86_64; singleton:=true
-Bundle-Version: 3.125.100.qualifier
+Bundle-Version: 3.126.0.qualifier
 Bundle-ManifestVersion: 2
 Bundle-Localization: fragment
 Export-Package: 

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/cocoa/org/eclipse/swt/internal/cocoa/OS.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/cocoa/org/eclipse/swt/internal/cocoa/OS.java
@@ -179,7 +179,7 @@ public class OS extends C {
 	 * Custom message that will be sent when setTheme is called for example from Platform UI code.
 	 */
 	public static final long sel_appAppearanceChanged = OS.sel_registerName("appAppearanceChanged");
-	
+
 	/**
 	 * Experimental API for dark theme.
 	 * <p>
@@ -194,7 +194,7 @@ public class OS extends C {
 	 * On GTK, behavior may be different as the boolean flag doesn't force dark
 	 * theme instead it specify that dark theme is preferred.
 	 * </p>
-	 * 
+	 *
 	 * @param isDarkTheme <code>true</code> for dark theme
 	 */
 	public static void setTheme(boolean isDarkTheme) {
@@ -2216,6 +2216,7 @@ public static final int NSEventTypeGesture = 29;
 public static final int NSEventTypeMagnify = 30;
 public static final int NSEventTypeRotate = 18;
 public static final int NSEventTypeSwipe = 31;
+public static final int NSFileHandlingPanelCancelButton = 0;
 public static final int NSFileHandlingPanelOKButton = 1;
 public static final int NSFlagsChanged = 12;
 public static final int NSFocusRingTypeNone = 1;

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/win32/org/eclipse/swt/internal/win32/OS.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/win32/org/eclipse/swt/internal/win32/OS.java
@@ -452,6 +452,7 @@ public class OS extends C {
 	public static final int EP_EDITTEXT = 1;
 	public static final int ERROR_FILE_NOT_FOUND = 0x2;
 	public static final int ERROR_NO_MORE_ITEMS = 0x103;
+	public static final int ERROR_CANCELED = 0x4C7;
 	public static final int ESB_DISABLE_BOTH = 0x3;
 	public static final int ESB_ENABLE_BOTH = 0x0;
 	public static final int ES_AUTOHSCROLL = 0x80;

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/FileDialog.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/FileDialog.java
@@ -15,6 +15,7 @@ package org.eclipse.swt.widgets;
 
 
 import java.io.*;
+import java.util.*;
 
 import org.eclipse.swt.*;
 import org.eclipse.swt.internal.*;
@@ -332,17 +333,45 @@ public boolean getOverwrite () {
  * </ul>
  */
 public String open () {
+	try {
+		return openDialog().orElse(null);
+	} catch (SWTException e) {
+		if (e.code == SWT.ERROR_INVALID_RETURN_VALUE) {
+			return null;
+		}
+		throw e;
+	}
+}
+
+/**
+ * Makes the dialog visible and brings it to the front of the display.
+ * Equal to {@link FileDialog#open()} but also exposes for state information like user cancellation.
+ *
+ * @return an Optional that either contains the absolute path of the first selected file
+ *         or is empty in case the dialog was canceled
+ *
+ * @exception SWTException <ul>
+ *    <li>ERROR_WIDGET_DISPOSED - if the dialog has been disposed</li>
+ *    <li>ERROR_THREAD_INVALID_ACCESS - if not called from the thread that created the dialog</li>
+ *    <li>ERROR_INVALID_RETURN_VALUE - if the dialog was not cancelled and did not return a valid path</li>
+ * </ul>
+ *
+ * @since 3.126
+ */
+public Optional<String> openDialog () {
 	return openNativeChooserDialog();
 }
+
 /**
  * Open the file chooser dialog using the GtkFileChooserNative API (GTK3.20+) for running applications
  * without direct filesystem access (such as Flatpak). API for GtkFileChoosernative does not
  * give access to any GtkWindow or GtkWidget for the dialog, thus this method omits calls that
  * requires such access. These are be handled by the GtkNativeDialog API.
  *
- * @return a string describing the absolute path of the first selected file, or null
+ * @return an Optional that contains a string describing the absolute path of the first selected file
+ *         or is empty if the dialog is canceled 
  */
-String openNativeChooserDialog () {
+Optional<String> openNativeChooserDialog () {
 	byte [] titleBytes = Converter.wcsToMbcs (title, true);
 	int action = (style & SWT.SAVE) != 0 ? GTK.GTK_FILE_CHOOSER_ACTION_SAVE : GTK.GTK_FILE_CHOOSER_ACTION_OPEN;
 	long shellHandle = parent.topHandle();
@@ -356,7 +385,6 @@ String openNativeChooserDialog () {
 	}
 	presetChooserDialog ();
 	display.addIdleProc ();
-	String answer = null;
 	int signalId = 0;
 	long hookId = 0;
 	if ((style & SWT.RIGHT_TO_LEFT) != 0) {
@@ -378,11 +406,16 @@ String openNativeChooserDialog () {
 	if ((style & SWT.RIGHT_TO_LEFT) != 0) {
 		OS.g_signal_remove_emission_hook (signalId, hookId);
 	}
+	
+	Optional<String> result = Optional.empty();
 	if (response == GTK.GTK_RESPONSE_ACCEPT) {
-		answer = computeResultChooserDialog ();
+		result = Optional.ofNullable(computeResultChooserDialog ());
 	}
 	display.removeIdleProc ();
-	return answer;
+	if (result.isPresent() || response == GTK.GTK_RESPONSE_CANCEL) {
+		return result;
+	}
+	throw new SWTException(SWT.ERROR_INVALID_RETURN_VALUE);
 }
 
 void presetChooserDialog () {

--- a/bundles/org.eclipse.swt/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.swt/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.swt; singleton:=true
-Bundle-Version: 3.125.100.qualifier
+Bundle-Version: 3.126.0.qualifier
 Bundle-ManifestVersion: 2
 Bundle-Localization: plugin
 DynamicImport-Package: org.eclipse.swt.accessibility2

--- a/bundles/org.eclipse.swt/pom.xml
+++ b/bundles/org.eclipse.swt/pom.xml
@@ -21,7 +21,7 @@
     </parent>
     <groupId>org.eclipse.swt</groupId>
     <artifactId>org.eclipse.swt</artifactId>
-    <version>3.125.100-SNAPSHOT</version>
+    <version>3.126.0-SNAPSHOT</version>
     <packaging>eclipse-plugin</packaging>
 
     <properties>


### PR DESCRIPTION
The `FileDialog` and `DirectoryDialog` implementations do currently not provide any way to identify that the dialog was canceled. The dialogs return a null string in case no file or folder was selected, but is not possible to identify whether this was intended (via a cancel action) or if there was some unexpected error while the dialog was open (such as too long file paths on Windows).

This change introduces the `openDialog()` method as an alternative to the existing `open()` method. This new method returns an optional String, which is only present if a file or directory was successfully selected. An empty Optional indicates a cancellation by the user and an actual error is realized as an SWTException. The dialogs evaluate the operating system's response code for the system's dialog control to identify the dialogs result state.

This PR is a result of the proposal by @laeubi in https://github.com/eclipse-platform/eclipse.platform.swt/pull/1005#issuecomment-1921684747. Supercedes and thus closes #1005.
