### PR TITLE
Use the new fragment-host timestamp provider

### DIFF
--- a/binaries/pom.xml
+++ b/binaries/pom.xml
@@ -51,6 +51,13 @@
 					<addSourceFolders>true</addSourceFolders>
 				</configuration>
 			</plugin>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-packaging-plugin</artifactId>
+				<configuration>
+					<timestampProvider>fragment-host</timestampProvider>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 
@@ -65,20 +72,6 @@
 			<build>
 				<plugins>
 					<plugin>
-						<artifactId>maven-clean-plugin</artifactId>
-						<configuration>
-							<filesets>
-								<fileset>
-									<directory>src</directory>
-									<includes>
-										<include>**/*</include>
-									</includes>
-									<followSymlinks>false</followSymlinks>
-								</fileset>
-							</filesets>
-						</configuration>
-					</plugin>
-					<plugin>
 						<groupId>org.eclipse.tycho</groupId>
 						<artifactId>target-platform-configuration</artifactId>
 						<configuration>
@@ -92,37 +85,8 @@
 						</configuration>
 					</plugin>
 					<plugin>
-						<groupId>org.eclipse.tycho</groupId>
-						<artifactId>tycho-packaging-plugin</artifactId>
-						<executions>
-							<execution>
-								<id>default-build-qualifier</id>
-								<phase>initialize</phase> <!-- Postpone default-build-qualifier execution from packaging's default-bindings until the qualifier was read below.-->
-								<goals>
-									<goal>build-qualifier</goal>
-								</goals>
-								<configuration>
-									<forceContextQualifier>${swtBuildQualifier}</forceContextQualifier>
-								</configuration>
-							</execution>
-						</executions>
-					</plugin>
-					<plugin>
 						<artifactId>maven-antrun-plugin</artifactId>
 						<executions>
-							<execution>
-								<id>read-build-qualifier</id>
-								<phase>validate</phase>
-								<goals>
-									<goal>run</goal>
-								</goals>
-								<configuration>
-									<target> <!-- Read git qualifier of 'org.eclipse.swt' project. -->
-										<loadfile property="swtBuildQualifier" srcFile="${swtMainProject}/target/swtBuildQualifier.txt"/>
-									</target>
-									<exportAntProperties>true</exportAntProperties>
-								</configuration>
-							</execution>
 							<execution>
 								<id>build-native-binaries</id>
 								<phase>process-resources</phase>

--- a/bundles/org.eclipse.swt/pom.xml
+++ b/bundles/org.eclipse.swt/pom.xml
@@ -31,24 +31,6 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-antrun-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>write-build-qualifier</id>
-                        <phase>generate-resources</phase>
-                        <goals>
-                            <goal>run</goal>
-                        </goals>
-                        <configuration>
-                            <target> <!-- Write computed qualifier to file so that the native fragments can read it as their qualifier. -->
-                                <echo file="${project.build.directory}/swtBuildQualifier.txt" message="${buildQualifier}" />
-                            </target>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
                 <groupId>org.eclipse.tycho</groupId>
                 <artifactId>target-platform-configuration</artifactId>
                 <configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,6 @@
           <plugin>
             <groupId>org.eclipse.tycho</groupId>
             <artifactId>target-platform-configuration</artifactId>
-            <version>${tycho.version}</version>
             <configuration>
               <dependency-resolution>
                 <profileProperties>
@@ -134,7 +133,6 @@
           <plugin>
             <groupId>org.eclipse.tycho</groupId>
             <artifactId>target-platform-configuration</artifactId>
-            <version>${tycho.version}</version>
             <configuration>
               <environments>
                 <environment>


### PR DESCRIPTION
Currently there are some  special configuration in the poms using ant scripts that want to ensure that swt host and fragements use the same build qualifier.

This now uses the new fragment-host timestamp provider to ensure this instead so we are able to get rid of this.