### PR TITLE
fix SWT table/tree control SelectionListener on Mac

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Table.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Table.java
@@ -3477,6 +3477,9 @@ void tableViewSelectionDidChange (long id, long sel, long aNotification) {
 
 @Override
 void tableViewSelectionIsChanging (long id, long sel, long aNotification) {
+	if (keyDown) {
+		return;
+	}
 	didSelect = true;
 	sendSelection();
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Table.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Table.java
@@ -3477,9 +3477,9 @@ void tableViewSelectionDidChange (long id, long sel, long aNotification) {
 
 @Override
 void tableViewSelectionIsChanging (long id, long sel, long aNotification) {
-	if (keyDown) {
-		return;
-	}
+	// tableViewSelectionIsChanging is called when pressing ARROW_DOWN, ARROW_UP key
+	// don't run sendSelection because it would then gather the "old" incorrect selected row
+	if (keyDown) return;
 	didSelect = true;
 	sendSelection();
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Tree.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Tree.java
@@ -96,6 +96,7 @@ public class Tree extends Composite {
 
 	/* Used to control drop feedback when DND.FEEDBACK_EXPAND and DND.FEEDBACK_SCROLL is set/not set */
 	boolean shouldExpand = true, shouldScroll = true;
+	boolean keyDown;
 
 	final int nativeItemHeight;
 
@@ -2108,7 +2109,9 @@ boolean isTrim (NSView view) {
 @Override
 void keyDown(long id, long sel, long theEvent) {
 	ignoreSelect = preventSelect = false;
+	keyDown = true;
 	super.keyDown(id, sel, theEvent);
+	keyDown = false;
 }
 
 @Override
@@ -2463,6 +2466,9 @@ void outlineViewSelectionDidChange (long id, long sel, long notification) {
 
 @Override
 void outlineViewSelectionIsChanging (long id, long sel, long notification) {
+	if (keyDown) {
+		return;
+	}
 	didSelect = true;
 	sendSelection ();
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Tree.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Tree.java
@@ -97,7 +97,6 @@ public class Tree extends Composite {
 	/* Used to control drop feedback when DND.FEEDBACK_EXPAND and DND.FEEDBACK_SCROLL is set/not set */
 	boolean shouldExpand = true, shouldScroll = true;
 	boolean keyDown;
-
 	final int nativeItemHeight;
 
 	static int NEXT_ID;
@@ -2466,9 +2465,9 @@ void outlineViewSelectionDidChange (long id, long sel, long notification) {
 
 @Override
 void outlineViewSelectionIsChanging (long id, long sel, long notification) {
-	if (keyDown) {
-		return;
-	}
+	// outlineViewSelectionIsChanging is called when pressing ARROW_DOWN, ARROW_UP key
+	// don't run sendSelection because it would then gather the "old" incorrect selected row
+	if (keyDown) return;
 	didSelect = true;
 	sendSelection ();
 }


### PR DESCRIPTION
SelectionEvent.item in callback method widgetSelected now contains the current selected item

Fixes: https://github.com/eclipse-platform/eclipse.platform.swt/issues/1052