### PR TITLE
Fix API warnings in macosx fragments

### DIFF
--- a/binaries/org.eclipse.swt.cocoa.macosx.aarch64/.settings/.api_filters
+++ b/binaries/org.eclipse.swt.cocoa.macosx.aarch64/.settings/.api_filters
@@ -248,6 +248,108 @@
             </message_arguments>
         </filter>
     </resource>
+    <resource path="Eclipse SWT/cocoa/org/eclipse/swt/graphics/GCData.java" type="org.eclipse.swt.graphics.GCData">
+        <filter id="338940029">
+            <message_arguments>
+                <message_argument value="org.eclipse.swt.graphics.GCData"/>
+                <message_argument value="bg"/>
+            </message_arguments>
+        </filter>
+        <filter id="338940029">
+            <message_arguments>
+                <message_argument value="org.eclipse.swt.graphics.GCData"/>
+                <message_argument value="clipPath"/>
+            </message_arguments>
+        </filter>
+        <filter id="338940029">
+            <message_arguments>
+                <message_argument value="org.eclipse.swt.graphics.GCData"/>
+                <message_argument value="fg"/>
+            </message_arguments>
+        </filter>
+        <filter id="338940029">
+            <message_arguments>
+                <message_argument value="org.eclipse.swt.graphics.GCData"/>
+                <message_argument value="flippedContext"/>
+            </message_arguments>
+        </filter>
+        <filter id="338940029">
+            <message_arguments>
+                <message_argument value="org.eclipse.swt.graphics.GCData"/>
+                <message_argument value="inverseTransform"/>
+            </message_arguments>
+        </filter>
+        <filter id="338940029">
+            <message_arguments>
+                <message_argument value="org.eclipse.swt.graphics.GCData"/>
+                <message_argument value="layoutManager"/>
+            </message_arguments>
+        </filter>
+        <filter id="338940029">
+            <message_arguments>
+                <message_argument value="org.eclipse.swt.graphics.GCData"/>
+                <message_argument value="paintRect"/>
+            </message_arguments>
+        </filter>
+        <filter id="338940029">
+            <message_arguments>
+                <message_argument value="org.eclipse.swt.graphics.GCData"/>
+                <message_argument value="path"/>
+            </message_arguments>
+        </filter>
+        <filter id="338940029">
+            <message_arguments>
+                <message_argument value="org.eclipse.swt.graphics.GCData"/>
+                <message_argument value="size"/>
+            </message_arguments>
+        </filter>
+        <filter id="338940029">
+            <message_arguments>
+                <message_argument value="org.eclipse.swt.graphics.GCData"/>
+                <message_argument value="textContainer"/>
+            </message_arguments>
+        </filter>
+        <filter id="338940029">
+            <message_arguments>
+                <message_argument value="org.eclipse.swt.graphics.GCData"/>
+                <message_argument value="textStorage"/>
+            </message_arguments>
+        </filter>
+        <filter id="338940029">
+            <message_arguments>
+                <message_argument value="org.eclipse.swt.graphics.GCData"/>
+                <message_argument value="transform"/>
+            </message_arguments>
+        </filter>
+        <filter id="338940029">
+            <message_arguments>
+                <message_argument value="org.eclipse.swt.graphics.GCData"/>
+                <message_argument value="view"/>
+            </message_arguments>
+        </filter>
+        <filter id="338940029">
+            <message_arguments>
+                <message_argument value="org.eclipse.swt.graphics.GCData"/>
+                <message_argument value="visiblePath"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/cocoa/org/eclipse/swt/widgets/Composite.java" type="org.eclipse.swt.widgets.Composite">
+        <filter id="576778288">
+            <message_arguments>
+                <message_argument value="Scrollable"/>
+                <message_argument value="Composite"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/cocoa/org/eclipse/swt/widgets/Display.java" type="org.eclipse.swt.widgets.Display">
+        <filter id="336744520">
+            <message_arguments>
+                <message_argument value="@noextend"/>
+                <message_argument value="org.eclipse.swt.widgets.Display"/>
+            </message_arguments>
+        </filter>
+    </resource>
     <resource path="Eclipse SWT/common/org/eclipse/swt/events/ArmListener.java" type="org.eclipse.swt.events.ArmListener">
         <filter id="576720909">
             <message_arguments>
