### PR TITLE
Add API to add and obtain typed listeners to Widgets

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CCombo.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CCombo.java
@@ -301,10 +301,7 @@ public void add (String string, int index) {
  * @see #removeModifyListener
  */
 public void addModifyListener (ModifyListener listener) {
-	checkWidget();
-	if (listener == null) SWT.error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.Modify, typedListener);
+	addTypedListener(listener, SWT.Modify);
 }
 /**
  * Adds the listener to the collection of listeners who will
@@ -331,11 +328,7 @@ public void addModifyListener (ModifyListener listener) {
  * @see SelectionEvent
  */
 public void addSelectionListener(SelectionListener listener) {
-	checkWidget();
-	if (listener == null) SWT.error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.Selection,typedListener);
-	addListener (SWT.DefaultSelection,typedListener);
+	addTypedListener(listener, SWT.Selection, SWT.DefaultSelection);
 }
 /**
  * Adds the listener to the collection of listeners who will
@@ -359,11 +352,9 @@ public void addSelectionListener(SelectionListener listener) {
  * @since 3.3
  */
 public void addVerifyListener (VerifyListener listener) {
-	checkWidget();
-	if (listener == null) SWT.error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.Verify,typedListener);
+	addTypedListener(listener, SWT.Verify);
 }
+
 void arrowEvent (Event event) {
 	switch (event.type) {
 		case SWT.FocusIn: {
@@ -1451,7 +1442,7 @@ public void removeAll () {
 public void removeModifyListener (ModifyListener listener) {
 	checkWidget();
 	if (listener == null) SWT.error (SWT.ERROR_NULL_ARGUMENT);
-	removeListener(SWT.Modify, listener);
+	removeTypedListener(SWT.Modify, listener);
 }
 /**
  * Removes the listener from the collection of listeners who will
@@ -1473,8 +1464,8 @@ public void removeModifyListener (ModifyListener listener) {
 public void removeSelectionListener (SelectionListener listener) {
 	checkWidget();
 	if (listener == null) SWT.error (SWT.ERROR_NULL_ARGUMENT);
-	removeListener(SWT.Selection, listener);
-	removeListener(SWT.DefaultSelection,listener);
+	removeTypedListener(SWT.Selection, listener);
+	removeTypedListener(SWT.DefaultSelection, listener);
 }
 /**
  * Removes the listener from the collection of listeners who will
@@ -1498,7 +1489,7 @@ public void removeSelectionListener (SelectionListener listener) {
 public void removeVerifyListener (VerifyListener listener) {
 	checkWidget();
 	if (listener == null) SWT.error (SWT.ERROR_NULL_ARGUMENT);
-	removeListener(SWT.Verify, listener);
+	removeTypedListener(SWT.Verify, listener);
 }
 /**
  * Selects the item at the given zero-relative index in the receiver's

--- a/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CTabFolder.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CTabFolder.java
@@ -503,13 +503,7 @@ public void addCTabFolderListener(CTabFolderListener listener) {
  * @see SelectionEvent
  */
 public void addSelectionListener(SelectionListener listener) {
-	checkWidget();
-	if (listener == null) {
-		SWT.error(SWT.ERROR_NULL_ARGUMENT);
-	}
-	TypedListener typedListener = new TypedListener(listener);
-	addListener(SWT.Selection, typedListener);
-	addListener(SWT.DefaultSelection, typedListener);
+	addTypedListener(listener, SWT.Selection, SWT.DefaultSelection);
 }
 
 Rectangle[] computeControlBounds (Point size, boolean[][] position) {
@@ -2353,8 +2347,8 @@ public void removeSelectionListener(SelectionListener listener) {
 	if (listener == null) {
 		SWT.error(SWT.ERROR_NULL_ARGUMENT);
 	}
-	removeListener(SWT.Selection, listener);
-	removeListener(SWT.DefaultSelection, listener);
+	removeTypedListener(SWT.Selection, listener);
+	removeTypedListener(SWT.DefaultSelection, listener);
 }
 
 @Override

--- a/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/StyledText.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/StyledText.java
@@ -886,9 +886,7 @@ public void addLineStyleListener(LineStyleListener listener) {
  * </ul>
  */
 public void addModifyListener(ModifyListener modifyListener) {
-	checkWidget();
-	if (modifyListener == null) SWT.error(SWT.ERROR_NULL_ARGUMENT);
-	addListener(SWT.Modify, new TypedListener(modifyListener));
+	addTypedListener(modifyListener, SWT.Modify);
 }
 /**
  * Adds a paint object listener. A paint object event is sent by the widget when an object
@@ -940,9 +938,7 @@ public void addPaintObjectListener(PaintObjectListener listener) {
  * @see SelectionEvent
  */
 public void addSelectionListener(SelectionListener listener) {
-	checkWidget();
-	if (listener == null) SWT.error(SWT.ERROR_NULL_ARGUMENT);
-	addListener(SWT.Selection, new TypedListener(listener));
+	addTypedListener(listener, SWT.Selection);
 }
 /**
  * Adds a verify key listener. A VerifyKey event is sent by the widget when a key
@@ -979,9 +975,7 @@ public void addVerifyKeyListener(VerifyKeyListener listener) {
  * </ul>
  */
 public void addVerifyListener(VerifyListener verifyListener) {
-	checkWidget();
-	if (verifyListener == null) SWT.error(SWT.ERROR_NULL_ARGUMENT);
-	addListener(SWT.Verify, new TypedListener(verifyListener));
+	addTypedListener(verifyListener, SWT.Verify);
 }
 /**
  * Adds a word movement listener. A movement event is sent when the boundary
@@ -7486,7 +7480,7 @@ public void redrawRange(int start, int length, boolean clearBackground) {
 public void removeBidiSegmentListener(BidiSegmentListener listener) {
 	checkWidget();
 	if (listener == null) SWT.error(SWT.ERROR_NULL_ARGUMENT);
-	removeListener(ST.LineGetSegments, listener);
+	removeTypedListener(ST.LineGetSegments, listener);
 	resetCache(0, content.getLineCount());
 	setCaretLocations();
 	super.redraw();
@@ -7509,7 +7503,7 @@ public void removeBidiSegmentListener(BidiSegmentListener listener) {
 public void removeCaretListener(CaretListener listener) {
 	checkWidget();
 	if (listener == null) SWT.error(SWT.ERROR_NULL_ARGUMENT);
-	removeListener(ST.CaretMoved, listener);
+	removeTypedListener(ST.CaretMoved, listener);
 }
 /**
  * Removes the specified extended modify listener.
@@ -7527,7 +7521,7 @@ public void removeCaretListener(CaretListener listener) {
 public void removeExtendedModifyListener(ExtendedModifyListener extendedModifyListener) {
 	checkWidget();
 	if (extendedModifyListener == null) SWT.error(SWT.ERROR_NULL_ARGUMENT);
-	removeListener(ST.ExtendedModify, extendedModifyListener);
+	removeTypedListener(ST.ExtendedModify, extendedModifyListener);
 }
 /**
  * Removes the specified line background listener.
@@ -7545,7 +7539,7 @@ public void removeExtendedModifyListener(ExtendedModifyListener extendedModifyLi
 public void removeLineBackgroundListener(LineBackgroundListener listener) {
 	checkWidget();
 	if (listener == null) SWT.error(SWT.ERROR_NULL_ARGUMENT);
-	removeListener(ST.LineGetBackground, listener);
+	removeTypedListener(ST.LineGetBackground, listener);
 }
 /**
  * Removes the specified line style listener.
@@ -7563,7 +7557,7 @@ public void removeLineBackgroundListener(LineBackgroundListener listener) {
 public void removeLineStyleListener(LineStyleListener listener) {
 	checkWidget();
 	if (listener == null) SWT.error(SWT.ERROR_NULL_ARGUMENT);
-	removeListener(ST.LineGetStyle, listener);
+	removeTypedListener(ST.LineGetStyle, listener);
 	setCaretLocations();
 }
 /**
@@ -7582,7 +7576,7 @@ public void removeLineStyleListener(LineStyleListener listener) {
 public void removeModifyListener(ModifyListener modifyListener) {
 	checkWidget();
 	if (modifyListener == null) SWT.error(SWT.ERROR_NULL_ARGUMENT);
-	removeListener(SWT.Modify, modifyListener);
+	removeTypedListener(SWT.Modify, modifyListener);
 }
 /**
  * Removes the specified listener.
@@ -7601,7 +7595,7 @@ public void removeModifyListener(ModifyListener modifyListener) {
 public void removePaintObjectListener(PaintObjectListener listener) {
 	checkWidget();
 	if (listener == null) SWT.error(SWT.ERROR_NULL_ARGUMENT);
-	removeListener(ST.PaintObject, listener);
+	removeTypedListener(ST.PaintObject, listener);
 }
 /**
  * Removes the listener from the collection of listeners who will
@@ -7623,7 +7617,7 @@ public void removePaintObjectListener(PaintObjectListener listener) {
 public void removeSelectionListener(SelectionListener listener) {
 	checkWidget();
 	if (listener == null) SWT.error(SWT.ERROR_NULL_ARGUMENT);
-	removeListener(SWT.Selection, listener);
+	removeTypedListener(SWT.Selection, listener);
 }
 /**
  * Removes the specified verify listener.
@@ -7641,7 +7635,7 @@ public void removeSelectionListener(SelectionListener listener) {
 public void removeVerifyListener(VerifyListener verifyListener) {
 	checkWidget();
 	if (verifyListener == null) SWT.error(SWT.ERROR_NULL_ARGUMENT);
-	removeListener(SWT.Verify, verifyListener);
+	removeTypedListener(SWT.Verify, verifyListener);
 }
 /**
  * Removes the specified key verify listener.
@@ -7658,7 +7652,7 @@ public void removeVerifyListener(VerifyListener verifyListener) {
  */
 public void removeVerifyKeyListener(VerifyKeyListener listener) {
 	if (listener == null) SWT.error(SWT.ERROR_NULL_ARGUMENT);
-	removeListener(ST.VerifyKey, listener);
+	removeTypedListener(ST.VerifyKey, listener);
 }
 /**
  * Removes the specified word movement listener.
@@ -7683,8 +7677,8 @@ public void removeVerifyKeyListener(VerifyKeyListener listener) {
 public void removeWordMovementListener(MovementListener listener) {
 	checkWidget();
 	if (listener == null) SWT.error(SWT.ERROR_NULL_ARGUMENT);
-	removeListener(ST.WordNext, listener);
-	removeListener(ST.WordPrevious, listener);
+	removeTypedListener(ST.WordNext, listener);
+	removeTypedListener(ST.WordPrevious, listener);
 }
 /**
  * Replaces the styles in the given range with new styles.  This method

--- a/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/TableCursor.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/TableCursor.java
@@ -197,12 +197,7 @@ public TableCursor(Table parent, int style) {
  * @see #removeSelectionListener(SelectionListener)
  */
 public void addSelectionListener(SelectionListener listener) {
-	checkWidget();
-	if (listener == null)
-		SWT.error(SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener(listener);
-	addListener(SWT.Selection, typedListener);
-	addListener(SWT.DefaultSelection, typedListener);
+	addTypedListener(listener, SWT.Selection, SWT.DefaultSelection);
 }
 
 void onDispose(Event event) {
@@ -502,8 +497,8 @@ public void removeSelectionListener(SelectionListener listener) {
 	if (listener == null) {
 		SWT.error(SWT.ERROR_NULL_ARGUMENT);
 	}
-	removeListener(SWT.Selection, listener);
-	removeListener(SWT.DefaultSelection, listener);
+	removeTypedListener(SWT.Selection, listener);
+	removeTypedListener(SWT.DefaultSelection, listener);
 }
 
 void _resize() {

--- a/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/TreeCursor.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/TreeCursor.java
@@ -268,11 +268,7 @@ public TreeCursor(Tree parent, int style) {
  * @see #removeSelectionListener(SelectionListener)
  */
 public void addSelectionListener(SelectionListener listener) {
-	checkWidget();
-	if (listener == null) SWT.error(SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener(listener);
-	addListener(SWT.Selection, typedListener);
-	addListener(SWT.DefaultSelection, typedListener);
+	addTypedListener(listener, SWT.Selection, SWT.DefaultSelection);
 }
 
 int countSubTreePages(TreeItem root) {
@@ -704,8 +700,8 @@ void paint(Event event) {
 public void removeSelectionListener(SelectionListener listener) {
 	checkWidget();
 	if (listener == null) SWT.error(SWT.ERROR_NULL_ARGUMENT);
-	removeListener(SWT.Selection, listener);
-	removeListener(SWT.DefaultSelection, listener);
+	removeTypedListener(SWT.Selection, listener);
+	removeTypedListener(SWT.DefaultSelection, listener);
 }
 
 void _resize() {

--- a/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/cocoa/org/eclipse/swt/dnd/DragSource.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/cocoa/org/eclipse/swt/dnd/DragSource.java
@@ -616,21 +616,7 @@ public Control getControl () {
  * @since 3.4
  */
 public DragSourceListener[] getDragListeners() {
-	Listener[] listeners = getListeners(DND.DragStart);
-	int length = listeners.length;
-	DragSourceListener[] dragListeners = new DragSourceListener[length];
-	int count = 0;
-	for (int i = 0; i < length; i++) {
-		Listener listener = listeners[i];
-		if (listener instanceof DNDListener) {
-			dragListeners[count] = (DragSourceListener) ((DNDListener) listener).getEventListener();
-			count++;
-		}
-	}
-	if (count == length) return dragListeners;
-	DragSourceListener[] result = new DragSourceListener[count];
-	System.arraycopy(dragListeners, 0, result, 0, count);
-	return result;
+	return getTypedListeners(DND.DragStart, DragSourceListener.class).toArray(DragSourceListener[]::new);
 }
 
 /**
@@ -790,9 +776,9 @@ void pasteboard_provideDataForType(long id, long sel, long arg0, long arg1) {
  */
 public void removeDragListener(DragSourceListener listener) {
 	if (listener == null) DND.error (SWT.ERROR_NULL_ARGUMENT);
-	removeListener (DND.DragStart, listener);
-	removeListener (DND.DragSetData, listener);
-	removeListener (DND.DragEnd, listener);
+	removeTypedListener(DND.DragStart, listener);
+	removeTypedListener(DND.DragSetData, listener);
+	removeTypedListener(DND.DragEnd, listener);
 }
 
 /**

--- a/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/cocoa/org/eclipse/swt/dnd/DropTarget.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/cocoa/org/eclipse/swt/dnd/DropTarget.java
@@ -506,21 +506,7 @@ public Control getControl () {
  * @since 3.4
  */
 public DropTargetListener[] getDropListeners() {
-	Listener[] listeners = getListeners(DND.DragEnter);
-	int length = listeners.length;
-	DropTargetListener[] dropListeners = new DropTargetListener[length];
-	int count = 0;
-	for (int i = 0; i < length; i++) {
-		Listener listener = listeners[i];
-		if (listener instanceof DNDListener) {
-			dropListeners[count] = (DropTargetListener) ((DNDListener) listener).getEventListener();
-			count++;
-		}
-	}
-	if (count == length) return dropListeners;
-	DropTargetListener[] result = new DropTargetListener[count];
-	System.arraycopy(dropListeners, 0, result, 0, count);
-	return result;
+	return getTypedListeners(DND.DragEnter, DropTargetListener.class).toArray(DropTargetListener[]::new);
 }
 
 /**
@@ -798,12 +784,12 @@ long outlineView_validateDrop_proposedItem_proposedChildIndex(long id, long sel,
  */
 public void removeDropListener(DropTargetListener listener) {
 	if (listener == null) DND.error (SWT.ERROR_NULL_ARGUMENT);
-	removeListener (DND.DragEnter, listener);
-	removeListener (DND.DragLeave, listener);
-	removeListener (DND.DragOver, listener);
-	removeListener (DND.DragOperationChanged, listener);
-	removeListener (DND.Drop, listener);
-	removeListener (DND.DropAccept, listener);
+	removeTypedListener(DND.DragEnter, listener);
+	removeTypedListener(DND.DragLeave, listener);
+	removeTypedListener(DND.DragOver, listener);
+	removeTypedListener(DND.DragOperationChanged, listener);
+	removeTypedListener(DND.Drop, listener);
+	removeTypedListener(DND.DropAccept, listener);
 }
 
 /**

--- a/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/gtk/org/eclipse/swt/dnd/DragSource.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/gtk/org/eclipse/swt/dnd/DragSource.java
@@ -577,21 +577,7 @@ public Control getControl () {
  * @since 3.4
  */
 public DragSourceListener[] getDragListeners() {
-	Listener[] listeners = getListeners(DND.DragStart);
-	int length = listeners.length;
-	DragSourceListener[] dragListeners = new DragSourceListener[length];
-	int count = 0;
-	for (int i = 0; i < length; i++) {
-		Listener listener = listeners[i];
-		if (listener instanceof DNDListener) {
-			dragListeners[count] = (DragSourceListener) ((DNDListener) listener).getEventListener();
-			count++;
-		}
-	}
-	if (count == length) return dragListeners;
-	DragSourceListener[] result = new DragSourceListener[count];
-	System.arraycopy(dragListeners, 0, result, 0, count);
-	return result;
+	return getTypedListeners(DND.DragStart, DragSourceListener.class).toArray(DragSourceListener[]::new);
 }
 
 /**
@@ -677,9 +663,9 @@ int osOpToOp(int osOperation){
  */
 public void removeDragListener(DragSourceListener listener) {
 	if (listener == null) DND.error (SWT.ERROR_NULL_ARGUMENT);
-	removeListener (DND.DragStart, listener);
-	removeListener (DND.DragSetData, listener);
-	removeListener (DND.DragEnd, listener);
+	removeTypedListener(DND.DragStart, listener);
+	removeTypedListener(DND.DragSetData, listener);
+	removeTypedListener(DND.DragEnd, listener);
 }
 
 /**

--- a/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/gtk/org/eclipse/swt/dnd/DropTarget.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/gtk/org/eclipse/swt/dnd/DropTarget.java
@@ -546,21 +546,7 @@ public Control getControl () {
  * @since 3.4
  */
 public DropTargetListener[] getDropListeners() {
-	Listener[] listeners = getListeners(DND.DragEnter);
-	int length = listeners.length;
-	DropTargetListener[] dropListeners = new DropTargetListener[length];
-	int count = 0;
-	for (int i = 0; i < length; i++) {
-		Listener listener = listeners[i];
-		if (listener instanceof DNDListener) {
-			dropListeners[count] = (DropTargetListener) ((DNDListener) listener).getEventListener();
-			count++;
-		}
-	}
-	if (count == length) return dropListeners;
-	DropTargetListener[] result = new DropTargetListener[count];
-	System.arraycopy(dropListeners, 0, result, 0, count);
-	return result;
+	return getTypedListeners(DND.DragEnter, DropTargetListener.class).toArray(DropTargetListener[]::new);
 }
 
 /**
@@ -663,12 +649,12 @@ int osOpToOp(int osOperation){
  */
 public void removeDropListener(DropTargetListener listener) {
 	if (listener == null) DND.error (SWT.ERROR_NULL_ARGUMENT);
-	removeListener (DND.DragEnter, listener);
-	removeListener (DND.DragLeave, listener);
-	removeListener (DND.DragOver, listener);
-	removeListener (DND.DragOperationChanged, listener);
-	removeListener (DND.Drop, listener);
-	removeListener (DND.DropAccept, listener);
+	removeTypedListener(DND.DragEnter, listener);
+	removeTypedListener(DND.DragLeave, listener);
+	removeTypedListener(DND.DragOver, listener);
+	removeTypedListener(DND.DragOperationChanged, listener);
+	removeTypedListener(DND.Drop, listener);
+	removeTypedListener(DND.DropAccept, listener);
 }
 
 /**

--- a/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/win32/org/eclipse/swt/dnd/DragSource.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/win32/org/eclipse/swt/dnd/DragSource.java
@@ -639,21 +639,7 @@ public Control getControl() {
  * @since 3.4
  */
 public DragSourceListener[] getDragListeners() {
-	Listener[] listeners = getListeners(DND.DragStart);
-	int length = listeners.length;
-	DragSourceListener[] dragListeners = new DragSourceListener[length];
-	int count = 0;
-	for (int i = 0; i < length; i++) {
-		Listener listener = listeners[i];
-		if (listener instanceof DNDListener) {
-			dragListeners[count] = (DragSourceListener) ((DNDListener) listener).getEventListener();
-			count++;
-		}
-	}
-	if (count == length) return dragListeners;
-	DragSourceListener[] result = new DragSourceListener[count];
-	System.arraycopy(dragListeners, 0, result, 0, count);
-	return result;
+	return getTypedListeners(DND.DragStart, DragSourceListener.class).toArray(DragSourceListener[]::new);
 }
 
 /**
@@ -809,9 +795,9 @@ private static int QueryInterface(COMObject comObject, long riid, long ppvObject
  */
 public void removeDragListener(DragSourceListener listener) {
 	if (listener == null) DND.error(SWT.ERROR_NULL_ARGUMENT);
-	removeListener(DND.DragStart, listener);
-	removeListener(DND.DragSetData, listener);
-	removeListener(DND.DragEnd, listener);
+	removeTypedListener(DND.DragStart, listener);
+	removeTypedListener(DND.DragSetData, listener);
+	removeTypedListener(DND.DragEnd, listener);
 }
 
 /**

--- a/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/win32/org/eclipse/swt/dnd/DropTarget.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/win32/org/eclipse/swt/dnd/DropTarget.java
@@ -515,21 +515,7 @@ public Control getControl () {
  * @since 3.4
  */
 public DropTargetListener[] getDropListeners() {
-	Listener[] listeners = getListeners(DND.DragEnter);
-	int length = listeners.length;
-	DropTargetListener[] dropListeners = new DropTargetListener[length];
-	int count = 0;
-	for (int i = 0; i < length; i++) {
-		Listener listener = listeners[i];
-		if (listener instanceof DNDListener) {
-			dropListeners[count] = (DropTargetListener) ((DNDListener) listener).getEventListener();
-			count++;
-		}
-	}
-	if (count == length) return dropListeners;
-	DropTargetListener[] result = new DropTargetListener[count];
-	System.arraycopy(dropListeners, 0, result, 0, count);
-	return result;
+	return getTypedListeners(DND.DragEnter, DropTargetListener.class).toArray(DropTargetListener[]::new);
 }
 
 /**
@@ -685,12 +671,12 @@ void refresh() {
  */
 public void removeDropListener(DropTargetListener listener) {
 	if (listener == null) DND.error (SWT.ERROR_NULL_ARGUMENT);
-	removeListener (DND.DragEnter, listener);
-	removeListener (DND.DragLeave, listener);
-	removeListener (DND.DragOver, listener);
-	removeListener (DND.DragOperationChanged, listener);
-	removeListener (DND.Drop, listener);
-	removeListener (DND.DropAccept, listener);
+	removeTypedListener(DND.DragEnter, listener);
+	removeTypedListener(DND.DragLeave, listener);
+	removeTypedListener(DND.DragOver, listener);
+	removeTypedListener(DND.DragOperationChanged, listener);
+	removeTypedListener(DND.Drop, listener);
+	removeTypedListener(DND.DropAccept, listener);
 }
 
 /**

--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Button.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Button.java
@@ -139,11 +139,7 @@ public Button (Composite parent, int style) {
  * @see SelectionEvent
  */
 public void addSelectionListener(SelectionListener listener) {
-	checkWidget();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener(listener);
-	addListener(SWT.Selection,typedListener);
-	addListener(SWT.DefaultSelection,typedListener);
+	addTypedListener(listener, SWT.Selection, SWT.DefaultSelection);
 }
 
 @Override

--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Combo.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Combo.java
@@ -225,10 +225,7 @@ public void add (String string, int index) {
  * @see #removeModifyListener
  */
 public void addModifyListener (ModifyListener listener) {
-	checkWidget();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.Modify, typedListener);
+	addTypedListener(listener, SWT.Modify);
 }
 
 /**
@@ -266,9 +263,7 @@ public void addModifyListener (ModifyListener listener) {
  * @since 3.103
  */
 public void addSegmentListener (SegmentListener listener) {
-	checkWidget ();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	addListener (SWT.Segments, new TypedListener (listener));
+	addTypedListener(listener, SWT.Segments);
 }
 
 /**
@@ -296,11 +291,7 @@ public void addSegmentListener (SegmentListener listener) {
  * @see SelectionEvent
  */
 public void addSelectionListener(SelectionListener listener) {
-	checkWidget();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.Selection,typedListener);
-	addListener (SWT.DefaultSelection,typedListener);
+	addTypedListener(listener, SWT.Selection, SWT.DefaultSelection);
 }
 
 /**
@@ -325,10 +316,7 @@ public void addSelectionListener(SelectionListener listener) {
  * @since 3.1
  */
 public void addVerifyListener (VerifyListener listener) {
-	checkWidget();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.Verify, typedListener);
+	addTypedListener(listener, SWT.Verify);
 }
 
 @Override

--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Control.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Control.java
@@ -353,11 +353,7 @@ void accessibilitySetValue_forAttribute(long id, long sel, long arg0, long arg1)
  * @see #removeControlListener
  */
 public void addControlListener(ControlListener listener) {
-	checkWidget();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.Resize,typedListener);
-	addListener (SWT.Move,typedListener);
+	addTypedListener(listener, SWT.Resize, SWT.Move);
 }
 
 /**
@@ -382,10 +378,7 @@ public void addControlListener(ControlListener listener) {
  * @since 3.3
  */
 public void addDragDetectListener (DragDetectListener listener) {
-	checkWidget ();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.DragDetect,typedListener);
+	addTypedListener(listener, SWT.DragDetect);
 }
 
 /**
@@ -408,11 +401,7 @@ public void addDragDetectListener (DragDetectListener listener) {
  * @see #removeFocusListener
  */
 public void addFocusListener(FocusListener listener) {
-	checkWidget();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener(SWT.FocusIn,typedListener);
-	addListener(SWT.FocusOut,typedListener);
+	addTypedListener(listener, SWT.FocusIn, SWT.FocusOut);
 }
 
 /**
@@ -448,10 +437,7 @@ public void addFocusListener(FocusListener listener) {
  * @since 3.7
  */
 public void addGestureListener (GestureListener listener) {
-	checkWidget();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.Gesture, typedListener);
+	addTypedListener(listener, SWT.Gesture);
 }
 
 /**
@@ -474,10 +460,7 @@ public void addGestureListener (GestureListener listener) {
  * @see #removeHelpListener
  */
 public void addHelpListener (HelpListener listener) {
-	checkWidget();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.Help, typedListener);
+	addTypedListener(listener, SWT.Help);
 }
 
 /**
@@ -511,11 +494,7 @@ public void addHelpListener (HelpListener listener) {
  * @see #removeKeyListener
  */
 public void addKeyListener(KeyListener listener) {
-	checkWidget();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener(SWT.KeyUp,typedListener);
-	addListener(SWT.KeyDown,typedListener);
+	addTypedListener(listener, SWT.KeyUp, SWT.KeyDown);
 }
 
 /**
@@ -540,10 +519,7 @@ public void addKeyListener(KeyListener listener) {
  * @since 3.3
  */
 public void addMenuDetectListener (MenuDetectListener listener) {
-	checkWidget ();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.MenuDetect, typedListener);
+	addTypedListener(listener, SWT.MenuDetect);
 }
 
 /**
@@ -566,12 +542,7 @@ public void addMenuDetectListener (MenuDetectListener listener) {
  * @see #removeMouseListener
  */
 public void addMouseListener(MouseListener listener) {
-	checkWidget();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener(SWT.MouseDown,typedListener);
-	addListener(SWT.MouseUp,typedListener);
-	addListener(SWT.MouseDoubleClick,typedListener);
+	addTypedListener(listener, SWT.MouseDown, SWT.MouseUp, SWT.MouseDoubleClick);
 }
 
 /**
@@ -594,12 +565,7 @@ public void addMouseListener(MouseListener listener) {
  * @see #removeMouseTrackListener
  */
 public void addMouseTrackListener (MouseTrackListener listener) {
-	checkWidget();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.MouseEnter,typedListener);
-	addListener (SWT.MouseExit,typedListener);
-	addListener (SWT.MouseHover,typedListener);
+	addTypedListener(listener, SWT.MouseEnter, SWT.MouseExit, SWT.MouseHover);
 }
 
 /**
@@ -622,10 +588,7 @@ public void addMouseTrackListener (MouseTrackListener listener) {
  * @see #removeMouseMoveListener
  */
 public void addMouseMoveListener(MouseMoveListener listener) {
-	checkWidget();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener(SWT.MouseMove,typedListener);
+	addTypedListener(listener, SWT.MouseMove);
 }
 
 /**
@@ -650,10 +613,7 @@ public void addMouseMoveListener(MouseMoveListener listener) {
  * @since 3.3
  */
 public void addMouseWheelListener (MouseWheelListener listener) {
-	checkWidget ();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.MouseWheel, typedListener);
+	addTypedListener(listener, SWT.MouseWheel);
 }
 
 void addRelation (Control control) {
@@ -679,10 +639,7 @@ void addRelation (Control control) {
  * @see #removePaintListener
  */
 public void addPaintListener(PaintListener listener) {
-	checkWidget();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener(SWT.Paint,typedListener);
+	addTypedListener(listener, SWT.Paint);
 }
 
 static final double SYNTHETIC_BOLD = -2.5;
@@ -729,10 +686,7 @@ void addTraits(NSMutableDictionary dict, Font font) {
  * @since 3.7
  */
 public void addTouchListener (TouchListener listener) {
-	checkWidget();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.Touch,typedListener);
+	addTypedListener(listener, SWT.Touch);
 }
 
 /**
@@ -755,10 +709,7 @@ public void addTouchListener (TouchListener listener) {
  * @see #removeTraverseListener
  */
 public void addTraverseListener (TraverseListener listener) {
-	checkWidget();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.Traverse,typedListener);
+	addTypedListener(listener, SWT.Traverse);
 }
 
 @Override

--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/DateTime.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/DateTime.java
@@ -143,11 +143,7 @@ protected void checkSubclass () {
  * @see SelectionEvent
  */
 public void addSelectionListener (SelectionListener listener) {
-	checkWidget ();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.Selection, typedListener);
-	addListener (SWT.DefaultSelection, typedListener);
+	addTypedListener(listener, SWT.Selection, SWT.DefaultSelection);
 }
 
 @Override

--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Link.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Link.java
@@ -110,11 +110,7 @@ public Link (Composite parent, int style) {
  * @see SelectionEvent
  */
 public void addSelectionListener (SelectionListener listener) {
-	checkWidget ();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.Selection, typedListener);
-	addListener (SWT.DefaultSelection, typedListener);
+	addTypedListener(listener, SWT.Selection, SWT.DefaultSelection);
 }
 
 @Override

--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/List.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/List.java
@@ -205,11 +205,7 @@ public void add (String string, int index) {
  * @see SelectionEvent
  */
 public void addSelectionListener(SelectionListener listener) {
-	checkWidget();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener(listener);
-	addListener(SWT.Selection,typedListener);
-	addListener(SWT.DefaultSelection,typedListener);
+	addTypedListener(listener, SWT.Selection, SWT.DefaultSelection);
 }
 
 static int checkStyle (int style) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Menu.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Menu.java
@@ -298,10 +298,7 @@ void _setVisible (boolean visible) {
  * @see #removeHelpListener
  */
 public void addHelpListener (HelpListener listener) {
-	checkWidget ();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.Help, typedListener);
+	addTypedListener(listener, SWT.Help);
 }
 
 /**
@@ -324,11 +321,7 @@ public void addHelpListener (HelpListener listener) {
  * @see #removeMenuListener
  */
 public void addMenuListener (MenuListener listener) {
-	checkWidget ();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.Hide,typedListener);
-	addListener (SWT.Show,typedListener);
+	addTypedListener(listener, SWT.Hide, SWT.Show);
 }
 
 @Override

--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/MenuItem.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/MenuItem.java
@@ -14,10 +14,10 @@
 package org.eclipse.swt.widgets;
 
 
-import org.eclipse.swt.internal.cocoa.*;
 import org.eclipse.swt.*;
-import org.eclipse.swt.graphics.*;
 import org.eclipse.swt.events.*;
+import org.eclipse.swt.graphics.*;
+import org.eclipse.swt.internal.cocoa.*;
 
 /**
  * Instances of this class represent a selectable user interface object
@@ -155,10 +155,7 @@ MenuItem (Menu parent, NSMenuItem nsMenuItem) {
  * @see #removeArmListener
  */
 public void addArmListener (ArmListener listener) {
-	checkWidget ();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.Arm, typedListener);
+	addTypedListener(listener, SWT.Arm);
 }
 
 /**
@@ -181,10 +178,7 @@ public void addArmListener (ArmListener listener) {
  * @see #removeHelpListener
  */
 public void addHelpListener (HelpListener listener) {
-	checkWidget ();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.Help, typedListener);
+	addTypedListener(listener, SWT.Help);
 }
 
 /**
@@ -218,11 +212,7 @@ public void addHelpListener (HelpListener listener) {
  * @see SelectionEvent
  */
 public void addSelectionListener (SelectionListener listener) {
-	checkWidget ();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener(listener);
-	addListener (SWT.Selection,typedListener);
-	addListener (SWT.DefaultSelection,typedListener);
+	addTypedListener(listener, SWT.Selection, SWT.DefaultSelection);
 }
 
 @Override

--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Sash.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Sash.java
@@ -234,11 +234,7 @@ boolean accessibilityIsIgnored(long id, long sel) {
  * @see SelectionEvent
  */
 public void addSelectionListener(SelectionListener listener) {
-	checkWidget();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener(listener);
-	addListener(SWT.Selection,typedListener);
-	addListener(SWT.DefaultSelection,typedListener);
+	addTypedListener(listener, SWT.Selection, SWT.DefaultSelection);
 }
 
 static int checkStyle (int style) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Scale.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Scale.java
@@ -102,11 +102,7 @@ public Scale (Composite parent, int style) {
  * @see #removeSelectionListener
  */
 public void addSelectionListener(SelectionListener listener) {
-	checkWidget();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener(listener);
-	addListener(SWT.Selection,typedListener);
-	addListener(SWT.DefaultSelection,typedListener);
+	addTypedListener(listener, SWT.Selection, SWT.DefaultSelection);
 }
 
 static int checkStyle (int style) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/ScrollBar.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/ScrollBar.java
@@ -132,11 +132,7 @@ ScrollBar () {
  * @see SelectionEvent
  */
 public void addSelectionListener(SelectionListener listener) {
-	checkWidget();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener(listener);
-	addListener(SWT.Selection,typedListener);
-	addListener(SWT.DefaultSelection,typedListener);
+	addTypedListener(listener, SWT.Selection, SWT.DefaultSelection);
 }
 
 static int checkStyle (int style) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Shell.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Shell.java
@@ -478,14 +478,7 @@ boolean accessibilityIsIgnored(long id, long sel) {
  * @see #removeShellListener
  */
 public void addShellListener(ShellListener listener) {
-	checkWidget();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener(SWT.Activate,typedListener);
-	addListener(SWT.Close,typedListener);
-	addListener(SWT.Deactivate,typedListener);
-	addListener(SWT.Iconify,typedListener);
-	addListener(SWT.Deiconify,typedListener);
+	addTypedListener(listener, SWT.Activate, SWT.Close, SWT.Deactivate, SWT.Iconify, SWT.Deiconify);
 }
 
 void attachObserversToWindow(NSWindow newWindow) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Slider.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Slider.java
@@ -14,11 +14,10 @@
 package org.eclipse.swt.widgets;
 
 
-import org.eclipse.swt.internal.cocoa.*;
-
 import org.eclipse.swt.*;
 import org.eclipse.swt.events.*;
 import org.eclipse.swt.graphics.*;
+import org.eclipse.swt.internal.cocoa.*;
 
 /**
  * Instances of this class are selectable user interface
@@ -146,11 +145,7 @@ public Slider (Composite parent, int style) {
  * @see SelectionEvent
  */
 public void addSelectionListener(SelectionListener listener) {
-	checkWidget();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener(listener);
-	addListener(SWT.Selection,typedListener);
-	addListener(SWT.DefaultSelection,typedListener);
+	addTypedListener(listener, SWT.Selection, SWT.DefaultSelection);
 }
 
 static int checkStyle (int style) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Spinner.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Spinner.java
@@ -134,10 +134,7 @@ boolean accessibilityIsIgnored(long id, long sel) {
  * @see #removeModifyListener
  */
 public void addModifyListener (ModifyListener listener) {
-	checkWidget ();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.Modify, typedListener);
+	addTypedListener(listener, SWT.Modify);
 }
 
 /**
@@ -165,11 +162,7 @@ public void addModifyListener (ModifyListener listener) {
  * @see SelectionEvent
  */
 public void addSelectionListener(SelectionListener listener) {
-	checkWidget ();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener(listener);
-	addListener (SWT.Selection,typedListener);
-	addListener (SWT.DefaultSelection,typedListener);
+	addTypedListener(listener, SWT.Selection, SWT.DefaultSelection);
 }
 
 /**
@@ -192,10 +185,7 @@ public void addSelectionListener(SelectionListener listener) {
  * @see #removeVerifyListener
  */
 void addVerifyListener (VerifyListener listener) {
-	checkWidget();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.Verify, typedListener);
+	addTypedListener(listener, SWT.Verify);
 }
 
 static int checkStyle (int style) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/TabFolder.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/TabFolder.java
@@ -114,11 +114,7 @@ public TabFolder (Composite parent, int style) {
  * @see SelectionEvent
  */
 public void addSelectionListener(SelectionListener listener) {
-	checkWidget ();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.Selection,typedListener);
-	addListener (SWT.DefaultSelection,typedListener);
+	addTypedListener(listener, SWT.Selection, SWT.DefaultSelection);
 }
 
 static int checkStyle (int style) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Table.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Table.java
@@ -200,11 +200,7 @@ void _addListener (int eventType, Listener listener) {
  * @see SelectionEvent
  */
 public void addSelectionListener (SelectionListener listener) {
-	checkWidget ();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.Selection, typedListener);
-	addListener (SWT.DefaultSelection, typedListener);
+	addTypedListener(listener, SWT.Selection, SWT.DefaultSelection);
 }
 
 TableItem _getItem (int index) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/TableColumn.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/TableColumn.java
@@ -146,11 +146,7 @@ public TableColumn (Table parent, int style, int index) {
  * @see #removeControlListener
  */
 public void addControlListener(ControlListener listener) {
-	checkWidget ();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.Resize,typedListener);
-	addListener (SWT.Move,typedListener);
+	addTypedListener(listener, SWT.Resize, SWT.Move);
 }
 
 /**
@@ -178,11 +174,7 @@ public void addControlListener(ControlListener listener) {
  * @see SelectionEvent
  */
 public void addSelectionListener (SelectionListener listener) {
-	checkWidget ();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.Selection,typedListener);
-	addListener (SWT.DefaultSelection,typedListener);
+	addTypedListener(listener, SWT.Selection, SWT.DefaultSelection);
 }
 
 static int checkStyle (int style) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Text.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Text.java
@@ -191,10 +191,7 @@ public Text (Composite parent, int style) {
  * @see #removeModifyListener
  */
 public void addModifyListener (ModifyListener listener) {
-	checkWidget ();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.Modify, typedListener);
+	addTypedListener(listener, SWT.Modify);
 }
 
 /**
@@ -232,9 +229,7 @@ public void addModifyListener (ModifyListener listener) {
  * @since 3.8
  */
 public void addSegmentListener (SegmentListener listener) {
-	checkWidget ();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	addListener (SWT.Segments, new TypedListener (listener));
+	addTypedListener(listener, SWT.Segments);
 }
 
 /**
@@ -266,11 +261,7 @@ public void addSegmentListener (SegmentListener listener) {
  * @see SelectionEvent
  */
 public void addSelectionListener(SelectionListener listener) {
-	checkWidget ();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.Selection,typedListener);
-	addListener (SWT.DefaultSelection,typedListener);
+	addTypedListener(listener, SWT.Selection, SWT.DefaultSelection);
 }
 
 /**
@@ -293,10 +284,7 @@ public void addSelectionListener(SelectionListener listener) {
  * @see #removeVerifyListener
  */
 public void addVerifyListener (VerifyListener listener) {
-	checkWidget ();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.Verify, typedListener);
+	addTypedListener(listener, SWT.Verify);
 }
 
 /**

--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/ToolItem.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/ToolItem.java
@@ -283,11 +283,7 @@ boolean accessibilityIsIgnored(long id, long sel) {
  * @see SelectionEvent
  */
 public void addSelectionListener(SelectionListener listener) {
-	checkWidget();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener(listener);
-	addListener(SWT.Selection,typedListener);
-	addListener(SWT.DefaultSelection,typedListener);
+	addTypedListener(listener, SWT.Selection, SWT.DefaultSelection);
 }
 
 static int checkStyle (int style) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Tracker.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Tracker.java
@@ -162,11 +162,7 @@ public Tracker (Display display, int style) {
  * @see #removeControlListener
  */
 public void addControlListener (ControlListener listener) {
-	checkWidget ();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.Resize, typedListener);
-	addListener (SWT.Move, typedListener);
+	addTypedListener(listener, SWT.Resize, SWT.Move);
 }
 
 /**
@@ -189,11 +185,7 @@ public void addControlListener (ControlListener listener) {
  * @see #removeKeyListener
  */
 public void addKeyListener(KeyListener listener) {
-	checkWidget();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener(SWT.KeyUp,typedListener);
-	addListener(SWT.KeyDown,typedListener);
+	addTypedListener(listener, SWT.KeyUp, SWT.KeyDown);
 }
 
 Point adjustMoveCursor () {

--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/TrayItem.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/TrayItem.java
@@ -106,10 +106,7 @@ public TrayItem (Tray parent, int style) {
  * @since 3.3
  */
 public void addMenuDetectListener (MenuDetectListener listener) {
-	checkWidget ();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.MenuDetect, typedListener);
+	addTypedListener(listener, SWT.MenuDetect);
 }
 
 /**
@@ -137,11 +134,7 @@ public void addMenuDetectListener (MenuDetectListener listener) {
  * @see SelectionEvent
  */
 public void addSelectionListener(SelectionListener listener) {
-	checkWidget ();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.Selection,typedListener);
-	addListener (SWT.DefaultSelection,typedListener);
+	addTypedListener(listener, SWT.Selection, SWT.DefaultSelection);
 }
 
 @Override

--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Tree.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Tree.java
@@ -233,11 +233,7 @@ long accessibilityAttributeValue(long id, long sel, long arg0) {
  * @see SelectionEvent
  */
 public void addSelectionListener(SelectionListener listener) {
-	checkWidget ();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.Selection, typedListener);
-	addListener (SWT.DefaultSelection, typedListener);
+	addTypedListener(listener, SWT.Selection, SWT.DefaultSelection);
 }
 
 /**
@@ -260,11 +256,7 @@ public void addSelectionListener(SelectionListener listener) {
  * @see #removeTreeListener
  */
 public void addTreeListener(TreeListener listener) {
-	checkWidget ();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.Expand, typedListener);
-	addListener (SWT.Collapse, typedListener);
+	addTypedListener(listener, SWT.Expand, SWT.Collapse);
 }
 
 int calculateWidth (TreeItem[] items, int index, GC gc, boolean recurse) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/TreeColumn.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/TreeColumn.java
@@ -148,11 +148,7 @@ public TreeColumn (Tree parent, int style, int index) {
  * @see #removeControlListener
  */
 public void addControlListener(ControlListener listener) {
-	checkWidget ();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.Resize,typedListener);
-	addListener (SWT.Move,typedListener);
+	addTypedListener(listener, SWT.Resize, SWT.Move);
 }
 
 /**
@@ -180,11 +176,7 @@ public void addControlListener(ControlListener listener) {
  * @see SelectionEvent
  */
 public void addSelectionListener (SelectionListener listener) {
-	checkWidget ();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.Selection,typedListener);
-	addListener (SWT.DefaultSelection,typedListener);
+	addTypedListener(listener, SWT.Selection, SWT.DefaultSelection);
 }
 
 static int checkStyle (int style) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Widget.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Widget.java
@@ -531,10 +531,7 @@ void _addListener (int eventType, Listener listener) {
  * @see #removeDisposeListener
  */
 public void addDisposeListener (DisposeListener listener) {
-	checkWidget();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.Dispose, typedListener);
+	addTypedListener(listener, SWT.Dispose);
 }
 
 boolean canBecomeKeyView(long id, long sel) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/EventTable.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/EventTable.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2011 IBM Corporation and others.
+ * Copyright (c) 2000, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.swt.widgets;
 
+
+import java.util.*;
 
 import org.eclipse.swt.*;
 import org.eclipse.swt.internal.*;
@@ -145,12 +147,12 @@ public void unhook (int eventType, Listener listener) {
 	}
 }
 
-public void unhook (int eventType, SWTEventListener listener) {
+public void unhook (int eventType, EventListener listener) {
 	if (types == null) return;
 	for (int i=0; i<types.length; i++) {
 		if (types [i] == eventType) {
 			if (listeners [i] instanceof TypedListener typedListener) {
-				if (typedListener.getEventListener () == listener) {
+				if (typedListener.eventListener == listener) {
 					remove (i);
 					return;
 				}

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/TypedListener.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/TypedListener.java
@@ -14,9 +14,11 @@
 package org.eclipse.swt.widgets;
 
 
-import org.eclipse.swt.internal.SWTEventListener;
+import java.util.*;
+
 import org.eclipse.swt.*;
 import org.eclipse.swt.events.*;
+import org.eclipse.swt.internal.*;
 
 /**
  * Instances of this class are <em>internal SWT implementation</em>
@@ -40,7 +42,7 @@ public class TypedListener implements Listener {
 	/**
 	 * The receiver's event listener
 	 */
-	protected SWTEventListener eventListener;
+	protected EventListener eventListener;
 
 /**
  * Constructs a new instance of this class for the given event listener.
@@ -59,6 +61,10 @@ public TypedListener (SWTEventListener listener) {
 	eventListener = listener;
 }
 
+TypedListener (EventListener listener) {
+	eventListener = listener;
+}
+
 /**
  * Returns the receiver's event listener.
  * <p>
@@ -73,7 +79,11 @@ public TypedListener (SWTEventListener listener) {
  * @noreference This method is not intended to be referenced by clients.
  */
 public SWTEventListener getEventListener () {
-	return eventListener;
+	// At the moment all typed listeners implement SWTEventListener but that interface is intended to be removed in the future and then they will only implement EventListener.
+	// This method should not be called for typed listeners listeners that only implement EventListener.
+	// This is only relevant for custom typed listeners that implement EventListener directly before SWTEventListener is eventually removed.
+	// But then the new Widget.getTypedListener() method can be used.
+	return (SWTEventListener) eventListener;
 }
 
 /**

--- a/bundles/org.eclipse.swt/Eclipse SWT/emulated/coolbar/org/eclipse/swt/widgets/CoolItem.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/emulated/coolbar/org/eclipse/swt/widgets/CoolItem.java
@@ -160,11 +160,7 @@ public CoolItem (CoolBar parent, int style, int index) {
  * @since 2.0
  */
 public void addSelectionListener(SelectionListener listener) {
-	checkWidget();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.Selection,typedListener);
-	addListener (SWT.DefaultSelection,typedListener);
+	addTypedListener(listener, SWT.Selection, SWT.DefaultSelection);
 }
 @Override
 protected void checkSubclass () {

--- a/bundles/org.eclipse.swt/Eclipse SWT/emulated/expand/org/eclipse/swt/widgets/ExpandBar.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/emulated/expand/org/eclipse/swt/widgets/ExpandBar.java
@@ -137,11 +137,7 @@ public ExpandBar (Composite parent, int style) {
  * @see #removeExpandListener
  */
 public void addExpandListener (ExpandListener listener) {
-	checkWidget ();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.Expand, typedListener);
-	addListener (SWT.Collapse, typedListener);
+	addTypedListener(listener, SWT.Expand, SWT.Collapse);
 }
 
 static int checkStyle (int style) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/emulated/tooltip/org/eclipse/swt/widgets/ToolTip.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/emulated/tooltip/org/eclipse/swt/widgets/ToolTip.java
@@ -145,11 +145,7 @@ static int checkStyle (int style) {
  * @see SelectionEvent
  */
 public void addSelectionListener (SelectionListener listener) {
-	checkWidget ();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.Selection,typedListener);
-	addListener (SWT.DefaultSelection,typedListener);
+	addTypedListener(listener, SWT.Selection, SWT.DefaultSelection);
 }
 
 void configure () {

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Button.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Button.java
@@ -183,11 +183,7 @@ GdkRGBA getContextBackgroundGdkRGBA () {
  * @see SelectionEvent
  */
 public void addSelectionListener (SelectionListener listener) {
-	checkWidget ();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.Selection,typedListener);
-	addListener (SWT.DefaultSelection,typedListener);
+	addTypedListener(listener, SWT.Selection, SWT.DefaultSelection);
 }
 
 @Override

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Combo.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Combo.java
@@ -269,10 +269,7 @@ private void gtk_combo_box_toggle_wrap (boolean wrap) {
  * @see #removeModifyListener
  */
 public void addModifyListener (ModifyListener listener) {
-	checkWidget();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.Modify, typedListener);
+	addTypedListener(listener, SWT.Modify);
 }
 
 /**
@@ -310,9 +307,7 @@ public void addModifyListener (ModifyListener listener) {
  * @since 3.103
  */
 public void addSegmentListener (SegmentListener listener) {
-	checkWidget ();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	addListener (SWT.Segments, new TypedListener (listener));
+	addTypedListener(listener, SWT.Segments);
 }
 
 /**
@@ -340,11 +335,7 @@ public void addSegmentListener (SegmentListener listener) {
  * @see SelectionEvent
  */
 public void addSelectionListener(SelectionListener listener) {
-	checkWidget();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.Selection,typedListener);
-	addListener (SWT.DefaultSelection,typedListener);
+	addTypedListener(listener, SWT.Selection, SWT.DefaultSelection);
 }
 
 /**
@@ -369,10 +360,7 @@ public void addSelectionListener(SelectionListener listener) {
  * @since 3.1
  */
 public void addVerifyListener (VerifyListener listener) {
-	checkWidget ();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.Verify, typedListener);
+	addTypedListener(listener, SWT.Verify);
 }
 
 static int checkStyle (int style) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Control.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Control.java
@@ -1811,11 +1811,7 @@ Point getControlOrigin() {
  * @see #removeControlListener
  */
 public void addControlListener(ControlListener listener) {
-	checkWidget();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.Resize,typedListener);
-	addListener (SWT.Move,typedListener);
+	addTypedListener(listener, SWT.Resize, SWT.Move);
 }
 
 /**
@@ -1840,10 +1836,7 @@ public void addControlListener(ControlListener listener) {
  * @since 3.3
  */
 public void addDragDetectListener (DragDetectListener listener) {
-	checkWidget ();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.DragDetect,typedListener);
+	addTypedListener(listener, SWT.DragDetect);
 }
 
 /**
@@ -1866,11 +1859,7 @@ public void addDragDetectListener (DragDetectListener listener) {
  * @see #removeFocusListener
  */
 public void addFocusListener(FocusListener listener) {
-	checkWidget();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener(SWT.FocusIn,typedListener);
-	addListener(SWT.FocusOut,typedListener);
+	addTypedListener(listener, SWT.FocusIn, SWT.FocusOut);
 }
 
 /**
@@ -1906,10 +1895,7 @@ public void addFocusListener(FocusListener listener) {
  * @since 3.7
  */
 public void addGestureListener (GestureListener listener) {
-	checkWidget();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.Gesture, typedListener);
+	addTypedListener(listener, SWT.Gesture);
 }
 
 /**
@@ -1932,10 +1918,7 @@ public void addGestureListener (GestureListener listener) {
  * @see #removeHelpListener
  */
 public void addHelpListener (HelpListener listener) {
-	checkWidget();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.Help, typedListener);
+	addTypedListener(listener, SWT.Help);
 }
 
 /**
@@ -1969,11 +1952,7 @@ public void addHelpListener (HelpListener listener) {
  * @see #removeKeyListener
  */
 public void addKeyListener(KeyListener listener) {
-	checkWidget();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener(SWT.KeyUp,typedListener);
-	addListener(SWT.KeyDown,typedListener);
+	addTypedListener(listener, SWT.KeyUp, SWT.KeyDown);
 }
 
 /**
@@ -1998,10 +1977,7 @@ public void addKeyListener(KeyListener listener) {
  * @since 3.3
  */
 public void addMenuDetectListener (MenuDetectListener listener) {
-	checkWidget ();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.MenuDetect, typedListener);
+	addTypedListener(listener, SWT.MenuDetect);
 }
 
 /**
@@ -2024,12 +2000,7 @@ public void addMenuDetectListener (MenuDetectListener listener) {
  * @see #removeMouseListener
  */
 public void addMouseListener(MouseListener listener) {
-	checkWidget();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener(SWT.MouseDown,typedListener);
-	addListener(SWT.MouseUp,typedListener);
-	addListener(SWT.MouseDoubleClick,typedListener);
+	addTypedListener(listener, SWT.MouseDown, SWT.MouseUp, SWT.MouseDoubleClick);
 }
 
 /**
@@ -2052,10 +2023,7 @@ public void addMouseListener(MouseListener listener) {
  * @see #removeMouseMoveListener
  */
 public void addMouseMoveListener(MouseMoveListener listener) {
-	checkWidget();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener(SWT.MouseMove,typedListener);
+	addTypedListener(listener, SWT.MouseMove);
 }
 
 /**
@@ -2078,12 +2046,7 @@ public void addMouseMoveListener(MouseMoveListener listener) {
  * @see #removeMouseTrackListener
  */
 public void addMouseTrackListener (MouseTrackListener listener) {
-	checkWidget();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.MouseEnter,typedListener);
-	addListener (SWT.MouseExit,typedListener);
-	addListener (SWT.MouseHover,typedListener);
+	addTypedListener(listener, SWT.MouseEnter, SWT.MouseExit, SWT.MouseHover);
 }
 
 /**
@@ -2108,10 +2071,7 @@ public void addMouseTrackListener (MouseTrackListener listener) {
  * @since 3.3
  */
 public void addMouseWheelListener (MouseWheelListener listener) {
-	checkWidget ();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.MouseWheel, typedListener);
+	addTypedListener(listener, SWT.MouseWheel);
 }
 
 /**
@@ -2134,11 +2094,7 @@ public void addMouseWheelListener (MouseWheelListener listener) {
  * @see #removePaintListener
  */
 public void addPaintListener(PaintListener listener) {
-	checkWidget();
-	if (listener == null) error(SWT.ERROR_NULL_ARGUMENT);
-
-	TypedListener typedListener = new TypedListener(listener);
-	addListener(SWT.Paint, typedListener);
+	addTypedListener(listener, SWT.Paint);
 }
 
 /**
@@ -2185,10 +2141,7 @@ void addRelation (Control control) {
  * @since 3.7
  */
 public void addTouchListener (TouchListener listener) {
-	checkWidget();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.Touch,typedListener);
+	addTypedListener(listener, SWT.Touch);
 }
 
 /**
@@ -2211,10 +2164,7 @@ public void addTouchListener (TouchListener listener) {
  * @see #removeTraverseListener
  */
 public void addTraverseListener (TraverseListener listener) {
-	checkWidget();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.Traverse,typedListener);
+	addTypedListener(listener, SWT.Traverse);
 }
 
 /**

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/DateTime.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/DateTime.java
@@ -252,11 +252,7 @@ static int checkStyle (int style) {
  * @see SelectionEvent
  */
 public void addSelectionListener (SelectionListener listener) {
-	checkWidget ();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.Selection, typedListener);
-	addListener (SWT.DefaultSelection, typedListener);
+	addTypedListener(listener, SWT.Selection, SWT.DefaultSelection);
 }
 
 @Override

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/ExpandBar.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/ExpandBar.java
@@ -107,11 +107,7 @@ public ExpandBar (Composite parent, int style) {
  * @see #removeExpandListener
  */
 public void addExpandListener (ExpandListener listener) {
-	checkWidget ();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.Expand, typedListener);
-	addListener (SWT.Collapse, typedListener);
+	addTypedListener(listener, SWT.Expand, SWT.Collapse);
 }
 
 @Override

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Link.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Link.java
@@ -117,11 +117,7 @@ public Link (Composite parent, int style) {
  * @see SelectionEvent
  */
 public void addSelectionListener (SelectionListener listener) {
-	checkWidget ();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.Selection, typedListener);
-	addListener (SWT.DefaultSelection, typedListener);
+	addTypedListener(listener, SWT.Selection, SWT.DefaultSelection);
 }
 
 @Override

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/List.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/List.java
@@ -188,11 +188,7 @@ public void add (String string, int index) {
  * @see SelectionEvent
  */
 public void addSelectionListener(SelectionListener listener) {
-	checkWidget();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.Selection,typedListener);
-	addListener (SWT.DefaultSelection,typedListener);
+	addTypedListener(listener, SWT.Selection, SWT.DefaultSelection);
 }
 
 static int checkStyle (int style) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Menu.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Menu.java
