### PR TITLE
Correct GC offset calculation #788

### DIFF
--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_GC.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_GC.java
@@ -15,6 +15,9 @@
 package org.eclipse.swt.tests.junit;
 
 import static org.eclipse.swt.tests.junit.SwtTestUtil.assertSWTProblem;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -35,6 +38,7 @@ import org.eclipse.swt.graphics.PaletteData;
 import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.graphics.RGB;
 import org.eclipse.swt.graphics.Rectangle;
+import org.eclipse.swt.graphics.Transform;
 import org.eclipse.swt.internal.DPIUtil;
 import org.eclipse.swt.widgets.Canvas;
 import org.eclipse.swt.widgets.Display;
@@ -731,6 +735,35 @@ public void test_bug493455_drawImageAlpha_srcPos() {
 		}
 	}
 
+}
+
+/**
+ * @see <a href="https://github.com/eclipse-platform/eclipse.platform.swt/issues/788">Issue 788</a>
+ */
+@Test
+public void test_drawLine_noSingularitiesIn45DregreeRotation() {
+	int imageSize = 3;
+	int centerPixel = imageSize / 2;
+	Image image = new Image(Display.getDefault(), imageSize, imageSize);
+	GC gc = new GC(image);
+	Transform rotation = new Transform(gc.getDevice());
+	gc.getTransform(rotation);
+
+	try {
+		// Rotate 45° around image center
+		rotation.translate(centerPixel, centerPixel);
+		rotation.rotate(45);
+		rotation.translate(- centerPixel, - centerPixel);
+		gc.setTransform(rotation);
+		gc.drawLine(centerPixel, centerPixel, centerPixel + 1, centerPixel);
+
+		assertThat("line is not drawn with 45 degree rotation",
+				image.getImageData().getPixel(centerPixel, centerPixel), not(is(-1)));
+	} finally {
+		rotation.dispose();
+		gc.dispose();
+		image.dispose();
+	}
 }
 
 /* custom */


### PR DESCRIPTION
The offset calculation in the GC when having an odd line width is erroneous in case rotation transformations have been applied to the GC. With a rotation of 45°, the calculation even suffers from singularities that result in effectively nothing being drawn. With other transformation properties, off-by-one error occur.

This change inverts the offset calculation: Instead of performing a forward transformation of a dummy point whose result is applied to the expected offset, the inverse transformation is applied to the expected offset. This avoids singularities and imprecision in the calculation and ensures that when applying rotations to the GC, the drawing figures are as expected.

The behavior can be evaluated with [Snippet 381](https://github.com/eclipse-platform/eclipse.platform.swt/blob/c61465f079addb7cecfe9b42bbef8e5bedcc0bea/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet381.java).


Fixes https://github.com/eclipse-platform/eclipse.platform.swt/issues/788.

### Additional Information

This is a revision of the original fix contributed in #789, which has been reverted because of a regression in #1068. The regression is documented in #1067 and could be seen on Mac and Linux when drawing a rectangle with line width 2 into a drawing area of a size in which it should fit (and did before), but was cut off after #789. The reason was that anti-aliasing was (erroneously) considered to be activate. In addition, anti-aliasing behavior was treated equally for all OS', but differs between Windows and Mac/Linux. To ensure compatibility with existing expectations on the behavior, I have removed the additional anti-aliasing handling added in #789 in this PR. Note that the positioning behavior in SWT is not very consistent anyway: for odd line widths, it adds an offset of 0.5 pixels in x and y direction to the points, which is not done when the line width is even. While this may be reasonable for simple scenarios, it becomes complicated when transformations are applied to the GC. And, in particular, in case of a non-integer line width, the line width for offset calculation is checked for being odd or even via integer conversion, whereas the drawing engines properly round that value, which results in unexpected results for non-integer line widths anyway. In case of anti-aliasing the situation becomes even more complicated, since then depending on the offset, the shading due to the anti-aliasing changes. This does, however, only seem to be a problem on Windows, as anti-aliasing behavior is different on Mac/Linux.

In total, this PR is a reduced version of #789 to only make the offset calculation more consistent and, in particular, to avoid the singularities documented in #788. It does not change anti-aliasing offset calculation anymore, so the regression documented in #1068 is avoided.

@Phillipus It would be great if you can test this patch, so that we avoid further regressions. If there are no objections, I would like to merge this PR as soon as possible in the coming development cycle to have sufficient time to notice potential remaining regressions.