@@ -445,14 +547,6 @@
             <message_arguments>
                 <message_argument value="SWTEventListener"/>
                 <message_argument value="ImageLoaderListener"/>
-            </message_arguments>
-        </filter>
-    </resource>
-    <resource path="Eclipse SWT/cocoa/org/eclipse/swt/widgets/Display.java" type="org.eclipse.swt.widgets.Display">
-        <filter id="336744520">
-            <message_arguments>
-                <message_argument value="@noextend"/>
-                <message_argument value="org.eclipse.swt.widgets.Display"/>
             </message_arguments>
         </filter>
     </resource>

--- a/binaries/org.eclipse.swt.cocoa.macosx.x86_64/.settings/.api_filters
+++ b/binaries/org.eclipse.swt.cocoa.macosx.x86_64/.settings/.api_filters
@@ -248,6 +248,108 @@
             </message_arguments>
         </filter>
     </resource>
+    <resource path="Eclipse SWT/cocoa/org/eclipse/swt/graphics/GCData.java" type="org.eclipse.swt.graphics.GCData">
+        <filter id="338940029">
+            <message_arguments>
+                <message_argument value="org.eclipse.swt.graphics.GCData"/>
+                <message_argument value="bg"/>
+            </message_arguments>
+        </filter>
+        <filter id="338940029">
+            <message_arguments>
+                <message_argument value="org.eclipse.swt.graphics.GCData"/>
+                <message_argument value="clipPath"/>
+            </message_arguments>
+        </filter>
+        <filter id="338940029">
+            <message_arguments>
+                <message_argument value="org.eclipse.swt.graphics.GCData"/>
+                <message_argument value="fg"/>
+            </message_arguments>
+        </filter>
+        <filter id="338940029">
+            <message_arguments>
+                <message_argument value="org.eclipse.swt.graphics.GCData"/>
+                <message_argument value="flippedContext"/>
+            </message_arguments>
+        </filter>
+        <filter id="338940029">
+            <message_arguments>
+                <message_argument value="org.eclipse.swt.graphics.GCData"/>
+                <message_argument value="inverseTransform"/>
+            </message_arguments>
+        </filter>
+        <filter id="338940029">
+            <message_arguments>
+                <message_argument value="org.eclipse.swt.graphics.GCData"/>
+                <message_argument value="layoutManager"/>
+            </message_arguments>
+        </filter>
+        <filter id="338940029">
+            <message_arguments>
+                <message_argument value="org.eclipse.swt.graphics.GCData"/>
+                <message_argument value="paintRect"/>
+            </message_arguments>
+        </filter>
+        <filter id="338940029">
+            <message_arguments>
+                <message_argument value="org.eclipse.swt.graphics.GCData"/>
+                <message_argument value="path"/>
+            </message_arguments>
+        </filter>
+        <filter id="338940029">
+            <message_arguments>
+                <message_argument value="org.eclipse.swt.graphics.GCData"/>
+                <message_argument value="size"/>
+            </message_arguments>
+        </filter>
+        <filter id="338940029">
+            <message_arguments>
+                <message_argument value="org.eclipse.swt.graphics.GCData"/>
+                <message_argument value="textContainer"/>
+            </message_arguments>
+        </filter>
+        <filter id="338940029">
+            <message_arguments>
+                <message_argument value="org.eclipse.swt.graphics.GCData"/>
+                <message_argument value="textStorage"/>
+            </message_arguments>
+        </filter>
+        <filter id="338940029">
+            <message_arguments>
+                <message_argument value="org.eclipse.swt.graphics.GCData"/>
+                <message_argument value="transform"/>
+            </message_arguments>
+        </filter>
+        <filter id="338940029">
+            <message_arguments>
+                <message_argument value="org.eclipse.swt.graphics.GCData"/>
+                <message_argument value="view"/>
+            </message_arguments>
+        </filter>
+        <filter id="338940029">
+            <message_arguments>
+                <message_argument value="org.eclipse.swt.graphics.GCData"/>
+                <message_argument value="visiblePath"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/cocoa/org/eclipse/swt/widgets/Composite.java" type="org.eclipse.swt.widgets.Composite">
+        <filter id="576778288">
+            <message_arguments>
+                <message_argument value="Scrollable"/>
+                <message_argument value="Composite"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/cocoa/org/eclipse/swt/widgets/Display.java" type="org.eclipse.swt.widgets.Display">
+        <filter id="336744520">
+            <message_arguments>
+                <message_argument value="@noextend"/>
+                <message_argument value="org.eclipse.swt.widgets.Display"/>
+            </message_arguments>
+        </filter>
+    </resource>
     <resource path="Eclipse SWT/common/org/eclipse/swt/events/ArmListener.java" type="org.eclipse.swt.events.ArmListener">
         <filter id="576720909">
             <message_arguments>
