### PR TITLE
Rescaling of widgets on DPI zoom changes for basic controls (win32)

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT PI/win32/library/os.c
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/win32/library/os.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2022 IBM Corporation and others.
+ * Copyright (c) 2000, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -3254,6 +3254,18 @@ JNIEXPORT jint JNICALL OS_NATIVE(GetSystemMetrics)
 	OS_NATIVE_ENTER(env, that, GetSystemMetrics_FUNC);
 	rc = (jint)GetSystemMetrics(arg0);
 	OS_NATIVE_EXIT(env, that, GetSystemMetrics_FUNC);
+	return rc;
+}
+#endif
+
+#ifndef NO_GetSystemMetricsForDpi
+JNIEXPORT jint JNICALL OS_NATIVE(GetSystemMetricsForDpi)
+	(JNIEnv *env, jclass that, jint arg0, jint arg1)
+{
+	jint rc = 0;
+	OS_NATIVE_ENTER(env, that, GetSystemMetricsForDpi_FUNC);
+	rc = (jint)GetSystemMetricsForDpi(arg0, arg1);
+	OS_NATIVE_EXIT(env, that, GetSystemMetricsForDpi_FUNC);
 	return rc;
 }
 #endif

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/win32/library/os.c
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/win32/library/os.c
@@ -9128,6 +9128,22 @@ fail:
 }
 #endif
 
