### PR TITLE
Revert 1101

### DIFF
--- a/binaries/org.eclipse.swt.cocoa.macosx.aarch64/.settings/.api_filters
+++ b/binaries/org.eclipse.swt.cocoa.macosx.aarch64/.settings/.api_filters
@@ -1,5 +1,453 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <component id="org.eclipse.swt.cocoa.macosx.aarch64" version="2">
+    <resource path="Eclipse SWT Accessibility/common/org/eclipse/swt/accessibility/AccessibleActionListener.java" type="org.eclipse.swt.accessibility.AccessibleActionListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="AccessibleActionListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Accessibility/common/org/eclipse/swt/accessibility/AccessibleAttributeListener.java" type="org.eclipse.swt.accessibility.AccessibleAttributeListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="AccessibleAttributeListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Accessibility/common/org/eclipse/swt/accessibility/AccessibleControlListener.java" type="org.eclipse.swt.accessibility.AccessibleControlListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="AccessibleControlListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Accessibility/common/org/eclipse/swt/accessibility/AccessibleEditableTextListener.java" type="org.eclipse.swt.accessibility.AccessibleEditableTextListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="AccessibleEditableTextListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Accessibility/common/org/eclipse/swt/accessibility/AccessibleHyperlinkListener.java" type="org.eclipse.swt.accessibility.AccessibleHyperlinkListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="AccessibleHyperlinkListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Accessibility/common/org/eclipse/swt/accessibility/AccessibleListener.java" type="org.eclipse.swt.accessibility.AccessibleListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="AccessibleListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Accessibility/common/org/eclipse/swt/accessibility/AccessibleTableCellListener.java" type="org.eclipse.swt.accessibility.AccessibleTableCellListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="AccessibleTableCellListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Accessibility/common/org/eclipse/swt/accessibility/AccessibleTableListener.java" type="org.eclipse.swt.accessibility.AccessibleTableListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="AccessibleTableListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Accessibility/common/org/eclipse/swt/accessibility/AccessibleTextListener.java" type="org.eclipse.swt.accessibility.AccessibleTextListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="AccessibleTextListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Accessibility/common/org/eclipse/swt/accessibility/AccessibleValueListener.java" type="org.eclipse.swt.accessibility.AccessibleValueListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="AccessibleValueListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Browser/common/org/eclipse/swt/browser/AuthenticationListener.java" type="org.eclipse.swt.browser.AuthenticationListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="AuthenticationListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Browser/common/org/eclipse/swt/browser/CloseWindowListener.java" type="org.eclipse.swt.browser.CloseWindowListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="CloseWindowListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Browser/common/org/eclipse/swt/browser/LocationListener.java" type="org.eclipse.swt.browser.LocationListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="LocationListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Browser/common/org/eclipse/swt/browser/OpenWindowListener.java" type="org.eclipse.swt.browser.OpenWindowListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="OpenWindowListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Browser/common/org/eclipse/swt/browser/ProgressListener.java" type="org.eclipse.swt.browser.ProgressListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="ProgressListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Browser/common/org/eclipse/swt/browser/StatusTextListener.java" type="org.eclipse.swt.browser.StatusTextListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="StatusTextListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Browser/common/org/eclipse/swt/browser/TitleListener.java" type="org.eclipse.swt.browser.TitleListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="TitleListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Browser/common/org/eclipse/swt/browser/VisibilityWindowListener.java" type="org.eclipse.swt.browser.VisibilityWindowListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="VisibilityWindowListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/BidiSegmentListener.java" type="org.eclipse.swt.custom.BidiSegmentListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="BidiSegmentListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CTabFolder2Listener.java" type="org.eclipse.swt.custom.CTabFolder2Listener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="CTabFolder2Listener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CTabFolderListener.java" type="org.eclipse.swt.custom.CTabFolderListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="CTabFolderListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CaretListener.java" type="org.eclipse.swt.custom.CaretListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="CaretListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/ExtendedModifyListener.java" type="org.eclipse.swt.custom.ExtendedModifyListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="ExtendedModifyListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/LineBackgroundListener.java" type="org.eclipse.swt.custom.LineBackgroundListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="LineBackgroundListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/LineStyleListener.java" type="org.eclipse.swt.custom.LineStyleListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="LineStyleListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/MovementListener.java" type="org.eclipse.swt.custom.MovementListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="MovementListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/PaintObjectListener.java" type="org.eclipse.swt.custom.PaintObjectListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="PaintObjectListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/TextChangeListener.java" type="org.eclipse.swt.custom.TextChangeListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="TextChangeListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/VerifyKeyListener.java" type="org.eclipse.swt.custom.VerifyKeyListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="VerifyKeyListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Drag and Drop/common/org/eclipse/swt/dnd/DragSourceListener.java" type="org.eclipse.swt.dnd.DragSourceListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="DragSourceListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Drag and Drop/common/org/eclipse/swt/dnd/DropTargetListener.java" type="org.eclipse.swt.dnd.DropTargetListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="DropTargetListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/ArmListener.java" type="org.eclipse.swt.events.ArmListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="ArmListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/ControlListener.java" type="org.eclipse.swt.events.ControlListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="ControlListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/DisposeListener.java" type="org.eclipse.swt.events.DisposeListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="DisposeListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/DragDetectListener.java" type="org.eclipse.swt.events.DragDetectListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="DragDetectListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/ExpandListener.java" type="org.eclipse.swt.events.ExpandListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="ExpandListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/FocusListener.java" type="org.eclipse.swt.events.FocusListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="FocusListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/GestureListener.java" type="org.eclipse.swt.events.GestureListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="GestureListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/HelpListener.java" type="org.eclipse.swt.events.HelpListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="HelpListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/KeyListener.java" type="org.eclipse.swt.events.KeyListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="KeyListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/MenuDetectListener.java" type="org.eclipse.swt.events.MenuDetectListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="MenuDetectListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/MenuListener.java" type="org.eclipse.swt.events.MenuListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="MenuListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/ModifyListener.java" type="org.eclipse.swt.events.ModifyListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="ModifyListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/MouseListener.java" type="org.eclipse.swt.events.MouseListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="MouseListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/MouseMoveListener.java" type="org.eclipse.swt.events.MouseMoveListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="MouseMoveListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/MouseTrackListener.java" type="org.eclipse.swt.events.MouseTrackListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="MouseTrackListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/MouseWheelListener.java" type="org.eclipse.swt.events.MouseWheelListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="MouseWheelListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/PaintListener.java" type="org.eclipse.swt.events.PaintListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="PaintListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/SegmentListener.java" type="org.eclipse.swt.events.SegmentListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="SegmentListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/SelectionListener.java" type="org.eclipse.swt.events.SelectionListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="SelectionListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/ShellListener.java" type="org.eclipse.swt.events.ShellListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="ShellListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/TouchListener.java" type="org.eclipse.swt.events.TouchListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="TouchListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/TraverseListener.java" type="org.eclipse.swt.events.TraverseListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="TraverseListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/TreeListener.java" type="org.eclipse.swt.events.TreeListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="TreeListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/VerifyListener.java" type="org.eclipse.swt.events.VerifyListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="VerifyListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/graphics/ImageLoaderListener.java" type="org.eclipse.swt.graphics.ImageLoaderListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="ImageLoaderListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
     <resource path="Eclipse SWT/cocoa/org/eclipse/swt/widgets/Display.java" type="org.eclipse.swt.widgets.Display">
         <filter id="336744520">
             <message_arguments>

--- a/binaries/org.eclipse.swt.cocoa.macosx.x86_64/.settings/.api_filters
+++ b/binaries/org.eclipse.swt.cocoa.macosx.x86_64/.settings/.api_filters
@@ -1,5 +1,453 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <component id="org.eclipse.swt.cocoa.macosx.x86_64" version="2">
+    <resource path="Eclipse SWT Accessibility/common/org/eclipse/swt/accessibility/AccessibleActionListener.java" type="org.eclipse.swt.accessibility.AccessibleActionListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="AccessibleActionListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Accessibility/common/org/eclipse/swt/accessibility/AccessibleAttributeListener.java" type="org.eclipse.swt.accessibility.AccessibleAttributeListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="AccessibleAttributeListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Accessibility/common/org/eclipse/swt/accessibility/AccessibleControlListener.java" type="org.eclipse.swt.accessibility.AccessibleControlListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="AccessibleControlListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Accessibility/common/org/eclipse/swt/accessibility/AccessibleEditableTextListener.java" type="org.eclipse.swt.accessibility.AccessibleEditableTextListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="AccessibleEditableTextListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Accessibility/common/org/eclipse/swt/accessibility/AccessibleHyperlinkListener.java" type="org.eclipse.swt.accessibility.AccessibleHyperlinkListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="AccessibleHyperlinkListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Accessibility/common/org/eclipse/swt/accessibility/AccessibleListener.java" type="org.eclipse.swt.accessibility.AccessibleListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="AccessibleListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Accessibility/common/org/eclipse/swt/accessibility/AccessibleTableCellListener.java" type="org.eclipse.swt.accessibility.AccessibleTableCellListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="AccessibleTableCellListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Accessibility/common/org/eclipse/swt/accessibility/AccessibleTableListener.java" type="org.eclipse.swt.accessibility.AccessibleTableListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="AccessibleTableListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Accessibility/common/org/eclipse/swt/accessibility/AccessibleTextListener.java" type="org.eclipse.swt.accessibility.AccessibleTextListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="AccessibleTextListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Accessibility/common/org/eclipse/swt/accessibility/AccessibleValueListener.java" type="org.eclipse.swt.accessibility.AccessibleValueListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="AccessibleValueListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Browser/common/org/eclipse/swt/browser/AuthenticationListener.java" type="org.eclipse.swt.browser.AuthenticationListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="AuthenticationListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Browser/common/org/eclipse/swt/browser/CloseWindowListener.java" type="org.eclipse.swt.browser.CloseWindowListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="CloseWindowListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Browser/common/org/eclipse/swt/browser/LocationListener.java" type="org.eclipse.swt.browser.LocationListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="LocationListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Browser/common/org/eclipse/swt/browser/OpenWindowListener.java" type="org.eclipse.swt.browser.OpenWindowListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="OpenWindowListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Browser/common/org/eclipse/swt/browser/ProgressListener.java" type="org.eclipse.swt.browser.ProgressListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="ProgressListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Browser/common/org/eclipse/swt/browser/StatusTextListener.java" type="org.eclipse.swt.browser.StatusTextListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="StatusTextListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Browser/common/org/eclipse/swt/browser/TitleListener.java" type="org.eclipse.swt.browser.TitleListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="TitleListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Browser/common/org/eclipse/swt/browser/VisibilityWindowListener.java" type="org.eclipse.swt.browser.VisibilityWindowListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="VisibilityWindowListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/BidiSegmentListener.java" type="org.eclipse.swt.custom.BidiSegmentListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="BidiSegmentListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CTabFolder2Listener.java" type="org.eclipse.swt.custom.CTabFolder2Listener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="CTabFolder2Listener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CTabFolderListener.java" type="org.eclipse.swt.custom.CTabFolderListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="CTabFolderListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CaretListener.java" type="org.eclipse.swt.custom.CaretListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="CaretListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/ExtendedModifyListener.java" type="org.eclipse.swt.custom.ExtendedModifyListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="ExtendedModifyListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/LineBackgroundListener.java" type="org.eclipse.swt.custom.LineBackgroundListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="LineBackgroundListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/LineStyleListener.java" type="org.eclipse.swt.custom.LineStyleListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="LineStyleListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/MovementListener.java" type="org.eclipse.swt.custom.MovementListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="MovementListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/PaintObjectListener.java" type="org.eclipse.swt.custom.PaintObjectListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="PaintObjectListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/TextChangeListener.java" type="org.eclipse.swt.custom.TextChangeListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="TextChangeListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/VerifyKeyListener.java" type="org.eclipse.swt.custom.VerifyKeyListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="VerifyKeyListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Drag and Drop/common/org/eclipse/swt/dnd/DragSourceListener.java" type="org.eclipse.swt.dnd.DragSourceListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="DragSourceListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Drag and Drop/common/org/eclipse/swt/dnd/DropTargetListener.java" type="org.eclipse.swt.dnd.DropTargetListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="DropTargetListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/ArmListener.java" type="org.eclipse.swt.events.ArmListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="ArmListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/ControlListener.java" type="org.eclipse.swt.events.ControlListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="ControlListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/DisposeListener.java" type="org.eclipse.swt.events.DisposeListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="DisposeListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/DragDetectListener.java" type="org.eclipse.swt.events.DragDetectListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="DragDetectListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/ExpandListener.java" type="org.eclipse.swt.events.ExpandListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="ExpandListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/FocusListener.java" type="org.eclipse.swt.events.FocusListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="FocusListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/GestureListener.java" type="org.eclipse.swt.events.GestureListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="GestureListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/HelpListener.java" type="org.eclipse.swt.events.HelpListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="HelpListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/KeyListener.java" type="org.eclipse.swt.events.KeyListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="KeyListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/MenuDetectListener.java" type="org.eclipse.swt.events.MenuDetectListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="MenuDetectListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/MenuListener.java" type="org.eclipse.swt.events.MenuListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="MenuListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/ModifyListener.java" type="org.eclipse.swt.events.ModifyListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="ModifyListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/MouseListener.java" type="org.eclipse.swt.events.MouseListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="MouseListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/MouseMoveListener.java" type="org.eclipse.swt.events.MouseMoveListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="MouseMoveListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/MouseTrackListener.java" type="org.eclipse.swt.events.MouseTrackListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="MouseTrackListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/MouseWheelListener.java" type="org.eclipse.swt.events.MouseWheelListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="MouseWheelListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/PaintListener.java" type="org.eclipse.swt.events.PaintListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="PaintListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/SegmentListener.java" type="org.eclipse.swt.events.SegmentListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="SegmentListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/SelectionListener.java" type="org.eclipse.swt.events.SelectionListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="SelectionListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/ShellListener.java" type="org.eclipse.swt.events.ShellListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="ShellListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/TouchListener.java" type="org.eclipse.swt.events.TouchListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="TouchListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/TraverseListener.java" type="org.eclipse.swt.events.TraverseListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="TraverseListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/TreeListener.java" type="org.eclipse.swt.events.TreeListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="TreeListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/VerifyListener.java" type="org.eclipse.swt.events.VerifyListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="VerifyListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/graphics/ImageLoaderListener.java" type="org.eclipse.swt.graphics.ImageLoaderListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="ImageLoaderListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
     <resource path="Eclipse SWT/cocoa/org/eclipse/swt/widgets/Display.java" type="org.eclipse.swt.widgets.Display">
         <filter id="336744520">
             <message_arguments>

