### PR TITLE
[Build] Simplify build-script in pipeline for windows native binaries

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -223,13 +223,10 @@ pipeline {
 												ls -1R libs
 											'''
 										} else {
-											withEnv(['PATH=C:\\tools\\cygwin\\bin;' + env.PATH]) {
-												bat '''
-													mkdir libs
-													cmd /c build.bat install
-													ls -1R libs
-												'''
-											}
+											bat '''
+												mkdir libs
+												cmd /c build.bat install
+											'''
 										}
 									}
 									dir('libs') {


### PR DESCRIPTION
This reduces the prerequisites for a Jenkins executor to run that part of the build pipeline.

Listing the just build binaries again does not help much but requires more setup and more software installed at the executing node.

Also required for https://github.com/eclipse-platform/eclipse.platform.swt/pull/1045.