### PR TITLE
Increment the version of org.eclipse.swt.tools.base

### DIFF
--- a/bundles/org.eclipse.swt.tools.base/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.swt.tools.base/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.swt.tools.base;singleton:=true
-Bundle-Version: 3.107.500.qualifier
+Bundle-Version: 3.107.600.qualifier
 Bundle-ManifestVersion: 2
 Bundle-ActivationPolicy: lazy
 Bundle-Localization: plugin

--- a/features/org.eclipse.swt.tools.feature/feature.xml
+++ b/features/org.eclipse.swt.tools.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.swt.tools.feature"
       label="%featureName"
-      version="3.109.300.qualifier"
+      version="3.109.400.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">


### PR DESCRIPTION
Force a new version so that publishing to Maven Central can update the version without specialized remapping rules.

https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1882