### PR TITLE
Fix for [macOS] some UI elements (e.g. list, tree views) seem to have more space between lines now #1674

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Display.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Display.java
@@ -166,6 +166,8 @@ public class Display extends Device implements Executor {
 	NSFont textViewFont, tableViewFont, outlineViewFont, datePickerFont;
 	NSFont boxFont, tabViewFont, progressIndicatorFont;
 
+	boolean useNativeItemHeight;
+
 	Shell [] modalShells;
 	Dialog modalDialog;
 	NSPanel modalPanel;
@@ -2404,6 +2406,8 @@ protected void init () {
 	initFonts ();
 	setDeviceZoom ();
 
+	useNativeItemHeight = initUseNativeItemHeight();
+
 	/*
 	 * Create an application delegate for app-level notifications.  The AWT may have already set a delegate;
 	 * if so, hold on to it so messages can be forwarded to it.
@@ -2500,6 +2504,19 @@ protected void init () {
 
 	isPainting = (NSMutableArray)new NSMutableArray().alloc();
 	isPainting = isPainting.initWithCapacity(12);
+}
+
+/**
+ * Checks if the native item height should be enforced as a minimum (which is true by default).
+ * 
+ * Newer version of macOS may use a default item height in Table, Tree and List
+ * controls that is larger than what is traditionally expected.
+ * 
+ * Enforcing the default height as a minimum may break existing assumptions and
+ * render UI elements with a padding that may be considered too large.
+ */
+private boolean initUseNativeItemHeight() {
+	return Boolean.parseBoolean(System.getProperty("org.eclipse.swt.internal.cocoa.useNativeItemHeight", "true"));
 }
 
 private static NSString getAwtRunLoopMode() {

--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/List.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/List.java
@@ -46,12 +46,11 @@ public class List extends Scrollable {
 	int itemCount;
 	boolean ignoreSelect, didSelect, rowsChanged, mouseIsDown;
 
+	final int nativeItemHeight;
+
 	static int NEXT_ID;
 
 	static final int CELL_GAP = 1;
-
-	/* Vertical cell padding for list item */
-	static final int VERTICAL_CELL_PADDING= 8;
 
 /**
  * Constructs a new instance of this class given its parent
@@ -84,6 +83,9 @@ public class List extends Scrollable {
  */
 public List (Composite parent, int style) {
 	super (parent, checkStyle (style));
+
+	this.nativeItemHeight = (int)((NSTableView)view).rowHeight();
+	setFont(defaultFont ().handle); // update height
 }
 
 @Override
@@ -1178,7 +1180,11 @@ void setFont (NSFont font) {
 	super.setFont (font);
 	double ascent = font.ascender ();
 	double descent = -font.descender () + font.leading ();
-	((NSTableView)view).setRowHeight ((int)Math.ceil (ascent + descent) + VERTICAL_CELL_PADDING);
+	int height = (int)Math.ceil (ascent + descent) + 1;
+	if (display.useNativeItemHeight) {
+		height = Math.max (height, nativeItemHeight);
+	}
+	((NSTableView)view).setRowHeight (height);
 	setScrollWidth();
 }
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Table.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Table.java
@@ -86,15 +86,14 @@ public class Table extends Composite {
 	boolean shouldScroll = true;
 	boolean keyDown;
 
+	final int nativeItemHeight;
+
 	static int NEXT_ID;
 
 	static final int FIRST_COLUMN_MINIMUM_WIDTH = 5;
 	static final int IMAGE_GAP = 3;
 	static final int TEXT_GAP = 2;
 	static final int CELL_GAP = 1;
-
-	/* Vertical cell padding for table item */
-	static final int VERTICAL_CELL_PADDING= 8;
 
 /**
  * Constructs a new instance of this class given its parent
@@ -132,6 +131,9 @@ public class Table extends Composite {
  */
 public Table (Composite parent, int style) {
 	super (parent, checkStyle (style));
+
+	this.nativeItemHeight = (int)((NSTableView)view).rowHeight();
+	setItemHeight(null, null, true);
 }
 
 @Override
@@ -2821,7 +2823,10 @@ void setItemHeight (Image image, NSFont font, boolean set) {
 	if (font == null) font = getFont ().handle;
 	double ascent = font.ascender ();
 	double descent = -font.descender () + font.leading ();
-	int height = (int)Math.ceil (ascent + descent) + VERTICAL_CELL_PADDING;
+	int height = (int)Math.ceil (ascent + descent) + 1;
+	if (display.useNativeItemHeight) {
+		height = Math.max (height, nativeItemHeight);
+	}
 	Rectangle bounds = image != null ? image.getBounds () : imageBounds;
 	if (bounds != null) {
 		imageBounds = bounds;

--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Tree.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Tree.java
@@ -97,6 +97,8 @@ public class Tree extends Composite {
 	/* Used to control drop feedback when DND.FEEDBACK_EXPAND and DND.FEEDBACK_SCROLL is set/not set */
 	boolean shouldExpand = true, shouldScroll = true;
 
+	final int nativeItemHeight;
+
 	static int NEXT_ID;
 
 	/*
@@ -108,9 +110,6 @@ public class Tree extends Composite {
 	static final int IMAGE_GAP = 3;
 	static final int TEXT_GAP = 2;
 	static final int CELL_GAP = 1;
-
-	/* Vertical cell padding for tree item */
-	static final int VERTICAL_CELL_PADDING= 8;
 
 /**
  * Constructs a new instance of this class given its parent
@@ -147,6 +146,9 @@ public class Tree extends Composite {
  */
 public Tree (Composite parent, int style) {
 	super (parent, checkStyle (style));
+
+	this.nativeItemHeight = (int)((NSTableView)view).rowHeight();
+	setItemHeight(null, null, true);
 }
 
 @Override
@@ -3165,7 +3167,10 @@ void setItemHeight (Image image, NSFont font, boolean set) {
 	if (font == null) font = getFont ().handle;
 	double ascent = font.ascender ();
 	double descent = -font.descender () + font.leading ();
-	int height = (int)Math.ceil (ascent + descent) + VERTICAL_CELL_PADDING;
+	int height = (int)Math.ceil (ascent + descent) + 1;
+	if (display.useNativeItemHeight) {
+		height = Math.max (height, nativeItemHeight);
+	}
 	Rectangle bounds = image != null ? image.getBounds () : imageBounds;
 	if (bounds != null) {
 		imageBounds = bounds;

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_List.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_List.java
@@ -498,7 +498,7 @@ public void test_getItemHeight() {
 	lineHeight = list.getItemHeight();
 	list.setFont(null);
 	font.dispose();
-	font = new Font(list.getDisplay(), fontData.getName(), 12, fontData.getStyle());
+	font = new Font(list.getDisplay(), fontData.getName(), 24, fontData.getStyle());
 	list.setFont(font);
 	int newLineHeight = list.getItemHeight();
 	assertTrue(":a:", newLineHeight > lineHeight);
@@ -1625,7 +1625,7 @@ public void test_setFontLorg_eclipse_swt_graphics_Font() {
 	lineHeight = list.getItemHeight();
 	list.setFont(null);
 	font.dispose();
-	font = new Font(list.getDisplay(), fontData.getName(), 12, fontData.getStyle());
+	font = new Font(list.getDisplay(), fontData.getName(), 24, fontData.getStyle());
 	list.setFont(font);
 	assertEquals(font, list.getFont());
 	assertTrue("itemHeight=" + list.getItemHeight() + ", lineHeight=" + lineHeight, list.getItemHeight() > lineHeight);


### PR DESCRIPTION
cocoa: Enforce native item height for Table, Tree, List if necessary

Newer versions of macOS introduced a new style of table rows with a
padding that is larger than previously seen. This broke item height
computations (#677). An attempt to fix this had the unexpected side
effect that now some UI elements in Eclipse IDE (and other apps with
"-Dorg.eclipse.swt.internal.carbon.smallFonts" enabled),
eclise.platform.ui #1674, and it also broke compatibility with older
versions of macOS that did not have the additional padding.

This change, reverts the previous fix and adds logic to enforce
the native item height by default, but only when smallFonts is not
enabled.

The setting can also be controlled by a new System property,
org.eclipse.swt.internal.cocoa.enforceNativeItemHeightMinimum, that, if
set, overrules any default (smallFonts or not). This allows apps to
bring brack the old macOS behavior even when the smallFonts setting is
undesired.

Lastly, we add support to selectively enable/disable the native item
height minimum for Table, Tree and List on a per-instance basis, so
applications can selectively control the behavior for specific use
cases.

Fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/1674
Fixes https://github.com/eclipse-platform/eclipse.platform.swt/issues/677
