### PR TITLE
Compile SWT natives for Windows on Arm64 (WoA).

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -51,6 +51,18 @@ spec:
 
 /** Returns the download URL of the JDK against whoose C headers (in the 'include/' folder) and native libaries the SWT natives are compiled.*/
 def getNativeJdkUrl(String os, String arch){ // To update the used JDK version update the URL template below
+	if('win32'.equals(os) && 'aarch64'.equals(arch)) {
+		// Temporary workaround until there are official Temurin GA releases for Windows on ARM that can be consumed through JustJ
+		dir("${WORKSPACE}/repackage-win32.aarch64-jdk") {
+			sh """
+				curl -L 'https://github.com/adoptium/temurin17-binaries/releases/download/jdk17u-2024-02-07-14-14-beta/OpenJDK17U-jdk_aarch64_windows_hotspot_2024-02-07-14-14.zip' > jdk.zip
+				unzip -q jdk.zip jdk-17.0.11+1/include/** jdk-17.0.11+1/lib/**
+				cd jdk-17.0.11+1
+				tar -czf ../jdk.tar.gz include/ lib/
+			"""
+		}
+		return "file://${WORKSPACE}/repackage-win32.aarch64-jdk/jdk.tar.gz"
+	}
 	return "https://download.eclipse.org/justj/jres/17/downloads/20230428_1804/org.eclipse.justj.openjdk.hotspot.jre.minimal.stripped-17.0.7-${os}-${arch}.tar.gz"
 }
 