@@ -424,11 +424,7 @@ void addAccelerators (long accelGroup) {
  * @see #removeMenuListener
  */
 public void addMenuListener (MenuListener listener) {
-	checkWidget();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.Hide,typedListener);
-	addListener (SWT.Show,typedListener);
+	addTypedListener(listener, SWT.Hide, SWT.Show);
 }
 
 /**
@@ -451,10 +447,7 @@ public void addMenuListener (MenuListener listener) {
  * @see #removeHelpListener
  */
 public void addHelpListener (HelpListener listener) {
-	checkWidget();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.Help, typedListener);
+	addTypedListener(listener, SWT.Help);
 }
 
 @Override

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/MenuItem.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/MenuItem.java
@@ -185,10 +185,7 @@ void addAccelerators (long accelGroup) {
  * @see #removeArmListener
  */
 public void addArmListener (ArmListener listener) {
-	checkWidget();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.Arm, typedListener);
+	addTypedListener(listener, SWT.Arm);
 }
 
 /**
@@ -211,10 +208,7 @@ public void addArmListener (ArmListener listener) {
  * @see #removeHelpListener
  */
 public void addHelpListener (HelpListener listener) {
-	checkWidget();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.Help, typedListener);
+	addTypedListener(listener, SWT.Help);
 }
 
 /**
@@ -248,11 +242,7 @@ public void addHelpListener (HelpListener listener) {
  * @see SelectionEvent
  */
 public void addSelectionListener (SelectionListener listener) {
-	checkWidget();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener(listener);
-	addListener (SWT.Selection,typedListener);
-	addListener (SWT.DefaultSelection,typedListener);
+	addTypedListener(listener, SWT.Selection, SWT.DefaultSelection);
 }
 
 static int checkStyle (int style) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Sash.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Sash.java