--- a/binaries/org.eclipse.swt.gtk.linux.aarch64/.settings/.api_filters
+++ b/binaries/org.eclipse.swt.gtk.linux.aarch64/.settings/.api_filters
@@ -1,10 +1,466 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <component id="org.eclipse.swt.gtk.linux.aarch64" version="2">
+    <resource path="Eclipse SWT Accessibility/common/org/eclipse/swt/accessibility/AccessibleActionListener.java" type="org.eclipse.swt.accessibility.AccessibleActionListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="AccessibleActionListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Accessibility/common/org/eclipse/swt/accessibility/AccessibleAttributeListener.java" type="org.eclipse.swt.accessibility.AccessibleAttributeListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="AccessibleAttributeListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Accessibility/common/org/eclipse/swt/accessibility/AccessibleControlListener.java" type="org.eclipse.swt.accessibility.AccessibleControlListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="AccessibleControlListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Accessibility/common/org/eclipse/swt/accessibility/AccessibleEditableTextListener.java" type="org.eclipse.swt.accessibility.AccessibleEditableTextListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="AccessibleEditableTextListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Accessibility/common/org/eclipse/swt/accessibility/AccessibleHyperlinkListener.java" type="org.eclipse.swt.accessibility.AccessibleHyperlinkListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="AccessibleHyperlinkListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Accessibility/common/org/eclipse/swt/accessibility/AccessibleListener.java" type="org.eclipse.swt.accessibility.AccessibleListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="AccessibleListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Accessibility/common/org/eclipse/swt/accessibility/AccessibleTableCellListener.java" type="org.eclipse.swt.accessibility.AccessibleTableCellListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="AccessibleTableCellListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Accessibility/common/org/eclipse/swt/accessibility/AccessibleTableListener.java" type="org.eclipse.swt.accessibility.AccessibleTableListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="AccessibleTableListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Accessibility/common/org/eclipse/swt/accessibility/AccessibleTextListener.java" type="org.eclipse.swt.accessibility.AccessibleTextListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="AccessibleTextListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Accessibility/common/org/eclipse/swt/accessibility/AccessibleValueListener.java" type="org.eclipse.swt.accessibility.AccessibleValueListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="AccessibleValueListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Browser/common/org/eclipse/swt/browser/AuthenticationListener.java" type="org.eclipse.swt.browser.AuthenticationListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="AuthenticationListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Browser/common/org/eclipse/swt/browser/CloseWindowListener.java" type="org.eclipse.swt.browser.CloseWindowListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="CloseWindowListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Browser/common/org/eclipse/swt/browser/LocationListener.java" type="org.eclipse.swt.browser.LocationListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="LocationListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Browser/common/org/eclipse/swt/browser/OpenWindowListener.java" type="org.eclipse.swt.browser.OpenWindowListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="OpenWindowListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Browser/common/org/eclipse/swt/browser/ProgressListener.java" type="org.eclipse.swt.browser.ProgressListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="ProgressListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Browser/common/org/eclipse/swt/browser/StatusTextListener.java" type="org.eclipse.swt.browser.StatusTextListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="StatusTextListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Browser/common/org/eclipse/swt/browser/TitleListener.java" type="org.eclipse.swt.browser.TitleListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="TitleListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Browser/common/org/eclipse/swt/browser/VisibilityWindowListener.java" type="org.eclipse.swt.browser.VisibilityWindowListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="VisibilityWindowListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/BidiSegmentListener.java" type="org.eclipse.swt.custom.BidiSegmentListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="BidiSegmentListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CTabFolder2Listener.java" type="org.eclipse.swt.custom.CTabFolder2Listener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="CTabFolder2Listener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CTabFolderListener.java" type="org.eclipse.swt.custom.CTabFolderListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="CTabFolderListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CaretListener.java" type="org.eclipse.swt.custom.CaretListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="CaretListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/ExtendedModifyListener.java" type="org.eclipse.swt.custom.ExtendedModifyListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="ExtendedModifyListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/LineBackgroundListener.java" type="org.eclipse.swt.custom.LineBackgroundListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="LineBackgroundListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/LineStyleListener.java" type="org.eclipse.swt.custom.LineStyleListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="LineStyleListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/MovementListener.java" type="org.eclipse.swt.custom.MovementListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="MovementListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/PaintObjectListener.java" type="org.eclipse.swt.custom.PaintObjectListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="PaintObjectListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/TextChangeListener.java" type="org.eclipse.swt.custom.TextChangeListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="TextChangeListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/VerifyKeyListener.java" type="org.eclipse.swt.custom.VerifyKeyListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="VerifyKeyListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Drag and Drop/common/org/eclipse/swt/dnd/DragSourceListener.java" type="org.eclipse.swt.dnd.DragSourceListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="DragSourceListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Drag and Drop/common/org/eclipse/swt/dnd/DropTargetListener.java" type="org.eclipse.swt.dnd.DropTargetListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="DropTargetListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/ArmListener.java" type="org.eclipse.swt.events.ArmListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="ArmListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/ControlListener.java" type="org.eclipse.swt.events.ControlListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="ControlListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/DisposeListener.java" type="org.eclipse.swt.events.DisposeListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="DisposeListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/DragDetectListener.java" type="org.eclipse.swt.events.DragDetectListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="DragDetectListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/ExpandListener.java" type="org.eclipse.swt.events.ExpandListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="ExpandListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/FocusListener.java" type="org.eclipse.swt.events.FocusListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="FocusListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/GestureListener.java" type="org.eclipse.swt.events.GestureListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="GestureListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/HelpListener.java" type="org.eclipse.swt.events.HelpListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="HelpListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/KeyListener.java" type="org.eclipse.swt.events.KeyListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="KeyListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/MenuDetectListener.java" type="org.eclipse.swt.events.MenuDetectListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="MenuDetectListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/MenuListener.java" type="org.eclipse.swt.events.MenuListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="MenuListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/ModifyListener.java" type="org.eclipse.swt.events.ModifyListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="ModifyListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/MouseListener.java" type="org.eclipse.swt.events.MouseListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="MouseListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/MouseMoveListener.java" type="org.eclipse.swt.events.MouseMoveListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="MouseMoveListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/MouseTrackListener.java" type="org.eclipse.swt.events.MouseTrackListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="MouseTrackListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/MouseWheelListener.java" type="org.eclipse.swt.events.MouseWheelListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="MouseWheelListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/PaintListener.java" type="org.eclipse.swt.events.PaintListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="PaintListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/SegmentListener.java" type="org.eclipse.swt.events.SegmentListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="SegmentListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/SelectionListener.java" type="org.eclipse.swt.events.SelectionListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="SelectionListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/ShellListener.java" type="org.eclipse.swt.events.ShellListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="ShellListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/TouchListener.java" type="org.eclipse.swt.events.TouchListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="TouchListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/TraverseListener.java" type="org.eclipse.swt.events.TraverseListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="TraverseListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/TreeListener.java" type="org.eclipse.swt.events.TreeListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="TreeListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/VerifyListener.java" type="org.eclipse.swt.events.VerifyListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="VerifyListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/graphics/ImageLoaderListener.java" type="org.eclipse.swt.graphics.ImageLoaderListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="ImageLoaderListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
     <resource path="Eclipse SWT/common/org/eclipse/swt/widgets/TypedListener.java" type="org.eclipse.swt.widgets.TypedListener">
         <filter comment="Class declared as internal in its JavaDoc since ever." id="336744520">
             <message_arguments>
                 <message_argument value="@noextend"/>
                 <message_argument value="org.eclipse.swt.widgets.TypedListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/gtk/org/eclipse/swt/widgets/Composite.java" type="org.eclipse.swt.widgets.Composite">
+        <filter id="576778288">
+            <message_arguments>
+                <message_argument value="Scrollable"/>
+                <message_argument value="Composite"/>
             </message_arguments>
         </filter>
     </resource>