@@ -445,14 +547,6 @@
             <message_arguments>
                 <message_argument value="SWTEventListener"/>
                 <message_argument value="ImageLoaderListener"/>
-            </message_arguments>
-        </filter>
-    </resource>
-    <resource path="Eclipse SWT/cocoa/org/eclipse/swt/widgets/Display.java" type="org.eclipse.swt.widgets.Display">
-        <filter id="336744520">
-            <message_arguments>
-                <message_argument value="@noextend"/>
-                <message_argument value="org.eclipse.swt.widgets.Display"/>
             </message_arguments>
         </filter>
     </resource>

--- a/bundles/org.eclipse.swt/Eclipse SWT Accessibility/cocoa/org/eclipse/swt/accessibility/Accessible.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Accessibility/cocoa/org/eclipse/swt/accessibility/Accessible.java
@@ -789,6 +789,7 @@ public class Accessible {
 	 * </p>
 	 *
 	 * @noreference This method is not intended to be referenced by clients.
+	 * @nooverride This method is not intended to be re-implemented or extended by clients.
 	 */
 	public id internal_accessibilityActionDescription(NSString action, int childID) {
 		NSString returnValue = NSString.string();
@@ -834,6 +835,7 @@ public class Accessible {
 	 * </p>
 	 *
 	 * @noreference This method is not intended to be referenced by clients.
+	 * @nooverride This method is not intended to be re-implemented or extended by clients.
 	 */
 	public NSArray internal_accessibilityActionNames(int childID) {
 		if (accessibleActionListenersSize() > 0) {
@@ -919,6 +921,7 @@ public class Accessible {
 	 * </p>
 	 *
 	 * @noreference This method is not intended to be referenced by clients.
+	 * @nooverride This method is not intended to be re-implemented or extended by clients.
 	 */
 	public boolean internal_accessibilityIsAttributeSettable(NSString attribute, int childID) {
 		if (accessibleTextExtendedListenersSize() > 0) {
@@ -944,6 +947,7 @@ public class Accessible {
 	 * </p>
 	 *
 	 * @noreference This method is not intended to be referenced by clients.
+	 * @nooverride This method is not intended to be re-implemented or extended by clients.
 	 */
 	public NSArray internal_accessibilityAttributeNames(int childID) {
 		// The supported attribute set depends on the role played by the control.
@@ -1226,6 +1230,7 @@ public class Accessible {
 	 * </p>
 	 *
 	 * @noreference This method is not intended to be referenced by clients.
+	 * @nooverride This method is not intended to be re-implemented or extended by clients.
 	 */
 	public id internal_accessibilityAttributeValue(NSString attribute, int childID) {
 		if (attribute.isEqualToString(OS.NSAccessibilityRoleAttribute)) return getRoleAttribute(childID);
@@ -1285,6 +1290,7 @@ public class Accessible {
 	 * </p>
 	 *
 	 * @noreference This method is not intended to be referenced by clients.
+	 * @nooverride This method is not intended to be re-implemented or extended by clients.
 	 */
 	public id internal_accessibilityAttributeValue_forParameter(NSString attribute, id parameter, int childID) {
 		if (attribute.isEqualToString(OS.NSAccessibilityStringForRangeParameterizedAttribute)) return getStringForRangeParameterizedAttribute(parameter, childID);
@@ -1312,6 +1318,7 @@ public class Accessible {
 	 * </p>
 	 *
 	 * @noreference This method is not intended to be referenced by clients.
+	 * @nooverride This method is not intended to be re-implemented or extended by clients.
 	 */
 	public id internal_accessibilityFocusedUIElement(int childID) {
 		AccessibleControlEvent event = new AccessibleControlEvent(this);
@@ -1352,6 +1359,7 @@ public class Accessible {
 	 * </p>
 	 *
 	 * @noreference This method is not intended to be referenced by clients.
+	 * @nooverride This method is not intended to be re-implemented or extended by clients.
 	 */
 	public id internal_accessibilityHitTest(NSPoint point, int childID) {
 		AccessibleControlEvent event = new AccessibleControlEvent(this);
@@ -1422,6 +1430,7 @@ public class Accessible {
 	 * </p>
 	 *
 	 * @noreference This method is not intended to be referenced by clients.
+	 * @nooverride This method is not intended to be re-implemented or extended by clients.
 	 */
 	public NSArray internal_accessibilityParameterizedAttributeNames(int childID) {
 		AccessibleControlEvent event = new AccessibleControlEvent(this);
@@ -1483,6 +1492,7 @@ public class Accessible {
 	 * </p>
 	 *
 	 * @noreference This method is not intended to be referenced by clients.
+	 * @nooverride This method is not intended to be re-implemented or extended by clients.
 	 */
 	public boolean internal_accessibilityPerformAction(NSString action, int childID) {
 		String actionName = action.getString();
@@ -1528,6 +1538,7 @@ public class Accessible {
 	 * </p>
 	 *
 	 * @noreference This method is not intended to be referenced by clients.
+	 * @nooverride This method is not intended to be re-implemented or extended by clients.
 	 */
 	public void internal_accessibilitySetValue_forAttribute(id value, NSString attribute, int childId) {
 		if (attribute.isEqualToString(OS.NSAccessibilitySelectedTextRangeAttribute)) setSelectedTextRangeAttribute(value, childId);

--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/graphics/GCData.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/graphics/GCData.java
@@ -51,19 +51,30 @@ public final class GCData {
 	public int fillRule = SWT.FILL_EVEN_ODD;
 	public Image image;
 
+	/** @noreference This field is not intended to be referenced by clients. */
 	public NSTextStorage textStorage;
+	/** @noreference This field is not intended to be referenced by clients. */
 	public NSLayoutManager layoutManager;
+	/** @noreference This field is not intended to be referenced by clients. */
 	public NSTextContainer textContainer;
+	/** @noreference This field is not intended to be referenced by clients. */
 	public NSColor fg, bg;
 	public double drawXOffset, drawYOffset;
+	/** @noreference This field is not intended to be referenced by clients. */
 	public NSRect paintRect;
+	/** @noreference This field is not intended to be referenced by clients. */
 	public NSBezierPath path;
+	/** @noreference This field is not intended to be referenced by clients. */
 	public NSAffineTransform transform, inverseTransform;
+	/** @noreference This field is not intended to be referenced by clients. */
 	public NSBezierPath clipPath, visiblePath;
 	public long visibleRgn;
+	/** @noreference This field is not intended to be referenced by clients. */
 	public NSView view;
+	/** @noreference This field is not intended to be referenced by clients. */
 	public NSSize size;
 	public Thread thread;
+	/** @noreference This field is not intended to be referenced by clients. */
 	public NSGraphicsContext flippedContext;
 	public boolean restoreContext;
 }


### PR DESCRIPTION
For cocoa specific implementations of
- o.e.swt.accessibility.Accessible tag methods already tagged as @noreference also with @nooverride so that API tools considers them as internal and does not complain about non-API types being referenced in their signature.

- o.e.swt.graphics.GCData tag all fields as @noreference so that API tools does not complain about non-API types being used in public fields of this actually internal class (tagged as @noreference).

Suppress issue about forbidden extension of Scrollable by Composite.