### PR TITLE
Increment the version of org.eclipse.swt.tests

### DIFF
--- a/tests/org.eclipse.swt.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.swt.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SWT Tests
 Bundle-SymbolicName: org.eclipse.swt.tests
-Bundle-Version: 3.107.300.qualifier
+Bundle-Version: 3.107.400.qualifier
 Bundle-Vendor: Eclipse.org
 Export-Package: org.eclipse.swt.tests.junit,
  org.eclipse.swt.tests.junit.performance

--- a/tests/org.eclipse.swt.tests/pom.xml
+++ b/tests/org.eclipse.swt.tests/pom.xml
@@ -21,7 +21,7 @@
   </parent>
   <groupId>org.eclipse.swt</groupId>
   <artifactId>org.eclipse.swt.tests</artifactId>
-  <version>3.107.300-SNAPSHOT</version>
+  <version>3.107.400-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
   <properties>
     <tycho.testArgLine></tycho.testArgLine>


### PR DESCRIPTION
This is needed to fix builds in #918

The builds were failing with message:

```
Only qualifier changed for
(org.eclipse.swt.tests/3.107.300.v20240313-1307). Expected to have bigger x.y.z than what is available in baseline (3.107.300.v20240227-1638)
```