### PR TITLE
[Win32] Extract alpha values from icons if available #715 #1130 

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Program/win32/org/eclipse/swt/program/Program.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Program/win32/org/eclipse/swt/program/Program.java
@@ -35,6 +35,7 @@ public final class Program {
 	String name;
 	String command;
 	String iconName;
+	String extension;
 	static final String [] ARGUMENTS = new String [] {"%1", "%l", "%L"}; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 
 /**
@@ -101,6 +102,7 @@ public static Program findProgram (String extension) {
 		program.name = name;
 		program.command = command;
 		program.iconName = iconName;
+		program.extension = extension;
 	}
 	return program;
 }
@@ -182,7 +184,7 @@ static String getKeyValue (String string, boolean expand) {
 	return result;
 }
 
-static Program getProgram (String key) {
+static Program getProgram (String key, String extension) {
 
 	/* Name */
 	String name = getKeyValue (key, false);
@@ -208,6 +210,7 @@ static Program getProgram (String key) {
 	program.name = name;
 	program.command = command;
 	program.iconName = iconName;
+	program.extension = extension;
 	return program;
 }
 
@@ -233,7 +236,7 @@ public static Program [] getPrograms () {
 	//map paths to programs in parallel which takes now ~ 4/5 of time:
 	ConcurrentHashMap<String, Program> programs = new ConcurrentHashMap<>(paths.size());
 	paths.stream().parallel().forEach(path -> {
-		Program program = getProgram(path); // getProgram takes most time
+		Program program = getProgram(path, null); // getProgram takes most time
 		if (program != null) {
 			programs.put(path, program);
 		}
@@ -377,6 +380,22 @@ public ImageData getImageData () {
  * @since 3.125
  */
 public ImageData getImageData (int zoom) {
+	// Windows API returns image data according to primary monitor zoom factor
+	// rather than at original scaling
+	int nativeZoomFactor = 100 * Display.getCurrent().getPrimaryMonitor().getZoom() / DPIUtil.getDeviceZoom();
+	int imageZoomFactor = 100 * zoom / nativeZoomFactor;
+	if (extension != null) {
+		SHFILEINFO shfi = new SHFILEINFO ();
+		int flags = OS.SHGFI_ICON | OS.SHGFI_SMALLICON | OS.SHGFI_USEFILEATTRIBUTES;
+		TCHAR pszPath = new TCHAR (0, extension, true);
+		OS.SHGetFileInfo (pszPath.chars, OS.FILE_ATTRIBUTE_NORMAL, shfi, SHFILEINFO.sizeof, flags);
+		if (shfi.hIcon != 0) {
+			Image image = Image.win32_new (null, SWT.ICON, shfi.hIcon);
+			ImageData imageData = image.getImageData (imageZoomFactor);
+			image.dispose ();
+			return imageData;
+		}
+	}
 	int nIconIndex = 0;
 	String fileName = iconName;
 	int index = iconName.indexOf (',');
@@ -398,10 +417,7 @@ public ImageData getImageData (int zoom) {
 	OS.ExtractIconEx (lpszFile, nIconIndex, phiconLarge, phiconSmall, 1);
 	if (phiconSmall [0] == 0) return null;
 	Image image = Image.win32_new (null, SWT.ICON, phiconSmall [0]);
-	// Windows API returns image data according to primary monitor zoom factor
-	// rather than at original scaling
-	int nativeZoomFactor = 100 * Display.getCurrent().getPrimaryMonitor().getZoom() / DPIUtil.getDeviceZoom();
-	ImageData imageData = image.getImageData (100 * zoom / nativeZoomFactor);
+	ImageData imageData = image.getImageData (imageZoomFactor);
 	image.dispose ();
 	return imageData;
 }


### PR DESCRIPTION
This replaces the fix for black icon background because of faulty alpha values contributed via #999 with the solution proposed in #998. As documented in #1130, #999 produced a regression as some program icons (such as for `.exe` files) are not loaded anymore.

Under certain conditions, program icons loaded on Windows via GDI+ have empty mask data, even though the original icon has proper mask data. As a result, these icons are printed with a black instead of a transparent background. Still these icons can contain valid alpha data in their usual 32-bit data.

With this change, alpha data is extracted for icons which are loaded
without proper mask data to ensure that they have proper transparency
information.

Fixes https://github.com/eclipse-platform/eclipse.platform.swt/issues/715
Fixes https://github.com/eclipse-platform/eclipse.platform.swt/issues/1130