### PR TITLE
Use smaller row heights on Mac if smallFonts specified

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/List.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/List.java
@@ -1182,7 +1182,8 @@ void setFont (NSFont font) {
 	super.setFont (font);
 	double ascent = font.ascender ();
 	double descent = -font.descender () + font.leading ();
-	((NSTableView)view).setRowHeight ((int)Math.ceil (ascent + descent) + VERTICAL_CELL_PADDING);
+	// If small fonts are set with -Dorg.eclipse.swt.internal.carbon.smallFonts then use smaller vertical padding
+	((NSTableView)view).setRowHeight ((int)Math.ceil (ascent + descent) + (display.smallFonts ? 1 : VERTICAL_CELL_PADDING));
 	setScrollWidth();
 }
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Table.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Table.java
@@ -2825,7 +2825,8 @@ void setItemHeight (Image image, NSFont font, boolean set) {
 	if (font == null) font = getFont ().handle;
 	double ascent = font.ascender ();
 	double descent = -font.descender () + font.leading ();
-	int height = (int)Math.ceil (ascent + descent) + VERTICAL_CELL_PADDING;
+	// If small fonts are set with -Dorg.eclipse.swt.internal.carbon.smallFonts then use smaller vertical padding
+    int height = (int)Math.ceil (ascent + descent) + (display.smallFonts ? 1 : VERTICAL_CELL_PADDING);
 	Rectangle bounds = image != null ? image.getBounds () : imageBounds;
 	if (bounds != null) {
 		imageBounds = bounds;

--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Tree.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Tree.java
@@ -3173,7 +3173,8 @@ void setItemHeight (Image image, NSFont font, boolean set) {
 	if (font == null) font = getFont ().handle;
 	double ascent = font.ascender ();
 	double descent = -font.descender () + font.leading ();
-	int height = (int)Math.ceil (ascent + descent) + VERTICAL_CELL_PADDING;
+	// If small fonts are set with -Dorg.eclipse.swt.internal.carbon.smallFonts then use smaller vertical padding
+	int height = (int)Math.ceil (ascent + descent) + (display.smallFonts ? 1 : VERTICAL_CELL_PADDING);
 	Rectangle bounds = image != null ? image.getBounds () : imageBounds;
 	if (bounds != null) {
 		imageBounds = bounds;


### PR DESCRIPTION
- If small fonts are set with -Dorg.eclipse.swt.internal.carbon.smallFonts then use smaller vertical padding
- This maintains backward compatibility
- See discussion at https://github.com/eclipse-platform/eclipse.platform.ui/issues/1674