--- a/binaries/org.eclipse.swt.gtk.linux.loongarch64/.settings/.api_filters
+++ b/binaries/org.eclipse.swt.gtk.linux.loongarch64/.settings/.api_filters
@@ -1,10 +1,466 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <component id="org.eclipse.swt.gtk.linux.loongarch64" version="2">
+    <resource path="Eclipse SWT Accessibility/common/org/eclipse/swt/accessibility/AccessibleActionListener.java" type="org.eclipse.swt.accessibility.AccessibleActionListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="AccessibleActionListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Accessibility/common/org/eclipse/swt/accessibility/AccessibleAttributeListener.java" type="org.eclipse.swt.accessibility.AccessibleAttributeListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="AccessibleAttributeListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Accessibility/common/org/eclipse/swt/accessibility/AccessibleControlListener.java" type="org.eclipse.swt.accessibility.AccessibleControlListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="AccessibleControlListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Accessibility/common/org/eclipse/swt/accessibility/AccessibleEditableTextListener.java" type="org.eclipse.swt.accessibility.AccessibleEditableTextListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="AccessibleEditableTextListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Accessibility/common/org/eclipse/swt/accessibility/AccessibleHyperlinkListener.java" type="org.eclipse.swt.accessibility.AccessibleHyperlinkListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="AccessibleHyperlinkListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Accessibility/common/org/eclipse/swt/accessibility/AccessibleListener.java" type="org.eclipse.swt.accessibility.AccessibleListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="AccessibleListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Accessibility/common/org/eclipse/swt/accessibility/AccessibleTableCellListener.java" type="org.eclipse.swt.accessibility.AccessibleTableCellListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="AccessibleTableCellListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Accessibility/common/org/eclipse/swt/accessibility/AccessibleTableListener.java" type="org.eclipse.swt.accessibility.AccessibleTableListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="AccessibleTableListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Accessibility/common/org/eclipse/swt/accessibility/AccessibleTextListener.java" type="org.eclipse.swt.accessibility.AccessibleTextListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="AccessibleTextListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Accessibility/common/org/eclipse/swt/accessibility/AccessibleValueListener.java" type="org.eclipse.swt.accessibility.AccessibleValueListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="AccessibleValueListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Browser/common/org/eclipse/swt/browser/AuthenticationListener.java" type="org.eclipse.swt.browser.AuthenticationListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="AuthenticationListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Browser/common/org/eclipse/swt/browser/CloseWindowListener.java" type="org.eclipse.swt.browser.CloseWindowListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="CloseWindowListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Browser/common/org/eclipse/swt/browser/LocationListener.java" type="org.eclipse.swt.browser.LocationListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="LocationListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Browser/common/org/eclipse/swt/browser/OpenWindowListener.java" type="org.eclipse.swt.browser.OpenWindowListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="OpenWindowListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Browser/common/org/eclipse/swt/browser/ProgressListener.java" type="org.eclipse.swt.browser.ProgressListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="ProgressListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Browser/common/org/eclipse/swt/browser/StatusTextListener.java" type="org.eclipse.swt.browser.StatusTextListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="StatusTextListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Browser/common/org/eclipse/swt/browser/TitleListener.java" type="org.eclipse.swt.browser.TitleListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="TitleListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Browser/common/org/eclipse/swt/browser/VisibilityWindowListener.java" type="org.eclipse.swt.browser.VisibilityWindowListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="VisibilityWindowListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/BidiSegmentListener.java" type="org.eclipse.swt.custom.BidiSegmentListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="BidiSegmentListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CTabFolder2Listener.java" type="org.eclipse.swt.custom.CTabFolder2Listener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="CTabFolder2Listener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CTabFolderListener.java" type="org.eclipse.swt.custom.CTabFolderListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="CTabFolderListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CaretListener.java" type="org.eclipse.swt.custom.CaretListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="CaretListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/ExtendedModifyListener.java" type="org.eclipse.swt.custom.ExtendedModifyListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="ExtendedModifyListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/LineBackgroundListener.java" type="org.eclipse.swt.custom.LineBackgroundListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="LineBackgroundListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/LineStyleListener.java" type="org.eclipse.swt.custom.LineStyleListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="LineStyleListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/MovementListener.java" type="org.eclipse.swt.custom.MovementListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="MovementListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/PaintObjectListener.java" type="org.eclipse.swt.custom.PaintObjectListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="PaintObjectListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/TextChangeListener.java" type="org.eclipse.swt.custom.TextChangeListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="TextChangeListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/VerifyKeyListener.java" type="org.eclipse.swt.custom.VerifyKeyListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="VerifyKeyListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Drag and Drop/common/org/eclipse/swt/dnd/DragSourceListener.java" type="org.eclipse.swt.dnd.DragSourceListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="DragSourceListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Drag and Drop/common/org/eclipse/swt/dnd/DropTargetListener.java" type="org.eclipse.swt.dnd.DropTargetListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="DropTargetListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/ArmListener.java" type="org.eclipse.swt.events.ArmListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="ArmListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/ControlListener.java" type="org.eclipse.swt.events.ControlListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="ControlListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/DisposeListener.java" type="org.eclipse.swt.events.DisposeListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="DisposeListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/DragDetectListener.java" type="org.eclipse.swt.events.DragDetectListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="DragDetectListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/ExpandListener.java" type="org.eclipse.swt.events.ExpandListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="ExpandListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/FocusListener.java" type="org.eclipse.swt.events.FocusListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="FocusListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/GestureListener.java" type="org.eclipse.swt.events.GestureListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="GestureListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/HelpListener.java" type="org.eclipse.swt.events.HelpListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="HelpListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/KeyListener.java" type="org.eclipse.swt.events.KeyListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="KeyListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/MenuDetectListener.java" type="org.eclipse.swt.events.MenuDetectListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="MenuDetectListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/MenuListener.java" type="org.eclipse.swt.events.MenuListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="MenuListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/ModifyListener.java" type="org.eclipse.swt.events.ModifyListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="ModifyListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/MouseListener.java" type="org.eclipse.swt.events.MouseListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="MouseListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/MouseMoveListener.java" type="org.eclipse.swt.events.MouseMoveListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="MouseMoveListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/MouseTrackListener.java" type="org.eclipse.swt.events.MouseTrackListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="MouseTrackListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/MouseWheelListener.java" type="org.eclipse.swt.events.MouseWheelListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="MouseWheelListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/PaintListener.java" type="org.eclipse.swt.events.PaintListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="PaintListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/SegmentListener.java" type="org.eclipse.swt.events.SegmentListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="SegmentListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/SelectionListener.java" type="org.eclipse.swt.events.SelectionListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="SelectionListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/ShellListener.java" type="org.eclipse.swt.events.ShellListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="ShellListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/TouchListener.java" type="org.eclipse.swt.events.TouchListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="TouchListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/TraverseListener.java" type="org.eclipse.swt.events.TraverseListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="TraverseListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/TreeListener.java" type="org.eclipse.swt.events.TreeListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="TreeListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/VerifyListener.java" type="org.eclipse.swt.events.VerifyListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="VerifyListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/graphics/ImageLoaderListener.java" type="org.eclipse.swt.graphics.ImageLoaderListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="ImageLoaderListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
     <resource path="Eclipse SWT/common/org/eclipse/swt/widgets/TypedListener.java" type="org.eclipse.swt.widgets.TypedListener">
         <filter comment="Class declared as internal in its JavaDoc since ever." id="336744520">
             <message_arguments>
                 <message_argument value="@noextend"/>
                 <message_argument value="org.eclipse.swt.widgets.TypedListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/gtk/org/eclipse/swt/widgets/Composite.java" type="org.eclipse.swt.widgets.Composite">
+        <filter id="576778288">
+            <message_arguments>
+                <message_argument value="Scrollable"/>
+                <message_argument value="Composite"/>
             </message_arguments>
         </filter>
     </resource>

--- a/binaries/org.eclipse.swt.gtk.linux.ppc64le/.settings/.api_filters
+++ b/binaries/org.eclipse.swt.gtk.linux.ppc64le/.settings/.api_filters
@@ -1,10 +1,466 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <component id="org.eclipse.swt.gtk.linux.ppc64le" version="2">
+    <resource path="Eclipse SWT Accessibility/common/org/eclipse/swt/accessibility/AccessibleActionListener.java" type="org.eclipse.swt.accessibility.AccessibleActionListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="AccessibleActionListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Accessibility/common/org/eclipse/swt/accessibility/AccessibleAttributeListener.java" type="org.eclipse.swt.accessibility.AccessibleAttributeListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="AccessibleAttributeListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Accessibility/common/org/eclipse/swt/accessibility/AccessibleControlListener.java" type="org.eclipse.swt.accessibility.AccessibleControlListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="AccessibleControlListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Accessibility/common/org/eclipse/swt/accessibility/AccessibleEditableTextListener.java" type="org.eclipse.swt.accessibility.AccessibleEditableTextListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="AccessibleEditableTextListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Accessibility/common/org/eclipse/swt/accessibility/AccessibleHyperlinkListener.java" type="org.eclipse.swt.accessibility.AccessibleHyperlinkListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="AccessibleHyperlinkListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Accessibility/common/org/eclipse/swt/accessibility/AccessibleListener.java" type="org.eclipse.swt.accessibility.AccessibleListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="AccessibleListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Accessibility/common/org/eclipse/swt/accessibility/AccessibleTableCellListener.java" type="org.eclipse.swt.accessibility.AccessibleTableCellListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="AccessibleTableCellListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Accessibility/common/org/eclipse/swt/accessibility/AccessibleTableListener.java" type="org.eclipse.swt.accessibility.AccessibleTableListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="AccessibleTableListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Accessibility/common/org/eclipse/swt/accessibility/AccessibleTextListener.java" type="org.eclipse.swt.accessibility.AccessibleTextListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="AccessibleTextListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Accessibility/common/org/eclipse/swt/accessibility/AccessibleValueListener.java" type="org.eclipse.swt.accessibility.AccessibleValueListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="AccessibleValueListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Browser/common/org/eclipse/swt/browser/AuthenticationListener.java" type="org.eclipse.swt.browser.AuthenticationListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="AuthenticationListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Browser/common/org/eclipse/swt/browser/CloseWindowListener.java" type="org.eclipse.swt.browser.CloseWindowListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="CloseWindowListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Browser/common/org/eclipse/swt/browser/LocationListener.java" type="org.eclipse.swt.browser.LocationListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="LocationListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Browser/common/org/eclipse/swt/browser/OpenWindowListener.java" type="org.eclipse.swt.browser.OpenWindowListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="OpenWindowListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Browser/common/org/eclipse/swt/browser/ProgressListener.java" type="org.eclipse.swt.browser.ProgressListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="ProgressListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Browser/common/org/eclipse/swt/browser/StatusTextListener.java" type="org.eclipse.swt.browser.StatusTextListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="StatusTextListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Browser/common/org/eclipse/swt/browser/TitleListener.java" type="org.eclipse.swt.browser.TitleListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="TitleListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Browser/common/org/eclipse/swt/browser/VisibilityWindowListener.java" type="org.eclipse.swt.browser.VisibilityWindowListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="VisibilityWindowListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/BidiSegmentListener.java" type="org.eclipse.swt.custom.BidiSegmentListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="BidiSegmentListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CTabFolder2Listener.java" type="org.eclipse.swt.custom.CTabFolder2Listener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="CTabFolder2Listener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CTabFolderListener.java" type="org.eclipse.swt.custom.CTabFolderListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="CTabFolderListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CaretListener.java" type="org.eclipse.swt.custom.CaretListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="CaretListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/ExtendedModifyListener.java" type="org.eclipse.swt.custom.ExtendedModifyListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="ExtendedModifyListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/LineBackgroundListener.java" type="org.eclipse.swt.custom.LineBackgroundListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="LineBackgroundListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/LineStyleListener.java" type="org.eclipse.swt.custom.LineStyleListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="LineStyleListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/MovementListener.java" type="org.eclipse.swt.custom.MovementListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="MovementListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/PaintObjectListener.java" type="org.eclipse.swt.custom.PaintObjectListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="PaintObjectListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/TextChangeListener.java" type="org.eclipse.swt.custom.TextChangeListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="TextChangeListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/VerifyKeyListener.java" type="org.eclipse.swt.custom.VerifyKeyListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="VerifyKeyListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Drag and Drop/common/org/eclipse/swt/dnd/DragSourceListener.java" type="org.eclipse.swt.dnd.DragSourceListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="DragSourceListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Drag and Drop/common/org/eclipse/swt/dnd/DropTargetListener.java" type="org.eclipse.swt.dnd.DropTargetListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="DropTargetListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/ArmListener.java" type="org.eclipse.swt.events.ArmListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="ArmListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/ControlListener.java" type="org.eclipse.swt.events.ControlListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="ControlListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/DisposeListener.java" type="org.eclipse.swt.events.DisposeListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="DisposeListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/DragDetectListener.java" type="org.eclipse.swt.events.DragDetectListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="DragDetectListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/ExpandListener.java" type="org.eclipse.swt.events.ExpandListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="ExpandListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/FocusListener.java" type="org.eclipse.swt.events.FocusListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="FocusListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/GestureListener.java" type="org.eclipse.swt.events.GestureListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="GestureListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/HelpListener.java" type="org.eclipse.swt.events.HelpListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="HelpListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/KeyListener.java" type="org.eclipse.swt.events.KeyListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="KeyListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/MenuDetectListener.java" type="org.eclipse.swt.events.MenuDetectListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="MenuDetectListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/MenuListener.java" type="org.eclipse.swt.events.MenuListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="MenuListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/ModifyListener.java" type="org.eclipse.swt.events.ModifyListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="ModifyListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/MouseListener.java" type="org.eclipse.swt.events.MouseListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="MouseListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/MouseMoveListener.java" type="org.eclipse.swt.events.MouseMoveListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="MouseMoveListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/MouseTrackListener.java" type="org.eclipse.swt.events.MouseTrackListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="MouseTrackListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/MouseWheelListener.java" type="org.eclipse.swt.events.MouseWheelListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="MouseWheelListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/PaintListener.java" type="org.eclipse.swt.events.PaintListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="PaintListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/SegmentListener.java" type="org.eclipse.swt.events.SegmentListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="SegmentListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/SelectionListener.java" type="org.eclipse.swt.events.SelectionListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="SelectionListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/ShellListener.java" type="org.eclipse.swt.events.ShellListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="ShellListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/TouchListener.java" type="org.eclipse.swt.events.TouchListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="TouchListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/TraverseListener.java" type="org.eclipse.swt.events.TraverseListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="TraverseListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/TreeListener.java" type="org.eclipse.swt.events.TreeListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="TreeListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/VerifyListener.java" type="org.eclipse.swt.events.VerifyListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="VerifyListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/graphics/ImageLoaderListener.java" type="org.eclipse.swt.graphics.ImageLoaderListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="ImageLoaderListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
     <resource path="Eclipse SWT/common/org/eclipse/swt/widgets/TypedListener.java" type="org.eclipse.swt.widgets.TypedListener">
         <filter comment="Class declared as internal in its JavaDoc since ever." id="336744520">
             <message_arguments>
                 <message_argument value="@noextend"/>
                 <message_argument value="org.eclipse.swt.widgets.TypedListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/gtk/org/eclipse/swt/widgets/Composite.java" type="org.eclipse.swt.widgets.Composite">