@@ -113,12 +113,7 @@ public Sash(Composite parent, int style) {
  * @see SelectionEvent
  */
 public void addSelectionListener(SelectionListener listener) {
-	checkWidget();
-	if (listener == null) error(SWT.ERROR_NULL_ARGUMENT);
-
-	TypedListener typedListener = new TypedListener(listener);
-	addListener(SWT.Selection, typedListener);
-	addListener(SWT.DefaultSelection, typedListener);
+	addTypedListener(listener, SWT.Selection, SWT.DefaultSelection);
 }
 
 static int checkStyle(int style) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Scale.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Scale.java
@@ -101,11 +101,7 @@ public Scale (Composite parent, int style) {
  * @see #removeSelectionListener
  */
 public void addSelectionListener (SelectionListener listener) {
-	checkWidget ();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.Selection,typedListener);
-	addListener (SWT.DefaultSelection,typedListener);
+	addTypedListener(listener, SWT.Selection, SWT.DefaultSelection);
 }
 
 static int checkStyle (int style) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/ScrollBar.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/ScrollBar.java
@@ -140,11 +140,7 @@ ScrollBar (Scrollable parent, int style) {
  * @see SelectionEvent
  */
 public void addSelectionListener (SelectionListener listener) {
-	checkWidget ();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.Selection,typedListener);
-	addListener (SWT.DefaultSelection,typedListener);
+	addTypedListener(listener, SWT.Selection, SWT.DefaultSelection);
 }
 
 static int checkStyle (int style) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Shell.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Shell.java
@@ -462,14 +462,7 @@ static int checkStyle (Shell parent, int style) {
  * @see #removeShellListener
  */
 public void addShellListener (ShellListener listener) {
-	checkWidget();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.Close,typedListener);
-	addListener (SWT.Iconify,typedListener);
-	addListener (SWT.Deiconify,typedListener);
-	addListener (SWT.Activate, typedListener);
-	addListener (SWT.Deactivate, typedListener);
+	addTypedListener(listener, SWT.Close, SWT.Iconify, SWT.Deiconify, SWT.Activate, SWT.Deactivate);
 }
 
 void addToolTip (ToolTip toolTip) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Slider.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Slider.java
@@ -150,11 +150,7 @@ public Slider (Composite parent, int style) {
  * @see SelectionEvent
  */
 public void addSelectionListener (SelectionListener listener) {
-	checkWidget ();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.Selection,typedListener);
-	addListener (SWT.DefaultSelection,typedListener);
+	addTypedListener(listener, SWT.Selection, SWT.DefaultSelection);
 }
 
 static int checkStyle (int style) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Spinner.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Spinner.java
@@ -129,10 +129,7 @@ public Spinner (Composite parent, int style) {
  * @see #removeModifyListener
  */
 public void addModifyListener (ModifyListener listener) {
-	checkWidget ();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.Modify, typedListener);
+	addTypedListener(listener, SWT.Modify);
 }
 
 /**
@@ -160,11 +157,7 @@ public void addModifyListener (ModifyListener listener) {
  * @see SelectionEvent
  */
 public void addSelectionListener(SelectionListener listener) {
-	checkWidget ();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener(listener);
-	addListener(SWT.Selection,typedListener);
-	addListener(SWT.DefaultSelection,typedListener);
+	addTypedListener(listener, SWT.Selection, SWT.DefaultSelection);
 }
 
 /**
@@ -187,10 +180,7 @@ public void addSelectionListener(SelectionListener listener) {
  * @see #removeVerifyListener
  */
 void addVerifyListener (VerifyListener listener) {
-	checkWidget();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.Verify, typedListener);
+	addTypedListener(listener, SWT.Verify);
 }
 
 static int checkStyle (int style) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/TabFolder.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/TabFolder.java
