### PR TITLE
[gtk] Make Fonts GC disposable

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Accessibility/gtk/org/eclipse/swt/accessibility/AccessibleObject.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Accessibility/gtk/org/eclipse/swt/accessibility/AccessibleObject.java
@@ -2879,37 +2879,37 @@ class AccessibleObject {
 						long attrPtr;
 						attrPtr = OS.g_malloc(AtkAttribute.sizeof);
 						attr.name = OS.g_strdup (ATK.atk_text_attribute_get_name(ATK.ATK_TEXT_ATTR_FAMILY_NAME));
-						attr.value = OS.g_strdup (OS.pango_font_description_get_family (font.handle));
+						attr.value = OS.g_strdup (font.handle.getFamily());
 						ATK.memmove(attrPtr, attr, AtkAttribute.sizeof);
 						result = OS.g_slist_append(result, attrPtr);
 
 						attrPtr = OS.g_malloc(AtkAttribute.sizeof);
 						attr.name = OS.g_strdup (ATK.atk_text_attribute_get_name(ATK.ATK_TEXT_ATTR_SIZE));
-						attr.value = getStringPtr (String.valueOf (OS.pango_font_description_get_size(font.handle) / OS.PANGO_SCALE));
+						attr.value = getStringPtr (String.valueOf (font.handle.getHeight()));
 						ATK.memmove(attrPtr, attr, AtkAttribute.sizeof);
 						result = OS.g_slist_append(result, attrPtr);
 
 						attrPtr = OS.g_malloc(AtkAttribute.sizeof);
 						attr.name = OS.g_strdup (ATK.atk_text_attribute_get_name(ATK.ATK_TEXT_ATTR_STYLE));
-						attr.value = OS.g_strdup (ATK.atk_text_attribute_get_value(ATK.ATK_TEXT_ATTR_STYLE, OS.pango_font_description_get_style(font.handle)));
+						attr.value = OS.g_strdup (ATK.atk_text_attribute_get_value(ATK.ATK_TEXT_ATTR_STYLE, font.handle.getStyle()));
 						ATK.memmove(attrPtr, attr, AtkAttribute.sizeof);
 						result = OS.g_slist_append(result, attrPtr);
 
 						attrPtr = OS.g_malloc(AtkAttribute.sizeof);
 						attr.name = OS.g_strdup (ATK.atk_text_attribute_get_name(ATK.ATK_TEXT_ATTR_VARIANT));
-						attr.value = OS.g_strdup (ATK.atk_text_attribute_get_value(ATK.ATK_TEXT_ATTR_VARIANT, OS.pango_font_description_get_variant(font.handle)));
+						attr.value = OS.g_strdup (ATK.atk_text_attribute_get_value(ATK.ATK_TEXT_ATTR_VARIANT, font.handle.getVariant()));
 						ATK.memmove(attrPtr, attr, AtkAttribute.sizeof);
 						result = OS.g_slist_append(result, attrPtr);
 
 						attrPtr = OS.g_malloc(AtkAttribute.sizeof);
 						attr.name = OS.g_strdup (ATK.atk_text_attribute_get_name(ATK.ATK_TEXT_ATTR_STRETCH));
-						attr.value = OS.g_strdup (ATK.atk_text_attribute_get_value(ATK.ATK_TEXT_ATTR_STRETCH, OS.pango_font_description_get_stretch(font.handle)));
+						attr.value = OS.g_strdup (ATK.atk_text_attribute_get_value(ATK.ATK_TEXT_ATTR_STRETCH, font.handle.getStretch()));
 						ATK.memmove(attrPtr, attr, AtkAttribute.sizeof);
 						result = OS.g_slist_append(result, attrPtr);
 
 						attrPtr = OS.g_malloc(AtkAttribute.sizeof);
 						attr.name = OS.g_strdup (ATK.atk_text_attribute_get_name(ATK.ATK_TEXT_ATTR_WEIGHT));
-						attr.value = getStringPtr (String.valueOf (OS.pango_font_description_get_weight(font.handle)));
+						attr.value = getStringPtr (String.valueOf (font.handle.getWeight()));
 						ATK.memmove(attrPtr, attr, AtkAttribute.sizeof);
 						result = OS.g_slist_append(result, attrPtr);
 					}

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/Resource.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/Resource.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.swt.graphics;
 
+import java.lang.ref.*;
 import java.util.function.*;
 
 import org.eclipse.swt.*;