+        <filter id="576778288">
+            <message_arguments>
+                <message_argument value="Scrollable"/>
+                <message_argument value="Composite"/>
             </message_arguments>
         </filter>
     </resource>

--- a/binaries/org.eclipse.swt.gtk.linux.x86_64/.settings/.api_filters
+++ b/binaries/org.eclipse.swt.gtk.linux.x86_64/.settings/.api_filters
@@ -1,10 +1,466 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <component id="org.eclipse.swt.gtk.linux.x86_64" version="2">
+    <resource path="Eclipse SWT Accessibility/common/org/eclipse/swt/accessibility/AccessibleActionListener.java" type="org.eclipse.swt.accessibility.AccessibleActionListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="AccessibleActionListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Accessibility/common/org/eclipse/swt/accessibility/AccessibleAttributeListener.java" type="org.eclipse.swt.accessibility.AccessibleAttributeListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="AccessibleAttributeListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Accessibility/common/org/eclipse/swt/accessibility/AccessibleControlListener.java" type="org.eclipse.swt.accessibility.AccessibleControlListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="AccessibleControlListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Accessibility/common/org/eclipse/swt/accessibility/AccessibleEditableTextListener.java" type="org.eclipse.swt.accessibility.AccessibleEditableTextListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="AccessibleEditableTextListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Accessibility/common/org/eclipse/swt/accessibility/AccessibleHyperlinkListener.java" type="org.eclipse.swt.accessibility.AccessibleHyperlinkListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="AccessibleHyperlinkListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Accessibility/common/org/eclipse/swt/accessibility/AccessibleListener.java" type="org.eclipse.swt.accessibility.AccessibleListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="AccessibleListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Accessibility/common/org/eclipse/swt/accessibility/AccessibleTableCellListener.java" type="org.eclipse.swt.accessibility.AccessibleTableCellListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="AccessibleTableCellListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Accessibility/common/org/eclipse/swt/accessibility/AccessibleTableListener.java" type="org.eclipse.swt.accessibility.AccessibleTableListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="AccessibleTableListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Accessibility/common/org/eclipse/swt/accessibility/AccessibleTextListener.java" type="org.eclipse.swt.accessibility.AccessibleTextListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="AccessibleTextListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Accessibility/common/org/eclipse/swt/accessibility/AccessibleValueListener.java" type="org.eclipse.swt.accessibility.AccessibleValueListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="AccessibleValueListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Browser/common/org/eclipse/swt/browser/AuthenticationListener.java" type="org.eclipse.swt.browser.AuthenticationListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="AuthenticationListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Browser/common/org/eclipse/swt/browser/CloseWindowListener.java" type="org.eclipse.swt.browser.CloseWindowListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="CloseWindowListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Browser/common/org/eclipse/swt/browser/LocationListener.java" type="org.eclipse.swt.browser.LocationListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="LocationListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Browser/common/org/eclipse/swt/browser/OpenWindowListener.java" type="org.eclipse.swt.browser.OpenWindowListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="OpenWindowListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Browser/common/org/eclipse/swt/browser/ProgressListener.java" type="org.eclipse.swt.browser.ProgressListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="ProgressListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Browser/common/org/eclipse/swt/browser/StatusTextListener.java" type="org.eclipse.swt.browser.StatusTextListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="StatusTextListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Browser/common/org/eclipse/swt/browser/TitleListener.java" type="org.eclipse.swt.browser.TitleListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="TitleListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Browser/common/org/eclipse/swt/browser/VisibilityWindowListener.java" type="org.eclipse.swt.browser.VisibilityWindowListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="VisibilityWindowListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/BidiSegmentListener.java" type="org.eclipse.swt.custom.BidiSegmentListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="BidiSegmentListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CTabFolder2Listener.java" type="org.eclipse.swt.custom.CTabFolder2Listener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="CTabFolder2Listener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CTabFolderListener.java" type="org.eclipse.swt.custom.CTabFolderListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="CTabFolderListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CaretListener.java" type="org.eclipse.swt.custom.CaretListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="CaretListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/ExtendedModifyListener.java" type="org.eclipse.swt.custom.ExtendedModifyListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="ExtendedModifyListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/LineBackgroundListener.java" type="org.eclipse.swt.custom.LineBackgroundListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="LineBackgroundListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/LineStyleListener.java" type="org.eclipse.swt.custom.LineStyleListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="LineStyleListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/MovementListener.java" type="org.eclipse.swt.custom.MovementListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="MovementListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/PaintObjectListener.java" type="org.eclipse.swt.custom.PaintObjectListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="PaintObjectListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/TextChangeListener.java" type="org.eclipse.swt.custom.TextChangeListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="TextChangeListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/VerifyKeyListener.java" type="org.eclipse.swt.custom.VerifyKeyListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="VerifyKeyListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Drag and Drop/common/org/eclipse/swt/dnd/DragSourceListener.java" type="org.eclipse.swt.dnd.DragSourceListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="DragSourceListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Drag and Drop/common/org/eclipse/swt/dnd/DropTargetListener.java" type="org.eclipse.swt.dnd.DropTargetListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="DropTargetListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/ArmListener.java" type="org.eclipse.swt.events.ArmListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="ArmListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/ControlListener.java" type="org.eclipse.swt.events.ControlListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="ControlListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/DisposeListener.java" type="org.eclipse.swt.events.DisposeListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="DisposeListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/DragDetectListener.java" type="org.eclipse.swt.events.DragDetectListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="DragDetectListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/ExpandListener.java" type="org.eclipse.swt.events.ExpandListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="ExpandListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/FocusListener.java" type="org.eclipse.swt.events.FocusListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="FocusListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/GestureListener.java" type="org.eclipse.swt.events.GestureListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="GestureListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/HelpListener.java" type="org.eclipse.swt.events.HelpListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="HelpListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/KeyListener.java" type="org.eclipse.swt.events.KeyListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="KeyListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/MenuDetectListener.java" type="org.eclipse.swt.events.MenuDetectListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="MenuDetectListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/MenuListener.java" type="org.eclipse.swt.events.MenuListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="MenuListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/ModifyListener.java" type="org.eclipse.swt.events.ModifyListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="ModifyListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/MouseListener.java" type="org.eclipse.swt.events.MouseListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="MouseListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/MouseMoveListener.java" type="org.eclipse.swt.events.MouseMoveListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="MouseMoveListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/MouseTrackListener.java" type="org.eclipse.swt.events.MouseTrackListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="MouseTrackListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/MouseWheelListener.java" type="org.eclipse.swt.events.MouseWheelListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="MouseWheelListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/PaintListener.java" type="org.eclipse.swt.events.PaintListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="PaintListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/SegmentListener.java" type="org.eclipse.swt.events.SegmentListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="SegmentListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/SelectionListener.java" type="org.eclipse.swt.events.SelectionListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="SelectionListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/ShellListener.java" type="org.eclipse.swt.events.ShellListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="ShellListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/TouchListener.java" type="org.eclipse.swt.events.TouchListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="TouchListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/TraverseListener.java" type="org.eclipse.swt.events.TraverseListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="TraverseListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/TreeListener.java" type="org.eclipse.swt.events.TreeListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="TreeListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/VerifyListener.java" type="org.eclipse.swt.events.VerifyListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="VerifyListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/graphics/ImageLoaderListener.java" type="org.eclipse.swt.graphics.ImageLoaderListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="ImageLoaderListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
     <resource path="Eclipse SWT/common/org/eclipse/swt/widgets/TypedListener.java" type="org.eclipse.swt.widgets.TypedListener">
         <filter comment="Class declared as internal in its JavaDoc since ever." id="336744520">
             <message_arguments>
                 <message_argument value="@noextend"/>
                 <message_argument value="org.eclipse.swt.widgets.TypedListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/gtk/org/eclipse/swt/widgets/Composite.java" type="org.eclipse.swt.widgets.Composite">
+        <filter id="576778288">
+            <message_arguments>
+                <message_argument value="Scrollable"/>
+                <message_argument value="Composite"/>
             </message_arguments>
         </filter>
     </resource>

--- a/binaries/org.eclipse.swt.win32.win32.x86_64/.settings/.api_filters
+++ b/binaries/org.eclipse.swt.win32.win32.x86_64/.settings/.api_filters
@@ -1,5 +1,453 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <component id="org.eclipse.swt.win32.win32.x86_64" version="2">
+    <resource path="Eclipse SWT Accessibility/common/org/eclipse/swt/accessibility/AccessibleActionListener.java" type="org.eclipse.swt.accessibility.AccessibleActionListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="AccessibleActionListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Accessibility/common/org/eclipse/swt/accessibility/AccessibleAttributeListener.java" type="org.eclipse.swt.accessibility.AccessibleAttributeListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="AccessibleAttributeListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Accessibility/common/org/eclipse/swt/accessibility/AccessibleControlListener.java" type="org.eclipse.swt.accessibility.AccessibleControlListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="AccessibleControlListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Accessibility/common/org/eclipse/swt/accessibility/AccessibleEditableTextListener.java" type="org.eclipse.swt.accessibility.AccessibleEditableTextListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="AccessibleEditableTextListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Accessibility/common/org/eclipse/swt/accessibility/AccessibleHyperlinkListener.java" type="org.eclipse.swt.accessibility.AccessibleHyperlinkListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="AccessibleHyperlinkListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Accessibility/common/org/eclipse/swt/accessibility/AccessibleListener.java" type="org.eclipse.swt.accessibility.AccessibleListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="AccessibleListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Accessibility/common/org/eclipse/swt/accessibility/AccessibleTableCellListener.java" type="org.eclipse.swt.accessibility.AccessibleTableCellListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="AccessibleTableCellListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Accessibility/common/org/eclipse/swt/accessibility/AccessibleTableListener.java" type="org.eclipse.swt.accessibility.AccessibleTableListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="AccessibleTableListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Accessibility/common/org/eclipse/swt/accessibility/AccessibleTextListener.java" type="org.eclipse.swt.accessibility.AccessibleTextListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="AccessibleTextListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Accessibility/common/org/eclipse/swt/accessibility/AccessibleValueListener.java" type="org.eclipse.swt.accessibility.AccessibleValueListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="AccessibleValueListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Browser/common/org/eclipse/swt/browser/AuthenticationListener.java" type="org.eclipse.swt.browser.AuthenticationListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="AuthenticationListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Browser/common/org/eclipse/swt/browser/CloseWindowListener.java" type="org.eclipse.swt.browser.CloseWindowListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="CloseWindowListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Browser/common/org/eclipse/swt/browser/LocationListener.java" type="org.eclipse.swt.browser.LocationListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="LocationListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Browser/common/org/eclipse/swt/browser/OpenWindowListener.java" type="org.eclipse.swt.browser.OpenWindowListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="OpenWindowListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Browser/common/org/eclipse/swt/browser/ProgressListener.java" type="org.eclipse.swt.browser.ProgressListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="ProgressListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Browser/common/org/eclipse/swt/browser/StatusTextListener.java" type="org.eclipse.swt.browser.StatusTextListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="StatusTextListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Browser/common/org/eclipse/swt/browser/TitleListener.java" type="org.eclipse.swt.browser.TitleListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="TitleListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Browser/common/org/eclipse/swt/browser/VisibilityWindowListener.java" type="org.eclipse.swt.browser.VisibilityWindowListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="VisibilityWindowListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/BidiSegmentListener.java" type="org.eclipse.swt.custom.BidiSegmentListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="BidiSegmentListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CTabFolder2Listener.java" type="org.eclipse.swt.custom.CTabFolder2Listener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="CTabFolder2Listener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CTabFolderListener.java" type="org.eclipse.swt.custom.CTabFolderListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="CTabFolderListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CaretListener.java" type="org.eclipse.swt.custom.CaretListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="CaretListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/ExtendedModifyListener.java" type="org.eclipse.swt.custom.ExtendedModifyListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="ExtendedModifyListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/LineBackgroundListener.java" type="org.eclipse.swt.custom.LineBackgroundListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="LineBackgroundListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/LineStyleListener.java" type="org.eclipse.swt.custom.LineStyleListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="LineStyleListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/MovementListener.java" type="org.eclipse.swt.custom.MovementListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="MovementListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/PaintObjectListener.java" type="org.eclipse.swt.custom.PaintObjectListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="PaintObjectListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/TextChangeListener.java" type="org.eclipse.swt.custom.TextChangeListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="TextChangeListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/VerifyKeyListener.java" type="org.eclipse.swt.custom.VerifyKeyListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="VerifyKeyListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Drag and Drop/common/org/eclipse/swt/dnd/DragSourceListener.java" type="org.eclipse.swt.dnd.DragSourceListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="DragSourceListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Drag and Drop/common/org/eclipse/swt/dnd/DropTargetListener.java" type="org.eclipse.swt.dnd.DropTargetListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="DropTargetListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/ArmListener.java" type="org.eclipse.swt.events.ArmListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="ArmListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/ControlListener.java" type="org.eclipse.swt.events.ControlListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="ControlListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/DisposeListener.java" type="org.eclipse.swt.events.DisposeListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="DisposeListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/DragDetectListener.java" type="org.eclipse.swt.events.DragDetectListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="DragDetectListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/ExpandListener.java" type="org.eclipse.swt.events.ExpandListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="ExpandListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/FocusListener.java" type="org.eclipse.swt.events.FocusListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="FocusListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/GestureListener.java" type="org.eclipse.swt.events.GestureListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="GestureListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/HelpListener.java" type="org.eclipse.swt.events.HelpListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="HelpListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/KeyListener.java" type="org.eclipse.swt.events.KeyListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="KeyListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/MenuDetectListener.java" type="org.eclipse.swt.events.MenuDetectListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="MenuDetectListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/MenuListener.java" type="org.eclipse.swt.events.MenuListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="MenuListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/ModifyListener.java" type="org.eclipse.swt.events.ModifyListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="ModifyListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/MouseListener.java" type="org.eclipse.swt.events.MouseListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="MouseListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/MouseMoveListener.java" type="org.eclipse.swt.events.MouseMoveListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="MouseMoveListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/MouseTrackListener.java" type="org.eclipse.swt.events.MouseTrackListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="MouseTrackListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/MouseWheelListener.java" type="org.eclipse.swt.events.MouseWheelListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="MouseWheelListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/PaintListener.java" type="org.eclipse.swt.events.PaintListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="PaintListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/SegmentListener.java" type="org.eclipse.swt.events.SegmentListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="SegmentListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/SelectionListener.java" type="org.eclipse.swt.events.SelectionListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="SelectionListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/ShellListener.java" type="org.eclipse.swt.events.ShellListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="ShellListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/TouchListener.java" type="org.eclipse.swt.events.TouchListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="TouchListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/TraverseListener.java" type="org.eclipse.swt.events.TraverseListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="TraverseListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/TreeListener.java" type="org.eclipse.swt.events.TreeListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="TreeListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/VerifyListener.java" type="org.eclipse.swt.events.VerifyListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="VerifyListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/graphics/ImageLoaderListener.java" type="org.eclipse.swt.graphics.ImageLoaderListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="ImageLoaderListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
     <resource path="Eclipse SWT/common/org/eclipse/swt/widgets/TypedListener.java" type="org.eclipse.swt.widgets.TypedListener">
         <filter comment="Class declared as internal in its JavaDoc since ever." id="336744520">
             <message_arguments>

