### PR TITLE
[DO NOT MERGE] Change breaks SWT API by adding/removing annotations

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/cairo/org/eclipse/swt/graphics/Path.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cairo/org/eclipse/swt/graphics/Path.java
@@ -50,7 +50,6 @@ public class Path extends Resource {
 	 * platforms and should never be accessed from application code.
 	 * </p>
 	 *
-	 * @noreference This field is not intended to be referenced by clients.
 	 */
 	public long handle;
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Display.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Display.java
@@ -2387,6 +2387,7 @@ String gtk_widget_class_get_css_name(long handle) {
  * if it did not already exist.
  *
  * @return the default display
+ * @noreference This method is not intended to be referenced by clients.
  */
 public static Display getDefault () {
 	synchronized (Device.class) {


### PR DESCRIPTION
The only purpose is to see if that will fail Jenkins / Github validation.

The `@noreference` is supposed to be read either from Java sources (in IDE) or from *generated* .api_description files from compiled SWT native fragments.

See https://github.com/eclipse-platform/eclipse.platform.swt/issues/1093