### PR TITLE
Add option for smaller item (row) height on Mac

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Display.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Display.java
@@ -166,6 +166,9 @@ public class Display extends Device implements Executor {
 	NSFont textViewFont, tableViewFont, outlineViewFont, datePickerFont;
 	NSFont boxFont, tabViewFont, progressIndicatorFont;
 
+	/* Option for smaller padding on table/tree/list item (row) height */
+	boolean smallItemHeight;
+
 	Shell [] modalShells;
 	Dialog modalDialog;
 	NSPanel modalPanel;
@@ -2403,6 +2406,12 @@ protected void init () {
 	initColors ();
 	initFonts ();
 	setDeviceZoom ();
+
+	/*
+	 * If this property exists then use smaller padding for item heights in Table, Tree and List controls
+	 * TODO: this is initialized here, could this be put in a better place? And use a better property name?
+	 */
+	smallItemHeight = System.getProperty("org.eclipse.swt.internal.cocoa.smallItemHeight") != null;
 
 	/*
 	 * Create an application delegate for app-level notifications.  The AWT may have already set a delegate;

--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Display.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Display.java
@@ -166,8 +166,8 @@ public class Display extends Device implements Executor {
 	NSFont textViewFont, tableViewFont, outlineViewFont, datePickerFont;
 	NSFont boxFont, tabViewFont, progressIndicatorFont;
 
-	/* Option for smaller padding on table/tree/list item (row) height */
-	boolean smallItemHeight;
+	/* Option for native table/tree/list item (row) height */
+	boolean enforceNativeItemHeightMinimum;
 
 	Shell [] modalShells;
 	Dialog modalDialog;
@@ -2408,10 +2408,9 @@ protected void init () {
 	setDeviceZoom ();
 
 	/*
-	 * If this property exists then use smaller padding for item heights in Table, Tree and List controls
-	 * TODO: this is initialized here, could this be put in a better place? And use a better property name?
+	 * If this property exists then enforce native item heights in Table, Tree and List controls
 	 */
-	smallItemHeight = System.getProperty("org.eclipse.swt.internal.cocoa.smallItemHeight") != null;
+	enforceNativeItemHeightMinimum = System.getProperty("org.eclipse.swt.internal.cocoa.enforceNativeItemHeightMinimum") != null;
 
 	/*
 	 * Create an application delegate for app-level notifications.  The AWT may have already set a delegate;

--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/List.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/List.java
@@ -46,12 +46,11 @@ public class List extends Scrollable {
 	int itemCount;
 	boolean ignoreSelect, didSelect, rowsChanged, mouseIsDown;
 
+	final int nativeItemHeight;
+
 	static int NEXT_ID;
 
 	static final int CELL_GAP = 1;
-
-	/* Vertical cell padding for list item */
-	static final int VERTICAL_CELL_PADDING= 8;
 
 /**
  * Constructs a new instance of this class given its parent
@@ -84,11 +83,8 @@ public class List extends Scrollable {
  */
 public List (Composite parent, int style) {
 	super (parent, checkStyle (style));
-
-    // Have to initialize item height here by calling setFont() in case option set for smaller item height
-	if(display.smallItemHeight) {
-		setFont((Font)null);
-	}
+	nativeItemHeight = (int)((NSTableView)view).rowHeight();
+	setFont((Font)null);
 }
 
 @Override
@@ -1187,8 +1183,11 @@ void setFont (NSFont font) {
 	super.setFont (font);
 	double ascent = font.ascender ();
 	double descent = -font.descender () + font.leading ();
-    // If small item height is set with option then use smaller vertical padding
-	((NSTableView)view).setRowHeight ((int)Math.ceil (ascent + descent) + (display.smallItemHeight ? 1 : VERTICAL_CELL_PADDING));
+    int height = (int)Math.ceil (ascent + descent) + 1;
+    if (display.enforceNativeItemHeightMinimum) {
+        height = Math.max (height, nativeItemHeight);
+    }
+    ((NSTableView)view).setRowHeight (height);
 	setScrollWidth();
 }
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/List.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/List.java
@@ -84,6 +84,11 @@ public class List extends Scrollable {
  */
 public List (Composite parent, int style) {
 	super (parent, checkStyle (style));
+
+    // Have to initialize item height here by calling setFont() in case option set for smaller item height
+	if(display.smallItemHeight) {
+		setFont((Font)null);
+	}
 }
 
 @Override
@@ -1182,7 +1187,8 @@ void setFont (NSFont font) {
 	super.setFont (font);
 	double ascent = font.ascender ();
 	double descent = -font.descender () + font.leading ();
-	((NSTableView)view).setRowHeight ((int)Math.ceil (ascent + descent) + VERTICAL_CELL_PADDING);
+    // If small item height is set with option then use smaller vertical padding
+	((NSTableView)view).setRowHeight ((int)Math.ceil (ascent + descent) + (display.smallItemHeight ? 1 : VERTICAL_CELL_PADDING));
 	setScrollWidth();
 }
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Table.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Table.java
@@ -132,6 +132,11 @@ public class Table extends Composite {
  */
 public Table (Composite parent, int style) {
 	super (parent, checkStyle (style));
+
+	// Have to initialize item height here in case option set for smaller item height
+	if(display.smallItemHeight) {
+		setItemHeight(null, null, true);
+	}
 }
 
 @Override
@@ -2825,7 +2830,8 @@ void setItemHeight (Image image, NSFont font, boolean set) {
 	if (font == null) font = getFont ().handle;
 	double ascent = font.ascender ();
 	double descent = -font.descender () + font.leading ();
-	int height = (int)Math.ceil (ascent + descent) + VERTICAL_CELL_PADDING;
+    // If small item height is set with option then use smaller vertical padding
+    int height = (int)Math.ceil (ascent + descent) + (display.smallItemHeight ? 1 : VERTICAL_CELL_PADDING);
 	Rectangle bounds = image != null ? image.getBounds () : imageBounds;
 	if (bounds != null) {
 		imageBounds = bounds;

--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Table.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Table.java
@@ -86,15 +86,14 @@ public class Table extends Composite {
 	boolean shouldScroll = true;
 	boolean keyDown;
 
+	final int nativeItemHeight;
+
 	static int NEXT_ID;
 
 	static final int FIRST_COLUMN_MINIMUM_WIDTH = 5;
 	static final int IMAGE_GAP = 3;
 	static final int TEXT_GAP = 2;
 	static final int CELL_GAP = 1;
-
-	/* Vertical cell padding for table item */
-	static final int VERTICAL_CELL_PADDING= 8;
 
 /**
  * Constructs a new instance of this class given its parent
@@ -132,11 +131,8 @@ public class Table extends Composite {
  */
 public Table (Composite parent, int style) {
 	super (parent, checkStyle (style));
-
-	// Have to initialize item height here in case option set for smaller item height
-	if(display.smallItemHeight) {
-		setItemHeight(null, null, true);
-	}
+	nativeItemHeight = (int)((NSTableView)view).rowHeight();
+	setItemHeight(null, null, true);
 }
 
 @Override
@@ -2830,8 +2826,11 @@ void setItemHeight (Image image, NSFont font, boolean set) {
 	if (font == null) font = getFont ().handle;
 	double ascent = font.ascender ();
 	double descent = -font.descender () + font.leading ();
-    // If small item height is set with option then use smaller vertical padding
-    int height = (int)Math.ceil (ascent + descent) + (display.smallItemHeight ? 1 : VERTICAL_CELL_PADDING);
+    int height = (int)Math.ceil (ascent + descent) + 1;
+    if(display.enforceNativeItemHeightMinimum) {
+        height = Math.max (height, nativeItemHeight);
+    }
+
 	Rectangle bounds = image != null ? image.getBounds () : imageBounds;
 	if (bounds != null) {
 		imageBounds = bounds;

--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Tree.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Tree.java
@@ -97,6 +97,8 @@ public class Tree extends Composite {
 	/* Used to control drop feedback when DND.FEEDBACK_EXPAND and DND.FEEDBACK_SCROLL is set/not set */
 	boolean shouldExpand = true, shouldScroll = true;
 
+	final int nativeItemHeight;
+
 	static int NEXT_ID;
 
 	/*
@@ -108,9 +110,6 @@ public class Tree extends Composite {
 	static final int IMAGE_GAP = 3;
 	static final int TEXT_GAP = 2;
 	static final int CELL_GAP = 1;
-
-	/* Vertical cell padding for tree item */
-	static final int VERTICAL_CELL_PADDING= 8;
 
 /**
  * Constructs a new instance of this class given its parent
@@ -147,11 +146,8 @@ public class Tree extends Composite {
  */
 public Tree (Composite parent, int style) {
 	super (parent, checkStyle (style));
-
-	// Have to initialize item height here in case option set for smaller item height
-	if(display.smallItemHeight) {
-		setItemHeight(null, null, true);
-	}
+	nativeItemHeight = (int)((NSTableView)view).rowHeight();
+	setItemHeight(null, null, true);
 }
 
 @Override
@@ -3178,8 +3174,10 @@ void setItemHeight (Image image, NSFont font, boolean set) {
 	if (font == null) font = getFont ().handle;
 	double ascent = font.ascender ();
 	double descent = -font.descender () + font.leading ();
-	// If small item height is set with option then use smaller vertical padding
-	int height = (int)Math.ceil (ascent + descent) + (display.smallItemHeight ? 1 : VERTICAL_CELL_PADDING);
+	int height = (int)Math.ceil (ascent + descent) + 1;
+	if(display.enforceNativeItemHeightMinimum) {
+        height = Math.max (height, nativeItemHeight);
+    }
 	Rectangle bounds = image != null ? image.getBounds () : imageBounds;
 	if (bounds != null) {
 		imageBounds = bounds;

--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Tree.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Tree.java
@@ -147,6 +147,11 @@ public class Tree extends Composite {
  */
 public Tree (Composite parent, int style) {
 	super (parent, checkStyle (style));
+
+	// Have to initialize item height here in case option set for smaller item height
+	if(display.smallItemHeight) {
+		setItemHeight(null, null, true);
+	}
 }
 
 @Override
@@ -3173,7 +3178,8 @@ void setItemHeight (Image image, NSFont font, boolean set) {
 	if (font == null) font = getFont ().handle;
 	double ascent = font.ascender ();
 	double descent = -font.descender () + font.leading ();
-	int height = (int)Math.ceil (ascent + descent) + VERTICAL_CELL_PADDING;
+	// If small item height is set with option then use smaller vertical padding
+	int height = (int)Math.ceil (ascent + descent) + (display.smallItemHeight ? 1 : VERTICAL_CELL_PADDING);
 	Rectangle bounds = image != null ? image.getBounds () : imageBounds;
 	if (bounds != null) {
 		imageBounds = bounds;


### PR DESCRIPTION
- This is POC
- Set property -Dorg.eclipse.swt.internal.cocoa.smallItemHeight
- Need to set the initial item height in the constructors of List, Table and Tree
- See discussion at https://github.com/eclipse-platform/eclipse.platform.ui/issues/1674