@@ -41,6 +42,11 @@ import org.eclipse.swt.*;
  * @since 3.1
  */
 public abstract class Resource {
+
+	/**
+	 * A cleaner that can be used to track automatic disposal of resources by the cleaning API see <a href="https://docs.oracle.com/javase%2F9%2Fdocs%2Fapi%2F%2F/java/lang/ref/Cleaner.html">Cleaner</a>
+	 */
+	protected static final Cleaner cleaner = Cleaner.create();
 
 	/**
 	 * Used to track not disposed SWT resource. A separate class allows

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/graphics/GC.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/graphics/GC.java
@@ -206,7 +206,7 @@ static void addCairoString(long cairo, String string, float x, float y, Font fon
 	long layout = OS.pango_cairo_create_layout(cairo);
 	if (layout == 0) SWT.error(SWT.ERROR_NO_HANDLES);
 	OS.pango_layout_set_text(layout, buffer, -1);
-	OS.pango_layout_set_font_description(layout, font.handle);
+	OS.pango_layout_set_font_description(layout, font.handle.pointer);
 	double[] currentX = new double[1], currentY = new double[1];
 	Cairo.cairo_get_current_point(cairo, currentX, currentY);
 	if (currentX[0] != x || currentY[0] != y) {
@@ -321,7 +321,7 @@ void checkGC (int mask) {
 	if ((state & FONT) != 0) {
 		if (data.layout != 0) {
 			Font font = data.font;
-			OS.pango_layout_set_font_description(data.layout, font.handle);
+			OS.pango_layout_set_font_description(data.layout, font.handle.pointer);
 		}
 	}
 	if ((state & LINE_CAP) != 0) {
@@ -2237,8 +2237,7 @@ public FontMetrics getFontMetrics() {
 	checkGC(FONT);
 	Font font = data.font;
 	long context = data.context;
-	long lang = OS.pango_context_get_language(context);
-	long metrics = OS.pango_context_get_metrics(context, font.handle, lang);
+	long metrics = font.handle.getMetrics(context);
 	FontMetrics fm = new FontMetrics();
 	int ascent = OS.pango_font_metrics_get_ascent(metrics);
 	int descent = OS.pango_font_metrics_get_descent(metrics);
@@ -2912,7 +2911,7 @@ public void setBackgroundPattern(Pattern pattern) {
 
 static void setCairoFont(long cairo, Font font) {
 	if (font == null || font.isDisposed()) return;
-	setCairoFont(cairo, font.handle);
+	setCairoFont(cairo, font.handle.pointer);
 }
 
 static void setCairoFont(long cairo, long font) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/graphics/TextLayout.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/graphics/TextLayout.java
@@ -245,7 +245,7 @@ public TextLayout (Device device) {
 	OS.pango_context_set_base_dir(context, OS.PANGO_DIRECTION_LTR);
 	layout = OS.pango_layout_new(context);
 	if (layout == 0) SWT.error(SWT.ERROR_NO_HANDLES);
-	OS.pango_layout_set_font_description(layout, device.systemFont.handle);
+	OS.pango_layout_set_font_description(layout, device.systemFont.handle.pointer);
 	OS.pango_layout_set_wrap(layout, OS.PANGO_WRAP_WORD_CHAR);
 	OS.pango_layout_set_tabs(layout, device.emptyTab);
 	OS.pango_layout_set_auto_dir(layout, false);
@@ -371,7 +371,7 @@ void computeRuns () {
 		byteEnd = Math.min(byteEnd, strlen);
 		Font font = style.font;
 		if (font != null && !font.isDisposed() && !defaultFont.equals(font)) {
-			long attr = OS.pango_attr_font_desc_new (font.handle);
+			long attr = font.handle.newFontAttributes();
 			OS.memmove (attribute, attr, PangoAttribute.sizeof);
 			attribute.start_index = byteStart;
 			attribute.end_index = byteEnd;
@@ -1240,7 +1240,7 @@ public FontMetrics getLineMetrics (int lineIndex) {
 	int heightInPoints;
 	int ascentInPoints;
 	if (line.runs == 0) {
-		long font = this.font != null ? this.font.handle : device.systemFont.handle;
+		long font = this.font != null ? this.font.handle.pointer : device.systemFont.handle.pointer;
 		long lang = OS.pango_context_get_language(context);
 		long metrics = OS.pango_context_get_metrics(context, font, lang);
 		int ascent = OS.pango_font_metrics_get_ascent(metrics);
@@ -2013,7 +2013,7 @@ public void setFont (Font font) {
 	freeRuns();
 	this.font = font;
 	if (oldFont != null && oldFont.equals(font)) return;
-	OS.pango_layout_set_font_description(layout, font != null ? font.handle : device.systemFont.handle);
+	OS.pango_layout_set_font_description(layout, font != null ? font.handle.pointer : device.systemFont.handle.pointer);
 }
 
 /**

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Button.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Button.java
@@ -429,7 +429,7 @@ void createHandle (int index) {
 	if ((style & SWT.ARROW) != 0) return;
 	// In GTK 3 font description is inherited from parent widget which is not how SWT has always worked,
 	// reset to default font to get the usual behavior
-	setFontDescription(defaultFont().handle);
+	setFontDescription(defaultFont().handle.pointer);
 	_setAlignment (style & (SWT.LEFT | SWT.CENTER | SWT.RIGHT));
 }
 
@@ -1294,7 +1294,7 @@ public void setText (String string) {
 	_setAlignment (style);
 	// Now that text has been added, set the font. This ensures
 	// the Button's size is correctly calculated/updated.
-	setFontDescription(font == null ? defaultFont().handle : font.handle);
+	setFontDescription(font == null ? defaultFont().handle.pointer : font.handle.pointer);
 }
 
 private void updateWidgetsVisibility() {

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Combo.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Combo.java
@@ -601,7 +601,7 @@ void createHandle (int index) {
 	}
 	// In GTK 3 font description is inherited from parent widget which is not how SWT has always worked,
 	// reset to default font to get the usual behavior
-	setFontDescription(defaultFont().handle);
+	setFontDescription(defaultFont().handle.pointer);
 }
 
 /**

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Control.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Control.java
@@ -5546,10 +5546,10 @@ public void setFont (Font font) {
 	this.font = font;
 	long fontDesc;
 	if (font == null) {
-		fontDesc = defaultFont ().handle;
+		fontDesc = defaultFont ().handle.pointer;
 	} else {
 		if (font.isDisposed ()) error(SWT.ERROR_INVALID_ARGUMENT);
-		fontDesc = font.handle;
+		fontDesc = font.handle.pointer;
 	}
 	if (font == null) {
 		state &= ~FONT;

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/DateTime.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/DateTime.java
@@ -467,7 +467,7 @@ private void createHandleForDateWithDropDown () {
 
 		// In GTK 3 font description is inherited from parent widget which is not how SWT has always worked,
 		// reset to default font to get the usual behavior
-		setFontDescription(defaultFont().handle);
+		setFontDescription(defaultFont().handle.pointer);
 	}
 }
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/ExpandBar.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/ExpandBar.java
@@ -174,7 +174,7 @@ void createHandle (int index) {
 	gtk_container_set_border_width (handle, 0);
 	// In GTK 3 font description is inherited from parent widget which is not how SWT has always worked,
 	// reset to default font to get the usual behavior
-	setFontDescription(defaultFont().handle);
+	setFontDescription(defaultFont().handle.pointer);
 }
 
 void createItem (ExpandItem item, int style, int index) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/FontDialog.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/FontDialog.java
@@ -178,7 +178,7 @@ public FontData open () {
 	if (fontData != null) {
 		Font font = new Font(display, fontData);
 
-		long fontName = OS.pango_font_description_to_string(font.handle);
+		long fontName = font.handle.getFontName();
 		int length = C.strlen(fontName);
 		byte[] buffer = new byte[length + 1];
 		C.memmove(buffer, fontName, length);

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Group.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Group.java
@@ -213,7 +213,7 @@ void createHandle(int index) {
 
 	// In GTK 3 font description is inherited from parent widget which is not how SWT has always worked,
 	// reset to default font to get the usual behavior
-	setFontDescription (defaultFont ().handle);
+	setFontDescription (defaultFont ().handle.pointer);
 }
 
 @Override

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Label.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Label.java
@@ -313,7 +313,7 @@ void createHandle (int index) {
 	}
 	// In GTK 3 font description is inherited from parent widget which is not how SWT has always worked,
 	// reset to default font to get the usual behavior
-	setFontDescription(defaultFont ().handle);
+	setFontDescription(defaultFont ().handle.pointer);
 	setAlignment ();
 }
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/List.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/List.java
@@ -264,7 +264,7 @@ void createHandle (int index) {
 	}
 	// In GTK 3 font description is inherited from parent widget which is not how SWT has always worked,
 	// reset to default font to get the usual behavior
-	setFontDescription(defaultFont().handle);
+	setFontDescription(defaultFont().handle.pointer);
 }
 
 @Override

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Spinner.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Spinner.java
@@ -345,7 +345,7 @@ void createHandle (int index) {
 	imContext = OS.imContextLast();
 	// In GTK 3 font description is inherited from parent widget which is not how SWT has always worked,
 	// reset to default font to get the usual behavior
-	setFontDescription(defaultFont().handle);
+	setFontDescription(defaultFont().handle.pointer);
 }
 
 /**

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Table.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Table.java
@@ -927,7 +927,7 @@ void createWidget (int index) {
 	itemCount = columnCount = 0;
 	// In GTK 3 font description is inherited from parent widget which is not how SWT has always worked,
 	// reset to default font to get the usual behavior
-	setFontDescription(defaultFont().handle);
+	setFontDescription(defaultFont().handle.pointer);
 }
 
 @Override

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/TableItem.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/TableItem.java
@@ -980,7 +980,7 @@ public void setFont (Font font){
 	if (oldFont == font) return;
 	this.font = font;
 	if (oldFont != null && oldFont.equals (font)) return;
-	long fontHandle = font != null ? font.handle : 0;
+	long fontHandle = font != null ? font.handle.pointer : 0;
 	GTK.gtk_list_store_set (parent.modelHandle, handle, Table.FONT_COLUMN, fontHandle, -1);
 	cached = true;
 }
@@ -1021,7 +1021,7 @@ public void setFont (int index, Font font) {
 	if (oldFont != null && oldFont.equals (font)) return;
 
 	int modelIndex = parent.columnCount == 0 ? Table.FIRST_COLUMN : parent.columns [index].modelIndex;
-	long fontHandle  = font != null ? font.handle : 0;
+	long fontHandle  = font != null ? font.handle.pointer : 0;
 	GTK.gtk_list_store_set (parent.modelHandle, handle, modelIndex + Table.CELL_FONT, fontHandle, -1);
 	cached = true;
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Text.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Text.java
@@ -318,7 +318,7 @@ void createHandle (int index) {
 
 	// In GTK 3 font description is inherited from parent widget which is not how SWT has always worked,
 	// reset to default font to get the usual behavior
-	setFontDescription(defaultFont().handle);
+	setFontDescription(defaultFont().handle.pointer);
 }
 
 @Override

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/ToolBar.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/ToolBar.java
@@ -163,7 +163,7 @@ void createHandle (int index) {
 
 	// In GTK 3 font description is inherited from parent widget which is not how SWT has always worked,
 	// reset to default font to get the usual behavior
-	setFontDescription(defaultFont().handle);
+	setFontDescription(defaultFont().handle.pointer);
 }
 
 @Override

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Tree.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Tree.java
@@ -1156,7 +1156,7 @@ void createWidget (int index) {
 	columnCount = 0;
 	// In GTK 3 font description is inherited from parent widget which is not how SWT has always worked,
 	// reset to default font to get the usual behavior
-	setFontDescription(defaultFont().handle);
+	setFontDescription(defaultFont().handle.pointer);
 }
 
 @Override

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/TreeItem.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/TreeItem.java
@@ -1293,7 +1293,7 @@ public void setFont (Font font){
 	if (oldFont == font) return;
 	this.font = font;
 	if (oldFont != null && oldFont.equals (font)) return;
-	long fontHandle = font != null ? font.handle : 0;
+	long fontHandle = font != null ? font.handle.pointer : 0;
 	GTK.gtk_tree_store_set (parent.modelHandle, handle, Tree.FONT_COLUMN, fontHandle, -1);
 	cached = true;
 }
@@ -1334,7 +1334,7 @@ public void setFont (int index, Font font) {
 	if (oldFont != null && oldFont.equals (font)) return;
 
 	int modelIndex = parent.columnCount == 0 ? Tree.FIRST_COLUMN : parent.columns [index].modelIndex;
-	long fontHandle  = font != null ? font.handle : 0;
+	long fontHandle  = font != null ? font.handle.pointer : 0;
 	GTK.gtk_tree_store_set (parent.modelHandle, handle, modelIndex + Tree.CELL_FONT, fontHandle, -1);
 	cached = true;
 


### PR DESCRIPTION
# Current State

Currently handling fonts in SWT is hard and cumbersome, because one can't use the usual java techniques users are forced to either explicitly manage fonts (what maybe retain them longer as needed) or even create and dispose them for individual widgets (what hurts performance). This also leads to a lot of boilerplate code e.g. installing dispose handlers or having managed caches or local resource managers as well as requires documentation who 'owns' a font for example set on a label. Especially for newcommers or seldom users of SWT this is hard to get right and hinders them to use SWT correctly as java is usually managing objects automatically.

# What this changes

This now introduces the concept of [Cleaners added to Java 9+](https://docs.oracle.com/javase%2F9%2Fdocs%2Fapi%2F%2F/java/lang/ref/Cleaner.html) that allows automatic management of external resources that get automatically disposed when the JVM decides that an object is only phantom reachable and eligible for garbage collection.

I also used this to have a `Handle` act as a proxy to the native method calls so these are much more readable and the grouped together even related calls or required transformations to reduce code duplication.

# Further considerations

This itself is just meant as an initial starting point, we actually should extends this concept to any native resource handled by SWT (e.g. Images) so it become much more convenient for users to use these. I just choosing a font here as the only managed resource is a long pointer.

I also like to encourage users of other platforms (Win/Mac) to use this as a hint to prototype something similar like this as well so we can evaluate how it works out.

Also this will not replace `dispose()` or make it completely redundant as of course a user can always better dispose a resource directly if it is known that it is no longer in use. Also it might not be suitable for any "root objects" like a `Display` that is like a `Thread` in java some kind of UI root that always needs to be disposed explicitly.