@@ -158,11 +158,7 @@ protected void checkSubclass () {
  * @see SelectionEvent
  */
 public void addSelectionListener(SelectionListener listener) {
-	checkWidget ();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener(listener);
-	addListener(SWT.Selection,typedListener);
-	addListener(SWT.DefaultSelection,typedListener);
+	addTypedListener(listener, SWT.Selection, SWT.DefaultSelection);
 }
 
 @Override

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Table.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Table.java
@@ -330,11 +330,7 @@ protected void checkSubclass () {
  * @see SelectionEvent
  */
 public void addSelectionListener (SelectionListener listener) {
-	checkWidget ();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.Selection, typedListener);
-	addListener (SWT.DefaultSelection, typedListener);
+	addTypedListener(listener, SWT.Selection, SWT.DefaultSelection);
 }
 
 int calculateWidth (long column, long iter) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/TableColumn.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/TableColumn.java
@@ -149,11 +149,7 @@ public TableColumn (Table parent, int style, int index) {
  * @see #removeControlListener
  */
 public void addControlListener(ControlListener listener) {
-	checkWidget();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.Resize,typedListener);
-	addListener (SWT.Move,typedListener);
+	addTypedListener(listener, SWT.Resize, SWT.Move);
 }
 
 /**
@@ -181,11 +177,7 @@ public void addControlListener(ControlListener listener) {
  * @see SelectionEvent
  */
 public void addSelectionListener (SelectionListener listener) {
-	checkWidget();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.Selection,typedListener);
-	addListener (SWT.DefaultSelection,typedListener);
+	addTypedListener(listener, SWT.Selection, SWT.DefaultSelection);
 }
 
 static int checkStyle (int style) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Text.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Text.java