+#ifndef NO_SystemParametersInfoForDpi
+JNIEXPORT jboolean JNICALL OS_NATIVE(SystemParametersInfoForDpi)
+	(JNIEnv *env, jclass that, jint arg0, jint arg1, jobject arg2, jint arg3, jint arg4)
+{
+	NONCLIENTMETRICS _arg2, *lparg2=NULL;
+	jboolean rc = 0;
+	OS_NATIVE_ENTER(env, that, SystemParametersInfoForDpi_FUNC);
+	if (arg2) if ((lparg2 = getNONCLIENTMETRICSFields(env, arg2, &_arg2)) == NULL) goto fail;
+	rc = (jboolean)SystemParametersInfoForDpi(arg0, arg1, lparg2, arg3, arg4);
+fail:
+	if (arg2 && lparg2) setNONCLIENTMETRICSFields(env, arg2, lparg2);
+	OS_NATIVE_EXIT(env, that, SystemParametersInfoForDpi_FUNC);
+	return rc;
+}
+#endif
+
 #ifndef NO_TBBUTTONINFO_1sizeof
 JNIEXPORT jint JNICALL OS_NATIVE(TBBUTTONINFO_1sizeof)
 	(JNIEnv *env, jclass that)

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/win32/library/os_stats.h
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/win32/library/os_stats.h
@@ -680,6 +680,7 @@ typedef enum {
 	SystemParametersInfo__IILorg_eclipse_swt_internal_win32_NONCLIENTMETRICS_2I_FUNC,
 	SystemParametersInfo__IILorg_eclipse_swt_internal_win32_RECT_2I_FUNC,
 	SystemParametersInfo__II_3II_FUNC,
+	SystemParametersInfoForDpi_FUNC,
 	TBBUTTONINFO_1sizeof_FUNC,
 	TBBUTTON_1sizeof_FUNC,
 	TCHITTESTINFO_1sizeof_FUNC,

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/win32/library/os_stats.h
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/win32/library/os_stats.h
@@ -257,6 +257,7 @@ typedef enum {
 	GetSysColorBrush_FUNC,
 	GetSystemMenu_FUNC,
 	GetSystemMetrics_FUNC,
+	GetSystemMetricsForDpi_FUNC,
 	GetTextColor_FUNC,
 	GetTextExtentPoint32_FUNC,
 	GetTextMetrics_FUNC,

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/win32/org/eclipse/swt/internal/win32/OS.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/win32/org/eclipse/swt/internal/win32/OS.java
@@ -39,6 +39,7 @@ public class OS extends C {
 	/**
 	 * Values taken from https://en.wikipedia.org/wiki/List_of_Microsoft_Windows_versions
 	 */
+	public static final int WIN32_BUILD_WIN10_1607 = 14393; // "Windows 10 August 2016 Update"
 	public static final int WIN32_BUILD_WIN10_1809 = 17763; // "Windows 10 October 2018 Update"
 	public static final int WIN32_BUILD_WIN10_2004 = 19041; // "Windows 10 May 2020 Update"
 	public static final int WIN32_BUILD_WIN11_21H2 = 22000; // Initial Windows 11 release
@@ -4436,6 +4437,7 @@ public static final native boolean SystemParametersInfo (int uiAction, int uiPar
 public static final native boolean SystemParametersInfo (int uiAction, int uiParam, RECT pvParam, int fWinIni);
 public static final native boolean SystemParametersInfo (int uiAction, int uiParam, NONCLIENTMETRICS pvParam, int fWinIni);
 public static final native boolean SystemParametersInfo (int uiAction, int uiParam, int [] pvParam, int fWinIni);
+public static final native boolean SystemParametersInfoForDpi (int uiAction, int uiParam, NONCLIENTMETRICS pvParam, int fWinIni, int dpi);
 /**
  * @param lpKeyState cast=(PBYTE)
  * @param pwszBuff cast=(LPWSTR)

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/win32/org/eclipse/swt/internal/win32/OS.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/win32/org/eclipse/swt/internal/win32/OS.java
@@ -2976,6 +2976,7 @@ public static final native long GetSysColorBrush (int nIndex);
 /** @param hWnd cast=(HWND) */
 public static final native long GetSystemMenu (long hWnd, boolean bRevert);
 public static final native int GetSystemMetrics (int nIndex);
+public static final native int GetSystemMetricsForDpi (int nIndex, int dpi);
 /** @param hDC cast=(HDC) */
 public static final native int GetTextColor (long hDC);
 /**

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/DPIUtil.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/DPIUtil.java
@@ -280,7 +280,7 @@ private static ImageData autoScaleImageData (Device device, final ImageData imag
  * Returns a new rectangle as per the scaleFactor.
  */
 public static Rectangle autoScaleBounds (Rectangle rect, int targetZoom, int currentZoom) {
-	if (deviceZoom == 100 || rect == null || targetZoom == currentZoom) return rect;
+	if (rect == null || targetZoom == currentZoom) return rect;
 	float scaleFactor = ((float)targetZoom) / (float)currentZoom;
 	Rectangle returnRect = new Rectangle (0,0,0,0);
 	returnRect.x = Math.round (rect.x * scaleFactor);

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/DPIUtil.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/DPIUtil.java
@@ -241,6 +241,11 @@ public static ImageData autoScaleImageData (Device device, final ImageData image
 	return autoScaleImageData(device, imageData, scaleFactor);
 }
 
+
+public static ImageData autoScaleImageData (Device device, final ElementAtZoom<ImageData> elementAtZoom, int targetZoom) {
+	return autoScaleImageData(device, elementAtZoom.element(), targetZoom, elementAtZoom.zoom());
+}
+
 private static ImageData autoScaleImageData (Device device, final ImageData imageData, float scaleFactor) {
 	// Guards are already implemented in callers: if (deviceZoom == 100 || imageData == null || scaleFactor == 1.0f) return imageData;
 	int width = imageData.width;
@@ -301,6 +306,10 @@ public static ImageData autoScaleUp (Device device, final ImageData imageData) {
 	return autoScaleImageData(device, imageData, 100);
 }
 
+public static ImageData autoScaleUp (Device device, final ElementAtZoom<ImageData> elementAtZoom) {
+	return autoScaleImageData(device, elementAtZoom.element(), elementAtZoom.zoom());
+}
+
 public static int[] autoScaleUp(int[] pointArray) {
 	if (deviceZoom == 100 || pointArray == null) return pointArray;
 	float scaleFactor = getScalingFactor ();
@@ -322,6 +331,14 @@ public static int[] autoScaleUp(Drawable drawable, int[] pointArray) {
 public static int autoScaleUp (int size) {
 	if (deviceZoom == 100 || size == SWT.DEFAULT) return size;
 	float scaleFactor = getScalingFactor ();
+	return Math.round (size * scaleFactor);
+}
+
+/**
+ * Auto-scale up int dimensions to match the given zoom level
+ */
+public static int autoScaleUp (int size, int zoom) {
+	float scaleFactor = getScalingFactor (zoom);
 	return Math.round (size * scaleFactor);
 }
 
@@ -402,10 +419,18 @@ public static Rectangle autoScaleUp (Drawable drawable, Rectangle rect) {
  * @return float scaling factor
  */
 private static float getScalingFactor () {
+	return getScalingFactor(deviceZoom);
+}
+
+/**
+ * Returns scaling factor from the given device zoom
+ * @return float scaling factor
+ */
+private static float getScalingFactor (int shellDeviceZoom) {
 	if (useCairoAutoScale) {
 		return 1;
 	}
-	return deviceZoom / 100f;
+	return shellDeviceZoom / 100f;
 }
 
 /**
@@ -422,12 +447,12 @@ public static int mapDPIToZoom (int dpi) {
 /**
  * Compute the DPI value value based on the zoom.
  *
- * @return zoom
+ * @return DPI
  */
-public static int mapZoomToDPI (int dpi) {
-	double zoom = (double) dpi / 100 * DPI_ZOOM_100;
-	int roundedZoom = (int) Math.round (zoom);
-	return roundedZoom;
+public static int mapZoomToDPI (int zoom) {
+	double dpi = (double) zoom / 100 * DPI_ZOOM_100;
+	int roundedDpi = (int) Math.round (dpi);
+	return roundedDpi;
 }
 
 /**

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/DPIUtil.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/DPIUtil.java
@@ -420,6 +420,17 @@ public static int mapDPIToZoom (int dpi) {
 }
 
 /**
+ * Compute the DPI value value based on the zoom.
+ *
+ * @return zoom
+ */
+public static int mapZoomToDPI (int dpi) {
+	double zoom = (double) dpi / 100 * DPI_ZOOM_100;
+	int roundedZoom = (int) Math.round (zoom);
+	return roundedZoom;
+}
+
+/**
  * Represents an element, such as some image data, at a specific zoom level.
  *
  * @param <T> type of the element to be presented, e.g., {@link ImageData}
@@ -491,6 +502,10 @@ private static <T> ElementAtZoom<T> getElementAtZoom(Function<Integer, T> elemen
 		}
 	}
 	return null;
+}
+
+public static int getNativeDeviceZoom() {
+	return nativeDeviceZoom;
 }
 
 public static int getDeviceZoom() {

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/DPIUtil.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/DPIUtil.java
@@ -44,6 +44,7 @@ public class DPIUtil {
 	private static enum AutoScaleMethod { AUTO, NEAREST, SMOOTH }
 	private static AutoScaleMethod autoScaleMethodSetting = AutoScaleMethod.AUTO;
 	private static AutoScaleMethod autoScaleMethod = AutoScaleMethod.NEAREST;
+	private static boolean autoScaleOnRuntime = false;
 
 	private static String autoScaleValue;
 	private static boolean useCairoAutoScale = false;
@@ -84,6 +85,16 @@ public class DPIUtil {
 	 * <a href="https://bugs.eclipse.org/493455">bug 493455</a>.
 	 */
 	private static final String SWT_AUTOSCALE_METHOD = "swt.autoScale.method";
+
+	/**
+	 * System property to enable to scale the applicaiton on runtime
+	 * when a DPI change is detected.
+	 * <ul>
+	 * <li>"true": the application is scaled on DPI changes</li>
+	 * <li>"false": the application will remain in its initial scaling</li>
+	 * </ul>
+	 */
+	private static final String SWT_AUTOSCALE_UPDATE_ON_RUNTIME = "swt.autoScale.updateOnRuntime";
 	static {
 		autoScaleValue = System.getProperty (SWT_AUTOSCALE);
 
@@ -95,6 +106,9 @@ public class DPIUtil {
 				autoScaleMethod = autoScaleMethodSetting = AutoScaleMethod.SMOOTH;
 			}
 		}
+
+		String updateOnRuntimeValue = System.getProperty (SWT_AUTOSCALE_UPDATE_ON_RUNTIME);
+		autoScaleOnRuntime = Boolean.parseBoolean(updateOnRuntimeValue);
 	}
 
 /**
@@ -533,6 +547,10 @@ public static int getZoomForAutoscaleProperty (int nativeDeviceZoom) {
 		zoom = Math.max ((nativeDeviceZoom + 25) / 100 * 100, 100);
 	}
 	return zoom;
+}
+
+public static boolean isAutoScaleOnRuntimeActive() {
+	return autoScaleOnRuntime;
 }
 
 /**

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/GC.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/GC.java
@@ -980,7 +980,7 @@ public void drawImage (Image image, int srcX, int srcY, int srcWidth, int srcHei
 		 * the coordinates may be slightly off. The workaround is to restrict
 		 * coordinates to the allowed bounds.
 		 */
-		Rectangle b = image.getBoundsInPixels();
+		Rectangle b = image.getBounds(deviceZoom);
 		int errX = src.x + src.width - b.width;
 		int errY = src.y + src.height - b.height;
 		if (errX != 0 || errY != 0) {
@@ -996,8 +996,7 @@ public void drawImage (Image image, int srcX, int srcY, int srcWidth, int srcHei
 
 void drawImage(Image srcImage, int srcX, int srcY, int srcWidth, int srcHeight, int destX, int destY, int destWidth, int destHeight, boolean simple) {
 	/* Refresh Image as per zoom level, if required. */
-	srcImage.refreshImageForZoom ();
-
+	srcImage.handleDPIChange(DPIUtil.getDeviceZoom());
 	if (data.gdipGraphics != 0) {
 		//TODO - cache bitmap
 		long [] gdipImage = srcImage.createGdipImage();
@@ -4387,7 +4386,7 @@ public void setFillRule(int rule) {
 public void setFont (Font font) {
 	if (handle == 0) SWT.error(SWT.ERROR_GRAPHIC_DISPOSED);
 	if (font != null && font.isDisposed()) SWT.error(SWT.ERROR_INVALID_ARGUMENT);
-	data.font = font != null ? font : data.device.systemFont;
+	data.font = font != null ? Font.win32_new(font, DPIUtil.getNativeDeviceZoom()) : data.device.systemFont;
 	data.state &= ~FONT;
 }
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/CommonWidgetsDPIChangeHandlers.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/CommonWidgetsDPIChangeHandlers.java
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Yatta Solutions and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Yatta Solutions - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.swt.internal;
+
+import org.eclipse.swt.graphics.*;
+import org.eclipse.swt.widgets.*;
+
+/**
+ * This class is used in the win32 implementation only to support
+ * adjusting widgets in the common package to DPI changes
+ * <p>
+ * <b>IMPORTANT:</b> This class is <em>not</em> part of the public
+ * API for SWT. It is marked public only so that it can be shared
+ * within the packages provided by SWT. It is not available on all
+ * platforms, and should never be called from application code.
+ * </p>
+ * @noreference This class is not intended to be referenced by clients
+ */
+public class CommonWidgetsDPIChangeHandlers {
+
+	public static void registerCommonHandlers() {
+		DPIZoomChangeRegistry.registerHandler(CommonWidgetsDPIChangeHandlers::handleItemDPIChange, Item.class);
+	}
+
+	private static void handleItemDPIChange(Widget widget, int newZoom, float scalingFactor) {
+		if (!(widget instanceof Item item)) {
+			return;
+		}
+		// Refresh the image
+		Image image = item.getImage();
+		if (image != null) {
+			item.setImage(Image.win32_new(image, newZoom));
+		}
+	}
+}

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/DPIZoomChangeHandler.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/DPIZoomChangeHandler.java
@@ -1,0 +1,21 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Yatta Solutions and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Yatta Solutions - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.swt.internal;
+
+import org.eclipse.swt.widgets.*;
+
+@FunctionalInterface
+public interface DPIZoomChangeHandler {
+	public void handleDPIChange(Widget widget, int newZoom, float scalingFactor);
+}

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/DPIZoomChangeRegistry.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/DPIZoomChangeRegistry.java
@@ -1,0 +1,59 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Yatta Solutions and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Yatta Solutions - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.swt.internal;
+
+import java.util.*;
+import java.util.Map.*;
+
+import org.eclipse.swt.widgets.*;
+
+public class DPIZoomChangeRegistry {
+
+	private static Map<Class<? extends Widget>, DPIZoomChangeHandler> dpiZoomChangeHandlers =  new TreeMap<>(
+			(o1, o2) -> {
+	            if(o1.isAssignableFrom(o2)) {
+	            	return -1;
+	            }
+	            if(o2.isAssignableFrom(o1)) {
+	            	return 1;
+	            }
+	            return o1.getName().compareTo(o2.getName());
+	        });
+
+	/**
+	 * Calling this method will propagate the zoom change to all registered handlers that are responsible for the
+	 * class of the provided widget or one of its super classes or interfaces. Usually there will be multiple handlers
+	 * called per widget. To have a reliable and consistent execution order, the handler responsible for the most
+	 * general class in the class hierarchy is called first, e.g. if a {@code Composite} is updated, the handlers are
+	 * executed like ({@code Widget} -> {@code Control} -> {@code Scrollable} -> {@code Composite}). Each handler
+	 * should only take care to update the attributes the class, it is registered for, adds to the hierarchy.
+	 *
+	 * @param widget widget the zoom change shall be applied to
+	 * @param newZoom zoom in % of the standard resolution to be applied to the widget
+	 * @param scalingFactor factor as division between new zoom and old zoom, e.g. 1.5 for a scaling from 100% to 150%
+	 */
+	public static void applyChange(Widget widget, int newZoom, float scalingFactor) {
+		for (Entry<Class<? extends Widget>, DPIZoomChangeHandler> entry : dpiZoomChangeHandlers.entrySet()) {
+			Class<? extends Widget> clazz = entry.getKey();
+			DPIZoomChangeHandler handler = entry.getValue();
+			if (clazz.isInstance(widget)) {
+				handler.handleDPIChange(widget, newZoom, scalingFactor);
+			}
+		}
+	}
+
+	public static void registerHandler(DPIZoomChangeHandler zoomChangeVisitor, Class<? extends Widget> clazzToRegisterFor) {
+		dpiZoomChangeHandlers.put(clazzToRegisterFor, zoomChangeVisitor);
+	}
+}

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/DefaultSWTFontRegistry.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/DefaultSWTFontRegistry.java
@@ -1,0 +1,89 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Yatta Solutions
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Yatta Solutions - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.swt.internal;
+
+import java.util.*;
+
+import org.eclipse.swt.graphics.*;
+import org.eclipse.swt.internal.win32.*;
+
+/**
+ * This class is used in the win32 implementation only to support
+ * unscaled fonts in multiple DPI zoom levels.
+ *
+ * As this class is only intended to be used internally via {@code SWTFontProvider},
+ * it should neither be instantiated nor referenced in a client application.
+ * The behavior can change any time in a future release.
+ *
+ * @noreference This class is not intended to be referenced by clients.
+ * @noinstantiate This class is not intended to be instantiated by clients.
+ */
+public final class DefaultSWTFontRegistry implements SWTFontRegistry {
+	private static FontData KEY_SYSTEM_FONTS = new FontData();
+	private Map<FontData, Font> fontsMap = new HashMap<>();
+	private Device device;
+
+	public DefaultSWTFontRegistry(Device device) {
+		this.device = device;
+	}
+
+	@Override
+	public Font getSystemFont(int zoom) {
+		if (fontsMap.containsKey(KEY_SYSTEM_FONTS)) {
+			return fontsMap.get(KEY_SYSTEM_FONTS);
+		}
+
+		long hFont = 0;
+		NONCLIENTMETRICS info = new NONCLIENTMETRICS ();
+		info.cbSize = NONCLIENTMETRICS.sizeof;
+		if (OS.SystemParametersInfo (OS.SPI_GETNONCLIENTMETRICS, 0, info, 0)) {
+			hFont = OS.CreateFontIndirect (info.lfMessageFont);
+		}
+		if (hFont == 0) hFont = OS.GetStockObject (OS.DEFAULT_GUI_FONT);
+		if (hFont == 0) hFont = OS.GetStockObject (OS.SYSTEM_FONT);
+		Font font = Font.win32_new(device, hFont);
+		registerFont(KEY_SYSTEM_FONTS, font);
+		return font;
+	}
+
+	@Override
+	public Font getFont(FontData fontData, int zoom) {
+		if (fontsMap.containsKey(fontData)) {
+			Font font = fontsMap.get(fontData);
+			if (font.isDisposed()) {
+				// Remove disposed cached fonts
+				fontsMap.remove(fontData);
+			} else {
+				return font;
+			}
+		}
+		Font font = new Font(device, fontData);
+		registerFont(fontData, font);
+		return font;
+	}
+
+	private Font registerFont(FontData fontData, Font font) {
+		fontsMap.put(fontData, font);
+		return font;
+	}
+
+	@Override
+	public void dispose() {
+		for (Font font : fontsMap.values()) {
+			if (font != null) {
+				font.dispose();
+			}
+		}
+	}
+}

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/ImageList.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/ImageList.java
@@ -46,7 +46,7 @@ public int add (Image image) {
 		index++;
 	}
 	if (count == 0) {
-		Rectangle rect = image.getBoundsInPixels ();
+		Rectangle rect = image.getBoundsInPixels();
 		OS.ImageList_SetIconSize (handle, rect.width, rect.height);
 	}
 	set (index, image, count);
@@ -369,7 +369,7 @@ void set (int index, Image image, int count) {
 			* Note that the image size has to match the image list icon size.
 			*/
 			long hBitmap = 0, hMask = 0;
-			ImageData data = image.getImageData (DPIUtil.getDeviceZoom ());
+			ImageData data = image.getImageDataAtCurrentZoom();
 			switch (data.getTransparencyType ()) {
 				case SWT.TRANSPARENCY_ALPHA:
 					/*

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/SWTFontProvider.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/SWTFontProvider.java
@@ -1,0 +1,55 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Yatta Solutions and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Yatta Solutions - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.swt.internal;
+
+import java.util.*;
+
+import org.eclipse.swt.graphics.*;
+
+/**
+ * This internal class is used to provide and cache fonts scaled for different zoom levels in the win32
+ * implementation. Depending on the configuration of the SWT application, either a default behavior or
+ * the scaling behavior is used. The default behavior mimics the existing behavior that fonts are scaled
+ * to the zoom of the primary monitor and are not updated on runtime. The scaling behavior will always
+ * take the provided values for the zoom into consideration and return scaled variant of a font if necessary.
+ */
+public class SWTFontProvider {
+	private static Map<Device, SWTFontRegistry> fontRegistries = new HashMap<>();
+
+	private static SWTFontRegistry getFontRegistry(Device device) {
+		return fontRegistries.computeIfAbsent(device, SWTFontProvider::newFontRegistry);
+	}
+
+	public static Font getSystemFont(Device device, int zoom) {
+		return getFontRegistry(device).getSystemFont(zoom);
+	}
+
+	public static Font getFont(Device device, FontData fontData, int zoom) {
+		return getFontRegistry(device).getFont(fontData, zoom);
+	}
+
+	public static void disposeFontRegistry(Device device) {
+		SWTFontRegistry fontRegistry = fontRegistries.remove(device);
+		if (fontRegistry != null) {
+			fontRegistry.dispose();
+		}
+	}
+
+	private static SWTFontRegistry newFontRegistry(Device device) {
+		if (DPIUtil.isAutoScaleOnRuntimeActive()) {
+			return new ScalingSWTFontRegistry(device);
+		}
+		return new DefaultSWTFontRegistry(device);
+	}
+}

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/SWTFontRegistry.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/SWTFontRegistry.java
@@ -1,0 +1,53 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Yatta Solutions and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Yatta Solutions - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.swt.internal;
+
+import org.eclipse.swt.graphics.*;
+
+/**
+ * This class is used in the win32 implementation only to support
+ * re-usage of fonts.
+ * <p>
+ * <b>IMPORTANT:</b> This class is <em>not</em> part of the public
+ * API for SWT. It is marked public only so that it can be shared
+ * within the packages provided by SWT. It is not available on all
+ * platforms, and should never be called from application code.
+ * </p>
+ * @noreference This class is not intended to be referenced by clients
+ */
+public interface SWTFontRegistry {
+
+	/**
+	 * Returns a system font optimally suited for the specified zoom.
+	 *
+	 * @param zoom zoom in % of the standard resolution to determine the appropriate system font
+	 * @return the system font best suited for the specified zoom
+	 */
+	Font getSystemFont(int zoom);
+
+	/**
+	 * Provides a font optimally suited for the specified zoom. Fonts created in this manner
+	 * are managed by the font registry and should not be disposed of externally.
+	 *
+	 * @param fontData the data used to create the font
+	 * @param zoom zoom in % of the standard resolution to determine the appropriate font
+	 * @return the font best suited for the specified zoom
+	 */
+	Font getFont(FontData fontData, int zoom);
+
+	/**
+	 * Disposes all fonts managed by the font registry.
+	 */
+	void dispose();
+}

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/ScalingSWTFontRegistry.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/ScalingSWTFontRegistry.java
@@ -1,0 +1,191 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Yatta Solutions
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Yatta Solutions - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.swt.internal;
+
+import java.util.*;
+import java.util.Map.*;
+
+import org.eclipse.swt.graphics.*;
+import org.eclipse.swt.internal.win32.*;
+
+/**
+ * This class is used in the win32 implementation only to support
+ * scaling of fonts in multiple DPI zoom levels.
+ *
+ * As this class is only intended to be used internally via {@code SWTFontProvider},
+ * it should neither be instantiated nor referenced in a client application.
+ * The behavior can change any time in a future release.
+ *
+ * @noreference This class is not intended to be referenced by clients.
+ * @noinstantiate This class is not intended to be instantiated by clients.
+ */
+public final class ScalingSWTFontRegistry implements SWTFontRegistry {
+	private class ScaledFontContainer {
+		// the first (unknown) font to be requested as scaled variant
+		// usually it is scaled to the primary monitor zoom, but that is not guaranteed
+		private Font baseFont;
+		private Map<Integer, Font> scaledFonts = new HashMap<>();
+
+		ScaledFontContainer(Font baseFont, int fontZoom) {
+			this.baseFont = baseFont;
+			scaledFonts.put(fontZoom, baseFont);
+		}
+
+		private Font getScaledFont(int targetZoom) {
+			if (scaledFonts.containsKey(targetZoom)) {
+				Font font = scaledFonts.get(targetZoom);
+				if (font.isDisposed()) {
+					scaledFonts.remove(targetZoom);
+					return null;
+				}
+				return font;
+			}
+			return null;
+		}
+
+		private Font scaleFont(int zoom) {
+			FontData fontData = baseFont.getFontData()[0];
+			fontData.data.lfHeight = computePixels(zoom, fontData);
+			Font scaledFont = Font.win32_new(device, fontData, zoom);
+			addScaledFont(zoom, scaledFont);
+			return scaledFont;
+		}
+
+		private void addScaledFont(int targetZoom, Font scaledFont) {
+			scaledFonts.put(targetZoom, scaledFont);
+		}
+	}
+
+	private static FontData KEY_SYSTEM_FONTS = new FontData();
+	private Map<Long, ScaledFontContainer> fontHandleMap = new HashMap<>();
+	private Map<FontData, ScaledFontContainer> fontKeyMap = new HashMap<>();
+	private Device device;
+
+	public ScalingSWTFontRegistry(Device device) {
+		this.device = device;
+	}
+
+	@Override
+	public Font getSystemFont(int zoom) {
+		ScaledFontContainer container = getOrCreateBaseSystemFontContainer(device);
+
+		Font systemFont = container.getScaledFont(zoom);
+		if (systemFont != null) {
+			return systemFont;
+		}
+		long systemFontHandle = createSystemFont(zoom);
+		systemFont = Font.win32_new(device, systemFontHandle, zoom);
+		container.addScaledFont(zoom, systemFont);
+		return systemFont;
+	}
+
+	private ScaledFontContainer getOrCreateBaseSystemFontContainer(Device device) {
+		ScaledFontContainer systemFontContainer = fontKeyMap.get(KEY_SYSTEM_FONTS);
+		if (systemFontContainer == null) {
+			int targetZoom = DPIUtil.mapDPIToZoom(device.getDPI().x);
+			long systemFontHandle = createSystemFont(targetZoom);
+			Font systemFont = Font.win32_new(device, systemFontHandle);
+			systemFontContainer = new ScaledFontContainer(systemFont, targetZoom);
+			fontHandleMap.put(systemFont.handle, systemFontContainer);
+			fontKeyMap.put(KEY_SYSTEM_FONTS, systemFontContainer);
+		}
+		return systemFontContainer;
+	}
+
+	private long createSystemFont(int targetZoom) {
+		long hFont = 0;
+		NONCLIENTMETRICS info = new NONCLIENTMETRICS();
+		info.cbSize = NONCLIENTMETRICS.sizeof;
+		if (fetchSystemParametersInfo(info, targetZoom)) {
+			LOGFONT logFont = info.lfMessageFont;
+			hFont = OS.CreateFontIndirect(logFont);
+		}
+		if (hFont == 0)
+			hFont = OS.GetStockObject(OS.DEFAULT_GUI_FONT);
+		if (hFont == 0)
+			hFont = OS.GetStockObject(OS.SYSTEM_FONT);
+		return hFont;
+	}
+
+	private static boolean fetchSystemParametersInfo(NONCLIENTMETRICS info, int targetZoom) {
+		if (OS.WIN32_BUILD >= OS.WIN32_BUILD_WIN10_1607) {
+			return OS.SystemParametersInfoForDpi(OS.SPI_GETNONCLIENTMETRICS, NONCLIENTMETRICS.sizeof, info, 0,
+					DPIUtil.mapZoomToDPI(targetZoom));
+		} else {
+			return OS.SystemParametersInfo(OS.SPI_GETNONCLIENTMETRICS, 0, info, 0);
+		}
+	}
+
+	@Override
+	public Font getFont(FontData fontData, int zoom) {
+		ScaledFontContainer container;
+		if (fontKeyMap.containsKey(fontData)) {
+			container = fontKeyMap.get(fontData);
+		} else {
+			int calculatedZoom = computeZoom(fontData);
+			Font newFont = Font.win32_new(device, fontData, calculatedZoom);
+			container = new ScaledFontContainer(newFont, calculatedZoom);
+			fontHandleMap.put(newFont.handle, container);
+			fontKeyMap.put(fontData, container);
+		}
+		return getOrCreateFont(container, zoom);
+	}
+
+	@Override
+	public void dispose() {
+		for (Entry<FontData, ScaledFontContainer> fontContainerEntry : fontKeyMap.entrySet()) {
+			if (KEY_SYSTEM_FONTS.equals(fontContainerEntry.getKey())) {
+				// do not dispose the system fonts here, they are not tied to the device of this registry
+				continue;
+			}
+			ScaledFontContainer scaledFontContainer = fontContainerEntry.getValue();
+			for (Font font : scaledFontContainer.scaledFonts.values()) {
+				font.dispose();
+			}
+		}
+		fontKeyMap.clear();
+	}
+
+	private Font getOrCreateFont(ScaledFontContainer container, int zoom) {
+		Font scaledFont = container.getScaledFont(zoom);
+		if (scaledFont == null) {
+			scaledFont = container.scaleFont(zoom);
+			fontHandleMap.put(scaledFont.handle, container);
+			fontKeyMap.put(scaledFont.getFontData()[0], container);
+		}
+		return scaledFont;
+	}
+
+	private int computeZoom(FontData fontData) {
+		int dpi = device.getDPI().x;
+		int pixelsAtPrimaryMonitorZoom = computePixels(fontData.height);
+		int value = DPIUtil.mapDPIToZoom(dpi) * fontData.data.lfHeight / pixelsAtPrimaryMonitorZoom;
+		return value;
+	}
+
+	private int computePixels(int zoom, FontData fontData) {
+		int dpi = device.getDPI().x;
+		int adjustedLogFontHeight = computePixels(fontData.height);
+		int primaryZoom = DPIUtil.mapDPIToZoom(dpi);
+		if (zoom != primaryZoom) {
+			adjustedLogFontHeight *= (1f * zoom / primaryZoom);
+		}
+		return adjustedLogFontHeight;
+	}
+
+	private int computePixels(float height) {
+		int dpi = device.getDPI().x;
+		return -(int)(0.5f + (height * dpi / 72f));
+	}
+}

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Button.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Button.java
@@ -75,6 +75,8 @@ public class Button extends Control {
 		WNDCLASS lpWndClass = new WNDCLASS ();
 		OS.GetClassInfo (0, ButtonClass, lpWndClass);
 		ButtonProc = lpWndClass.lpfnWndProc;
+
+		DPIZoomChangeRegistry.registerHandler(Button::handleDPIChange, Button.class);
 	}
 
 /**
@@ -1543,4 +1545,14 @@ LRESULT wmDrawChild (long wParam, long lParam) {
 	return null;
 }
 
+private static void handleDPIChange(Widget widget, int newZoom, float scalingFactor) {
+	if (!(widget instanceof Button button)) {
+		return;
+	}
+	// Refresh the image
+	if (button.image != null) {
+		button._setImage(Image.win32_new(button.image, newZoom));
+		button.updateImageList();
+	}
+}
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Button.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Button.java
@@ -283,7 +283,7 @@ int computeLeftMargin () {
 	if ((style & (SWT.PUSH | SWT.TOGGLE)) == 0) return MARGIN;
 	int margin = 0;
 	if (image != null && text.length () != 0) {
-		Rectangle bounds = image.getBoundsInPixels ();
+		Rectangle bounds = DPIUtil.autoScaleBounds(image.getBounds(), this.getZoom(), 100);
 		margin += bounds.width + MARGIN * 2;
 		long oldFont = 0;
 		long hDC = OS.GetDC (handle);
@@ -345,7 +345,7 @@ int computeLeftMargin () {
 			boolean hasImage = image != null, hasText = true;
 			if (hasImage) {
 				if (image != null) {
-					Rectangle rect = image.getBoundsInPixels ();
+					Rectangle rect = DPIUtil.autoScaleBounds(image.getBounds(), this.getZoom(), 100);
 					width = rect.width;
 					if (hasText && text.length () != 0) {
 						width += MARGIN * 2;
@@ -1378,11 +1378,12 @@ LRESULT wmNotifyChild (NMHDR hdr, long wParam, long lParam) {
 							GC gc = GC.win32_new (nmcd.hdc, data);
 
 							int margin = computeLeftMargin();
-							int imageWidth = image.getBoundsInPixels().width;
+							Rectangle imageBounds = DPIUtil.autoScaleBounds(image.getBounds(), this.getZoom(), 100);
+							int imageWidth = imageBounds.width;
 							left += (imageWidth + (isRadioOrCheck() ? 2 * MARGIN : MARGIN)); // for SWT.RIGHT_TO_LEFT right and left are inverted
 
 							int x = margin + (isRadioOrCheck() ? radioOrCheckTextPadding : 3);
-							int y = Math.max (0, (nmcd.bottom - image.getBoundsInPixels().height) / 2);
+							int y = Math.max (0, (nmcd.bottom - imageBounds.height) / 2);
 							gc.drawImage (image, DPIUtil.autoScaleDown(x), DPIUtil.autoScaleDown(y));
 							gc.dispose ();
 						}

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Combo.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Combo.java
@@ -104,6 +104,7 @@ public class Combo extends Composite {
 		WNDCLASS lpWndClass = new WNDCLASS ();
 		OS.GetClassInfo (0, ComboClass, lpWndClass);
 		ComboProc = lpWndClass.lpfnWndProc;
+		DPIZoomChangeRegistry.registerHandler(Combo::handleDPIChange, Combo.class);
 	}
 
 	/* Undocumented values. Remained the same at least between Win7 and Win10 */
@@ -3358,4 +3359,13 @@ LRESULT wmSysKeyDown (long hwnd, long wParam, long lParam) {
 	return result;
 }
 
+private static void handleDPIChange(Widget widget, int newZoom, float scalingFactor) {
+	if (!(widget instanceof Combo combo)) {
+		return;
+	}
+	if ((combo.style & SWT.H_SCROLL) != 0) {
+		combo.scrollWidth = 0;
+		combo.setScrollWidth();
+	}
+}
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Composite.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Composite.java
@@ -57,6 +57,10 @@ public class Composite extends Scrollable {
 
 	static final int TOOLTIP_LIMIT = 4096;
 
+	static {
+		DPIZoomChangeRegistry.registerHandler(Composite::handleDPIChange, Composite.class);
+	}
+
 /**
  * Prevents uninitialized instances from being created outside the package.
  */
@@ -1966,4 +1970,13 @@ public String toString() {
 	return super.toString() + " [layout=" + layout + "]";
 }
 
+private static void handleDPIChange(Widget widget, int newZoom, float scalingFactor) {
+	if (!(widget instanceof Composite composite)) {
+		return;
+	}
+	for (Control child : composite.getChildren()) {
+		DPIZoomChangeRegistry.applyChange(child, newZoom, scalingFactor);
+	}
+	composite.redrawInPixels (null, true);
+}
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Control.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Control.java
@@ -711,8 +711,8 @@ int defaultBackground () {
 	return OS.GetSysColor (OS.COLOR_BTNFACE);
 }
 
-long defaultFont () {
-	return display.getSystemFont ().handle;
+long defaultFont() {
+	return display.getSystemFont(getShell().getNativeZoom()).handle;
 }
 
 int defaultForeground () {
@@ -1304,7 +1304,7 @@ public Font getFont () {
 	if (font != null) return font;
 	long hFont = OS.SendMessage (handle, OS.WM_GETFONT, 0, 0);
 	if (hFont == 0) hFont = defaultFont ();
-	return Font.win32_new (display, hFont);
+	return Font.win32_new (display, hFont, getShell().getNativeZoom());
 }
 
 /**
@@ -3309,7 +3309,7 @@ public void setCursor (Cursor cursor) {
 }
 
 void setDefaultFont () {
-	long hFont = display.getSystemFont ().handle;
+	long hFont = display.getSystemFont (getShell().getNativeZoom()).handle;
 	OS.SendMessage (handle, OS.WM_SETFONT, hFont, 0);
 }
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/CoolBar.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/CoolBar.java
@@ -58,6 +58,7 @@ public class CoolBar extends Composite {
 		WNDCLASS lpWndClass = new WNDCLASS ();
 		OS.GetClassInfo (0, ReBarClass, lpWndClass);
 		ReBarProc = lpWndClass.lpfnWndProc;
+		DPIZoomChangeRegistry.registerHandler(CoolBar::handleDPIChange, CoolBar.class);
 	}
 	static final int SEPARATOR_WIDTH = 2;
 	static final int MAX_WIDTH = 0x7FFF;
@@ -1197,5 +1198,48 @@ LRESULT wmNotifyChild (NMHDR hdr, long wParam, long lParam) {
 		}
 	}
 	return super.wmNotifyChild (hdr, wParam, lParam);
+}
+
+private static void handleDPIChange(Widget widget, int newZoom, float scalingFactor) {
+	if (!(widget instanceof CoolBar coolBar)) {
+		return;
+	}
+	Point[] sizes = coolBar.getItemSizesInPixels();
+	Point[] scaledSizes = new Point[sizes.length];
+	Point[] prefSizes = new Point[sizes.length];
+	Point[] minSizes = new Point[sizes.length];
+	int[] indices = coolBar.getWrapIndices();
+	int[] itemOrder = coolBar.getItemOrder();
+
+	CoolItem[] items = coolBar.getItems();
+	for (int index = 0; index < sizes.length; index++) {
+		minSizes[index] = items[index].getMinimumSizeInPixels();
+		prefSizes[index] = items[index].getPreferredSizeInPixels();
+	}
+
+	for (int index = 0; index < sizes.length; index++) {
+		CoolItem item = items[index];
+
+		Control control = item.control;
+		if (control != null) {
+			DPIZoomChangeRegistry.applyChange(control, newZoom, scalingFactor);
+			item.setControl(control);
+		}
+
+		Point preferredControlSize =  item.getControl().computeSizeInPixels(SWT.DEFAULT, SWT.DEFAULT, true);
+		int controlWidth = preferredControlSize.x;
+		int controlHeight = preferredControlSize.y;
+		if (((coolBar.style & SWT.VERTICAL) != 0)) {
+			scaledSizes[index] = new Point(Math.round((sizes[index].x)*scalingFactor), Math.max(Math.round((sizes[index].y)*scalingFactor),0));
+			item.setMinimumSizeInPixels(Math.round(minSizes[index].x*scalingFactor), Math.max(Math.round((minSizes[index].y)*scalingFactor),controlWidth));
+			item.setPreferredSizeInPixels(Math.round(prefSizes[index].x*scalingFactor), Math.max(Math.round((prefSizes[index].y)*scalingFactor),controlWidth));
+		} else {
+			scaledSizes[index] = new Point(Math.round((sizes[index].x)*scalingFactor),Math.max(Math.round((sizes[index].y)*scalingFactor),0));
+			item.setMinimumSizeInPixels(Math.round(minSizes[index].x*scalingFactor), controlHeight);
+			item.setPreferredSizeInPixels(Math.round(prefSizes[index].x*scalingFactor), controlHeight);
+		}
+	}
+	coolBar.setItemLayoutInPixels(itemOrder, indices, scaledSizes);
+	coolBar.updateLayout(true);
 }
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Decorations.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Decorations.java
@@ -112,6 +112,10 @@ public class Decorations extends Canvas {
 	int oldWidth = OS.CW_USEDEFAULT, oldHeight = OS.CW_USEDEFAULT;
 	RECT maxRect = new RECT();
 
+	static {
+		DPIZoomChangeRegistry.registerHandler(Decorations::handleDPIChange, Decorations.class);
+	}
+
 /**
  * Prevents uninitialized instances from being created outside the package.
  */
@@ -895,7 +899,7 @@ void setImages (Image image, Image [] images) {
 				System.arraycopy (images, 0, bestImages, 0, images.length);
 				datas = new ImageData [images.length];
 				for (int i=0; i<datas.length; i++) {
-					datas [i] = images [i].getImageData (DPIUtil.getDeviceZoom ());
+					datas [i] = images [i].getImageData (getZoom());
 				}
 				images = bestImages;
 				sort (images, datas, OS.GetSystemMetrics (OS.SM_CXSMICON), OS.GetSystemMetrics (OS.SM_CYSMICON), depth);
@@ -1684,4 +1688,29 @@ LRESULT WM_WINDOWPOSCHANGING (long wParam, long lParam) {
 	return result;
 }
 
+private static void handleDPIChange(Widget widget, int newZoom, float scalingFactor) {
+	if (!(widget instanceof Decorations decorations)) {
+		return;
+	}
+
+	Image image = decorations.getImage();
+	if (image != null) {
+		decorations.setImage(Image.win32_new(image, newZoom));
+	}
+
+	Image[] images = decorations.getImages();
+	if (images != null) {
+		for(Image subImage : images) {
+			if (subImage != null) {
+				Image.win32_new(subImage, newZoom);
+			}
+		}
+		decorations.setImages(images);
+	}
+
+	Menu menuBar = decorations.getMenuBar();
+	if (menuBar != null) {
+		DPIZoomChangeRegistry.applyChange(menuBar, newZoom, scalingFactor);
+	}
+}
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Display.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Display.java
@@ -540,6 +540,10 @@ public class Display extends Device implements Executor {
 		};
 	}
 
+	static {
+		CommonWidgetsDPIChangeHandlers.registerCommonHandlers();
+	}
+
 
 /*
 * TEMPORARY CODE.

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Display.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Display.java
@@ -1160,7 +1160,7 @@ static long create32bitDIB (long hBitmap, int alpha, byte [] alphaData, int tran
 
 static Image createIcon (Image image) {
 	Device device = image.getDevice ();
-	ImageData data = image.getImageData (DPIUtil.getDeviceZoom ());
+	ImageData data = image.getImageDataAtCurrentZoom();
 	if (data.alpha == -1 && data.alphaData == null) {
 		ImageData mask = data.getTransparencyMask ();
 		return new Image (device, data, mask);
@@ -2463,7 +2463,7 @@ Font getSystemFont (int zoom) {
 		this.systemFont = systemFont;
 		if (systemFont != null) {
 			this.lfSystemFont = systemFont.getFontData()[0].data;
-	}
+		}
 	}
 
 	return systemFont;

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ExpandBar.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ExpandBar.java
@@ -55,6 +55,9 @@ public class ExpandBar extends Composite {
 	int yCurrentScroll;
 	long hFont;
 
+	static {
+		DPIZoomChangeRegistry.registerHandler(ExpandBar::handleDPIChange, ExpandBar.class);
+	}
 
 /**
  * Constructs a new instance of this class given its parent
@@ -866,5 +869,15 @@ LRESULT wmScroll (ScrollBar bar, boolean update, long hwnd, int msg, long wParam
 		}
 	}
 	return result;
+}
+
+private static void handleDPIChange(Widget widget, int newZoom, float scalingFactor) {
+	if (!(widget instanceof ExpandBar expandBar)) {
+		return;
+	}
+	for (ExpandItem item : expandBar.getItems()) {
+		DPIZoomChangeRegistry.applyChange(item, newZoom, scalingFactor);
+	}
+	expandBar.redraw();
 }
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ExpandItem.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ExpandItem.java
@@ -47,6 +47,10 @@ public class ExpandItem extends Item {
 	static final int BORDER = 1;
 	static final int CHEVRON_SIZE = 24;
 
+	static {
+		DPIZoomChangeRegistry.registerHandler(ExpandItem::handleDPIChange, ExpandItem.class);
+	}
+
 /**
  * Constructs a new instance of this class given its parent
  * and a style value describing its behavior and appearance.
@@ -519,5 +523,16 @@ public void setText (String string) {
 		updateTextDirection (AUTO_TEXT_DIRECTION);
 	}
 	redraw (true);
+}
+
+private static void handleDPIChange(Widget widget, int newZoom, float scalingFactor) {
+	if (!(widget instanceof ExpandItem item)) {
+		return;
+	}
+	if (item.height != 0 || item.width != 0) {
+		int newWidth = Math.round(item.width * scalingFactor);
+		int newHeight = Math.round(item.height * scalingFactor);
+		item.setBoundsInPixels(item.x, item.y, newWidth, newHeight, false, true);
+	}
 }
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Label.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Label.java
@@ -63,6 +63,7 @@ public class Label extends Control {
 		WNDCLASS lpWndClass = new WNDCLASS ();
 		OS.GetClassInfo (0, LabelClass, lpWndClass);
 		LabelProc = lpWndClass.lpfnWndProc;
+		DPIZoomChangeRegistry.registerHandler(Label::handleDPIChange, Label.class);
 	}
 
 /**
@@ -619,4 +620,13 @@ LRESULT wmDrawChild (long wParam, long lParam) {
 	return null;
 }
 
+private static void handleDPIChange(Widget widget, int newZoom, float scalingFactor) {
+	if (!(widget instanceof Label label)) {
+		return;
+	}
+	Image image = label.getImage();
+	if (image != null) {
+		label.setImage(Image.win32_new(image, newZoom));
+	}
+}
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Label.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Label.java
@@ -147,7 +147,7 @@ static int checkStyle (int style) {
 		return new Point (width, height);
 	}
 	if (isImageMode) {
-		Rectangle rect = image.getBoundsInPixels();
+		Rectangle rect = DPIUtil.autoScaleBounds(image.getBounds(), this.getZoom(), 100);
 		width += rect.width;
 		height += rect.height;
 	} else {
@@ -553,7 +553,7 @@ void wmDrawChildImage(DRAWITEMSTRUCT struct) {
 	int height = struct.bottom - struct.top;
 	if (width == 0 || height == 0) return;
 
-	Rectangle imageRect = image.getBoundsInPixels ();
+	Rectangle imageRect = DPIUtil.autoScaleBounds(image.getBounds(), getZoom(), 100);
 
 	int x = 0;
 	if ((style & SWT.CENTER) != 0) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/List.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/List.java
@@ -50,6 +50,7 @@ public class List extends Scrollable {
 		WNDCLASS lpWndClass = new WNDCLASS ();
 		OS.GetClassInfo (0, ListClass, lpWndClass);
 		ListProc = lpWndClass.lpfnWndProc;
+		DPIZoomChangeRegistry.registerHandler(List::handleDPIChange, List.class);
 	}
 
 /**
@@ -1268,6 +1269,9 @@ public void setItems (String... items) {
 	if (index < items.length) error (SWT.ERROR_ITEM_NOT_ADDED);
 }
 
+/**
+ * Calculates the scroll width depending on the item with the highest width
+ */
 void setScrollWidth () {
 	int newWidth = 0;
 	RECT rect = new RECT ();
@@ -1847,6 +1851,13 @@ LRESULT wmCommandChild (long wParam, long lParam) {
 	return super.wmCommandChild (wParam, lParam);
 }
 
-
-
+private static void handleDPIChange(Widget widget, int newZoom, float scalingFactor) {
+	if (!(widget instanceof List list)) {
+		return;
+	}
+	if((list.style & SWT.H_SCROLL) != 0) {
+		// Recalculate the Scroll width, as length of items has changed
+		list.setScrollWidth();
+	}
+}
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Menu.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Menu.java
@@ -69,6 +69,10 @@ public class Menu extends Widget {
 	/* Timer ID for MenuItem ToolTip */
 	static final int ID_TOOLTIP_TIMER = 110;
 
+	static {
+		DPIZoomChangeRegistry.registerHandler(Menu::handleDPIChange, Menu.class);
+	}
+
 /**
  * Constructs a new instance of this class given its parent,
  * and sets the style for the instance so that the instance
@@ -1361,5 +1365,14 @@ LRESULT wmTimer (long wParam, long lParam) {
 	}
 
 	return null;
+}
+
+private static void handleDPIChange(Widget widget, int newZoom, float scalingFactor) {
+	if (!(widget instanceof Menu menu)) {
+		return;
+	}
+	for (MenuItem item : menu.getItems()) {
+		DPIZoomChangeRegistry.applyChange(item, newZoom, scalingFactor);
+	}
 }
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/MenuItem.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/MenuItem.java
@@ -48,6 +48,10 @@ public class MenuItem extends Item {
 	final static int MARGIN_WIDTH = 1;
 	final static int MARGIN_HEIGHT = 1;
 
+	static {
+		DPIZoomChangeRegistry.registerHandler(MenuItem::handleDPIChange, MenuItem.class);
+	}
+
 /**
  * Constructs a new instance of this class given its parent
  * (which must be a <code>Menu</code>) and a style value
@@ -1213,4 +1217,21 @@ private static final class MenuItemToolTip extends ToolTip {
 
 }
 
+private static void handleDPIChange(Widget widget, int newZoom, float scalingFactor) {
+	if (!(widget instanceof MenuItem menuItem)) {
+		return;
+	}
+	// Refresh the image
+	Image menuItemImage = menuItem.getImage();
+	if (menuItemImage != null) {
+		Image currentImage = menuItemImage;
+		menuItem.image = null;
+		menuItem.setImage (Image.win32_new(currentImage, newZoom));
+	}
+	// Refresh the sub menu
+	Menu subMenu = menuItem.getMenu();
+	if (subMenu != null) {
+		DPIZoomChangeRegistry.applyChange(subMenu, newZoom, scalingFactor);
+	}
+}
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TabFolder.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TabFolder.java
@@ -90,6 +90,7 @@ public class TabFolder extends Composite {
 		lpWndClass.hInstance = OS.GetModuleHandle (null);
 		lpWndClass.style &= ~(OS.CS_HREDRAW | OS.CS_VREDRAW | OS.CS_GLOBALCLASS);
 		OS.RegisterClass (TabFolderClass, lpWndClass);
+		DPIZoomChangeRegistry.registerHandler(TabFolder::handleDPIChange, TabFolder.class);
 	}
 
 /**
@@ -1126,4 +1127,18 @@ LRESULT wmNotifyChild (NMHDR hdr, long wParam, long lParam) {
 	return super.wmNotifyChild (hdr, wParam, lParam);
 }
 
+private static void handleDPIChange(Widget widget, int newZoom, float scalingFactor) {
+	if (!(widget instanceof TabFolder tabFolder)) {
+		return;
+	}
+	Display display = tabFolder.getDisplay();
+	if (tabFolder.imageList != null) {
+		display.releaseImageList (tabFolder.imageList);
+		tabFolder.imageList = null;
+	}
+	for (int i = 0; i < tabFolder.getItemCount(); i++) {
+		DPIZoomChangeRegistry.applyChange(tabFolder.items[i], newZoom, scalingFactor);
+	}
+	tabFolder.layout(true, true);
+}
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TabFolder.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TabFolder.java
@@ -455,7 +455,7 @@ int imageIndex (Image image) {
 	 */
 	if (image == null) return -1;
 	if (imageList == null) {
-		Rectangle bounds = image.getBoundsInPixels ();
+		Rectangle bounds = DPIUtil.autoScaleBounds(image.getBounds(), this.getZoom(), 100);
 		imageList = display.getImageList (style & SWT.RIGHT_TO_LEFT, bounds.width, bounds.height);
 		int index = imageList.add (image);
 		long hImageList = imageList.getHandle ();

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TableColumn.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TableColumn.java
@@ -44,6 +44,10 @@ public class TableColumn extends Item {
 	String toolTipText;
 	int id;
 
+	static {
+		DPIZoomChangeRegistry.registerHandler(TableColumn::handleDPIChange, TableColumn.class);
+	}
+
 /**
  * Constructs a new instance of this class given its parent
  * (which must be a <code>Table</code>) and a style value
@@ -883,4 +887,15 @@ void updateToolTip (int index) {
 	}
 }
 
+private static void handleDPIChange(Widget widget, int newZoom, float scalingFactor) {
+	if (!(widget instanceof TableColumn tableColumn)) {
+		return;
+	}
+	final int newColumnWidth = Math.round(tableColumn.getWidthInPixels() * scalingFactor);
+	tableColumn.setWidthInPixels(newColumnWidth);
+	Image image = tableColumn.getImage();
+	if (image != null) {
+		tableColumn.setImage(Image.win32_new(image, newZoom));
+	}
+}
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TableItem.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TableItem.java
@@ -46,6 +46,10 @@ public class TableItem extends Item {
 	int imageIndent, background = -1, foreground = -1;
 	int [] cellBackground, cellForeground;
 
+	static {
+		DPIZoomChangeRegistry.registerHandler(TableItem::handleDPIChange, TableItem.class);
+	}
+
 /**
  * Constructs a new instance of this class given its parent
  * (which must be a <code>Table</code>) and a style value
@@ -866,9 +870,11 @@ public void setFont (Font font){
 		error (SWT.ERROR_INVALID_ARGUMENT);
 	}
 	Font oldFont = this.font;
-	if (oldFont == font) return;
-	this.font = font;
-	if (oldFont != null && oldFont.equals (font)) return;
+	Shell shell = parent.getShell();
+	Font newFont = (font == null ? font : Font.win32_new(font, shell.getNativeZoom()));
+	if (oldFont == newFont) return;
+	this.font = newFont;
+	if (oldFont != null && oldFont.equals (newFont)) return;
 	if (font != null) parent.setCustomDraw (true);
 	if ((parent.style & SWT.VIRTUAL) != 0) cached = true;
 	/*
@@ -1266,4 +1272,29 @@ public void setText (String string) {
 	setText (0, string);
 }
 
+private static void handleDPIChange(Widget widget, int newZoom, float scalingFactor) {
+	if (!(widget instanceof TableItem tableItem)) {
+		return;
+	}
+	Image[] images = tableItem.images;
+	if (images != null) {
+		for (Image innerImage : images) {
+			if (innerImage != null) {
+				Image.win32_new(innerImage, newZoom);
+			}
+		}
+	}
+	Font font = tableItem.font;
+	if (font != null) {
+		tableItem.setFont(tableItem.font);
+	}
+	Font[] cellFonts = tableItem.cellFont;
+	if (cellFonts != null) {
+		Shell shell = tableItem.parent.getShell();
+		for (int index = 0; index < cellFonts.length; index++) {
+			Font cellFont = cellFonts[index];
+			cellFonts[index] = cellFont == null ? null : Font.win32_new(cellFont, shell.getNativeZoom());
+		}
+	}
+}
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Text.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Text.java
@@ -112,6 +112,7 @@ public class Text extends Scrollable {
 		WNDCLASS lpWndClass = new WNDCLASS ();
 		OS.GetClassInfo (0, EditClass, lpWndClass);
 		EditProc = lpWndClass.lpfnWndProc;
+		DPIZoomChangeRegistry.registerHandler(Text::handleDPIChange, Text.class);
 	}
 
 /**
@@ -336,6 +337,10 @@ void createHandle () {
 			state |= THEME_BACKGROUND;
 		}
 	}
+	addIcons();
+}
+
+private void addIcons() {
 	if ((style & SWT.SEARCH) != 0) {
 		if (display.hIconSearch == 0) {
 			long [] phicon = new long [1];
@@ -3166,4 +3171,11 @@ LRESULT wmKeyDown (long hwnd, long wParam, long lParam) {
 	return result;
 }
 
+private static void handleDPIChange(Widget widget, int newZoom, float scalingFactor) {
+	if (!(widget instanceof Text text)) {
+		return;
+	}
+	text.addIcons();
+	text.setMargins();
+}
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ToolItem.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ToolItem.java
@@ -50,6 +50,10 @@ public class ToolItem extends Item {
 	short cx;
 	int foreground = -1, background = -1;
 
+	static {
+		DPIZoomChangeRegistry.registerHandler(ToolItem::handleDPIChange, ToolItem.class);
+	}
+
 /**
  * Constructs a new instance of this class given its parent
  * (which must be a <code>ToolBar</code>) and a style value
@@ -1103,7 +1107,7 @@ void updateImages (boolean enabled) {
 	ImageList hotImageList = parent.getHotImageList ();
 	ImageList disabledImageList = parent.getDisabledImageList();
 	if (info.iImage == OS.I_IMAGENONE) {
-		Rectangle bounds = image.getBoundsInPixels ();
+		Rectangle bounds = DPIUtil.autoScaleBounds(image.getBounds(), 100, getParent().getZoom());
 		int listStyle = parent.style & SWT.RIGHT_TO_LEFT;
 		if (imageList == null) {
 			imageList = display.getImageListToolBar (listStyle, bounds.width, bounds.height);
@@ -1167,7 +1171,9 @@ void updateImages (boolean enabled) {
 		if ((style & (SWT.CHECK | SWT.RADIO)) != 0) {
 			if (!enabled) image2 = hot = disabled;
 		}
-		if (imageList != null) imageList.put (info.iImage, image2);
+		if (imageList != null) {
+			imageList.put (info.iImage, image2);
+		}
 		if (hotImageList != null) {
 			hotImageList.put (info.iImage, hot != null ? hot : image2);
 		}
@@ -1213,4 +1219,38 @@ LRESULT wmCommandChild (long wParam, long lParam) {
 	return null;
 }
 
+private static void handleDPIChange(Widget widget, int newZoom, float scalingFactor) {
+	if (!(widget instanceof ToolItem item)) {
+		return;
+	}
+	Image image = item.getImage();
+	if (image != null) {
+		ToolBar parent = item.getParent();
+		Display display = item.getDisplay();
+		int listStyle = parent.style & SWT.RIGHT_TO_LEFT;
+
+		Rectangle bounds = DPIUtil.autoScaleBounds(image.getBounds(), 100, newZoom);
+		if (parent.getImageList() == null) {
+			parent.setImageList (display.getImageListToolBar (listStyle, bounds.width, bounds.height));
+		}
+		if (parent.getDisabledImageList() == null) {
+			parent.setDisabledImageList (display.getImageListToolBarDisabled (listStyle, bounds.width, bounds.height));
+		}
+		if (parent.getHotImageList() == null) {
+			parent.setHotImageList (display.getImageListToolBarHot (listStyle, bounds.width, bounds.height));
+		}
+		Image.win32_new(image, newZoom);
+
+		Image disabledImage = item.getDisabledImage();
+		if (disabledImage != null && !disabledImage.isDisposed()) {
+			Image.win32_new(disabledImage, newZoom);
+		}
+
+		Image hotImage = item.getHotImage();
+		if (hotImage != null) {
+			Image.win32_new(hotImage, newZoom);
+		}
+	}
+	item.setWidthInPixels(0);
+}
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ToolItem.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ToolItem.java
@@ -1107,7 +1107,7 @@ void updateImages (boolean enabled) {
 	ImageList hotImageList = parent.getHotImageList ();
 	ImageList disabledImageList = parent.getDisabledImageList();
 	if (info.iImage == OS.I_IMAGENONE) {
-		Rectangle bounds = DPIUtil.autoScaleBounds(image.getBounds(), 100, getParent().getZoom());
+		Rectangle bounds = DPIUtil.autoScaleBounds(image.getBounds(), getParent().getZoom(), 100);
 		int listStyle = parent.style & SWT.RIGHT_TO_LEFT;
 		if (imageList == null) {
 			imageList = display.getImageListToolBar (listStyle, bounds.width, bounds.height);
@@ -1229,7 +1229,7 @@ private static void handleDPIChange(Widget widget, int newZoom, float scalingFac
 		Display display = item.getDisplay();
 		int listStyle = parent.style & SWT.RIGHT_TO_LEFT;
 
-		Rectangle bounds = DPIUtil.autoScaleBounds(image.getBounds(), 100, newZoom);
+		Rectangle bounds = DPIUtil.autoScaleBounds(image.getBounds(), newZoom, 100);
 		if (parent.getImageList() == null) {
 			parent.setImageList (display.getImageListToolBar (listStyle, bounds.width, bounds.height));
 		}

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Tree.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Tree.java
@@ -3739,7 +3739,7 @@ boolean hitTestSelection (long hItem, int x, int y) {
 int imageIndex (Image image, int index) {
 	if (image == null) return OS.I_IMAGENONE;
 	if (imageList == null) {
-		Rectangle bounds = image.getBoundsInPixels ();
+		Rectangle bounds = DPIUtil.autoScaleBounds(image.getBounds(), this.getZoom(), 100);
 		imageList = display.getImageList (style & SWT.RIGHT_TO_LEFT, bounds.width, bounds.height);
 	}
 	int imageIndex = imageList.indexOf (image);
@@ -3763,7 +3763,7 @@ int imageIndex (Image image, int index) {
 int imageIndexHeader (Image image) {
 	if (image == null) return OS.I_IMAGENONE;
 	if (headerImageList == null) {
-		Rectangle bounds = image.getBoundsInPixels ();
+		Rectangle bounds = DPIUtil.autoScaleBounds(image.getBounds(), this.getZoom(), 100);
 		headerImageList = display.getImageList (style & SWT.RIGHT_TO_LEFT, bounds.width, bounds.height);
 		int index = headerImageList.indexOf (image);
 		if (index == -1) index = headerImageList.add (image);
@@ -7540,7 +7540,7 @@ LRESULT wmNotifyChild (NMHDR hdr, long wParam, long lParam) {
 		}
 		case OS.NM_CUSTOMDRAW: {
 			if (hdr.hwndFrom == hwndHeader) break;
-			if (hooks (SWT.MeasureItem)) {
+			if  (hooks (SWT.MeasureItem)) {
 				if (hwndHeader == 0) createParent ();
 			}
 			if (!customDraw && findImageControl () == null) {
@@ -7926,9 +7926,10 @@ LRESULT wmNotifyHeader (NMHDR hdr, long wParam, long lParam) {
 							GCData data = new GCData();
 							data.device = display;
 							GC gc = GC.win32_new (nmcd.hdc, data);
-							int y = Math.max (0, (nmcd.bottom - columns[i].image.getBoundsInPixels().height) / 2);
+							Rectangle imageBounds = DPIUtil.autoScaleBounds(columns[i].image.getBounds(), this.getZoom(), 100);
+							int y = Math.max (0, (nmcd.bottom - imageBounds.height) / 2);
 							gc.drawImage (columns[i].image, DPIUtil.autoScaleDown(x), DPIUtil.autoScaleDown(y));
-							x += columns[i].image.getBoundsInPixels().width + 12;
+							x += imageBounds.width + 12;
 							gc.dispose ();
 						}
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Tree.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Tree.java
@@ -120,6 +120,8 @@ public class Tree extends Composite {
 	static final int INCREMENT = 5;
 	static final int EXPLORER_EXTRA = 2;
 	static final int DRAG_IMAGE_SIZE = 301;
+	// The default Indent at 100 dpi
+	static final int DEFAULT_INDENT = 16;
 	static final long TreeProc;
 	static final TCHAR TreeClass = new TCHAR (0, OS.WC_TREEVIEW, true);
 	static final long HeaderProc;
@@ -130,6 +132,7 @@ public class Tree extends Composite {
 		TreeProc = lpWndClass.lpfnWndProc;
 		OS.GetClassInfo (0, HeaderClass, lpWndClass);
 		HeaderProc = lpWndClass.lpfnWndProc;
+		DPIZoomChangeRegistry.registerHandler(Tree::handleDPIChange, Tree.class);
 	}
 
 /**
@@ -314,7 +317,10 @@ void _setBackgroundPixel (int newPixel) {
 		}
 
 		/* Set the checkbox image list */
-		if ((style & SWT.CHECK) != 0) setCheckboxImageList ();
+		if ((style & SWT.CHECK) != 0) {
+			setCheckboxImageList ();
+		}
+		updateImageList();
 	}
 }
 
@@ -1906,8 +1912,7 @@ void createHandle () {
 	 * scale with DPI resulting in distorted glyph image
 	 * at higher DPI settings.
 	 */
-	int indent = DPIUtil.autoScaleUpUsingNativeDPI(16);
-	OS.SendMessage(handle, OS.TVM_SETINDENT, indent, 0);
+	calculateAndApplyIndentSize();
 
 	createdAsRTL = (style & SWT.RIGHT_TO_LEFT) != 0;
 }
@@ -5360,6 +5365,15 @@ public void setTopItem (TreeItem item) {
 	updateScrollBar ();
 }
 
+/**
+ * Set indent for Tree;
+ * In a Tree without imageList, the indent also controls the chevron (glyph) size.
+ */
+private void calculateAndApplyIndentSize() {
+	int indent = DPIUtil.autoScaleUpUsingNativeDPI(DEFAULT_INDENT);
+	OS.SendMessage(handle, OS.TVM_SETINDENT, indent, 0);
+}
+
 void showItem (long hItem) {
 	/*
 	* Bug in Windows.  When TVM_ENSUREVISIBLE is used to ensure
@@ -8248,4 +8262,38 @@ LRESULT wmNotifyToolTip (NMTTCUSTOMDRAW nmcd, long lParam) {
 	return null;
 }
 
+private static void handleDPIChange(Widget widget, int newZoom, float scalingFactor) {
+	if (!(widget instanceof Tree tree)) {
+		return;
+	}
+	Display display = tree.getDisplay();
+	// Reset ImageList
+	if (tree.headerImageList != null) {
+		display.releaseImageList(tree.headerImageList);
+		tree.headerImageList = null;
+	}
+	if (tree.imageList != null) {
+		display.releaseImageList(tree.imageList);
+		// Reset the Imagelist of the OS as well; Will be recalculated when updating items
+		OS.SendMessage (tree.handle, OS.TVM_SETIMAGELIST, 0, 0);
+		tree.imageList = null;
+	}
+
+	if (tree.hooks(SWT.MeasureItem)) {
+		// with the measure item hook, the height must be programmatically recalculated
+		var itemHeight = tree.getItemHeightInPixels();
+		tree.setItemHeight(Math.round(itemHeight * scalingFactor));
+	}
+	for (TreeColumn treeColumn : tree.getColumns()) {
+		DPIZoomChangeRegistry.applyChange(treeColumn, newZoom, scalingFactor);
+	}
+	for (TreeItem item : tree.getItems()) {
+		DPIZoomChangeRegistry.applyChange(item, newZoom, scalingFactor);
+	}
+
+	tree.updateOrientation();
+	tree.setScrollWidth();
+	// Reset of CheckBox Size required (if SWT.Check is not set, this is a no-op)
+	tree.setCheckboxImageList();
+}
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TreeColumn.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TreeColumn.java
@@ -46,6 +46,10 @@ public class TreeColumn extends Item {
 	String toolTipText;
 	int id;
 
+	static {
+		DPIZoomChangeRegistry.registerHandler(TreeColumn::handleDPIChange, TreeColumn.class);
+	}
+
 /**
  * Constructs a new instance of this class given its parent
  * (which must be a <code>Tree</code>) and a style value
@@ -753,6 +757,17 @@ void updateToolTip (int index) {
 			lpti.bottom = rect.bottom;
 			OS.SendMessage (hwndHeaderToolTip, OS.TTM_NEWTOOLRECT, 0, lpti);
 		}
+	}
+}
+
+private static void handleDPIChange(Widget widget, int newZoom, float scalingFactor) {
+	if (!(widget instanceof TreeColumn treeColumn)) {
+		return;
+	}
+	treeColumn.setWidth(Math.round(treeColumn.getWidth() * scalingFactor));
+	Image image = treeColumn.image;
+	if (image != null) {
+		treeColumn.setImage (Image.win32_new(image, newZoom));
 	}
 }
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Widget.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Widget.java
@@ -51,6 +51,8 @@ import org.eclipse.swt.internal.win32.*;
  * @see <a href="http://www.eclipse.org/swt/">Sample code and further information</a>
  */
 public abstract class Widget {
+
+	private int zoom;
 	int style, state;
 	Display display;
 	EventTable eventTable;
@@ -166,6 +168,7 @@ public Widget (Widget parent, int style) {
 	checkSubclass ();
 	checkParent (parent);
 	this.style = style;
+	this.zoom = parent != null ? parent.getZoom() : DPIUtil.getDeviceZoom();
 	display = parent.display;
 	reskinWidget ();
 	notifyCreationTracker();
@@ -2631,4 +2634,15 @@ void notifyDisposalTracker() {
 	}
 }
 
+
+/**
+ * The current DPI zoom level the widget is scaled for
+ */
+int getZoom() {
+	return zoom;
+}
+
+void setZoom(int zoom) {
+	this.zoom = zoom;
+}
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Widget.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Widget.java
@@ -126,6 +126,7 @@ public abstract class Widget {
 		icce.dwSize = INITCOMMONCONTROLSEX.sizeof;
 		icce.dwICC = 0xffff;
 		OS.InitCommonControlsEx (icce);
+		DPIZoomChangeRegistry.registerHandler(Widget::handleDPIChange, Widget.class);
 	}
 
 /**
@@ -2644,5 +2645,9 @@ int getZoom() {
 
 void setZoom(int zoom) {
 	this.zoom = zoom;
+}
+
+private static void handleDPIChange(Widget widget, int newZoom, float scalingFactor) {
+	widget.setZoom(newZoom);
 }
 }

--- a/tests/org.eclipse.swt.tests.win32/JUnit Tests/org/eclipse/swt/graphics/ImageWin32Tests.java
+++ b/tests/org.eclipse.swt.tests.win32/JUnit Tests/org/eclipse/swt/graphics/ImageWin32Tests.java
@@ -1,0 +1,56 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Yatta Solutions
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Yatta Solutions - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.swt.graphics;
+
+
+import static org.junit.Assert.assertEquals;
+
+import org.eclipse.swt.internal.DPIUtil;
+import org.eclipse.swt.widgets.Display;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Automated Tests for class org.eclipse.swt.graphics.Image
+ * for Windows specific behavior
+ *
+ * @see org.eclipse.swt.graphics.Image
+ */
+public class ImageWin32Tests {
+	private Display display;
+
+	@Before
+	public void setUp() {
+		display = Display.getDefault();
+	}
+
+	@Test
+	public void imageMustBeRescaledOnZoomChange() {
+		int zoom = DPIUtil.getDeviceZoom();
+		Image image = new Image(display, 10, 10);
+
+		try {
+			ImageData baseImageData = image.getImageData(zoom);
+			assertEquals("Width should equal the initial width on the same zoom", 10, baseImageData.width);
+			Image scaledImage = Image.win32_new(image, zoom);
+			ImageData scaledImageData = scaledImage.getImageData(zoom*2);
+			assertEquals("Width should be doubled on doubled zoom", 10*2, scaledImageData.width);
+			scaledImage = Image.win32_new(image, zoom*2);
+			baseImageData = scaledImage.getImageData(zoom);
+			assertEquals("Width of ImageData must not be affected by a zoom change", 10, baseImageData.width);
+		} finally {
+			image.dispose();
+		}
+}
+}

--- a/tests/org.eclipse.swt.tests.win32/JUnit Tests/org/eclipse/swt/internal/DefaultSWTFontRegistryTests.java
+++ b/tests/org.eclipse.swt.tests.win32/JUnit Tests/org/eclipse/swt/internal/DefaultSWTFontRegistryTests.java
@@ -1,0 +1,94 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Yatta Solutions
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Yatta Solutions - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.swt.internal;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.graphics.Font;
+import org.eclipse.swt.graphics.FontData;
+import org.eclipse.swt.widgets.Display;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class DefaultSWTFontRegistryTests {
+	private static String TEST_FONT = "Helvetica";
+	private Display display;
+	private SWTFontRegistry fontRegistry;
+
+	@Before
+	public void setUp() {
+		this.display = Display.getDefault();
+		this.fontRegistry = new DefaultSWTFontRegistry(display);
+	}
+
+	@After
+	public void tearDown() {
+		if (this.fontRegistry != null) {
+			this.fontRegistry.dispose();
+		}
+	}
+
+	@Test
+	public void systemFontsAreCached() {
+		Font font1 = fontRegistry.getSystemFont(100);
+		Font font2 = fontRegistry.getSystemFont(100);
+		assertTrue("System fonts for same zoom factor must be reused", font1 == font2);
+	}
+
+	@Test
+	public void systemFontsAlwaysDependOnPrimaryZoom() {
+		int primaryZoom = display.getPrimaryMonitor().getZoom();
+		FontData fontPrimary = fontRegistry.getSystemFont(primaryZoom).getFontData()[0];
+		FontData font100 = fontRegistry.getSystemFont(100).getFontData()[0];
+		assertEquals("Point height must be equal for all zoom levels", fontPrimary.getHeight(), font100.getHeight());
+		FontData font200 = fontRegistry.getSystemFont(200).getFontData()[0];
+		assertEquals("Point height must be equal for all zoom levels", fontPrimary.getHeight(), font200.getHeight());
+
+		int heightFontPrimary = fontPrimary.data.lfHeight;
+		int heightFont100 = font100.data.lfHeight;
+		assertEquals("Pixel height must not differ between primary monitor and 100% zoom", heightFontPrimary, heightFont100);
+		int heightFont200 = font200.data.lfHeight;
+		assertEquals("Pixel height must not differ between primary monitor and 200% zoom", heightFontPrimary, heightFont200);
+	}
+
+	@Test
+	public void fontsAreCached() {
+		int primaryZoom = display.getPrimaryMonitor().getZoom();
+		FontData fontData = new FontData(TEST_FONT, 10, SWT.NORMAL);
+		Font font1 = fontRegistry.getFont(fontData, primaryZoom);
+		FontData fontData2 = new FontData(TEST_FONT, 10, SWT.NORMAL);
+		Font font2 = fontRegistry.getFont(fontData2, primaryZoom);
+		assertTrue("Fonts for same font data and zoom levels must be reused", font1 == font2);
+	}
+
+	@Test
+	public void fontsAlwaysDependOnPrimaryZoom() {
+		int primaryZoom = display.getPrimaryMonitor().getZoom();
+		FontData fontData = new FontData(TEST_FONT, 10, SWT.NORMAL);
+		FontData fontPrimary = fontRegistry.getFont(fontData, primaryZoom).getFontData()[0];
+		FontData font100 = fontRegistry.getFont(fontData, 100).getFontData()[0];
+		assertEquals("Point height must be equal for all zoom levels", fontPrimary.getHeight(), font100.getHeight());
+		FontData font200 = fontRegistry.getFont(fontData, 200).getFontData()[0];
+		assertEquals("Point height must be equal for all zoom levels", fontPrimary.getHeight(), font200.getHeight());
+
+		int heightFontPrimary = fontPrimary.data.lfHeight;
+		int heightFont100 = font100.data.lfHeight;
+		assertEquals("Pixel height must not differ between primary monitor and 100% zoom", heightFontPrimary, heightFont100);
+		int heightFont200 = font200.data.lfHeight;
+		assertEquals("Pixel height must not differ between primary monitor and 200% zoom", heightFontPrimary, heightFont200);
+	}
+}

--- a/tests/org.eclipse.swt.tests.win32/JUnit Tests/org/eclipse/swt/internal/ScalingSWTFontRegistryTests.java
+++ b/tests/org.eclipse.swt.tests.win32/JUnit Tests/org/eclipse/swt/internal/ScalingSWTFontRegistryTests.java
@@ -1,0 +1,94 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Yatta Solutions
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Yatta Solutions - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.swt.internal;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.graphics.Font;
+import org.eclipse.swt.graphics.FontData;
+import org.eclipse.swt.widgets.Display;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class ScalingSWTFontRegistryTests {
+	private static String TEST_FONT = "Helvetica";
+	private SWTFontRegistry fontRegistry;
+
+	@Before
+	public void setUp() {
+		this.fontRegistry = new ScalingSWTFontRegistry(Display.getDefault());
+	}
+
+	@After
+	public void tearDown() {
+		if (this.fontRegistry != null) {
+			this.fontRegistry.dispose();
+		}
+	}
+
+	@Test
+	public void systemFontsAreCached() {
+		Font font100_1 = fontRegistry.getSystemFont(100);
+		Font font100_2 = fontRegistry.getSystemFont(100);
+		assertTrue("System fonts for same zoom factor must be reused", font100_1 == font100_2);
+	}
+
+	@Test
+	public void systemFontsAreScaled() {
+		FontData font100 = fontRegistry.getSystemFont(100).getFontData()[0];
+		FontData font200 = fontRegistry.getSystemFont(200).getFontData()[0];
+		assertEquals("Point height must be equal for all zoom factors", font100.getHeight(), font200.getHeight());
+
+		int heightFont100 = font100.data.lfHeight;
+		int heightFont200 = font200.data.lfHeight;
+		assertEquals("Pixel height must be doubled between 100% and 200% zoom factor", heightFont100 * 2, heightFont200);
+	}
+
+	@Test
+	public void fontsAreCached() {
+		FontData fontData = new FontData(TEST_FONT, 10, SWT.NORMAL);
+		Font font100_1 = fontRegistry.getFont(fontData, 100);
+		FontData fontData2 = new FontData(TEST_FONT, 10, SWT.NORMAL);
+		Font font100_2 = fontRegistry.getFont(fontData2, 100);
+		assertTrue("Fonts for same font data and zoom factor must be reused", font100_1 == font100_2);
+	}
+
+	@Test
+	public void fontsAreScaled() {
+		FontData fontData = new FontData(TEST_FONT, 10, SWT.NORMAL);
+		FontData font100 = fontRegistry.getFont(fontData, 100).getFontData()[0];
+		FontData font200 = fontRegistry.getFont(fontData, 200).getFontData()[0];
+		assertEquals("Point height must be equal for all zoom factors", font100.getHeight(), font200.getHeight());
+
+		int heightFont100 = font100.data.lfHeight;
+		int heightFont200 = font200.data.lfHeight;
+		assertEquals("Pixel height must be doubled between 100% and 200% zoom factor", heightFont100 * 2, heightFont200);
+	}
+
+	@Test
+	public void recreateDisposedFonts() {
+		FontData fontData = new FontData(TEST_FONT, 10, SWT.NORMAL);
+		Font font200 = fontRegistry.getFont(fontData, 200);
+		assertFalse("Font must not be disposed", font200.isDisposed());
+
+		font200.dispose();
+		Font font200New = fontRegistry.getFont(fontData, 200);
+		assertFalse("Disposed fonts must not be reused in the font registry", font200 == font200New);
+		assertFalse("Font must not be disposed", font200New.isDisposed());
+	}
+}

--- a/tests/org.eclipse.swt.tests.win32/JUnit Tests/org/eclipse/swt/tests/win32/AllWin32Tests.java
+++ b/tests/org.eclipse.swt.tests.win32/JUnit Tests/org/eclipse/swt/tests/win32/AllWin32Tests.java
@@ -14,6 +14,7 @@
  */
 package org.eclipse.swt.tests.win32;
 
+import org.eclipse.swt.graphics.ImageWin32Tests;
 import org.eclipse.swt.internal.DefaultSWTFontRegistryTests;
 import org.eclipse.swt.internal.ScalingSWTFontRegistryTests;
 import org.eclipse.swt.tests.win32.widgets.TestTreeColumn;
@@ -25,6 +26,8 @@ import org.junit.runners.Suite;
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
+	DefaultSWTFontRegistryTests.class,
+	ImageWin32Tests.class,
 	ScalingSWTFontRegistryTests.class,
 	Test_org_eclipse_swt_dnd_DND.class,
 	Test_org_eclipse_swt_events_KeyEvent.class,

--- a/tests/org.eclipse.swt.tests.win32/JUnit Tests/org/eclipse/swt/tests/win32/AllWin32Tests.java
+++ b/tests/org.eclipse.swt.tests.win32/JUnit Tests/org/eclipse/swt/tests/win32/AllWin32Tests.java
@@ -14,6 +14,8 @@
  */
 package org.eclipse.swt.tests.win32;
 
+import org.eclipse.swt.internal.DefaultSWTFontRegistryTests;
+import org.eclipse.swt.internal.ScalingSWTFontRegistryTests;
 import org.eclipse.swt.tests.win32.widgets.TestTreeColumn;
 import org.eclipse.swt.tests.win32.widgets.Test_org_eclipse_swt_widgets_Display;
 import org.junit.runner.JUnitCore;
@@ -23,6 +25,7 @@ import org.junit.runners.Suite;
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
+	ScalingSWTFontRegistryTests.class,
 	Test_org_eclipse_swt_dnd_DND.class,
 	Test_org_eclipse_swt_events_KeyEvent.class,
 	Test_org_eclipse_swt_widgets_Display.class,

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_Image.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_Image.java
@@ -875,6 +875,14 @@ void getImageData_int(int zoom) {
 	Rectangle boundsAtZoom = new Rectangle(0, 0, imageDataAtZoom.width, imageDataAtZoom.height);
 	assertEquals(":a: Size of ImageData returned from Image.getImageData(int) method doesn't return matches with bounds in Pixel values.", scaleBounds(bounds, zoom, 100), boundsAtZoom);
 
+	// creates second bitmap image and compare size of imageData
+	image = new Image(display, bounds);
+	imageDataAtZoom = image.getImageData(zoom);
+	boundsAtZoom = new Rectangle(0, 0, imageDataAtZoom.width, imageDataAtZoom.height);
+	bounds = image.getBounds();
+	image.dispose();
+	assertEquals(":a: Size of ImageData returned from Image.getImageData(int) method doesn't return matches with bounds in Pixel values.", scaleBounds(bounds, zoom, 100), boundsAtZoom);
+
 	// create icon image and compare size of imageData
 	ImageData imageData = new ImageData(bounds.width, bounds.height, 1, new PaletteData(new RGB[] {new RGB(0, 0, 0)}));
 	image = new Image(display, imageData);


### PR DESCRIPTION
Hello everyone,

**DISCLAIMER:** We are currently testing it in more complex application to identify blockers, that could result in changes in the PR. **BUT**, except from the ongoing testing the feature set in this PR includes everything we target for this first PR.
We used the branch nmodi/DynamicDPI_4909 as source of ideas and a starting point for our approach.

We are working on improving the HiDPI behaviour in SWT in the implementation for Windows for quite some time now together with @HeikoKlare. We try to split the adaptions up into smaller contributions to make the PRs easier to review and to discuss. This is the smallest set we managed to bundle having a usuable state of SWT for a subset of widgets. 
Due to this, the PR is not yet suitable to provide a proper scaling for the Eclipse IDE as a whole - some controls will not be scaled correctly or you will experience side effects.

**How to test**
As said above, the PR is just the first step, so testing it with the Eclipse IDE is not really a good idea (except to rule out side effect when **not** activating the feature. Best way to play around with the PR is to use the _ControlExample_ with the VM arguments: _-Dswt.autoScale.updateOnRuntime=true -Dswt.autoScale=quarter_. Still expect Glitches in the UI like cut off texts after DPI changes.

In the following I try to give a structured insight in our approach:

**Limitations:** (that will be covered separately in other PRs)
- With this PR there is still a limitation for one zoom level per application (`DPIUtil.deviceZoom`, see #131)
- Widgets in the common-package (e.g. CTabFolder) are not yet contained in this PR (except Item)
- There are multiple static attributes or attributes that e.g. are initialized on startup with the primary monitor zoom level and are currently not updated
 
**Opt-in feature configuration:**
The new behaviour is implemented as opt-in feature activated with the _swt.autoScale.updateOnRuntime_ flag. The logic how the DPI level is calculated is unchanged. In Windows using it with _-Dswt.autoScale=quarter_ could make sense, because the recent Windows versions usually propose scaling in 25% steps.

**DPI zoom update propagation:**
The whole propagation is integrated into the event handling triggered by `Control::WM_DPICHANGED`. The event triggers a listener in `Shell::handleZoomEvent` that propagates it into a custom compoanont with a lifecycle managed by `DPIZoomChangeRegistry`. We evaluated multiple ideas for that, like
- Adding a method directly inside _Widget_, that takes care of neccessary updates. This method would be needed to be overriden by sublassed to add additional update logic. Two major drawback for that were:
	- Exposing an additional method into the API of Widget (it must be public to be accessible from all neccessary loocations)
	- Unclear how to integrate this (Windows specific) behaviour into the common widgets, like CTabFolder
- Propagating the SWT event for a zoom change through each widget in the hierarchy and bind the update behaviour via listener (similar to `Shell::handleZoomEvent` for the "main" event). Two major drawback for that were:
	- How to register the listener? Doing it in the constructor leads to problems to distinguish if a listener must be added or not. If a Composite would be instantiated directly, you would need to register it, but not, when a subclass of it was instantiated. We didn't came a with a reliable solution to cover all issues regarding this approach.
	- How to structure the callbacks? One implementation per class that is individually called or having the listeners match the class hierarchy of the widget to delegate the event directly in the listener. Both approaches had not solvable drawback either caused by similar issues like in point 1 or by having unsorted handling of events.

In the end we decided to implement an independent workflow to have full control over the order how the updates are handled. The execution order is starting with the most general class in the class hierarchy, e.g. if a Composite is updated, the handlers are executed like (Widget -> Control -> Scrollable -> Composite). This way each class can provide a handler that only takes care for the attributes/method it adds, but the order is reliable and consistent.

**Fonts:**
With fonts there are two main challenges: How to scale fonts and how to make sure fonts are used in the correct scale?
_Scaling fonts_
The main issue arises from the conversion of pixels to points of a font. The conversion is dependent on the primary monitor zoom (see `Device::computePoints(LOGFONT logFont, long hFont)`). Therefor we need additional informartion to adapt this conversion to the correct target zoom. We achieve this by adding a package protected attribute `zoomLevel` to fonts, that is used to correct this conversion. According to our testing we see this approach works reliable.
_Identify the correct scaled variant of a font_
As a font (_instance_) can and is usually reused for many controls, we must assume these controls will be rendered on monitors with different zoom levels. Each font (_instance_) stores the handle that links to the font resource in the OS. In case a control is affected by a zoom level change, this change must be applied to the assigned font as well -> _Solution:_ update the font to a scaled variant and pass it to the control. This would be sufficient, if SWT would have the full control of font creation. But fonts are almost always created (and commonly cached) outside of SWT and we cannot assume, that a font is scaled to the correct size when passed to a control. If we would not consider this as well, e.g. a scaled font can be replaced by a non-scaled variant at any time. To cover both scenarios we adapt fonts in two places:
- Zoom level change of the Control will update the font (if != null) as well
- Update the font (usually via _setFont_) must check for the correct zoom level and replace it by a proper one, if necessary.

Both scenarios make use of (1) `Font:scaleFor(zoomLevel)` to derive scaled font variants from each font and (2) caching them in `ScalingFontRegistry` to be able to reuse scaled variants of a font that is used for multiple controls.

_Note:_ In default or if _swt.autoScale.updateOnRuntime_ flag is set to false DefaultSWTFontRegistry is used instead of `ScalingFontRegistry`

**Images:**
There was already automatic scaling in Image. This was adapted to cover additional issues we faced when testing. To reuse an image for multiple zoom levels at the same time, there will be additional adaptions necessary, according to our testing so far.

Any feedback is highly appreciated. We hope we can provide a proper starting point for improving the HiDPI behaviour  in Windows and are planning to continue with this topic in the following week.