### PR TITLE
Fix Performance tests #882 #1010 #918

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -71,7 +71,7 @@ jobs:
         --fail-at-end
         -DskipNativeTests=false
         -DfailIfNoTests=false
-        clean verify
+        clean install
     - name: Performance tests
       if: contains(github.event.pull_request.labels.*.name, 'performance')
       uses: coactions/setup-xvfb@b6b4fcfb9f5a895edadc3bc76318fae0ac17c8b3 # v1.0.1


### PR DESCRIPTION
Optional performance tests rely on prebuilt SWT components to be available. `mvn install` phase is essential for this. This phase was removed in #1010.
Performance tests had started to [fail](https://github.com/eclipse-platform/eclipse.platform.swt/actions/runs/8203164002/job/22435425736?pr=918) with:
```
Error:  Cannot resolve project dependencies:
Error:    You requested to install 'osgi.bundle; org.eclipse.swt.fragments.localbuild 0.0.0' but it could not be found
```

Broken performance tests are blocking work in #918.

@laeubi could you please add [performance](https://github.com/eclipse-platform/eclipse.platform.swt/pulls?q=is%3Apr+is%3Aopen+label%3Aperformance) label to this MR?

@HannesWell please review