@@ -352,10 +352,7 @@ void createWidget (int index) {
  * @see #removeModifyListener
  */
 public void addModifyListener (ModifyListener listener) {
-	checkWidget ();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.Modify, typedListener);
+	addTypedListener(listener, SWT.Modify);
 }
 
 /**
@@ -393,9 +390,7 @@ public void addModifyListener (ModifyListener listener) {
  * @since 3.8
  */
 public void addSegmentListener (SegmentListener listener) {
-	checkWidget ();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	addListener (SWT.Segments, new TypedListener (listener));
+	addTypedListener(listener, SWT.Segments);
 	clearSegments (true);
 	applySegments ();
 }
@@ -429,11 +424,7 @@ public void addSegmentListener (SegmentListener listener) {
  * @see SelectionEvent
  */
 public void addSelectionListener(SelectionListener listener) {
-	checkWidget ();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener(listener);
-	addListener(SWT.Selection,typedListener);
-	addListener(SWT.DefaultSelection,typedListener);
+	addTypedListener(listener, SWT.Selection, SWT.DefaultSelection);
 }
 
 /**
@@ -456,10 +447,7 @@ public void addSelectionListener(SelectionListener listener) {
  * @see #removeVerifyListener
  */
 public void addVerifyListener (VerifyListener listener) {
-	checkWidget();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.Verify, typedListener);
+	addTypedListener(listener, SWT.Verify);
 }
 
 /**

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/ToolItem.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/ToolItem.java
@@ -189,11 +189,7 @@ public ToolItem (ToolBar parent, int style, int index) {
  * @see SelectionEvent
  */
 public void addSelectionListener(SelectionListener listener) {
-	checkWidget();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.Selection,typedListener);
-	addListener (SWT.DefaultSelection,typedListener);
+	addTypedListener(listener, SWT.Selection, SWT.DefaultSelection);
 }
 
 static int checkStyle (int style) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/ToolTip.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/ToolTip.java
@@ -132,11 +132,7 @@ static int checkStyle (int style) {
  * @see SelectionEvent
  */
 public void addSelectionListener (SelectionListener listener) {
-	checkWidget ();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.Selection,typedListener);
-	addListener (SWT.DefaultSelection,typedListener);
+	addTypedListener(listener, SWT.Selection, SWT.DefaultSelection);
 }
 
 void configure () {

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Tracker.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Tracker.java
@@ -169,11 +169,7 @@ public Tracker (Display display, int style) {
  * @see #removeControlListener
  */
 public void addControlListener(ControlListener listener) {
-	checkWidget();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.Resize, typedListener);
-	addListener (SWT.Move, typedListener);
+	addTypedListener(listener, SWT.Resize, SWT.Move);
 }
 
 /**
@@ -196,11 +192,7 @@ public void addControlListener(ControlListener listener) {
  * @see #removeKeyListener
  */
 public void addKeyListener(KeyListener listener) {
-	checkWidget();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener(SWT.KeyUp,typedListener);
-	addListener(SWT.KeyDown,typedListener);
+	addTypedListener(listener, SWT.KeyUp, SWT.KeyDown);
 }
 
 Point adjustMoveCursor () {

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/TrayItem.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/TrayItem.java
@@ -106,10 +106,7 @@ public TrayItem (Tray parent, int style) {
  * @since 3.3
  */
 public void addMenuDetectListener (MenuDetectListener listener) {
-	checkWidget ();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.MenuDetect, typedListener);
+	addTypedListener(listener, SWT.MenuDetect);
 }
 
 /**
@@ -137,11 +134,7 @@ public void addMenuDetectListener (MenuDetectListener listener) {
  * @see SelectionEvent
  */
 public void addSelectionListener(SelectionListener listener) {
-	checkWidget ();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.Selection, typedListener);
-	addListener (SWT.DefaultSelection, typedListener);
+	addTypedListener(listener, SWT.Selection, SWT.DefaultSelection);
 }
 
 @Override

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Tree.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Tree.java
@@ -413,11 +413,7 @@ protected void checkSubclass () {
  * @see SelectionEvent
  */
 public void addSelectionListener (SelectionListener listener) {
-	checkWidget ();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.Selection, typedListener);
-	addListener (SWT.DefaultSelection, typedListener);
+	addTypedListener(listener, SWT.Selection, SWT.DefaultSelection);
 }
 
 /**
@@ -440,11 +436,7 @@ public void addSelectionListener (SelectionListener listener) {
  * @see #removeTreeListener
  */
 public void addTreeListener(TreeListener listener) {
-	checkWidget ();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.Expand, typedListener);
-	addListener (SWT.Collapse, typedListener);
+	addTypedListener(listener, SWT.Expand, SWT.Collapse);
 }
 
 int calculateWidth (long column, long iter, boolean recurse) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/TreeColumn.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/TreeColumn.java
@@ -151,11 +151,7 @@ public TreeColumn (Tree parent, int style, int index) {
  * @see #removeControlListener
  */
 public void addControlListener(ControlListener listener) {
-	checkWidget();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.Resize,typedListener);
-	addListener (SWT.Move,typedListener);
+	addTypedListener(listener, SWT.Resize, SWT.Move);
 }
 
 /**
@@ -183,11 +179,7 @@ public void addControlListener(ControlListener listener) {
  * @see SelectionEvent
  */
 public void addSelectionListener (SelectionListener listener) {
-	checkWidget();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.Selection,typedListener);
-	addListener (SWT.DefaultSelection,typedListener);
+	addTypedListener(listener, SWT.Selection, SWT.DefaultSelection);
 }
 
 static int checkStyle (int style) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Widget.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Widget.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corporation and others.