--- a/binaries/org.eclipse.swt.win32.win32.x86_64/.settings/.api_filters
+++ b/binaries/org.eclipse.swt.win32.win32.x86_64/.settings/.api_filters
@@ -248,6 +248,133 @@
             </message_arguments>
         </filter>
     </resource>
+    <resource path="Eclipse SWT OLE Win32/win32/org/eclipse/swt/ole/win32/OleAutomation.java" type="org.eclipse.swt.ole.win32.OleAutomation">
+        <filter id="643842064">
+            <message_arguments>
+                <message_argument value="TYPEATTR"/>
+                <message_argument value="OleAutomation"/>
+                <message_argument value="getTypeInfoAttributes()"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT OLE Win32/win32/org/eclipse/swt/ole/win32/OleClientSite.java" type="org.eclipse.swt.ole.win32.OleClientSite">
+        <filter id="627060751">
+            <message_arguments>
+                <message_argument value="GUID"/>
+                <message_argument value="OleClientSite"/>
+                <message_argument value="appClsid"/>
+            </message_arguments>
+        </filter>
+        <filter id="627060751">
+            <message_arguments>
+                <message_argument value="IOleCommandTarget"/>
+                <message_argument value="OleClientSite"/>
+                <message_argument value="objIOleCommandTarget"/>
+            </message_arguments>
+        </filter>
+        <filter id="627060751">
+            <message_arguments>
+                <message_argument value="IOleDocumentView"/>
+                <message_argument value="OleClientSite"/>
+                <message_argument value="objDocumentView"/>
+            </message_arguments>
+        </filter>
+        <filter id="627060751">
+            <message_arguments>
+                <message_argument value="IOleInPlaceObject"/>
+                <message_argument value="OleClientSite"/>
+                <message_argument value="objIOleInPlaceObject"/>
+            </message_arguments>
+        </filter>
+        <filter id="627060751">
+            <message_arguments>
+                <message_argument value="IOleObject"/>
+                <message_argument value="OleClientSite"/>
+                <message_argument value="objIOleObject"/>
+            </message_arguments>
+        </filter>
+        <filter id="627060751">
+            <message_arguments>
+                <message_argument value="IStorage"/>
+                <message_argument value="OleClientSite"/>
+                <message_argument value="tempStorage"/>
+            </message_arguments>
+        </filter>
+        <filter id="627060751">
+            <message_arguments>
+                <message_argument value="IUnknown"/>
+                <message_argument value="OleClientSite"/>
+                <message_argument value="objIUnknown"/>
+            </message_arguments>
+        </filter>
+        <filter id="627060751">
+            <message_arguments>
+                <message_argument value="IViewObject2"/>
+                <message_argument value="OleClientSite"/>
+                <message_argument value="objIViewObject2"/>
+            </message_arguments>
+        </filter>
+        <filter id="643842064">
+            <message_arguments>
+                <message_argument value="GUID"/>
+                <message_argument value="OleClientSite"/>
+                <message_argument value="getClassID(String)"/>
+            </message_arguments>
+        </filter>
+        <filter id="643842064">
+            <message_arguments>
+                <message_argument value="IStorage"/>
+                <message_argument value="OleClientSite"/>
+                <message_argument value="createTempStorage()"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT OLE Win32/win32/org/eclipse/swt/ole/win32/OleControlSite.java" type="org.eclipse.swt.ole.win32.OleControlSite">
+        <filter id="643846161">
+            <message_arguments>
+                <message_argument value="GUID"/>
+                <message_argument value="OleControlSite"/>
+                <message_argument value="getLicenseInfo(GUID)"/>
+            </message_arguments>
+        </filter>
+        <filter id="643846161">
+            <message_arguments>
+                <message_argument value="GUID"/>
+                <message_argument value="OleControlSite"/>
+                <message_argument value="removeEventListener(OleAutomation, GUID, int, OleListener)"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT OLE Win32/win32/org/eclipse/swt/ole/win32/Variant.java" type="org.eclipse.swt.ole.win32.Variant">
+        <filter id="643842064">
+            <message_arguments>
+                <message_argument value="IDispatch"/>
+                <message_argument value="Variant"/>
+                <message_argument value="getDispatch()"/>
+            </message_arguments>
+        </filter>
+        <filter id="643842064">
+            <message_arguments>
+                <message_argument value="IUnknown"/>
+                <message_argument value="Variant"/>
+                <message_argument value="getUnknown()"/>
+            </message_arguments>
+        </filter>
+        <filter id="643850349">
+            <message_arguments>
+                <message_argument value="IDispatch"/>
+                <message_argument value="Variant"/>
+                <message_argument value="Variant(IDispatch)"/>
+            </message_arguments>
+        </filter>
+        <filter id="643850349">
+            <message_arguments>
+                <message_argument value="IUnknown"/>
+                <message_argument value="Variant"/>
+                <message_argument value="Variant(IUnknown)"/>
+            </message_arguments>
+        </filter>
+    </resource>
     <resource path="Eclipse SWT/common/org/eclipse/swt/events/ArmListener.java" type="org.eclipse.swt.events.ArmListener">
         <filter id="576720909">
             <message_arguments>
@@ -453,6 +580,23 @@
             <message_arguments>
                 <message_argument value="@noextend"/>
                 <message_argument value="org.eclipse.swt.widgets.TypedListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/win32/org/eclipse/swt/graphics/GCData.java" type="org.eclipse.swt.graphics.GCData">
+        <filter id="627060751">
+            <message_arguments>
+                <message_argument value="PAINTSTRUCT"/>
+                <message_argument value="GCData"/>
+                <message_argument value="ps"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/win32/org/eclipse/swt/widgets/Composite.java" type="org.eclipse.swt.widgets.Composite">
+        <filter id="576778288">
+            <message_arguments>
+                <message_argument value="Scrollable"/>
+                <message_argument value="Composite"/>
             </message_arguments>
         </filter>
     </resource>

--- a/bundles/org.eclipse.swt/Eclipse SWT Accessibility/common/org/eclipse/swt/accessibility/AccessibleActionListener.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Accessibility/common/org/eclipse/swt/accessibility/AccessibleActionListener.java
@@ -13,7 +13,7 @@
  *******************************************************************************/
 package org.eclipse.swt.accessibility;
 
-import java.util.*;
+import org.eclipse.swt.internal.SWTEventListener;
 
 /**
  * Classes which implement this interface provide methods
@@ -30,7 +30,7 @@ import java.util.*;
  *
  * @since 3.6
  */