@@ -177,7 +189,7 @@ pipeline {
 				axes {
 					axis {
 						name 'PLATFORM'
-						values 'cocoa.macosx.aarch64' , 'cocoa.macosx.x86_64', 'gtk.linux.aarch64', 'gtk.linux.ppc64le', 'gtk.linux.x86_64', 'win32.win32.x86_64'
+						values 'cocoa.macosx.aarch64' , 'cocoa.macosx.x86_64', 'gtk.linux.aarch64', 'gtk.linux.ppc64le', 'gtk.linux.x86_64', 'win32.win32.aarch64', 'win32.win32.x86_64'
 					}
 				}
 				stages {

--- a/binaries/org.eclipse.swt.win32.win32.aarch64/.project
+++ b/binaries/org.eclipse.swt.win32.win32.aarch64/.project
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>org.eclipse.swt.win32.win32.aarch64</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ManifestBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.SchemaBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.api.tools.apiAnalysisBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>org.eclipse.pde.PluginNature</nature>
+		<nature>org.eclipse.pde.api.tools.apiAnalysisNature</nature>
+	</natures>
+	<linkedResources>
+		<link>
+			<name>.classpath</name>
+			<type>1</type>
+			<locationURI>PARENT-1-PROJECT_LOC/.classpath_win32</locationURI>
+		</link>
+		<link>
+			<name>.settings/.api_filters</name>
+			<type>1</type>
+			<locationURI>PROJECT_LOC/.settings/.api_filters</locationURI>
+		</link>
+		<link>
+			<name>.settings</name>
+			<type>2</type>
+			<locationURI>PARENT-1-PROJECT_LOC/.settings</locationURI>
+		</link>
+		<link>
+			<name>Eclipse SWT</name>
+			<type>2</type>
+			<locationURI>SWT_HOST_PLUGIN/Eclipse%20SWT</locationURI>
+		</link>
+		<link>
+			<name>Eclipse SWT Accessibility</name>
+			<type>2</type>
+			<locationURI>SWT_HOST_PLUGIN/Eclipse%20SWT%20Accessibility</locationURI>
+		</link>
+		<link>
+			<name>Eclipse SWT AWT</name>
+			<type>2</type>
+			<locationURI>SWT_HOST_PLUGIN/Eclipse%20SWT%20AWT</locationURI>
+		</link>
+		<link>
+			<name>Eclipse SWT Browser</name>
+			<type>2</type>
+			<locationURI>SWT_HOST_PLUGIN/Eclipse%20SWT%20Browser</locationURI>
+		</link>
+		<link>
+			<name>Eclipse SWT Custom Widgets</name>
+			<type>2</type>
+			<locationURI>SWT_HOST_PLUGIN/Eclipse%20SWT%20Custom%20Widgets</locationURI>
+		</link>
+		<link>
+			<name>Eclipse SWT Drag and Drop</name>
+			<type>2</type>
+			<locationURI>SWT_HOST_PLUGIN/Eclipse%20SWT%20Drag%20and%20Drop</locationURI>
+		</link>
+		<link>
+			<name>Eclipse SWT OLE Win32</name>
+			<type>2</type>
+			<locationURI>SWT_HOST_PLUGIN/Eclipse%20SWT%20OLE%20Win32</locationURI>
+		</link>
+		<link>
+			<name>Eclipse SWT OpenGL</name>
+			<type>2</type>
+			<locationURI>SWT_HOST_PLUGIN/Eclipse%20SWT%20OpenGL</locationURI>
+		</link>
+		<link>
+			<name>Eclipse SWT PI</name>
+			<type>2</type>
+			<locationURI>SWT_HOST_PLUGIN/Eclipse%20SWT%20PI</locationURI>
+		</link>
+		<link>
+			<name>Eclipse SWT Printing</name>
+			<type>2</type>
+			<locationURI>SWT_HOST_PLUGIN/Eclipse%20SWT%20Printing</locationURI>
+		</link>
+		<link>
+			<name>Eclipse SWT Program</name>
+			<type>2</type>
+			<locationURI>SWT_HOST_PLUGIN/Eclipse%20SWT%20Program</locationURI>
+		</link>
+		<link>
+			<name>Eclipse SWT WebKit</name>
+			<type>2</type>
+			<locationURI>SWT_HOST_PLUGIN/Eclipse%20SWT%20WebKit</locationURI>
+		</link>
+	</linkedResources>
+	<variableList>
+		<variable>
+			<name>SWT_HOST_PLUGIN</name>
+			<value>$%7BPARENT-2-PROJECT_LOC%7D/bundles/org.eclipse.swt</value>
+		</variable>
+	</variableList>
+</projectDescription>

--- a/binaries/org.eclipse.swt.win32.win32.aarch64/.settings/.api_filters
+++ b/binaries/org.eclipse.swt.win32.win32.aarch64/.settings/.api_filters
@@ -1,0 +1,603 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<component id="org.eclipse.swt.win32.win32.aarch64" version="2">
+    <resource path="Eclipse SWT Accessibility/common/org/eclipse/swt/accessibility/AccessibleActionListener.java" type="org.eclipse.swt.accessibility.AccessibleActionListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="AccessibleActionListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Accessibility/common/org/eclipse/swt/accessibility/AccessibleAttributeListener.java" type="org.eclipse.swt.accessibility.AccessibleAttributeListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="AccessibleAttributeListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Accessibility/common/org/eclipse/swt/accessibility/AccessibleControlListener.java" type="org.eclipse.swt.accessibility.AccessibleControlListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="AccessibleControlListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Accessibility/common/org/eclipse/swt/accessibility/AccessibleEditableTextListener.java" type="org.eclipse.swt.accessibility.AccessibleEditableTextListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="AccessibleEditableTextListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Accessibility/common/org/eclipse/swt/accessibility/AccessibleHyperlinkListener.java" type="org.eclipse.swt.accessibility.AccessibleHyperlinkListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="AccessibleHyperlinkListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Accessibility/common/org/eclipse/swt/accessibility/AccessibleListener.java" type="org.eclipse.swt.accessibility.AccessibleListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="AccessibleListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Accessibility/common/org/eclipse/swt/accessibility/AccessibleTableCellListener.java" type="org.eclipse.swt.accessibility.AccessibleTableCellListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="AccessibleTableCellListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Accessibility/common/org/eclipse/swt/accessibility/AccessibleTableListener.java" type="org.eclipse.swt.accessibility.AccessibleTableListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="AccessibleTableListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Accessibility/common/org/eclipse/swt/accessibility/AccessibleTextListener.java" type="org.eclipse.swt.accessibility.AccessibleTextListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="AccessibleTextListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Accessibility/common/org/eclipse/swt/accessibility/AccessibleValueListener.java" type="org.eclipse.swt.accessibility.AccessibleValueListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="AccessibleValueListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Browser/common/org/eclipse/swt/browser/AuthenticationListener.java" type="org.eclipse.swt.browser.AuthenticationListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="AuthenticationListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Browser/common/org/eclipse/swt/browser/CloseWindowListener.java" type="org.eclipse.swt.browser.CloseWindowListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="CloseWindowListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Browser/common/org/eclipse/swt/browser/LocationListener.java" type="org.eclipse.swt.browser.LocationListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="LocationListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Browser/common/org/eclipse/swt/browser/OpenWindowListener.java" type="org.eclipse.swt.browser.OpenWindowListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="OpenWindowListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Browser/common/org/eclipse/swt/browser/ProgressListener.java" type="org.eclipse.swt.browser.ProgressListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="ProgressListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Browser/common/org/eclipse/swt/browser/StatusTextListener.java" type="org.eclipse.swt.browser.StatusTextListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="StatusTextListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Browser/common/org/eclipse/swt/browser/TitleListener.java" type="org.eclipse.swt.browser.TitleListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="TitleListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Browser/common/org/eclipse/swt/browser/VisibilityWindowListener.java" type="org.eclipse.swt.browser.VisibilityWindowListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="VisibilityWindowListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/BidiSegmentListener.java" type="org.eclipse.swt.custom.BidiSegmentListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="BidiSegmentListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CTabFolder2Listener.java" type="org.eclipse.swt.custom.CTabFolder2Listener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="CTabFolder2Listener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CTabFolderListener.java" type="org.eclipse.swt.custom.CTabFolderListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="CTabFolderListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CaretListener.java" type="org.eclipse.swt.custom.CaretListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="CaretListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/ExtendedModifyListener.java" type="org.eclipse.swt.custom.ExtendedModifyListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="ExtendedModifyListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/LineBackgroundListener.java" type="org.eclipse.swt.custom.LineBackgroundListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="LineBackgroundListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/LineStyleListener.java" type="org.eclipse.swt.custom.LineStyleListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="LineStyleListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/MovementListener.java" type="org.eclipse.swt.custom.MovementListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="MovementListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/PaintObjectListener.java" type="org.eclipse.swt.custom.PaintObjectListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="PaintObjectListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/TextChangeListener.java" type="org.eclipse.swt.custom.TextChangeListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="TextChangeListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/VerifyKeyListener.java" type="org.eclipse.swt.custom.VerifyKeyListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="VerifyKeyListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Drag and Drop/common/org/eclipse/swt/dnd/DragSourceListener.java" type="org.eclipse.swt.dnd.DragSourceListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="DragSourceListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Drag and Drop/common/org/eclipse/swt/dnd/DropTargetListener.java" type="org.eclipse.swt.dnd.DropTargetListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="DropTargetListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT OLE Win32/win32/org/eclipse/swt/ole/win32/OleAutomation.java" type="org.eclipse.swt.ole.win32.OleAutomation">
+        <filter id="643842064">
+            <message_arguments>
+                <message_argument value="TYPEATTR"/>
+                <message_argument value="OleAutomation"/>
+                <message_argument value="getTypeInfoAttributes()"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT OLE Win32/win32/org/eclipse/swt/ole/win32/OleClientSite.java" type="org.eclipse.swt.ole.win32.OleClientSite">
+        <filter id="627060751">
+            <message_arguments>
+                <message_argument value="GUID"/>
+                <message_argument value="OleClientSite"/>
+                <message_argument value="appClsid"/>
+            </message_arguments>
+        </filter>
+        <filter id="627060751">
+            <message_arguments>
+                <message_argument value="IOleCommandTarget"/>
+                <message_argument value="OleClientSite"/>
+                <message_argument value="objIOleCommandTarget"/>
+            </message_arguments>
+        </filter>
+        <filter id="627060751">
+            <message_arguments>
+                <message_argument value="IOleDocumentView"/>
+                <message_argument value="OleClientSite"/>
+                <message_argument value="objDocumentView"/>
+            </message_arguments>
+        </filter>
+        <filter id="627060751">
+            <message_arguments>
+                <message_argument value="IOleInPlaceObject"/>
+                <message_argument value="OleClientSite"/>
+                <message_argument value="objIOleInPlaceObject"/>
+            </message_arguments>
+        </filter>
+        <filter id="627060751">
+            <message_arguments>
+                <message_argument value="IOleObject"/>
+                <message_argument value="OleClientSite"/>
+                <message_argument value="objIOleObject"/>
+            </message_arguments>
+        </filter>
+        <filter id="627060751">
+            <message_arguments>
+                <message_argument value="IStorage"/>
+                <message_argument value="OleClientSite"/>
+                <message_argument value="tempStorage"/>
+            </message_arguments>
+        </filter>
+        <filter id="627060751">
+            <message_arguments>
+                <message_argument value="IUnknown"/>
+                <message_argument value="OleClientSite"/>
+                <message_argument value="objIUnknown"/>
+            </message_arguments>
+        </filter>
+        <filter id="627060751">
+            <message_arguments>
+                <message_argument value="IViewObject2"/>
+                <message_argument value="OleClientSite"/>
+                <message_argument value="objIViewObject2"/>
+            </message_arguments>
+        </filter>
+        <filter id="643842064">
+            <message_arguments>
+                <message_argument value="GUID"/>
+                <message_argument value="OleClientSite"/>
+                <message_argument value="getClassID(String)"/>
+            </message_arguments>
+        </filter>
+        <filter id="643842064">
+            <message_arguments>
+                <message_argument value="IStorage"/>
+                <message_argument value="OleClientSite"/>
+                <message_argument value="createTempStorage()"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT OLE Win32/win32/org/eclipse/swt/ole/win32/OleControlSite.java" type="org.eclipse.swt.ole.win32.OleControlSite">
+        <filter id="643846161">
+            <message_arguments>
+                <message_argument value="GUID"/>
+                <message_argument value="OleControlSite"/>
+                <message_argument value="getLicenseInfo(GUID)"/>
+            </message_arguments>
+        </filter>
+        <filter id="643846161">
+            <message_arguments>
+                <message_argument value="GUID"/>
+                <message_argument value="OleControlSite"/>
+                <message_argument value="removeEventListener(OleAutomation, GUID, int, OleListener)"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT OLE Win32/win32/org/eclipse/swt/ole/win32/Variant.java" type="org.eclipse.swt.ole.win32.Variant">
+        <filter id="643842064">
+            <message_arguments>
+                <message_argument value="IDispatch"/>
+                <message_argument value="Variant"/>
+                <message_argument value="getDispatch()"/>
+            </message_arguments>
+        </filter>
+        <filter id="643842064">
+            <message_arguments>
+                <message_argument value="IUnknown"/>
+                <message_argument value="Variant"/>
+                <message_argument value="getUnknown()"/>
+            </message_arguments>
+        </filter>
+        <filter id="643850349">
+            <message_arguments>
+                <message_argument value="IDispatch"/>
+                <message_argument value="Variant"/>
+                <message_argument value="Variant(IDispatch)"/>
+            </message_arguments>
+        </filter>
+        <filter id="643850349">
+            <message_arguments>
+                <message_argument value="IUnknown"/>
+                <message_argument value="Variant"/>
+                <message_argument value="Variant(IUnknown)"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/ArmListener.java" type="org.eclipse.swt.events.ArmListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="ArmListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/ControlListener.java" type="org.eclipse.swt.events.ControlListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="ControlListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/DisposeListener.java" type="org.eclipse.swt.events.DisposeListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="DisposeListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/DragDetectListener.java" type="org.eclipse.swt.events.DragDetectListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="DragDetectListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/ExpandListener.java" type="org.eclipse.swt.events.ExpandListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="ExpandListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/FocusListener.java" type="org.eclipse.swt.events.FocusListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="FocusListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/GestureListener.java" type="org.eclipse.swt.events.GestureListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="GestureListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/HelpListener.java" type="org.eclipse.swt.events.HelpListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="HelpListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/KeyListener.java" type="org.eclipse.swt.events.KeyListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="KeyListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/MenuDetectListener.java" type="org.eclipse.swt.events.MenuDetectListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="MenuDetectListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/MenuListener.java" type="org.eclipse.swt.events.MenuListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="MenuListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/ModifyListener.java" type="org.eclipse.swt.events.ModifyListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="ModifyListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/MouseListener.java" type="org.eclipse.swt.events.MouseListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="MouseListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/MouseMoveListener.java" type="org.eclipse.swt.events.MouseMoveListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="MouseMoveListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/MouseTrackListener.java" type="org.eclipse.swt.events.MouseTrackListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="MouseTrackListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/MouseWheelListener.java" type="org.eclipse.swt.events.MouseWheelListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="MouseWheelListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/PaintListener.java" type="org.eclipse.swt.events.PaintListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="PaintListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/SegmentListener.java" type="org.eclipse.swt.events.SegmentListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="SegmentListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/SelectionListener.java" type="org.eclipse.swt.events.SelectionListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="SelectionListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/ShellListener.java" type="org.eclipse.swt.events.ShellListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="ShellListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/TouchListener.java" type="org.eclipse.swt.events.TouchListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="TouchListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/TraverseListener.java" type="org.eclipse.swt.events.TraverseListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="TraverseListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/TreeListener.java" type="org.eclipse.swt.events.TreeListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="TreeListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/VerifyListener.java" type="org.eclipse.swt.events.VerifyListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="VerifyListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/graphics/ImageLoaderListener.java" type="org.eclipse.swt.graphics.ImageLoaderListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="ImageLoaderListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/widgets/TypedListener.java" type="org.eclipse.swt.widgets.TypedListener">
+        <filter comment="Class declared as internal in its JavaDoc since ever." id="336744520">
+            <message_arguments>
+                <message_argument value="@noextend"/>
+                <message_argument value="org.eclipse.swt.widgets.TypedListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/win32/org/eclipse/swt/graphics/GCData.java" type="org.eclipse.swt.graphics.GCData">
+        <filter id="627060751">
+            <message_arguments>
+                <message_argument value="PAINTSTRUCT"/>
+                <message_argument value="GCData"/>
+                <message_argument value="ps"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/win32/org/eclipse/swt/widgets/Composite.java" type="org.eclipse.swt.widgets.Composite">
+        <filter id="576778288">
+            <message_arguments>
+                <message_argument value="Scrollable"/>
+                <message_argument value="Composite"/>
+            </message_arguments>
+        </filter>
+    </resource>
+</component>

--- a/binaries/org.eclipse.swt.win32.win32.aarch64/META-INF/MANIFEST.MF
+++ b/binaries/org.eclipse.swt.win32.win32.aarch64/META-INF/MANIFEST.MF
@@ -1,0 +1,34 @@
+Manifest-Version: 1.0
+Fragment-Host: org.eclipse.swt;bundle-version="[3.125.100,4.0.0)"
+Bundle-Name: %fragmentName
+Bundle-Vendor: %providerName
+Bundle-SymbolicName: org.eclipse.swt.win32.win32.aarch64; singleton:=true
+Bundle-Version: 3.126.0.qualifier
+Bundle-ManifestVersion: 2
+Bundle-Localization: fragment
+Export-Package: 
+ org.eclipse.swt,
+ org.eclipse.swt.accessibility,
+ org.eclipse.swt.awt,
+ org.eclipse.swt.browser,
+ org.eclipse.swt.custom,
+ org.eclipse.swt.dnd,
+ org.eclipse.swt.events,
+ org.eclipse.swt.graphics,
+ org.eclipse.swt.layout,
+ org.eclipse.swt.opengl,
+ org.eclipse.swt.printing,
+ org.eclipse.swt.program,
+ org.eclipse.swt.widgets,
+ org.eclipse.swt.internal; x-friends:="org.eclipse.ui",
+ org.eclipse.swt.internal.image; x-internal:=true,
+ org.eclipse.swt.ole.win32,
+ org.eclipse.swt.internal.gdip; x-internal:=true,
+ org.eclipse.swt.internal.ole.win32; x-internal:=true,
+ org.eclipse.swt.internal.win32; x-internal:=true,
+ org.eclipse.swt.internal.opengl.win32; x-internal:=true
+Eclipse-PlatformFilter: (& (osgi.ws=win32) (osgi.os=win32) (osgi.arch=aarch64))
+SWT-WS: win32
+SWT-OS: win32
+SWT-Arch: aarch64
+Automatic-Module-Name: org.eclipse.swt.win32.win32.aarch64

--- a/binaries/org.eclipse.swt.win32.win32.aarch64/WebView2Loader.dll
+++ b/binaries/org.eclipse.swt.win32.win32.aarch64/WebView2Loader.dll
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dac2c67e5a21ba0a40a1a3ecdc9b7723708f10f5ecab26f2ddb729c2e27396ca
+size 127912

--- a/binaries/org.eclipse.swt.win32.win32.aarch64/build.properties
+++ b/binaries/org.eclipse.swt.win32.win32.aarch64/build.properties
@@ -1,0 +1,41 @@
+###############################################################################
+# Copyright (c) 2023, 2024 Tue Ton and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     Tue Ton - initial API and implementation
+#     Hannes Wellmann - Leverage Tycho pomless
+###############################################################################
+custom = true
+bin.includes = .,*.dll,fragment.properties
+bin.excludes = library/
+source.. = \
+	../legal_files/win32.win32,\
+	../../bundles/org.eclipse.swt/Eclipse SWT/win32,\
+	../../bundles/org.eclipse.swt/Eclipse SWT/common,\
+	../../bundles/org.eclipse.swt/Eclipse SWT PI/common,\
+	../../bundles/org.eclipse.swt/Eclipse SWT PI/win32,\
+	../../bundles/org.eclipse.swt/Eclipse SWT OLE Win32/win32,\
+	../../bundles/org.eclipse.swt/Eclipse SWT Accessibility/win32,\
+	../../bundles/org.eclipse.swt/Eclipse SWT Accessibility/common,\
+	../../bundles/org.eclipse.swt/Eclipse SWT AWT/win32,\
+	../../bundles/org.eclipse.swt/Eclipse SWT AWT/common,\
+	../../bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/win32,\
+	../../bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/common,\
+	../../bundles/org.eclipse.swt/Eclipse SWT Printing/win32,\
+	../../bundles/org.eclipse.swt/Eclipse SWT Printing/common,\
+	../../bundles/org.eclipse.swt/Eclipse SWT Program/win32,\
+	../../bundles/org.eclipse.swt/Eclipse SWT Program/common,\
+	../../bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common,\
+	../../bundles/org.eclipse.swt/Eclipse SWT Browser/common,\
+	../../bundles/org.eclipse.swt/Eclipse SWT Browser/win32,\
+	../../bundles/org.eclipse.swt/Eclipse SWT OpenGL/win32,\
+	../../bundles/org.eclipse.swt/Eclipse SWT OpenGL/common
+output.. = bin/
+
+pom.model.property.os=win32
+pom.model.property.ws=win32
+pom.model.property.arch=aarch64

--- a/binaries/org.eclipse.swt.win32.win32.aarch64/fragment.properties
+++ b/binaries/org.eclipse.swt.win32.win32.aarch64/fragment.properties
@@ -1,0 +1,12 @@
+###############################################################################
+# Copyright (c) 2023, 2024 Tue Ton and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     Tue Ton - initial API and implementation
+###############################################################################
+fragmentName = Standard Widget Toolkit for Windows on aarch64
+providerName = Eclipse.org

--- a/binaries/pom.xml
+++ b/binaries/pom.xml
@@ -38,6 +38,7 @@
 		<module>org.eclipse.swt.gtk.linux.aarch64</module>
 		<module>org.eclipse.swt.gtk.linux.ppc64le</module>
 		<module>org.eclipse.swt.gtk.linux.x86_64</module>
+		<module>org.eclipse.swt.win32.win32.aarch64</module>
 		<module>org.eclipse.swt.win32.win32.x86_64</module>
 	</modules>
 

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/win32/library/build.bat
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/win32/library/build.bat
@@ -13,7 +13,6 @@
 @rem ***************************************************************************
 
 @rem The original build.bat source is located in /org.eclipse.swt/Eclipse SWT PI/win32/library/build.bat. It is copied during various build(s).
-@rem Typically it's not ran directly, instead it is reached by build.xml's build_libraries target found in eclipse.platform.swt\bundles\org.eclipse.swt.win32.win32.x86*
 
 @echo off
 echo
@@ -51,15 +50,44 @@ IF NOT EXIST "%MSVC_HOME%" (
 @rem Check for a usable JDK
 IF "%SWT_JAVA_HOME%"=="" CALL :ECHO "'SWT_JAVA_HOME' was not provided"
 IF NOT EXIST "%SWT_JAVA_HOME%" (
-    CALL :ECHO "WARNING: x64 Java JDK not found. Please set SWT_JAVA_HOME to the JDK directory containing the intended JDK native headers."
+    CALL :ECHO "WARNING: 64-bit Java JDK not found. Please set SWT_JAVA_HOME to the JDK directory containing the intended JDK native headers."
 )
 
-@rem -----------------------
-set PROCESSOR_ARCHITECTURE=AMD64
-IF "x.%OUTPUT_DIR%"=="x." set OUTPUT_DIR=..\..\..\org.eclipse.swt.win32.win32.x86_64
+@REM Compose host architecture string for MSVC
+IF "%PROCESSOR_ARCHITECTURE%"=="AMD64" (
+  SET HOST_ARCH=x64
+) ELSE IF "%PROCESSOR_ARCHITECTURE%"=="ARM64" (
+  SET HOST_ARCH=arm64
+) ELSE (
+  CALL :ECHO "ERROR: Unknown host architecture: %PROCESSOR_ARCHITECTURE%."
+  EXIT /B 1
+)
+
+@REM %TARGET_ARCH% may be specified by the caller for cross-compiling.
+@REM If not, build for builder machine's architecture
+IF "%TARGET_ARCH%"=="" (
+  SET TARGET_ARCH=%HOST_ARCH%
+)
+
+@REM Compose build argument for MSVC
+IF "%TARGET_ARCH%"=="%HOST_ARCH%" (
+  SET BUILD_ARCH=%TARGET_ARCH%
+) ELSE (
+  SET BUILD_ARCH=%HOST_ARCH%_%TARGET_ARCH%
+)
+
+@REM Select build's output directory (if not specified) based on target arch
+IF "%TARGET_ARCH%"=="x64" (
+  IF "x.%OUTPUT_DIR%"=="x." SET OUTPUT_DIR=..\..\..\org.eclipse.swt.win32.win32.x86_64
+) ELSE IF "%TARGET_ARCH%"=="arm64" (
+  IF "x.%OUTPUT_DIR%"=="x." SET OUTPUT_DIR=..\..\..\org.eclipse.swt.win32.win32.aarch64
+) ELSE (
+  CALL :ECHO "ERROR: Unknown target architecture: %TARGET_ARCH%."
+  EXIT /B 1
+)
 
 set CFLAGS=-DJNI64
-call "%MSVC_HOME%\VC\Auxiliary\Build\vcvarsall.bat" x64
+call "%MSVC_HOME%\VC\Auxiliary\Build\vcvarsall.bat" %BUILD_ARCH%
 
 @rem if call to vcvarsall.bat (which sets up environment) silently fails, then provide advice to user.
 WHERE cl

--- a/local-build/org.eclipse.swt.fragments.localbuild/META-INF/p2.inf
+++ b/local-build/org.eclipse.swt.fragments.localbuild/META-INF/p2.inf
@@ -28,3 +28,8 @@ requires.6.namespace = org.eclipse.equinox.p2.iu
 requires.6.name = org.eclipse.swt.cocoa.macosx.aarch64
 requires.6.range = 0.0.0
 requires.6.filter = (&(osgi.os=macosx)(osgi.ws=cocoa)(osgi.arch=aarch64))
+
+requires.7.namespace = org.eclipse.equinox.p2.iu
+requires.7.name = org.eclipse.swt.win32.win32.aarch64
+requires.7.range = 0.0.0
+requires.7.filter = (&(osgi.os=win32)(osgi.ws=win32)(osgi.arch=aarch64))

--- a/pom.xml
+++ b/pom.xml
@@ -172,6 +172,11 @@
                   <ws>win32</ws>
                   <arch>x86_64</arch>
                 </environment>
+                <environment>
+                  <os>win32</os>
+                  <ws>win32</ws>
+                  <arch>aarch64</arch>
+                </environment>
               </environments>
             </configuration>
           </plugin>


### PR DESCRIPTION
This PR contains changes to the `build.bat` file, to support compiling the SWT natives for the WoA platform, and associated files to produce the SWT binaries module's jar/zip files for WoA.

On a WoA box, run the following commands to produce the SWT natives (`swt*.dll`) for WoA:
```batch
cd binaries\org.eclipse.swt.win32.win32.aarch64
mvn clean process-resources -Dnative=win32.win32.aarch64
```
and the `swt*.dll` files for WoA will be created in the current directory.

Cross-compiling between the x64 and Arm64 platforms, where either of them can be host or target, is also possible, after setting up the `TARGET_ARCH` environment variable with correct "target architecture" value, and with the `SWT_JAVA_HOME` property pointing to an available JDK of the target architecture.

For example, to cross-compile on an x64 host and produce SWT natives for Arm64 target, run the following commands:
```batch
set TARGET_ARCH=arm64
cd binaries\org.eclipse.swt.win32.win32.aarch64
mvn clean process-resources -Dnative=win32.win32.aarch64 -DSWT_JAVA_HOME=\path\to\arm64_jdk
```
and the `swt*.dll` files for WoA will be created in the current directory. Note the above `SWT_JAVA_HOME` property in the command line which points to an available Arm64 JDK of the target architecture. If needed, an Arm64 JDK for WoA can be downloaded from [Microsoft](https://learn.microsoft.com/en-us/java/openjdk/download), [Liberica](https://bell-sw.com/pages/downloads/), or [Zulu](https://www.azul.com/downloads/?package=jdk#download-openjdk).

Similarly, to cross-compile on an Arm64 host and produce SWT natives for x64 target, run the following commands:
```batch
set TARGET_ARCH=x64
cd binaries\org.eclipse.swt.win32.win32.x86_64
mvn clean process-resources -Dnative=win32.win32.x86_64 -DSWT_JAVA_HOME=\path\to\x64_jdk
```
and the `swt*.dll` files for x64 will be created in the current directory.

Note that for cross-compiling between x64 and Arm64 to work, install the MSVC compiler version 2022, with mandatory build tools for both platforms included in the installation. Further more, there must exist a JDK installation of the `target` platform available on the host machine, so that the `SWT_JAVA_HOME` variable can point to it during cross-compiling and linking.

Once the SWT natives for Arm64 are generated, the SWT binaries module's files can be produced with the following build commands in current directory:
```
mvn clean verify -DskipTests=true
```
and the module's jar/zip files will be produced in the `target` directory:
```
org.eclipse.swt.win32.win32.aarch64-<version>.jar
org.eclipse.swt.win32.win32.aarch64-<version>-sources.jar
swt-<version>-win32-win32-aarch64.zip
```