+ * Copyright (c) 2000, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -13,8 +13,8 @@
  *******************************************************************************/
 package org.eclipse.swt.widgets;
 
-
 import java.util.*;
+import java.util.stream.*;
 
 import org.eclipse.swt.*;
 import org.eclipse.swt.events.*;
@@ -303,11 +303,11 @@ void _addListener (int eventType, Listener listener) {
 }
 
 /**
- * Adds the listener to the collection of listeners who will
+ * Adds the listener to the collection of {@link Listener listeners} who will
  * be notified when an event of the given type occurs. When the
  * event does occur in the widget, the listener is notified by
  * sending it the <code>handleEvent()</code> message. The event
- * type is one of the event constants defined in class <code>SWT</code>.
+ * type is one of the event constants defined in class {@link SWTError}.
  *
  * @param eventType the type of event to listen for
  * @param listener the listener which should be notified when the event occurs
@@ -320,8 +320,6 @@ void _addListener (int eventType, Listener listener) {
  *    <li>ERROR_THREAD_INVALID_ACCESS - if not called from the thread that created the receiver</li>
  * </ul>
  *
- * @see Listener
- * @see SWT
  * @see #getListeners(int)
  * @see #removeListener(int, Listener)
  * @see #notifyListeners
@@ -330,6 +328,43 @@ public void addListener (int eventType, Listener listener) {
 	checkWidget ();
 	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
 	_addListener (eventType, listener);
+}
+
+/**
+ * Adds the {@link EventListener typed listener} to the collection of listeners
+ * who will be notified when an event of the given types occurs.
+ * When the event does occur in the widget, the listener is notified
+ * by calling the type's handling methods.
+ * The event type is one of the event constants defined in class {@link SWT}
+ * and must correspond to the listeners type.
+ * If for example a {@link SelectionListener} is passed the {@code eventTypes}
+ * can be {@link SWT#Selection} or {@link SWT#DefaultSelection}.
+ *
+ * @param listener the listener which should be notified when the event occurs
+ * @param eventTypes the types of event to listen for
+ *
+ * @exception IllegalArgumentException <ul>
+ *    <li>ERROR_NULL_ARGUMENT - if the listener is null</li>
+ * </ul>
+ * @exception SWTException <ul>
+ *    <li>ERROR_WIDGET_DISPOSED - if the receiver has been disposed</li>
+ *    <li>ERROR_THREAD_INVALID_ACCESS - if not called from the thread that created the receiver</li>
+ * </ul>
+ *
+ * @see #getTypedListeners(int, Class)
+ * @see #removeTypedListener(int, EventListener)
+ * @see #notifyListeners
+ * @since 3.126
+ */
+protected void addTypedListener (EventListener listener, int... eventTypes) {
+	checkWidget();
+	if (listener == null) {
+		SWT.error(SWT.ERROR_NULL_ARGUMENT);
+	}
+	TypedListener typedListener = new TypedListener(listener);
+	for (int eventType : eventTypes) {
+		_addListener(eventType, typedListener);
+	}
 }
 
 /**
@@ -653,9 +688,9 @@ public Display getDisplay () {
 }
 
 /**
- * Returns an array of listeners who will be notified when an event
+ * Returns an array of {@link Listener listeners} who will be notified when an event
  * of the given type occurs. The event type is one of the event constants
- * defined in class <code>SWT</code>.
+ * defined in class {@link SWT}.
  *
  * @param eventType the type of event to listen for
  * @return an array of listeners that will be notified when the event occurs
@@ -665,8 +700,6 @@ public Display getDisplay () {
  *    <li>ERROR_THREAD_INVALID_ACCESS - if not called from the thread that created the receiver</li>
  * </ul>
  *
- * @see Listener
- * @see SWT
  * @see #addListener(int, Listener)
  * @see #removeListener(int, Listener)
  * @see #notifyListeners
@@ -677,6 +710,33 @@ public Listener[] getListeners (int eventType) {
 	checkWidget();
 	if (eventTable == null) return new Listener[0];
 	return eventTable.getListeners(eventType);
+}
+
+/**
+ * Returns the typed listeners who will be notified when an event of the given type occurs.
+ * The event type is one of the event constants defined in class {@link SWT}
+ * and the specified listener-type must correspond to that event.
+ * If for example the {@code eventType} is {@link SWT#Selection},
+ * the listeners type should be {@link SelectionListener}.
+ *
+ * @param eventType the type of event to listen for
+ * @return a stream of typed listeners that will be notified when the event occurs
+ *
+ * @exception SWTException <ul>
+ *    <li>ERROR_WIDGET_DISPOSED - if the receiver has been disposed</li>
+ *    <li>ERROR_THREAD_INVALID_ACCESS - if not called from the thread that created the receiver</li>
+ * </ul>
+ *
+ * @see #addTypedListener(EventListener, int...)
+ * @see #removeTypedListener(int, EventListener)
+ * @see #notifyListeners
+ *
+ * @since 3.126
+ */
+public <L extends EventListener> Stream<L> getTypedListeners (int eventType, Class<L> listenerType) {
+	return Arrays.stream(getListeners(eventType)) //
+			.filter(TypedListener.class::isInstance).map(l -> ((TypedListener) l).eventListener)
+			.filter(listenerType::isInstance).map(listenerType::cast);
 }
 
 String getName () {
@@ -1436,11 +1496,42 @@ public void removeListener (int eventType, Listener listener) {
  * @noreference This method is not intended to be referenced by clients.
  * @nooverride This method is not intended to be re-implemented or extended by clients.
  */
-protected void removeListener (int eventType, SWTEventListener handler) {
-	checkWidget ();
-	if (handler == null) error (SWT.ERROR_NULL_ARGUMENT);
+protected void removeListener (int eventType, SWTEventListener listener) {
+	removeTypedListener(eventType, listener);
+}
+
+/**
+ * Removes the listener from the collection of listeners who will
+ * be notified when an event of the given type occurs.
+ * <p>
+ * <b>IMPORTANT:</b> This method is <em>not</em> part of the SWT
+ * public API. It is marked public only so that it can be shared
+ * within the packages provided by SWT. It should never be
+ * referenced from application code.
+ * </p>
+ *
+ * @param eventType the type of event to listen for
+ * @param listener the listener which should no longer be notified
+ *
+ * @exception IllegalArgumentException <ul>
+ *    <li>ERROR_NULL_ARGUMENT - if the listener is null</li>
+ * </ul>
+ * @exception SWTException <ul>
+ *    <li>ERROR_WIDGET_DISPOSED - if the receiver has been disposed</li>
+ *    <li>ERROR_THREAD_INVALID_ACCESS - if not called from the thread that created the receiver</li>
+ * </ul>
+ *
+ * @see Listener
+ * @see #addListener
+ *
+ * @noreference This method is not intended to be referenced by clients.
+ * @nooverride This method is not intended to be re-implemented or extended by clients.
+ */
+protected void removeTypedListener (int eventType, EventListener listener) {
+	checkWidget();
+	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
 	if (eventTable == null) return;
-	eventTable.unhook (eventType, handler);
+	eventTable.unhook (eventType, listener);
 }
 
 long rendererGetPreferredWidthProc (long cell, long handle, long minimun_size, long natural_size) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Widget.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Widget.java
@@ -387,10 +387,7 @@ protected void addTypedListener (EventListener listener, int... eventTypes) {
  * @see #removeDisposeListener
  */
 public void addDisposeListener (DisposeListener listener) {
-	checkWidget ();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.Dispose, typedListener);
+	addTypedListener(listener, SWT.Dispose);
 }
 
 long paintWindow () {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Button.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Button.java
@@ -240,11 +240,7 @@ void _setText (String text) {
  * @see SelectionEvent
  */
 public void addSelectionListener (SelectionListener listener) {
-	checkWidget ();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.Selection,typedListener);
-	addListener (SWT.DefaultSelection,typedListener);
+	addTypedListener(listener, SWT.Selection, SWT.DefaultSelection);
 }
 
 @Override

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Combo.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Combo.java
@@ -234,10 +234,7 @@ public void add (String string, int index) {
  * @see #removeModifyListener
  */
 public void addModifyListener (ModifyListener listener) {
-	checkWidget ();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.Modify, typedListener);
+	addTypedListener(listener, SWT.Modify);
 }
 
 /**
@@ -275,9 +272,7 @@ public void addModifyListener (ModifyListener listener) {
  * @since 3.103
  */
 public void addSegmentListener (SegmentListener listener) {
-	checkWidget ();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	addListener (SWT.Segments, new TypedListener (listener));
+	addTypedListener (listener, SWT.Segments);
 	int selection = OS.CB_ERR;
 	if (!noSelection) {
 		selection = (int)OS.SendMessage (handle, OS.CB_GETCURSEL, 0, 0);
@@ -315,11 +310,7 @@ public void addSegmentListener (SegmentListener listener) {
  * @see SelectionEvent
  */
 public void addSelectionListener(SelectionListener listener) {
-	checkWidget ();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.Selection,typedListener);
-	addListener (SWT.DefaultSelection,typedListener);
+	addTypedListener(listener, SWT.Selection, SWT.DefaultSelection);
 }
 
 /**
@@ -344,10 +335,7 @@ public void addSelectionListener(SelectionListener listener) {
  * @since 3.1
  */
 public void addVerifyListener (VerifyListener listener) {
-	checkWidget ();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.Verify, typedListener);
+	addTypedListener(listener, SWT.Verify);
 }
 
 void applyEditSegments () {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Control.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Control.java
@@ -136,11 +136,7 @@ public Control (Composite parent, int style) {
  * @see #removeControlListener
  */
 public void addControlListener(ControlListener listener) {
-	checkWidget ();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.Resize,typedListener);
-	addListener (SWT.Move,typedListener);
+	addTypedListener(listener, SWT.Resize, SWT.Move);
 }
 
 /**
@@ -165,10 +161,7 @@ public void addControlListener(ControlListener listener) {
  * @since 3.3
  */
 public void addDragDetectListener (DragDetectListener listener) {
-	checkWidget ();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.DragDetect,typedListener);
+	addTypedListener(listener, SWT.DragDetect);
 }
 
 /**
@@ -191,11 +184,7 @@ public void addDragDetectListener (DragDetectListener listener) {
  * @see #removeFocusListener
  */
 public void addFocusListener (FocusListener listener) {
-	checkWidget ();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.FocusIn,typedListener);
-	addListener (SWT.FocusOut,typedListener);
+	addTypedListener(listener, SWT.FocusIn, SWT.FocusOut);
 }
 
 /**
@@ -231,10 +220,7 @@ public void addFocusListener (FocusListener listener) {
  * @since 3.7
  */
 public void addGestureListener (GestureListener listener) {
-	checkWidget();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.Gesture, typedListener);
+	addTypedListener(listener, SWT.Gesture);
 }
 
 /**
@@ -257,10 +243,7 @@ public void addGestureListener (GestureListener listener) {
  * @see #removeHelpListener
  */
 public void addHelpListener (HelpListener listener) {
-	checkWidget ();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.Help, typedListener);
+	addTypedListener(listener, SWT.Help);
 }
 
 /**
@@ -294,11 +277,7 @@ public void addHelpListener (HelpListener listener) {
  * @see #removeKeyListener
  */
 public void addKeyListener (KeyListener listener) {
-	checkWidget ();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.KeyUp,typedListener);
-	addListener (SWT.KeyDown,typedListener);
+	addTypedListener(listener, SWT.KeyUp, SWT.KeyDown);
 }
 
 /**
@@ -323,10 +302,7 @@ public void addKeyListener (KeyListener listener) {
  * @since 3.3
  */
 public void addMenuDetectListener (MenuDetectListener listener) {
-	checkWidget ();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.MenuDetect, typedListener);
+	addTypedListener(listener, SWT.MenuDetect);
 }
 
 /**
@@ -349,12 +325,7 @@ public void addMenuDetectListener (MenuDetectListener listener) {
  * @see #removeMouseListener
  */
 public void addMouseListener (MouseListener listener) {
-	checkWidget ();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.MouseDown,typedListener);
-	addListener (SWT.MouseUp,typedListener);
-	addListener (SWT.MouseDoubleClick,typedListener);
+	addTypedListener(listener, SWT.MouseDown, SWT.MouseUp, SWT.MouseDoubleClick);
 }
 
 /**
@@ -377,12 +348,7 @@ public void addMouseListener (MouseListener listener) {
  * @see #removeMouseTrackListener
  */
 public void addMouseTrackListener (MouseTrackListener listener) {
-	checkWidget ();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.MouseEnter,typedListener);
-	addListener (SWT.MouseExit,typedListener);
-	addListener (SWT.MouseHover,typedListener);
+	addTypedListener(listener, SWT.MouseEnter, SWT.MouseExit, SWT.MouseHover);
 }
 
 /**
@@ -405,10 +371,7 @@ public void addMouseTrackListener (MouseTrackListener listener) {
  * @see #removeMouseMoveListener
  */
 public void addMouseMoveListener (MouseMoveListener listener) {
-	checkWidget ();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.MouseMove,typedListener);
+	addTypedListener(listener, SWT.MouseMove);
 }
 
 /**
@@ -433,10 +396,7 @@ public void addMouseMoveListener (MouseMoveListener listener) {
  * @since 3.3
  */
 public void addMouseWheelListener (MouseWheelListener listener) {
-	checkWidget ();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.MouseWheel, typedListener);
+	addTypedListener(listener, SWT.MouseWheel);
 }
 
 /**
@@ -459,10 +419,7 @@ public void addMouseWheelListener (MouseWheelListener listener) {
  * @see #removePaintListener
  */
 public void addPaintListener (PaintListener listener) {
-	checkWidget ();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.Paint,typedListener);
+	addTypedListener(listener, SWT.Paint);
 }
 
 /**
@@ -497,10 +454,7 @@ public void addPaintListener (PaintListener listener) {
  * @since 3.7
  */
 public void addTouchListener (TouchListener listener) {
-	checkWidget();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.Touch,typedListener);
+	addTypedListener(listener, SWT.Touch);
 }
 
 /**
@@ -523,10 +477,7 @@ public void addTouchListener (TouchListener listener) {
  * @see #removeTraverseListener
  */
 public void addTraverseListener (TraverseListener listener) {
-	checkWidget ();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.Traverse,typedListener);
+	addTypedListener(listener, SWT.Traverse);
 }
 
 int binarySearch (int [] indices, int start, int end, int index) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/CoolItem.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/CoolItem.java
