### PR TITLE
Disable WebkitGtk hardware-acceleration

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT WebKit/gtk/org/eclipse/swt/browser/WebKit.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT WebKit/gtk/org/eclipse/swt/browser/WebKit.java
@@ -741,6 +741,9 @@ public void create (Composite parent, int style) {
 	OS.g_object_set (settings, WebKitGTK.javascript_can_open_windows_automatically, 1, 0);
 	OS.g_object_set (settings, WebKitGTK.enable_webgl, 1, 0);
 	OS.g_object_set (settings, WebKitGTK.enable_developer_extras, 1, 0);
+	//disable hardware acceleration due to  https://bugs.webkit.org/show_bug.cgi?id=239429#c11
+	//even evolution ended up doing the same https://gitlab.gnome.org/GNOME/evolution/-/commit/eb62ccaa28bbbca7668913ce7d8056a6d75f9b05
+	OS.g_object_set (settings, WebKitGTK.hardware_acceleration_policy, 2, 0);
 
 	OS.g_object_set (settings, WebKitGTK.default_charset, utfBytes, 0);
 	if (WebKitGTK.webkit_get_minor_version() >= 14) {

--- a/bundles/org.eclipse.swt/Eclipse SWT WebKit/gtk/org/eclipse/swt/internal/webkit/WebKitGTK.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT WebKit/gtk/org/eclipse/swt/internal/webkit/WebKitGTK.java
@@ -147,6 +147,8 @@ public class WebKitGTK extends C {
 
 	public static final byte[] enable_webgl = ascii("enable-webgl"); // $NON-NLS-1$
 
+	public static final byte[] hardware_acceleration_policy = ascii("hardware-acceleration-policy"); // $NON-NLS-1$
+
 	public static final byte[] enable_back_forward_navigation_gestures = ascii("enable-back-forward-navigation-gestures"); // $NON-NLS-1$
 
 	// Since 2.14


### PR DESCRIPTION
It is tracked upstream
https://bugs.webkit.org/show_bug.cgi?id=239429#c11 and being open for years already without a clue where the problem is and this prevents us from disabling only in certain cases as it's not yet identified when the issue happens or not. In order to prevent crashes this seems to be the only option for now.
Even Gnome project like Evolution ended up doing the same ( https://gitlab.gnome.org/GNOME/evolution/-/commit/eb62ccaa28bbbca7668913ce7d8056a6d75f9b05 ).

Fixes https://github.com/eclipse-platform/eclipse.platform.swt/issues/1108 and https://github.com/eclipse-platform/eclipse.platform.swt/issues/179