### PR TITLE
Mark exported org.eclipse.swt.internal package as internal

### DIFF
--- a/bundles/org.eclipse.swt/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.swt/META-INF/MANIFEST.MF
@@ -15,7 +15,7 @@ Export-Package:
  org.eclipse.swt.dnd,
  org.eclipse.swt.events,
  org.eclipse.swt.graphics,
- org.eclipse.swt.internal,
+ org.eclipse.swt.internal;x-internal:=true,
  org.eclipse.swt.internal.image;x-internal:=true,
  org.eclipse.swt.layout,
  org.eclipse.swt.opengl,


### PR DESCRIPTION
Fixes few API errors reported after 2ca0b37ecbeff105797d5fce72675bf306ad5282