@@ -148,11 +148,7 @@ public CoolItem (CoolBar parent, int style, int index) {
  * @since 2.0
  */
 public void addSelectionListener(SelectionListener listener) {
-	checkWidget();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.Selection,typedListener);
-	addListener (SWT.DefaultSelection,typedListener);
+	addTypedListener(listener, SWT.Selection, SWT.DefaultSelection);
 }
 
 @Override

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/DateTime.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/DateTime.java
@@ -188,11 +188,7 @@ public DateTime (Composite parent, int style) {
  * @see SelectionEvent
  */
 public void addSelectionListener (SelectionListener listener) {
-	checkWidget ();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.Selection, typedListener);
-	addListener (SWT.DefaultSelection, typedListener);
+	addTypedListener(listener, SWT.Selection, SWT.DefaultSelection);
 }
 
 @Override

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ExpandBar.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ExpandBar.java
@@ -108,11 +108,7 @@ public ExpandBar (Composite parent, int style) {
  * @see #removeExpandListener
  */
 public void addExpandListener (ExpandListener listener) {
-	checkWidget ();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.Expand, typedListener);
-	addListener (SWT.Collapse, typedListener);
+	addTypedListener(listener, SWT.Expand, SWT.Collapse);
 }
 
 @Override

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Link.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Link.java
@@ -135,11 +135,7 @@ public Link (Composite parent, int style) {
  * @see SelectionEvent
  */
 public void addSelectionListener (SelectionListener listener) {
-	checkWidget ();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.Selection, typedListener);
-	addListener (SWT.DefaultSelection, typedListener);
+	addTypedListener(listener, SWT.Selection, SWT.DefaultSelection);
 }
 
 @Override

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/List.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/List.java
@@ -180,11 +180,7 @@ public void add (String string, int index) {
  * @see SelectionEvent
  */
 public void addSelectionListener(SelectionListener listener) {
-	checkWidget ();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.Selection,typedListener);
-	addListener (SWT.DefaultSelection,typedListener);
+	addTypedListener(listener, SWT.Selection, SWT.DefaultSelection);
 }
 
 @Override

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Menu.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Menu.java
@@ -274,10 +274,7 @@ void _setVisible (boolean visible) {
  * @see #removeHelpListener
  */
 public void addHelpListener (HelpListener listener) {
-	checkWidget ();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.Help, typedListener);
+	addTypedListener(listener, SWT.Help);
 }
 
 /**
@@ -300,11 +297,7 @@ public void addHelpListener (HelpListener listener) {
  * @see #removeMenuListener
  */
 public void addMenuListener (MenuListener listener) {
-	checkWidget ();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.Hide,typedListener);
-	addListener (SWT.Show,typedListener);
+	addTypedListener(listener, SWT.Hide, SWT.Show);
 }
 
 static Control checkNull (Control control) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/MenuItem.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/MenuItem.java
@@ -159,10 +159,7 @@ MenuItem (Menu parent, Menu menu, int style, int index) {
  * @see #removeArmListener
  */
 public void addArmListener (ArmListener listener) {
-	checkWidget ();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.Arm, typedListener);
+	addTypedListener(listener, SWT.Arm);
 }
 
 /**
@@ -185,10 +182,7 @@ public void addArmListener (ArmListener listener) {
  * @see #removeHelpListener
  */
 public void addHelpListener (HelpListener listener) {
-	checkWidget ();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.Help, typedListener);
+	addTypedListener(listener, SWT.Help);
 }
 
 /**
@@ -222,11 +216,7 @@ public void addHelpListener (HelpListener listener) {
  * @see SelectionEvent
  */
 public void addSelectionListener (SelectionListener listener) {
-	checkWidget ();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener(listener);
-	addListener (SWT.Selection,typedListener);
-	addListener (SWT.DefaultSelection,typedListener);
+	addTypedListener(listener, SWT.Selection, SWT.DefaultSelection);
 }
 
 @Override

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Sash.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Sash.java
@@ -106,11 +106,7 @@ public Sash (Composite parent, int style) {
  * @see SelectionEvent
  */
 public void addSelectionListener (SelectionListener listener) {
-	checkWidget ();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.Selection,typedListener);
-	addListener (SWT.DefaultSelection,typedListener);
+	addTypedListener(listener, SWT.Selection, SWT.DefaultSelection);
 }
 
 @Override

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Scale.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Scale.java
@@ -130,11 +130,7 @@ public Scale (Composite parent, int style) {
  * @see #removeSelectionListener
  */
 public void addSelectionListener(SelectionListener listener) {
-	checkWidget ();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.Selection,typedListener);
-	addListener (SWT.DefaultSelection,typedListener);
+	addTypedListener(listener, SWT.Selection, SWT.DefaultSelection);
 }
 
 @Override

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ScrollBar.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ScrollBar.java
@@ -159,11 +159,7 @@ ScrollBar (Scrollable parent, int style) {
  * @see SelectionEvent
  */
 public void addSelectionListener (SelectionListener listener) {
-	checkWidget();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener(listener);
-	addListener (SWT.Selection,typedListener);
-	addListener (SWT.DefaultSelection,typedListener);
+	addTypedListener(listener, SWT.Selection, SWT.DefaultSelection);
 }
 
 static int checkStyle (int style) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Shell.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Shell.java
@@ -463,14 +463,7 @@ static int checkStyle (Shell parent, int style) {
  * @see #removeShellListener
  */
 public void addShellListener (ShellListener listener) {
-	checkWidget ();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.Close,typedListener);
-	addListener (SWT.Iconify,typedListener);
-	addListener (SWT.Deiconify,typedListener);
-	addListener (SWT.Activate, typedListener);
-	addListener (SWT.Deactivate, typedListener);
+	addTypedListener(listener, SWT.Close, SWT.Iconify, SWT.Deiconify, SWT.Activate, SWT.Deactivate);
 }
 
 long balloonTipHandle () {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Slider.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Slider.java
@@ -150,11 +150,7 @@ public Slider (Composite parent, int style) {
  * @see SelectionEvent
  */
 public void addSelectionListener (SelectionListener listener) {
-	checkWidget ();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener(listener);
-	addListener (SWT.Selection,typedListener);
-	addListener (SWT.DefaultSelection,typedListener);
+	addTypedListener(listener, SWT.Selection, SWT.DefaultSelection);
 }
 
 @Override

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Spinner.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Spinner.java
@@ -202,10 +202,7 @@ void createHandle () {
  * @see #removeModifyListener
  */
 public void addModifyListener (ModifyListener listener) {
-	checkWidget ();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.Modify, typedListener);
+	addTypedListener(listener, SWT.Modify);
 }
 
 /**
@@ -233,11 +230,7 @@ public void addModifyListener (ModifyListener listener) {
  * @see SelectionEvent
  */
 public void addSelectionListener(SelectionListener listener) {
-	checkWidget ();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.Selection,typedListener);
-	addListener (SWT.DefaultSelection,typedListener);
+	addTypedListener(listener, SWT.Selection, SWT.DefaultSelection);
 }
 
 /**
@@ -260,10 +253,7 @@ public void addSelectionListener(SelectionListener listener) {
  * @see #removeVerifyListener
  */
 void addVerifyListener (VerifyListener listener) {
-	checkWidget();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.Verify, typedListener);
+	addTypedListener(listener, SWT.Verify);
 }
 
 @Override Point computeSizeInPixels (int wHint, int hHint, boolean changed) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TabFolder.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TabFolder.java
@@ -151,11 +151,7 @@ public TabFolder (Composite parent, int style) {
  * @see SelectionEvent
  */
 public void addSelectionListener(SelectionListener listener) {
-	checkWidget ();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener(listener);
-	addListener(SWT.Selection,typedListener);
-	addListener(SWT.DefaultSelection,typedListener);
+	addTypedListener(listener, SWT.Selection, SWT.DefaultSelection);
 }
 
 @Override

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Table.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Table.java
@@ -442,11 +442,7 @@ void _setItemCount (int count, int itemCount) {
  * @see SelectionEvent
  */
 public void addSelectionListener (SelectionListener listener) {
-	checkWidget ();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.Selection,typedListener);
-	addListener (SWT.DefaultSelection,typedListener);
+	addTypedListener(listener, SWT.Selection, SWT.DefaultSelection);
 }
 
 @Override

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TableColumn.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TableColumn.java
@@ -147,11 +147,7 @@ public TableColumn (Table parent, int style, int index) {
  * @see #removeControlListener
  */
 public void addControlListener(ControlListener listener) {
-	checkWidget ();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.Resize,typedListener);
-	addListener (SWT.Move,typedListener);
+	addTypedListener(listener, SWT.Resize, SWT.Move);
 }
 
 /**
@@ -179,11 +175,7 @@ public void addControlListener(ControlListener listener) {
  * @see SelectionEvent
  */
 public void addSelectionListener (SelectionListener listener) {
-	checkWidget ();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.Selection,typedListener);
-	addListener (SWT.DefaultSelection,typedListener);
+	addTypedListener(listener, SWT.Selection, SWT.DefaultSelection);
 }
 
 static int checkStyle (int style) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Text.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Text.java
@@ -404,10 +404,7 @@ int applyThemeBackground () {
  * @see #removeModifyListener
  */
 public void addModifyListener (ModifyListener listener) {
-	checkWidget ();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.Modify, typedListener);
+	addTypedListener(listener, SWT.Modify);
 }
 
 /**
@@ -445,9 +442,7 @@ public void addModifyListener (ModifyListener listener) {
  * @since 3.8
  */
 public void addSegmentListener (SegmentListener listener) {
-	checkWidget ();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	addListener (SWT.Segments, new TypedListener (listener));
+	addTypedListener (listener, SWT.Segments);
 	clearSegments (true);
 	applySegments ();
 }
@@ -481,11 +476,7 @@ public void addSegmentListener (SegmentListener listener) {
  * @see SelectionEvent
  */
 public void addSelectionListener (SelectionListener listener) {
-	checkWidget ();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.Selection,typedListener);
-	addListener (SWT.DefaultSelection,typedListener);
+	addTypedListener(listener, SWT.Selection, SWT.DefaultSelection);
 }
 
 /**
@@ -508,10 +499,7 @@ public void addSelectionListener (SelectionListener listener) {
  * @see #removeVerifyListener
  */
 public void addVerifyListener (VerifyListener listener) {
-	checkWidget ();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.Verify, typedListener);
+	addTypedListener(listener, SWT.Verify);
 }
 
 /**

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ToolItem.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ToolItem.java
@@ -164,11 +164,7 @@ public ToolItem (ToolBar parent, int style, int index) {
  * @see SelectionEvent
  */
 public void addSelectionListener(SelectionListener listener) {
-	checkWidget();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.Selection,typedListener);
-	addListener (SWT.DefaultSelection,typedListener);
+	addTypedListener(listener, SWT.Selection, SWT.DefaultSelection);
 }
 
 static int checkStyle (int style) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ToolTip.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ToolTip.java
@@ -120,11 +120,7 @@ static int checkStyle (int style) {
  * @see SelectionEvent
  */
 public void addSelectionListener (SelectionListener listener) {
-	checkWidget ();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener(listener);
-	addListener (SWT.Selection,typedListener);
-	addListener (SWT.DefaultSelection,typedListener);
+	addTypedListener(listener, SWT.Selection, SWT.DefaultSelection);
 }
 
 @Override

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Tracker.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Tracker.java
@@ -165,11 +165,7 @@ public Tracker (Display display, int style) {
  * @see #removeControlListener
  */
 public void addControlListener (ControlListener listener) {
-	checkWidget ();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.Resize, typedListener);
-	addListener (SWT.Move, typedListener);
+	addTypedListener(listener, SWT.Resize, SWT.Move);
 }
 
 /**
@@ -192,11 +188,7 @@ public void addControlListener (ControlListener listener) {
  * @see #removeKeyListener
  */
 public void addKeyListener (KeyListener listener) {
-	checkWidget ();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.KeyUp,typedListener);
-	addListener (SWT.KeyDown,typedListener);
+	addTypedListener(listener, SWT.KeyUp, SWT.KeyDown);
 }
 
 Point adjustMoveCursor () {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TrayItem.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TrayItem.java
@@ -108,11 +108,7 @@ public TrayItem (Tray parent, int style) {
  * @see SelectionEvent
  */
 public void addSelectionListener(SelectionListener listener) {
-	checkWidget ();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.Selection,typedListener);
-	addListener (SWT.DefaultSelection,typedListener);
+	addTypedListener(listener, SWT.Selection, SWT.DefaultSelection);
 }
 
 /**
@@ -137,10 +133,7 @@ public void addSelectionListener(SelectionListener listener) {
  * @since 3.3
  */
 public void addMenuDetectListener (MenuDetectListener listener) {
-	checkWidget ();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.MenuDetect, typedListener);
+	addTypedListener(listener, SWT.MenuDetect);
 }
 
 @Override

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Tree.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Tree.java
@@ -346,11 +346,7 @@ void _setBackgroundPixel (int newPixel) {
  * @see SelectionEvent
  */
 public void addSelectionListener(SelectionListener listener) {
-	checkWidget ();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.Selection, typedListener);
-	addListener (SWT.DefaultSelection, typedListener);
+	addTypedListener(listener, SWT.Selection, SWT.DefaultSelection);
 }
 
 /**
@@ -373,11 +369,7 @@ public void addSelectionListener(SelectionListener listener) {
  * @see #removeTreeListener
  */
 public void addTreeListener(TreeListener listener) {
-	checkWidget ();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.Expand, typedListener);
-	addListener (SWT.Collapse, typedListener);
+	addTypedListener(listener, SWT.Expand, SWT.Collapse);
 }
 
 @Override

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TreeColumn.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TreeColumn.java
@@ -149,11 +149,7 @@ public TreeColumn (Tree parent, int style, int index) {
  * @see #removeControlListener
  */
 public void addControlListener(ControlListener listener) {
-	checkWidget ();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.Resize,typedListener);
-	addListener (SWT.Move,typedListener);
+	addTypedListener(listener, SWT.Resize, SWT.Move);
 }
 
 /**
@@ -181,11 +177,7 @@ public void addControlListener(ControlListener listener) {
  * @see SelectionEvent
  */
 public void addSelectionListener (SelectionListener listener) {
-	checkWidget ();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.Selection,typedListener);
-	addListener (SWT.DefaultSelection,typedListener);
+	addTypedListener(listener, SWT.Selection, SWT.DefaultSelection);
 }
 
 static int checkStyle (int style) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Widget.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Widget.java
