### PR TITLE
Always vertical mouse wheel events are getting triggered even when horizontal mouse wheel events are generated.

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Scrollable.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Scrollable.java
@@ -374,7 +374,7 @@ LRESULT WM_VSCROLL (long wParam, long lParam) {
 }
 
 LRESULT wmScrollWheel (boolean update, long wParam, long lParam, boolean horzWheel) {
-	LRESULT result = super.WM_MOUSEWHEEL (wParam, lParam);
+	LRESULT result = horzWheel ? super.WM_MOUSEHWHEEL(wParam, lParam) : super.WM_MOUSEWHEEL(wParam, lParam);
 	if (result != null) return result;
 	/*
 	* Translate WM_MOUSEWHEEL and WM_MOUSEHWHEEL to WM_VSCROLL or WM_HSCROLL.


### PR DESCRIPTION
Horizontal mouse wheel event needs to be triggered when horizontal mouse wheel events are generated.

Fixes https://github.com/eclipse-platform/eclipse.platform.swt/issues/994

Can one of you review please
@merks
@niraj-modi
@sravanlakkimsetti