### PR TITLE
Restore CLASSPATH_ATTR_LIBRARY_PATH_ENTRYs in native .classpath files

### DIFF
--- a/binaries/.classpath_cocoa
+++ b/binaries/.classpath_cocoa
@@ -8,7 +8,11 @@
     <classpathentry kind="src" path="Eclipse SWT/emulated/expand"/>
     <classpathentry kind="src" path="Eclipse SWT/emulated/tooltip"/>
     <classpathentry kind="src" path="Eclipse SWT PI/common"/>
-    <classpathentry kind="src" path="Eclipse SWT PI/cocoa"/>
+    <classpathentry kind="src" path="Eclipse SWT PI/cocoa">
+        <attributes>
+            <attribute name="org.eclipse.jdt.launching.CLASSPATH_ATTR_LIBRARY_PATH_ENTRY" value="org.eclipse.swt.${target.ws}.${target.os}.${target.arch}"/>
+        </attributes>
+    </classpathentry>
     <classpathentry kind="src" path="Eclipse SWT Accessibility/common"/>
     <classpathentry kind="src" path="Eclipse SWT Accessibility/cocoa"/>
     <classpathentry kind="src" path="Eclipse SWT AWT/common"/>

--- a/binaries/.classpath_gtk
+++ b/binaries/.classpath_gtk
@@ -7,7 +7,11 @@
 	<classpathentry kind="src" path="Eclipse SWT/emulated/coolbar"/>
 	<classpathentry kind="src" path="Eclipse SWT/emulated/taskbar"/>
 	<classpathentry kind="src" path="Eclipse SWT/common"/>
-	<classpathentry kind="src" path="Eclipse SWT PI/gtk"/>
+	<classpathentry kind="src" path="Eclipse SWT PI/gtk">
+		<attributes>
+			<attribute name="org.eclipse.jdt.launching.CLASSPATH_ATTR_LIBRARY_PATH_ENTRY" value="org.eclipse.swt.${target.ws}.${target.os}.${target.arch}"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="src" path="Eclipse SWT PI/cairo"/>
 	<classpathentry kind="src" path="Eclipse SWT PI/common"/>
 	<classpathentry kind="src" path="Eclipse SWT Accessibility/gtk"/>

--- a/binaries/.classpath_win32
+++ b/binaries/.classpath_win32
@@ -4,7 +4,11 @@
 	<classpathentry kind="src" path="Eclipse SWT/win32"/>
 	<classpathentry kind="src" path="Eclipse SWT/common"/>
 	<classpathentry kind="src" path="Eclipse SWT PI/common"/>
-	<classpathentry kind="src" path="Eclipse SWT PI/win32"/>
+	<classpathentry kind="src" path="Eclipse SWT PI/win32">
+		<attributes>
+			<attribute name="org.eclipse.jdt.launching.CLASSPATH_ATTR_LIBRARY_PATH_ENTRY" value="org.eclipse.swt.${target.ws}.${target.os}.${target.arch}"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="src" path="Eclipse SWT OLE Win32/win32"/>
 	<classpathentry kind="src" path="Eclipse SWT Accessibility/win32"/>
 	<classpathentry kind="src" path="Eclipse SWT Accessibility/common"/>


### PR DESCRIPTION
Without that launching standalone Java SWT application from the development workspace fails to load the native binaries of the platform, as it was discovered in https://github.com/eclipse-platform/eclipse.platform.swt/pull/1008#discussion_r1478458586.

Unfortunately it looks like variable resolving does not work (at least it didn't work for me locally), altough this old forum post says it should work to resolve variables in `org.eclipse.jdt.launching.CLASSPATH_ATTR_LIBRARY_PATH_ENTRY`'s value:
https://www.eclipse.org/forums/index.php/t/152868/

Does anybody now if there is something else that needs to be done?