@@ -266,10 +266,7 @@ protected void addTypedListener (EventListener listener, int... eventTypes) {
  * @see #removeDisposeListener
  */
 public void addDisposeListener (DisposeListener listener) {
-	checkWidget();
-	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.Dispose, typedListener);
+	addTypedListener(listener, SWT.Dispose);
 }
 
 long callWindowProc (long hwnd, int msg, long wParam, long lParam) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Widget.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Widget.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corporation and others.
+ * Copyright (c) 2000, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -14,6 +14,8 @@
  *******************************************************************************/
 package org.eclipse.swt.widgets;
 
+import java.util.*;
+import java.util.stream.*;
 
 import org.eclipse.swt.*;
 import org.eclipse.swt.events.*;
@@ -180,11 +182,11 @@ void _removeListener (int eventType, Listener listener) {
 }
 
 /**
- * Adds the listener to the collection of listeners who will
+ * Adds the listener to the collection of {@link Listener listeners} who will
  * be notified when an event of the given type occurs. When the
  * event does occur in the widget, the listener is notified by
  * sending it the <code>handleEvent()</code> message. The event
- * type is one of the event constants defined in class <code>SWT</code>.
+ * type is one of the event constants defined in class {@link SWTError}.
  *
  * @param eventType the type of event to listen for
  * @param listener the listener which should be notified when the event occurs
@@ -197,8 +199,6 @@ void _removeListener (int eventType, Listener listener) {
  *    <li>ERROR_THREAD_INVALID_ACCESS - if not called from the thread that created the receiver</li>
  * </ul>
  *
- * @see Listener
- * @see SWT
  * @see #getListeners(int)
  * @see #removeListener(int, Listener)
  * @see #notifyListeners
@@ -207,6 +207,43 @@ public void addListener (int eventType, Listener listener) {
 	checkWidget();
 	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
 	_addListener (eventType, listener);
+}
+
+/**
+ * Adds the {@link EventListener typed listener} to the collection of listeners
+ * who will be notified when an event of the given types occurs.
+ * When the event does occur in the widget, the listener is notified
+ * by calling the type's handling methods.
+ * The event type is one of the event constants defined in class {@link SWT}
+ * and must correspond to the listeners type.
+ * If for example a {@link SelectionListener} is passed the {@code eventTypes}
+ * can be {@link SWT#Selection} or {@link SWT#DefaultSelection}.
+ *
+ * @param listener the listener which should be notified when the event occurs
+ * @param eventTypes the types of event to listen for
+ *
+ * @exception IllegalArgumentException <ul>
+ *    <li>ERROR_NULL_ARGUMENT - if the listener is null</li>
+ * </ul>
+ * @exception SWTException <ul>
+ *    <li>ERROR_WIDGET_DISPOSED - if the receiver has been disposed</li>
+ *    <li>ERROR_THREAD_INVALID_ACCESS - if not called from the thread that created the receiver</li>
+ * </ul>
+ *
+ * @see #getTypedListeners(int, Class)
+ * @see #removeTypedListener(int, EventListener)
+ * @see #notifyListeners
+ * @since 3.126
+ */
+protected void addTypedListener (EventListener listener, int... eventTypes) {
+	checkWidget();
+	if (listener == null) {
+		SWT.error(SWT.ERROR_NULL_ARGUMENT);
+	}
+	TypedListener typedListener = new TypedListener(listener);
+	for (int eventType : eventTypes) {
+		_addListener(eventType, typedListener);
+	}
 }
 
 /**
@@ -574,9 +611,9 @@ public Display getDisplay () {
 }
 
 /**
- * Returns an array of listeners who will be notified when an event
+ * Returns an array of {@link Listener listeners} who will be notified when an event
  * of the given type occurs. The event type is one of the event constants
- * defined in class <code>SWT</code>.
+ * defined in class {@link SWT}.
  *
  * @param eventType the type of event to listen for
  * @return an array of listeners that will be notified when the event occurs
@@ -586,8 +623,6 @@ public Display getDisplay () {
  *    <li>ERROR_THREAD_INVALID_ACCESS - if not called from the thread that created the receiver</li>
  * </ul>
  *
- * @see Listener
- * @see SWT
  * @see #addListener(int, Listener)
  * @see #removeListener(int, Listener)
  * @see #notifyListeners
@@ -598,6 +633,33 @@ public Listener[] getListeners (int eventType) {
 	checkWidget();
 	if (eventTable == null) return new Listener[0];
 	return eventTable.getListeners(eventType);
+}
+
+/**
+ * Returns the typed listeners who will be notified when an event of the given type occurs.
+ * The event type is one of the event constants defined in class {@link SWT}
+ * and the specified listener-type must correspond to that event.
+ * If for example the {@code eventType} is {@link SWT#Selection},
+ * the listeners type should be {@link SelectionListener}.
+ *
+ * @param eventType the type of event to listen for
+ * @return a stream of typed listeners that will be notified when the event occurs
+ *
+ * @exception SWTException <ul>
+ *    <li>ERROR_WIDGET_DISPOSED - if the receiver has been disposed</li>
+ *    <li>ERROR_THREAD_INVALID_ACCESS - if not called from the thread that created the receiver</li>
+ * </ul>
+ *
+ * @see #addTypedListener(EventListener, int...)
+ * @see #removeTypedListener(int, EventListener)
+ * @see #notifyListeners
+ *
+ * @since 3.126
+ */
+public <L extends EventListener> Stream<L> getTypedListeners (int eventType, Class<L> listenerType) {
+	return Arrays.stream(getListeners(eventType)) //
+			.filter(TypedListener.class::isInstance).map(l -> ((TypedListener) l).eventListener)
+			.filter(listenerType::isInstance).map(listenerType::cast);
 }
 
 Menu getMenu () {
@@ -966,6 +1028,37 @@ public void removeListener (int eventType, Listener listener) {
  * @nooverride This method is not intended to be re-implemented or extended by clients.
  */
 protected void removeListener (int eventType, SWTEventListener listener) {
+	removeTypedListener(eventType, listener);
+}
+
+/**
+ * Removes the listener from the collection of listeners who will
+ * be notified when an event of the given type occurs.
+ * <p>
+ * <b>IMPORTANT:</b> This method is <em>not</em> part of the SWT
+ * public API. It is marked public only so that it can be shared
+ * within the packages provided by SWT. It should never be
+ * referenced from application code.
+ * </p>
+ *
+ * @param eventType the type of event to listen for
+ * @param listener the listener which should no longer be notified
+ *
+ * @exception IllegalArgumentException <ul>
+ *    <li>ERROR_NULL_ARGUMENT - if the listener is null</li>
+ * </ul>
+ * @exception SWTException <ul>
+ *    <li>ERROR_WIDGET_DISPOSED - if the receiver has been disposed</li>
+ *    <li>ERROR_THREAD_INVALID_ACCESS - if not called from the thread that created the receiver</li>
+ * </ul>
+ *
+ * @see Listener
+ * @see #addListener
+ *
+ * @noreference This method is not intended to be referenced by clients.
+ * @nooverride This method is not intended to be re-implemented or extended by clients.
+ */
+protected void removeTypedListener (int eventType, EventListener listener) {
 	checkWidget();
 	if (listener == null) error (SWT.ERROR_NULL_ARGUMENT);
 	if (eventTable == null) return;

--- a/examples/org.eclipse.swt.examples/META-INF/MANIFEST.MF
+++ b/examples/org.eclipse.swt.examples/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %plugin.SWTStandaloneExampleSet.name
 Bundle-SymbolicName: org.eclipse.swt.examples; singleton:=true
-Bundle-Version: 3.108.300.qualifier
+Bundle-Version: 3.108.400.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/examples/org.eclipse.swt.examples/src/org/eclipse/swt/examples/accessibility/CTable.java
+++ b/examples/org.eclipse.swt.examples/src/org/eclipse/swt/examples/accessibility/CTable.java
@@ -45,7 +45,6 @@ import org.eclipse.swt.widgets.Menu;
 import org.eclipse.swt.widgets.ScrollBar;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.Tracker;
-import org.eclipse.swt.widgets.TypedListener;
 import org.eclipse.swt.widgets.Widget;
 
 /**
@@ -276,11 +275,7 @@ public CTable (Composite parent, int style) {
  * @see SelectionEvent
  */
 public void addSelectionListener (SelectionListener listener) {
-	checkWidget ();
-	if (listener == null) SWT.error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.Selection, typedListener);
-	addListener (SWT.DefaultSelection, typedListener);
+	addTypedListener(listener, SWT.Selection, SWT.DefaultSelection);
 }
 boolean checkData (CTableItem item, boolean redraw) {
 	if (item.cached) return true;
@@ -3550,8 +3545,8 @@ void removeSelectedItem (int index) {
 public void removeSelectionListener (SelectionListener listener) {
 	checkWidget ();
 	if (listener == null) SWT.error (SWT.ERROR_NULL_ARGUMENT);
-	removeListener (SWT.Selection, listener);
-	removeListener (SWT.DefaultSelection, listener);
+	removeTypedListener(SWT.Selection, listener);
+	removeTypedListener(SWT.DefaultSelection, listener);
 }
 /**
  * Selects the item at the given zero-relative index in the receiver.

--- a/examples/org.eclipse.swt.examples/src/org/eclipse/swt/examples/accessibility/CTableColumn.java
+++ b/examples/org.eclipse.swt.examples/src/org/eclipse/swt/examples/accessibility/CTableColumn.java
@@ -31,7 +31,6 @@ import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.graphics.Rectangle;
 import org.eclipse.swt.widgets.Item;
-import org.eclipse.swt.widgets.TypedListener;
 import org.eclipse.swt.widgets.Widget;
 
 /**
@@ -161,11 +160,7 @@ public CTableColumn (CTable parent, int style, int index) {
  * @see #removeControlListener
  */
 public void addControlListener (ControlListener listener) {
-	checkWidget ();
-	if (listener == null) SWT.error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.Resize, typedListener);
-	addListener (SWT.Move, typedListener);
+	addTypedListener(listener, SWT.Resize, SWT.Move);
 }
 /**
  * Adds the listener to the collection of listeners who will
@@ -192,11 +187,7 @@ public void addControlListener (ControlListener listener) {
  * @see SelectionEvent
  */
 public void addSelectionListener (SelectionListener listener) {
-	checkWidget ();
-	if (listener == null) SWT.error (SWT.ERROR_NULL_ARGUMENT);
-	TypedListener typedListener = new TypedListener (listener);
-	addListener (SWT.Selection, typedListener);
-	addListener (SWT.DefaultSelection, typedListener);
+	addTypedListener(listener, SWT.Selection, SWT.DefaultSelection);
 }
 static CTable checkNull (CTable table) {
 	if (table == null) SWT.error (SWT.ERROR_NULL_ARGUMENT);
@@ -554,8 +545,8 @@ void paint (GC gc) {
 public void removeControlListener (ControlListener listener) {
 	checkWidget ();
 	if (listener == null) SWT.error (SWT.ERROR_NULL_ARGUMENT);
-	removeListener (SWT.Move, listener);
-	removeListener (SWT.Resize, listener);
+	removeTypedListener(SWT.Move, listener);
+	removeTypedListener(SWT.Resize, listener);
 }
 /**
  * Removes the listener from the collection of listeners who will
@@ -577,8 +568,8 @@ public void removeControlListener (ControlListener listener) {
 public void removeSelectionListener (SelectionListener listener) {
 	checkWidget ();
 	if (listener == null) SWT.error (SWT.ERROR_NULL_ARGUMENT);
-	removeListener (SWT.Selection, listener);
-	removeListener (SWT.DefaultSelection, listener);
+	removeTypedListener(SWT.Selection, listener);
+	removeTypedListener(SWT.DefaultSelection, listener);
 }
 /**
  * Controls how text and images will be displayed in the receiver.


### PR DESCRIPTION
One of the two main, if not the only reasons why the actually (according to its doc) internal SWT type `TypedListener` and consequently also the internal type `SWTEventListener` is referenced in client code is to register typed listeners in custom widgets.

One example in the Eclipse SDK (outside SWT) is:
https://github.com/eclipse-platform/eclipse.platform/blob/c74c80065aa91f5e2f03377aae1cd80928e48534/ua/org.eclipse.help.ui/src/org/eclipse/help/ui/internal/HyperlinkLabel.java#L157-L164

The second pattern why `TypedListener` is used is to obtain the initially registered typed listeners from a widget:
https://github.com/eclipse-platform/eclipse.platform/blob/c74c80065aa91f5e2f03377aae1cd80928e48534/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/contentmergeviewer/TextMergeViewer.java#L3109-L3119

This pattern is used very often as one can see for example in the repositories of the eclipse organisation or CDT (and probably in more):
- https://github.com/search?q=org%3Aeclipse-cdt+org.eclipse.swt.widgets.TypedListener&type=code
- https://github.com/search?q=org%3Aeclipse+org.eclipse.swt.widgets.TypedListener++language%3AJava&type=code

This PR suggests to add two new methods to the Widget class to add and obtain typed listeners, which can act as API replacement for the patterns mentioned above and also significantly reduces code-duplications in SWT's own code base (see second commit):
- `protected void addTypedListener(EventListener listener, int... eventTypes)`
- `public EventListener[] getTypedListeners(int eventType)`

With that we can subsequently deprecate `SWTEventListener` for removal and `TypedListener` to be moved to an internal package.