### PR TITLE
Add back exports to the org.eclipse.swt host

### DIFF
--- a/bundles/org.eclipse.swt/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.swt/META-INF/MANIFEST.MF
@@ -6,6 +6,22 @@ Bundle-Version: 3.125.0.qualifier
 Bundle-ManifestVersion: 2
 Bundle-Localization: plugin
 DynamicImport-Package: org.eclipse.swt.accessibility2
+Export-Package: 
+ org.eclipse.swt,
+ org.eclipse.swt.accessibility,
+ org.eclipse.swt.awt,
+ org.eclipse.swt.browser,
+ org.eclipse.swt.custom,
+ org.eclipse.swt.dnd,
+ org.eclipse.swt.events,
+ org.eclipse.swt.graphics,
+ org.eclipse.swt.internal,
+ org.eclipse.swt.internal.image;x-internal:=true,
+ org.eclipse.swt.layout,
+ org.eclipse.swt.opengl,
+ org.eclipse.swt.printing,
+ org.eclipse.swt.program,
+ org.eclipse.swt.widgets
 Eclipse-ExtensibleAPI: true
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Automatic-Module-Name: org.eclipse.swt


### PR DESCRIPTION
Some projects, like BND tools, will avoid using require-bundle at great lengths. This becomes problematic when the APIs they want to use do not version there `Export-Package` properly.

Many Eclipse projects, including SWT, do not version their API packages.  They only version their individual bundles with respect to semantic versioning.

For BND they resorted to using `Import-Package` with the `bundle-version` and `bundle-symbolic-name` of the host. This "worked" because the SWT API packages were defined in the `Export-Package` header of the host bundle. But now with PR #1008 this changed and the host bundle no longer defines the exported packages. The end result is BND tools is now broken and has many unresolvable bundles.

Until this is sorted out, this PR simply adds back the `Export-Package` header of the SWT host. The longer term solution should be to properly version SWT API packages so that consumers of the API can properly use `Import-Package` to depend on the API.