### PR TITLE
Handle validation of uxtheme.dll undocumented exported functions in ARM64 builds

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT PI/win32/library/os_custom.c
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/win32/library/os_custom.c
@@ -79,6 +79,13 @@ BOOL Validate_AllowDarkModeForWindow(const BYTE* functionPtr)
 	}
 
 	return FALSE;
+#elif defined(_M_ARM64)
+	if (*(const DWORD*)(&functionPtr[0x18]) == 0xD29523C1) // mov x1,#0xA91E
+	{
+		return TRUE;
+	}
+
+	return FALSE;
 #else
 	#error Unsupported processor type
 #endif
@@ -124,6 +131,13 @@ BOOL Validate_AllowDarkModeForWindowWithTelemetryId(const BYTE* functionPtr)
 	/* Win11 builds from 22621 */
 	if ((functionPtr[0x15] == 0xBA) &&                      // mov      edx,
 		(*(const DWORD*)(functionPtr + 0x16) == 0xA91E))    //              0A91Eh
+	{
+		return TRUE;
+	}
+
+	return FALSE;
+#elif defined(_M_ARM64)
+	if (*(const DWORD*)(&functionPtr[0x18]) == 0xD29523C1) // mov x1,#0xA91E
 	{
 		return TRUE;
 	}
@@ -219,6 +233,13 @@ BOOL Validate_SetPreferredAppMode(const BYTE* functionPtr)
 		(functionPtr[0x00] == 0x8B) && (functionPtr[0x01] == 0x05) &&   // mov     eax,dword ptr [uxtheme!g_preferredAppMode]
 		(functionPtr[0x06] == 0x87) && (functionPtr[0x07] == 0x0D) &&   // xchg    ecx,dword ptr [uxtheme!g_preferredAppMode]
 		(functionPtr[0x0C] == 0xC3);                                    // ret
+#elif defined(_M_ARM64)
+	if (*(const DWORD*)(&functionPtr[0x1C]) == 0x912F6100) // add x0,x8,#0xBD8
+	{
+		return TRUE;
+	}
+
+	return FALSE;
 #else
 	#error Unsupported processor type
 #endif


### PR DESCRIPTION
This is required for https://github.com/eclipse-platform/eclipse.platform.swt/pull/1045 to continue.

For reference, here are the disassemblies:
`AllowDarkModeForWindow()`:
```
00007FFB16C32450 D503237F             pacibsp  
00007FFB16C32454 A9BE53F3             stp         x19,x20,[sp,#-0x20]!  
00007FFB16C32458 F9000BF5             str         x21,[sp,#0x10]  
00007FFB16C3245C A9BF7BFD             stp         fp,lr,[sp,#-0x10]!  
00007FFB16C32460 910003FD             mov         fp,sp  
00007FFB16C32464 53001C33             uxtb        w19,w1  
00007FFB16C32468 D29523C1             mov         x1,#0xA91E  
00007FFB16C3246C AA0003F5             mov         x21,x0  
00007FFB16C32470 9400F226             bl          #GetPropW (07FFB16C6ED08h)
...
```
`AllowDarkModeForWindowWithTelemetryId():`
```
00007FFB16C33210 D503237F             pacibsp  
00007FFB16C33214 A9BE53F3             stp         x19,x20,[sp,#-0x20]!  
00007FFB16C33218 F9000BF5             str         x21,[sp,#0x10]  
00007FFB16C3321C A9BF7BFD             stp         fp,lr,[sp,#-0x10]!  
00007FFB16C33220 910003FD             mov         fp,sp  
00007FFB16C33224 53001C34             uxtb        w20,w1  
00007FFB16C33228 D29523C1             mov         x1,#0xA91E  
00007FFB16C3322C AA0003F5             mov         x21,x0  
00007FFB16C33230 9400EEB6             bl          #GetPropW (07FFB16C6ED08h)
...
```
`SetPreferredAppMode()`:
```
00007FFB16C33E10 D503237F             pacibsp  
00007FFB16C33E14 F81F0FF3             str         x19,[sp,#-0x10]!  
00007FFB16C33E18 A9BF7BFD             stp         fp,lr,[sp,#-0x10]!  
00007FFB16C33E1C 910003FD             mov         fp,sp  
00007FFB16C33E20 D00007E8             adrp        x8,wil::details::g_enabledStateManager+40h (07FFB16D31000h)  
00007FFB16C33E24 B94BD913             ldr         w19,[x8,#0xBD8]  
00007FFB16C33E28 2A0003E1             mov         w1,w0  
00007FFB16C33E2C 912F6100             add         x0,x8,#0xBD8  
00007FFB16C33E30 97FF7910             bl          _InterlockedExchange (07FFB16C12270h)  
00007FFB16C33E34 2A1303E0             mov         w0,w19  
00007FFB16C33E38 A8C17BFD             ldp         fp,lr,[sp],#0x10  
00007FFB16C33E3C F84107F3             ldr         x19,[sp],#0x10  
00007FFB16C33E40 D50323FF             autibsp  
00007FFB16C33E44 D65F03C0             ret  
00007FFB16C33E48 B0000090             adrp        xip0,GetBufferedPaintBitsEx+7320h (07FFB16C44000h)
...
```