### PR TITLE
Reset the cached image width/height when the currentZoom of an image has changed

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Image.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Image.java
@@ -745,7 +745,7 @@ boolean refreshImageForZoom () {
 				init ();
 				refreshed = true;
 			}
-			currentDeviceZoom = deviceZoomLevel;
+			setCurrentDeviceZoom(deviceZoomLevel);
 		}
 	} else if (imageDataProvider != null) {
 		if (deviceZoomLevel != currentDeviceZoom) {
@@ -756,7 +756,7 @@ boolean refreshImageForZoom () {
 			init(resizedData);
 			init();
 			refreshed = true;
-			currentDeviceZoom = deviceZoomLevel;
+			setCurrentDeviceZoom(deviceZoomLevel);
 		}
 	} else {
 		if (deviceZoomLevel != currentDeviceZoom) {
@@ -766,7 +766,7 @@ boolean refreshImageForZoom () {
 			init(resizedData);
 			init();
 			refreshed = true;
-			currentDeviceZoom = deviceZoomLevel;
+			setCurrentDeviceZoom(deviceZoomLevel);
 		}
 	}
 	return refreshed;
@@ -2198,6 +2198,15 @@ public void setBackground(Color color) {
 
 	/* Release the HDC for the device */
 	device.internal_dispose_GC(hDC, null);
+}
+
+private void setCurrentDeviceZoom(int newZoomFactor) {
+	if (this.currentDeviceZoom != newZoomFactor) {
+		this.currentDeviceZoom = newZoomFactor;
+		// width and height are tied to the current device zoom
+		// they must be reset the the zoom factor changes
+		width = height = -1;
+	}
 }
 
 /**

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_Image.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_Image.java
@@ -1177,4 +1177,23 @@ public void test_bug566545_efficientGrayscaleImage() {
 	outImageDirect.dispose();
 }
 
+@Test
+public void test_updateWidthHeightAfterDPIChange() {
+	int deviceZoom = DPIUtil.getDeviceZoom();
+	try {
+		Rectangle imageSize = new Rectangle(0, 0, 16, 16);
+		Image baseImage = new Image(display, imageSize.width, imageSize.height);
+		GC gc = new GC(display);
+		gc.drawImage(baseImage, 10, 10);
+		assertEquals("Base image size differs unexpectedly", imageSize, baseImage.getBounds());
+
+		DPIUtil.setDeviceZoom(deviceZoom * 2);
+		gc.drawImage(baseImage, 10, 10);
+		assertEquals("Image size at 100% must always stay the same despite the zoom factor", imageSize, baseImage.getBounds());
+		gc.dispose();
+		baseImage.dispose();
+	} finally {
+		DPIUtil.setDeviceZoom(deviceZoom);
+	}
+}
 }


### PR DESCRIPTION
The cached image width/height must be reset when the zoom factor is changed, otherwise call to `getBounds` will return wrong values