-public interface AccessibleActionListener extends EventListener {
+public interface AccessibleActionListener extends SWTEventListener {
 	/**
 	 * Returns the number of accessible actions available in this object.
 	 * <p>

--- a/bundles/org.eclipse.swt/Eclipse SWT Accessibility/common/org/eclipse/swt/accessibility/AccessibleAttributeListener.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Accessibility/common/org/eclipse/swt/accessibility/AccessibleAttributeListener.java
@@ -13,7 +13,7 @@
  *******************************************************************************/
 package org.eclipse.swt.accessibility;
 
-import java.util.*;
+import org.eclipse.swt.internal.SWTEventListener;
 
 /**
  * Classes which implement this interface provide methods
@@ -31,7 +31,7 @@ import java.util.*;
  *
  * @since 3.6
  */
-public interface AccessibleAttributeListener extends EventListener {
+public interface AccessibleAttributeListener extends SWTEventListener {
 	/**
 	 * Returns attributes specific to this Accessible object.
 	 *

--- a/bundles/org.eclipse.swt/Eclipse SWT Accessibility/common/org/eclipse/swt/accessibility/AccessibleControlListener.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Accessibility/common/org/eclipse/swt/accessibility/AccessibleControlListener.java
@@ -14,7 +14,7 @@
 package org.eclipse.swt.accessibility;
 
 
-import java.util.*;
+import org.eclipse.swt.internal.*;
 
 /**
  * Classes that implement this interface provide methods
@@ -43,7 +43,7 @@ import java.util.*;
  *
  * @since 2.0
  */
-public interface AccessibleControlListener extends EventListener {
+public interface AccessibleControlListener extends SWTEventListener {
 
 	/**
 	 * Sent when an accessibility client requests the identifier

--- a/bundles/org.eclipse.swt/Eclipse SWT Accessibility/common/org/eclipse/swt/accessibility/AccessibleEditableTextListener.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Accessibility/common/org/eclipse/swt/accessibility/AccessibleEditableTextListener.java
@@ -13,7 +13,7 @@
  *******************************************************************************/
 package org.eclipse.swt.accessibility;
 
-import java.util.*;
+import org.eclipse.swt.internal.SWTEventListener;
 
 /**
  * Classes which implement this interface provide methods
@@ -31,7 +31,7 @@ import java.util.*;
  *
  * @since 3.7
  */
-public interface AccessibleEditableTextListener extends EventListener {
+public interface AccessibleEditableTextListener extends SWTEventListener {
 	/**
 	 * Copies the substring beginning at the specified <code>start</code> offset
 	 * and extending to the character at offset <code>end - 1</code> to the clipboard.

--- a/bundles/org.eclipse.swt/Eclipse SWT Accessibility/common/org/eclipse/swt/accessibility/AccessibleHyperlinkListener.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Accessibility/common/org/eclipse/swt/accessibility/AccessibleHyperlinkListener.java
@@ -13,7 +13,7 @@
  *******************************************************************************/
 package org.eclipse.swt.accessibility;
 
-import java.util.*;
+import org.eclipse.swt.internal.SWTEventListener;
 
 /**
  * Classes which implement this interface provide methods
@@ -30,7 +30,7 @@ import java.util.*;
  *
  * @since 3.6
  */
-public interface AccessibleHyperlinkListener extends EventListener {
+public interface AccessibleHyperlinkListener extends SWTEventListener {
 	/**
 	 * Returns the anchor for the link at the specified index.
 	 *

--- a/bundles/org.eclipse.swt/Eclipse SWT Accessibility/common/org/eclipse/swt/accessibility/AccessibleListener.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Accessibility/common/org/eclipse/swt/accessibility/AccessibleListener.java
@@ -14,8 +14,9 @@
 package org.eclipse.swt.accessibility;
 
 
-import java.util.*;
 import java.util.function.*;
+
+import org.eclipse.swt.internal.*;
 
 /**
  * Classes that implement this interface provide methods
@@ -40,7 +41,7 @@ import java.util.function.*;
  *
  * @since 2.0
  */
-public interface AccessibleListener extends EventListener {
+public interface AccessibleListener extends SWTEventListener {
 
 	/**
 	 * Sent when an accessibility client requests the name

--- a/bundles/org.eclipse.swt/Eclipse SWT Accessibility/common/org/eclipse/swt/accessibility/AccessibleTableCellListener.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Accessibility/common/org/eclipse/swt/accessibility/AccessibleTableCellListener.java
@@ -13,7 +13,7 @@
  *******************************************************************************/
 package org.eclipse.swt.accessibility;
 
-import java.util.*;
+import org.eclipse.swt.internal.SWTEventListener;
 
 /**
  * Classes which implement this interface provide methods
@@ -30,7 +30,7 @@ import java.util.*;
  *
  * @since 3.6
  */
-public interface AccessibleTableCellListener extends EventListener {
+public interface AccessibleTableCellListener extends SWTEventListener {
 	/**
 	 * Returns the number of columns occupied by this cell accessible.
 	 * <p>

--- a/bundles/org.eclipse.swt/Eclipse SWT Accessibility/common/org/eclipse/swt/accessibility/AccessibleTableListener.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Accessibility/common/org/eclipse/swt/accessibility/AccessibleTableListener.java
@@ -13,7 +13,7 @@
  *******************************************************************************/
 package org.eclipse.swt.accessibility;
 
-import java.util.*;
+import org.eclipse.swt.internal.*;
 
 /**
  * Classes which implement this interface provide methods
@@ -35,7 +35,7 @@ import java.util.*;
  *
  * @since 3.6
  */
-public interface AccessibleTableListener extends EventListener {
+public interface AccessibleTableListener extends SWTEventListener {
 	/**
 	 * Deselects one column, leaving other selected columns selected (if any).
 	 *

--- a/bundles/org.eclipse.swt/Eclipse SWT Accessibility/common/org/eclipse/swt/accessibility/AccessibleTextListener.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Accessibility/common/org/eclipse/swt/accessibility/AccessibleTextListener.java
@@ -14,7 +14,7 @@
 package org.eclipse.swt.accessibility;
 
 
-import java.util.*;
+import org.eclipse.swt.internal.*;
 
 /**
  * Classes that implement this interface provide methods
@@ -43,7 +43,7 @@ import java.util.*;
  *
  * @since 3.0
  */
-public interface AccessibleTextListener extends EventListener {
+public interface AccessibleTextListener extends SWTEventListener {
 
 	/**
 	 * Sent when an accessibility client requests the current character offset

--- a/bundles/org.eclipse.swt/Eclipse SWT Accessibility/common/org/eclipse/swt/accessibility/AccessibleValueListener.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Accessibility/common/org/eclipse/swt/accessibility/AccessibleValueListener.java
@@ -13,7 +13,7 @@
  *******************************************************************************/
 package org.eclipse.swt.accessibility;
 
-import java.util.*;
+import org.eclipse.swt.internal.SWTEventListener;
 
 /**
  * Classes which implement this interface provide methods
@@ -30,7 +30,7 @@ import java.util.*;
  *
  * @since 3.6
  */
-public interface AccessibleValueListener extends EventListener {
+public interface AccessibleValueListener extends SWTEventListener {
 	/**
 	 * Returns the value of this object as a number.
 	 *

--- a/bundles/org.eclipse.swt/Eclipse SWT Browser/common/org/eclipse/swt/browser/AuthenticationListener.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Browser/common/org/eclipse/swt/browser/AuthenticationListener.java
@@ -13,7 +13,7 @@
  *******************************************************************************/
 package org.eclipse.swt.browser;
 
-import java.util.*;
+import org.eclipse.swt.internal.*;
 
 /**
  * This listener interface may be implemented in order to receive
@@ -26,7 +26,7 @@ import java.util.*;
  * @since 3.5
  */
 @FunctionalInterface
-public interface AuthenticationListener extends EventListener {
+public interface AuthenticationListener extends SWTEventListener {
 
 /**
  * This method is called when a page is navigated to that requires

--- a/bundles/org.eclipse.swt/Eclipse SWT Browser/common/org/eclipse/swt/browser/CloseWindowListener.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Browser/common/org/eclipse/swt/browser/CloseWindowListener.java
@@ -13,7 +13,7 @@
  *******************************************************************************/
 package org.eclipse.swt.browser;
 
-import java.util.*;
+import org.eclipse.swt.internal.*;
 
 /**
  * This listener interface may be implemented in order to receive
@@ -29,7 +29,7 @@ import java.util.*;
  * @since 3.0
  */
 @FunctionalInterface
-public interface CloseWindowListener extends EventListener {
+public interface CloseWindowListener extends SWTEventListener {
 
 /**
  * This method is called when the window hosting a {@link Browser} should be closed.

--- a/bundles/org.eclipse.swt/Eclipse SWT Browser/common/org/eclipse/swt/browser/LocationListener.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Browser/common/org/eclipse/swt/browser/LocationListener.java
@@ -13,8 +13,9 @@
  *******************************************************************************/
 package org.eclipse.swt.browser;
 
-import java.util.*;
 import java.util.function.*;
+
+import org.eclipse.swt.internal.*;
 
 /**
  * This listener interface may be implemented in order to receive
@@ -27,7 +28,7 @@ import java.util.function.*;
  *
  * @since 3.0
  */
-public interface LocationListener extends EventListener {
+public interface LocationListener extends SWTEventListener {
 
 /**
  * This method is called when the current location is about to be changed.

--- a/bundles/org.eclipse.swt/Eclipse SWT Browser/common/org/eclipse/swt/browser/OpenWindowListener.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Browser/common/org/eclipse/swt/browser/OpenWindowListener.java
@@ -13,7 +13,7 @@
  *******************************************************************************/
 package org.eclipse.swt.browser;
 
-import java.util.*;
+import org.eclipse.swt.internal.*;
 
 /**
  * This listener interface may be implemented in order to receive
@@ -28,7 +28,7 @@ import java.util.*;
  * @since 3.0
  */
 @FunctionalInterface
-public interface OpenWindowListener extends EventListener {
+public interface OpenWindowListener extends SWTEventListener {
 
 /**
  * This method is called when a new window needs to be created.

--- a/bundles/org.eclipse.swt/Eclipse SWT Browser/common/org/eclipse/swt/browser/ProgressListener.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Browser/common/org/eclipse/swt/browser/ProgressListener.java
@@ -13,8 +13,9 @@
  *******************************************************************************/
 package org.eclipse.swt.browser;
 
-import java.util.*;
 import java.util.function.*;
+
+import org.eclipse.swt.internal.*;
 
 /**
  * This listener interface may be implemented in order to receive
@@ -28,7 +29,7 @@ import java.util.function.*;
  *
  * @since 3.0
  */
-public interface ProgressListener extends EventListener {
+public interface ProgressListener extends SWTEventListener {
 
 /**
  * This method is called when a progress is made during the loading of the

--- a/bundles/org.eclipse.swt/Eclipse SWT Browser/common/org/eclipse/swt/browser/StatusTextListener.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Browser/common/org/eclipse/swt/browser/StatusTextListener.java
@@ -13,7 +13,7 @@
  *******************************************************************************/
 package org.eclipse.swt.browser;
 
-import java.util.*;
+import org.eclipse.swt.internal.*;
 
 /**
  * This listener interface may be implemented in order to receive
@@ -26,7 +26,7 @@ import java.util.*;
  * @since 3.0
  */
 @FunctionalInterface
-public interface StatusTextListener extends EventListener {
+public interface StatusTextListener extends SWTEventListener {
 
 /**
  * This method is called when the status text is changed. The

--- a/bundles/org.eclipse.swt/Eclipse SWT Browser/common/org/eclipse/swt/browser/TitleListener.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Browser/common/org/eclipse/swt/browser/TitleListener.java
@@ -13,7 +13,7 @@
  *******************************************************************************/
 package org.eclipse.swt.browser;
 
-import java.util.*;
+import org.eclipse.swt.internal.*;
 
 /**
  * This listener interface may be implemented in order to receive
@@ -26,7 +26,7 @@ import java.util.*;
  * @since 3.0
  */
 @FunctionalInterface
-public interface TitleListener extends EventListener {
+public interface TitleListener extends SWTEventListener {
 
 /**
  * This method is called when the title of the current document

--- a/bundles/org.eclipse.swt/Eclipse SWT Browser/common/org/eclipse/swt/browser/VisibilityWindowListener.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Browser/common/org/eclipse/swt/browser/VisibilityWindowListener.java
@@ -13,8 +13,9 @@
  *******************************************************************************/
 package org.eclipse.swt.browser;
 
-import java.util.*;
 import java.util.function.*;
+
+import org.eclipse.swt.internal.*;
 
 /**
  * This listener interface may be implemented in order to receive
@@ -28,7 +29,7 @@ import java.util.function.*;
  *
  * @since 3.0
  */
-public interface VisibilityWindowListener extends EventListener {
+public interface VisibilityWindowListener extends SWTEventListener {
 
 /**
  * This method is called when the window hosting a <code>Browser</code>

--- a/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/BidiSegmentListener.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/BidiSegmentListener.java
@@ -13,7 +13,7 @@
  *******************************************************************************/
 package org.eclipse.swt.custom;
 
-import java.util.*;
+import org.eclipse.swt.internal.*;
 
 /**
  * This listener interface may be implemented in order to receive
@@ -21,7 +21,7 @@ import java.util.*;
  * @see BidiSegmentEvent
  */
 @FunctionalInterface
-public interface BidiSegmentListener extends EventListener {
+public interface BidiSegmentListener extends SWTEventListener {
 
 /**
  * This method is called when a line needs to be reordered for

--- a/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CTabFolder2Listener.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CTabFolder2Listener.java
@@ -13,8 +13,9 @@
  *******************************************************************************/
 package org.eclipse.swt.custom;
 
-import java.util.*;
 import java.util.function.*;
+
+import org.eclipse.swt.internal.*;
 
 /**
  * Classes which implement this interface provide methods
@@ -34,7 +35,7 @@ import java.util.function.*;
  *
  * @since 3.0
  */
-public interface CTabFolder2Listener extends EventListener {
+public interface CTabFolder2Listener extends SWTEventListener {
 
 /**
  * Sent when the user clicks on the close button of an item in the CTabFolder.
@@ -116,7 +117,7 @@ public void showList(CTabFolderEvent event);
 
 /**
  * Sent when the tab items count changes
- *
+ * 
  * @param event from observed tab folder
  * @since 3.124
  */

--- a/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CTabFolderListener.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CTabFolderListener.java
@@ -13,7 +13,7 @@
  *******************************************************************************/
 package org.eclipse.swt.custom;
 
-import java.util.*;
+import org.eclipse.swt.internal.*;
 
 /**
  * Classes which implement this interface provide a method
@@ -29,7 +29,7 @@ import java.util.*;
  * @see CTabFolderEvent
  */
 @FunctionalInterface
-public interface CTabFolderListener extends EventListener {
+public interface CTabFolderListener extends SWTEventListener {
 
 /**
  * Sent when the user clicks on the close button of an item in the CTabFolder.  The item being closed is specified

--- a/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CaretListener.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CaretListener.java
@@ -13,7 +13,7 @@
  *******************************************************************************/
 package org.eclipse.swt.custom;
 
-import java.util.*;
+import org.eclipse.swt.internal.*;
 
 /**
  * This listener interface may be implemented in order to receive
@@ -24,7 +24,7 @@ import java.util.*;
  * @since 3.5
  */
 @FunctionalInterface
-public interface CaretListener extends EventListener {
+public interface CaretListener extends SWTEventListener {
 
 /**
  * This method is called after the caret offset is changed.

--- a/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/ExtendedModifyListener.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/ExtendedModifyListener.java
@@ -13,7 +13,7 @@
  *******************************************************************************/
 package org.eclipse.swt.custom;
 
-import java.util.*;
+import org.eclipse.swt.internal.*;
 
 /**
  * Classes which implement this interface provide a method
@@ -24,7 +24,7 @@ import java.util.*;
  * @see <a href="http://www.eclipse.org/swt/">Sample code and further information</a>
  */
 @FunctionalInterface
-public interface ExtendedModifyListener extends EventListener {
+public interface ExtendedModifyListener extends SWTEventListener {
 
 /**
  * This method is called after a text change occurs.

--- a/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/LineBackgroundListener.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/LineBackgroundListener.java
@@ -13,7 +13,7 @@
  *******************************************************************************/
 package org.eclipse.swt.custom;
 
-import java.util.*;
+import org.eclipse.swt.internal.*;
 
 /**
  * Classes which implement this interface provide a method
@@ -24,7 +24,7 @@ import java.util.*;
  * @see <a href="http://www.eclipse.org/swt/">Sample code and further information</a>
  */
 @FunctionalInterface
-public interface LineBackgroundListener extends EventListener {
+public interface LineBackgroundListener extends SWTEventListener {
 
 /**
  * This method is called when a line is about to be drawn in order to get its

--- a/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/LineStyleListener.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/LineStyleListener.java
@@ -13,7 +13,7 @@
  *******************************************************************************/
 package org.eclipse.swt.custom;
 
-import java.util.*;
+import org.eclipse.swt.internal.*;
 
 /**
  * Classes which implement this interface provide a method
@@ -24,7 +24,7 @@ import java.util.*;
  * @see <a href="http://www.eclipse.org/swt/">Sample code and further information</a>
  */
 @FunctionalInterface
-public interface LineStyleListener extends EventListener {
+public interface LineStyleListener extends SWTEventListener {
 
 /**
  * This method is called when a line is about to be drawn in order to get the

--- a/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/MovementListener.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/MovementListener.java
@@ -13,7 +13,7 @@
  *******************************************************************************/
 package org.eclipse.swt.custom;
 
-import java.util.*;
+import org.eclipse.swt.internal.SWTEventListener;
 
 /**
  * This listener is invoked when a new offset is required based on the current
@@ -27,7 +27,7 @@ import java.util.*;
  *
  * @since 3.3
  */
-public interface MovementListener extends EventListener {
+public interface MovementListener extends SWTEventListener {
 /**
  * This method is called when a new offset is required based on the current
  * offset and a movement type.

--- a/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/PaintObjectListener.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/PaintObjectListener.java
@@ -14,14 +14,14 @@
 package org.eclipse.swt.custom;
 
 
-import java.util.*;
+import org.eclipse.swt.internal.*;
 /**
  * This listener is invoked when an object needs to be drawn.
  *
  * @since 3.2
  */
 @FunctionalInterface
-public interface PaintObjectListener extends EventListener {
+public interface PaintObjectListener extends SWTEventListener {
 /**
  * This method is called when an object needs to be drawn.
  *

--- a/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/StyledTextListener.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/StyledTextListener.java
@@ -13,13 +13,12 @@
  *******************************************************************************/
 package org.eclipse.swt.custom;
 
-import java.util.*;
-
 import org.eclipse.swt.events.*;
+import org.eclipse.swt.internal.*;
 import org.eclipse.swt.widgets.*;
 
 class StyledTextListener extends TypedListener {
-StyledTextListener(EventListener listener) {
+StyledTextListener(SWTEventListener listener) {
 	super(listener);
 }
 /**

--- a/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/TextChangeListener.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/TextChangeListener.java
@@ -14,7 +14,7 @@
 package org.eclipse.swt.custom;
 
 
-import java.util.*;
+import org.eclipse.swt.internal.SWTEventListener;
 
 /**
  * The StyledText widget implements this listener to receive
@@ -29,7 +29,7 @@ import java.util.*;
  * below. If the entire text is replaced the textSet method
  * should be called instead.
  */
-public interface TextChangeListener extends EventListener {
+public interface TextChangeListener extends SWTEventListener {
 
 /**
  * This method is called when the content is about to be changed.

--- a/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/VerifyKeyListener.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/VerifyKeyListener.java
@@ -13,9 +13,8 @@
  *******************************************************************************/
 package org.eclipse.swt.custom;
 
-import java.util.*;
-
 import org.eclipse.swt.events.*;
+import org.eclipse.swt.internal.*;
 
 /**
  * Classes which implement this interface provide a method
@@ -26,7 +25,7 @@ import org.eclipse.swt.events.*;
  * @see <a href="http://www.eclipse.org/swt/">Sample code and further information</a>
  */
 @FunctionalInterface
-public interface VerifyKeyListener extends EventListener {
+public interface VerifyKeyListener extends SWTEventListener {
 /**
  * The following event fields are used:<ul>
  * <li>event.character is the character that was typed (input)</li>

--- a/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/common/org/eclipse/swt/dnd/DNDListener.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/common/org/eclipse/swt/dnd/DNDListener.java
@@ -13,8 +13,7 @@
  *******************************************************************************/
 package org.eclipse.swt.dnd;
 
-import java.util.*;
-
+import org.eclipse.swt.internal.*;
 import org.eclipse.swt.widgets.*;
 
 
@@ -24,7 +23,7 @@ class DNDListener extends TypedListener {
  * DNDListener constructor comment.
  * @param listener org.eclipse.swt.internal.SWTEventListener
  */
-DNDListener(EventListener listener) {
+DNDListener(SWTEventListener listener) {
 	super(listener);
 }
 @Override

--- a/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/common/org/eclipse/swt/dnd/DragSourceListener.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/common/org/eclipse/swt/dnd/DragSourceListener.java
@@ -13,7 +13,7 @@
  *******************************************************************************/
 package org.eclipse.swt.dnd;
 
-import java.util.*;
+import org.eclipse.swt.internal.*;
 
 /**
  * The <code>DragSourceListener</code> class provides event notification to the application for DragSource events.
@@ -26,7 +26,7 @@ import java.util.*;
  * <code>DragSource</code> is required to take the appropriate cleanup action.  In the case of a successful
  * <b>move</b> operation, the application must remove the data that was transferred.</p>
  */
-public interface DragSourceListener extends EventListener {
+public interface DragSourceListener extends SWTEventListener {
 
 /**
  * The user has begun the actions required to drag the widget. This event gives the application

--- a/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/common/org/eclipse/swt/dnd/DropTargetListener.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/common/org/eclipse/swt/dnd/DropTargetListener.java
@@ -13,7 +13,7 @@
  *******************************************************************************/
 package org.eclipse.swt.dnd;
 
-import java.util.*;
+import org.eclipse.swt.internal.*;
 
 /**
  * The <code>DropTargetListener</code> class provides event notification to the application
@@ -35,7 +35,7 @@ import java.util.*;
  *
  * @see DropTargetEvent
  */
-public interface DropTargetListener extends EventListener {
+public interface DropTargetListener extends SWTEventListener {
 
 /**
  * The cursor has entered the drop target boundaries.

--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Widget.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Widget.java
@@ -13,8 +13,6 @@
  *******************************************************************************/
 package org.eclipse.swt.widgets;
 
-import java.util.*;
-
 import org.eclipse.swt.*;
 import org.eclipse.swt.events.*;
 import org.eclipse.swt.internal.*;
@@ -1465,7 +1463,7 @@ public void removeListener (int eventType, Listener listener) {
  * @noreference This method is not intended to be referenced by clients.
  * @nooverride This method is not intended to be re-implemented or extended by clients.
  */
-protected void removeListener (int eventType, EventListener handler) {
+protected void removeListener (int eventType, SWTEventListener handler) {
 	checkWidget();
 	if (handler == null) error (SWT.ERROR_NULL_ARGUMENT);
 	if (eventTable == null) return;

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/events/ArmListener.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/events/ArmListener.java
@@ -15,7 +15,7 @@
 package org.eclipse.swt.events;
 
 
-import java.util.*;
+import org.eclipse.swt.internal.*;
 
 /**
  * Classes which implement this interface provide a method
@@ -32,7 +32,7 @@ import java.util.*;
  * @see ArmEvent
  */
 @FunctionalInterface
-public interface ArmListener extends EventListener {
+public interface ArmListener extends SWTEventListener {
 
 /**
  * Sent when a widget is armed, or 'about to be selected'.

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/events/ControlListener.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/events/ControlListener.java
@@ -14,8 +14,9 @@
 package org.eclipse.swt.events;
 
 
-import java.util.*;
 import java.util.function.*;
+
+import org.eclipse.swt.internal.*;
 
 /**
  * Classes which implement this interface provide methods
@@ -33,7 +34,7 @@ import java.util.function.*;
  * @see ControlAdapter
  * @see ControlEvent
  */
-public interface ControlListener extends EventListener {
+public interface ControlListener extends SWTEventListener {
 
 /**
  * Sent when the location (x, y) of a control changes relative

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/events/DisposeListener.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/events/DisposeListener.java
@@ -15,7 +15,7 @@
 package org.eclipse.swt.events;
 
 
-import java.util.*;
+import org.eclipse.swt.internal.*;
 
 /**
  * Classes which implement this interface provide a method
@@ -33,7 +33,7 @@ import java.util.*;
  * @see DisposeEvent
  */
 @FunctionalInterface
-public interface DisposeListener extends EventListener {
+public interface DisposeListener extends SWTEventListener {
 
 /**
  * Sent when the widget is disposed.

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/events/DragDetectListener.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/events/DragDetectListener.java
@@ -15,7 +15,7 @@
 package org.eclipse.swt.events;
 
 
-import java.util.*;
+import org.eclipse.swt.internal.*;
 
 /**
  * Classes which implement this interface provide methods that deal with the
@@ -33,7 +33,7 @@ import java.util.*;
  * @since 3.3
  */
 @FunctionalInterface
-public interface DragDetectListener extends EventListener {
+public interface DragDetectListener extends SWTEventListener {
 
 /**
  * Sent when a drag gesture is detected.

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/events/ExpandListener.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/events/ExpandListener.java
@@ -14,8 +14,9 @@
 package org.eclipse.swt.events;
 
 
-import java.util.*;
 import java.util.function.*;
+
+import org.eclipse.swt.internal.*;
 
 /**
  * Classes which implement this interface provide methods
@@ -35,7 +36,7 @@ import java.util.function.*;
  *
  * @since 3.2
  */
-public interface ExpandListener extends EventListener {
+public interface ExpandListener extends SWTEventListener {
 
 /**
  * Sent when an item is collapsed.

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/events/FocusListener.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/events/FocusListener.java
@@ -15,8 +15,9 @@
 package org.eclipse.swt.events;
 
 
-import java.util.*;
 import java.util.function.*;
+
+import org.eclipse.swt.internal.*;
 
 /**
  * Classes which implement this interface provide methods
@@ -34,7 +35,7 @@ import java.util.function.*;
  * @see FocusAdapter
  * @see FocusEvent
  */
-public interface FocusListener extends EventListener {
+public interface FocusListener extends SWTEventListener {
 
 /**
  * Sent when a control gets focus.

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/events/GestureListener.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/events/GestureListener.java
@@ -15,7 +15,7 @@
 package org.eclipse.swt.events;
 
 
-import java.util.*;
+import org.eclipse.swt.internal.*;
 
 /**
  * Classes which implement this interface provide methods
@@ -39,7 +39,7 @@ import java.util.*;
  * @since 3.7
  */
 @FunctionalInterface
-public interface GestureListener extends EventListener {
+public interface GestureListener extends SWTEventListener {
 
 /**
  * Sent when a recognized gesture has occurred.

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/events/HelpListener.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/events/HelpListener.java
@@ -15,7 +15,7 @@
 package org.eclipse.swt.events;
 
 
-import java.util.*;
+import org.eclipse.swt.internal.*;
 
 /**
  * Classes which implement this interface provide a method
@@ -33,7 +33,7 @@ import java.util.*;
  * @see HelpEvent
  */
 @FunctionalInterface
-public interface HelpListener extends EventListener {
+public interface HelpListener extends SWTEventListener {
 
 /**
  * Sent when help is requested for a control, typically

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/events/KeyListener.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/events/KeyListener.java
@@ -15,8 +15,9 @@
 package org.eclipse.swt.events;
 
 
-import java.util.*;
 import java.util.function.*;
+
+import org.eclipse.swt.internal.*;
 
 /**
  * Classes which implement this interface provide methods
@@ -34,7 +35,7 @@ import java.util.function.*;
  * @see KeyAdapter
  * @see KeyEvent
  */
-public interface KeyListener extends EventListener {
+public interface KeyListener extends SWTEventListener {
 
 /**
  * Sent when a key is pressed on the system keyboard.

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/events/MenuDetectListener.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/events/MenuDetectListener.java
@@ -15,7 +15,7 @@
 package org.eclipse.swt.events;
 
 
-import java.util.*;
+import org.eclipse.swt.internal.*;
 
 /**
  * Classes which implement this interface provide methods
@@ -36,7 +36,7 @@ import java.util.*;
  * @since 3.3
  */
 @FunctionalInterface
-public interface MenuDetectListener extends EventListener {
+public interface MenuDetectListener extends SWTEventListener {
 
 /**
  * Sent when the platform-dependent trigger for showing a menu item is detected.

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/events/MenuListener.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/events/MenuListener.java
@@ -14,8 +14,9 @@
 package org.eclipse.swt.events;
 
 
-import java.util.*;
 import java.util.function.*;
+
+import org.eclipse.swt.internal.*;
 
 /**
  * Classes which implement this interface provide methods
@@ -32,7 +33,7 @@ import java.util.function.*;
  * @see MenuAdapter
  * @see MenuEvent
  */
-public interface MenuListener extends EventListener {
+public interface MenuListener extends SWTEventListener {
 
 /**
  * Sent when a menu is hidden.

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/events/ModifyListener.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/events/ModifyListener.java
@@ -15,7 +15,7 @@
 package org.eclipse.swt.events;
 
 
-import java.util.*;
+import org.eclipse.swt.internal.*;
 
 /**
  * Classes which implement this interface provide a method
@@ -32,7 +32,7 @@ import java.util.*;
  * @see ModifyEvent
  */
 @FunctionalInterface
-public interface ModifyListener extends EventListener {
+public interface ModifyListener extends SWTEventListener {
 
 /**
  * Sent when the text is modified.

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/events/MouseListener.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/events/MouseListener.java
@@ -15,8 +15,9 @@
 package org.eclipse.swt.events;
 
 
-import java.util.*;
 import java.util.function.*;
+
+import org.eclipse.swt.internal.*;
 
 /**
  * Classes which implement this interface provide methods
@@ -34,7 +35,7 @@ import java.util.function.*;
  * @see MouseAdapter
  * @see MouseEvent
  */
-public interface MouseListener extends EventListener {
+public interface MouseListener extends SWTEventListener {
 
 /**
  * Sent when a mouse button is pressed twice within the

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/events/MouseMoveListener.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/events/MouseMoveListener.java
@@ -15,7 +15,7 @@
 package org.eclipse.swt.events;
 
 
-import java.util.*;
+import org.eclipse.swt.internal.*;
 
 /**
  * Classes which implement this interface provide a method
@@ -32,7 +32,7 @@ import java.util.*;
  * @see MouseEvent
  */
 @FunctionalInterface
-public interface MouseMoveListener extends EventListener {
+public interface MouseMoveListener extends SWTEventListener {
 
 /**
  * Sent when the mouse moves.

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/events/MouseTrackListener.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/events/MouseTrackListener.java
@@ -14,8 +14,9 @@
 package org.eclipse.swt.events;
 
 
-import java.util.*;
 import java.util.function.*;
+
+import org.eclipse.swt.internal.*;
 
 /**
  * Classes which implement this interface provide methods
@@ -34,7 +35,7 @@ import java.util.function.*;
  * @see MouseTrackAdapter
  * @see MouseEvent
  */
-public interface MouseTrackListener extends EventListener {
+public interface MouseTrackListener extends SWTEventListener {
 
 /**
  * Sent when the mouse pointer passes into the area of

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/events/MouseWheelListener.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/events/MouseWheelListener.java
@@ -14,7 +14,7 @@
 package org.eclipse.swt.events;
 
 
-import java.util.*;
+import org.eclipse.swt.internal.*;
 
 /**
  * Classes which implement this interface provide a method
@@ -34,7 +34,7 @@ import java.util.*;
  * @since 3.3
  */
 @FunctionalInterface
-public interface MouseWheelListener extends EventListener {
+public interface MouseWheelListener extends SWTEventListener {
 
 /**
  * Sent when the mouse wheel is scrolled.

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/events/PaintListener.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/events/PaintListener.java
@@ -15,7 +15,7 @@
 package org.eclipse.swt.events;
 
 
-import java.util.*;
+import org.eclipse.swt.internal.*;
 
 /**
  * Classes which implement this interface provide methods
@@ -33,7 +33,7 @@ import java.util.*;
  * @see PaintEvent
  */
 @FunctionalInterface
-public interface PaintListener extends EventListener {
+public interface PaintListener extends SWTEventListener {
 
 /**
  * Sent when a paint event occurs for the control.

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/events/SegmentListener.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/events/SegmentListener.java
@@ -14,7 +14,7 @@
  *******************************************************************************/
 package org.eclipse.swt.events;
 
-import java.util.*;
+import org.eclipse.swt.internal.*;
 
 /**
  * This listener interface may be implemented in order to receive
@@ -24,7 +24,7 @@ import java.util.*;
  * @since 3.8
  */
 @FunctionalInterface
-public interface SegmentListener extends EventListener {
+public interface SegmentListener extends SWTEventListener {
 
 /**
  * This method is called when text content is being modified.

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/events/SelectionListener.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/events/SelectionListener.java
@@ -15,8 +15,9 @@
 package org.eclipse.swt.events;
 
 
-import java.util.*;
 import java.util.function.*;
+
+import org.eclipse.swt.internal.*;
 
 /**
  * Classes which implement this interface provide methods
@@ -34,7 +35,7 @@ import java.util.function.*;
  * @see SelectionAdapter
  * @see SelectionEvent
  */
-public interface SelectionListener extends EventListener {
+public interface SelectionListener extends SWTEventListener {
 
 /**
  * Sent when selection occurs in the control.

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/events/ShellListener.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/events/ShellListener.java
@@ -14,8 +14,9 @@
 package org.eclipse.swt.events;
 
 
-import java.util.*;
 import java.util.function.*;
+
+import org.eclipse.swt.internal.*;
 
 /**
  * Classes which implement this interface provide methods
@@ -32,7 +33,7 @@ import java.util.function.*;
  * @see ShellAdapter
  * @see ShellEvent
  */
-public interface ShellListener extends EventListener {
+public interface ShellListener extends SWTEventListener {
 
 /**
  * Sent when a shell becomes the active window.

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/events/TouchListener.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/events/TouchListener.java
@@ -15,7 +15,7 @@
 package org.eclipse.swt.events;
 
 
-import java.util.*;
+import org.eclipse.swt.internal.*;
 
 /**
  * Classes which implement this interface provide methods
@@ -39,7 +39,7 @@ import java.util.*;
  * @since 3.7
  */
 @FunctionalInterface
-public interface TouchListener extends EventListener {
+public interface TouchListener extends SWTEventListener {
 
 /**
  * Sent when a touch sequence begins, changes state, or ends.

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/events/TraverseListener.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/events/TraverseListener.java
@@ -15,7 +15,7 @@
 package org.eclipse.swt.events;
 
 
-import java.util.*;
+import org.eclipse.swt.internal.*;
 
 /**
  * Classes which implement this interface provide a method
@@ -33,7 +33,7 @@ import java.util.*;
  * @see TraverseEvent
  */
 @FunctionalInterface
-public interface TraverseListener extends EventListener {
+public interface TraverseListener extends SWTEventListener {
 
 /**
  * Sent when a traverse event occurs in a control.

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/events/TreeListener.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/events/TreeListener.java
@@ -14,8 +14,9 @@
 package org.eclipse.swt.events;
 
 
-import java.util.*;
 import java.util.function.*;
+
+import org.eclipse.swt.internal.*;
 
 /**
  * Classes which implement this interface provide methods
@@ -33,7 +34,7 @@ import java.util.function.*;
  * @see TreeAdapter
  * @see TreeEvent
  */
-public interface TreeListener extends EventListener {
+public interface TreeListener extends SWTEventListener {
 
 /**
  * Sent when a tree branch is collapsed.

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/events/VerifyListener.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/events/VerifyListener.java
@@ -15,7 +15,7 @@
 package org.eclipse.swt.events;
 
 
-import java.util.*;
+import org.eclipse.swt.internal.*;
 
 /**
  * Classes which implement this interface provide a method
@@ -33,7 +33,7 @@ import java.util.*;
  * @see VerifyEvent
  */
 @FunctionalInterface
-public interface VerifyListener extends EventListener {
+public interface VerifyListener extends SWTEventListener {
 
 /**
  * Sent when the text is about to be modified.

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/ImageLoaderListener.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/ImageLoaderListener.java
@@ -14,7 +14,7 @@
 package org.eclipse.swt.graphics;
 
 
-import java.util.*;
+import org.eclipse.swt.internal.*;
 
 /**
  * Classes which implement this interface provide methods
@@ -32,7 +32,7 @@ import java.util.*;
  * @see ImageLoaderEvent
  */
 @FunctionalInterface
-public interface ImageLoaderListener extends EventListener {
+public interface ImageLoaderListener extends SWTEventListener {
 
 /**
  * Sent when image data is either partially or completely loaded.

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/SWTEventListener.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/SWTEventListener.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2000, 2014 IBM Corporation and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.swt.internal;
+
+
+import java.util.EventListener;
+
+/**
+ * This interface is the cross-platform version of the
+ * java.util.EventListener interface.
+ * <p>
+ * It is part of our effort to provide support for both J2SE
+ * and J2ME platforms. Under this scheme, classes need to
+ * implement SWTEventListener instead of java.util.EventListener.
+ * </p>
+ * <p>
+ * Note: java.util.EventListener is not part of CDC and CLDC.
+ * </p>
+ * @noreference This interface is not intended to be referenced by clients.
+ */
+public interface SWTEventListener extends EventListener {
+}

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/EventTable.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/EventTable.java
@@ -14,8 +14,6 @@
 package org.eclipse.swt.widgets;
 
 
-import java.util.*;
-
 import org.eclipse.swt.*;
 import org.eclipse.swt.internal.*;
 
@@ -147,7 +145,7 @@ public void unhook (int eventType, Listener listener) {
 	}
 }
 
-public void unhook (int eventType, EventListener listener) {
+public void unhook (int eventType, SWTEventListener listener) {
 	if (types == null) return;
 	for (int i=0; i<types.length; i++) {
 		if (types [i] == eventType) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/TypedListener.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/TypedListener.java
@@ -14,8 +14,7 @@
 package org.eclipse.swt.widgets;
 
 
-import java.util.*;
-
+import org.eclipse.swt.internal.SWTEventListener;
 import org.eclipse.swt.*;
 import org.eclipse.swt.events.*;
 
@@ -41,7 +40,7 @@ public class TypedListener implements Listener {
 	/**
 	 * The receiver's event listener
 	 */
-	protected EventListener eventListener;
+	protected SWTEventListener eventListener;
 
 /**
  * Constructs a new instance of this class for the given event listener.
@@ -56,7 +55,7 @@ public class TypedListener implements Listener {
  *
  * @noreference This method is not intended to be referenced by clients.
  */
-public TypedListener (EventListener listener) {
+public TypedListener (SWTEventListener listener) {
 	eventListener = listener;
 }
 
@@ -73,7 +72,7 @@ public TypedListener (EventListener listener) {
  *
  * @noreference This method is not intended to be referenced by clients.
  */
-public EventListener getEventListener () {
+public SWTEventListener getEventListener () {
 	return eventListener;
 }
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Widget.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Widget.java
@@ -1436,7 +1436,7 @@ public void removeListener (int eventType, Listener listener) {
  * @noreference This method is not intended to be referenced by clients.
  * @nooverride This method is not intended to be re-implemented or extended by clients.
  */
-protected void removeListener (int eventType, EventListener handler) {
+protected void removeListener (int eventType, SWTEventListener handler) {
 	checkWidget ();
 	if (handler == null) error (SWT.ERROR_NULL_ARGUMENT);
 	if (eventTable == null) return;

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Widget.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Widget.java
@@ -15,8 +15,6 @@
 package org.eclipse.swt.widgets;
 
 
-import java.util.*;
-
 import org.eclipse.swt.*;
 import org.eclipse.swt.events.*;
 import org.eclipse.swt.graphics.*;
@@ -967,7 +965,7 @@ public void removeListener (int eventType, Listener listener) {
  * @noreference This method is not intended to be referenced by clients.
  * @nooverride This method is not intended to be re-implemented or extended by clients.
  */
-protected void removeListener (int eventType, EventListener listener) {
+protected void removeListener (int eventType, SWTEventListener listener) {
 	checkWidget();
 	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
 	if (eventTable == null) return;


### PR DESCRIPTION
1) Revert "Replace internal SWTEventListener directly with java.util.EventListener"

This reverts commit bd306acb742a18bb7a234ae493a2b02257beaad2.
Replacing SWTEventListener directly with java.util.EventListener breaks binary compatibility with bundles compiled against any older SWT version.
- See discussion on https://github.com/eclipse-platform/eclipse.platform.swt/pull/1101

2) Added filters for SWTEventListener used in SWT API
- See https://github.com/eclipse-platform/eclipse.platform.swt/pull/1011
- See https://github.com/eclipse-platform/eclipse.platform.swt/pull/1101