### PR TITLE
Fix for Mac drawing bug

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT PI/cocoa/org/eclipse/swt/internal/cocoa/OS.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/cocoa/org/eclipse/swt/internal/cocoa/OS.java
@@ -156,6 +156,9 @@ public class OS extends C {
 	public static final long sel_setStyle = Selector.sel_setStyle.value;
 	public static final int NSTableViewStylePlain = 4;
 
+    /** 14.0 selector */
+    public static final long sel_setClipsToBounds_ = Selector.sel_setClipsToBounds_.value;
+
 	/* AWT application delegate. Remove these when JavaRuntimeSupport.framework has bridgesupport generated for it. */
 	public static final long class_JRSAppKitAWT = objc_getClass("JRSAppKitAWT");
 	public static final long sel_awtAppDelegate = Selector.sel_awtAppDelegate.value;

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/cocoa/org/eclipse/swt/internal/cocoa/Selector.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/cocoa/org/eclipse/swt/internal/cocoa/Selector.java
@@ -82,6 +82,9 @@ public enum Selector {
 	/** 11.0 selector */
 	, sel_setStyle("setStyle:")
 
+	/** 14.0 selector */
+	, sel_setClipsToBounds_("setClipsToBounds:")
+
 	, sel_awtAppDelegate("awtAppDelegate")
 
 	  /** This section is auto generated */

--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Widget.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Widget.java
@@ -759,6 +759,13 @@ void drawRect (long id, long sel, NSRect rect) {
 	if (!isDrawing()) return;
 	Display display = this.display;
 	NSView view = new NSView(id);
+
+	/*
+	* Since macOS 14 the clipsToBounds property of NSView has to be set to true
+	* See https://developer.apple.com/documentation/macos-release-notes/appkit-release-notes-for-macos-14
+	*/
+	OS.objc_msgSend(id, OS.sel_setClipsToBounds_, true);
+
 	display.isPainting.addObject(view);
 	NSGraphicsContext context = NSGraphicsContext.currentContext();
 	context.saveGraphicsState();


### PR DESCRIPTION
- Add a new selector setClipsToBounds
- Set this selector to true in Widget#drawRect
- See https://github.com/eclipse-platform/eclipse.platform.swt/issues/1012