### PR TITLE
fix missing win32.aarch64 fragment in various p2.inf

### DIFF
--- a/bundles/org.eclipse.swt/META-INF/p2.inf
+++ b/bundles/org.eclipse.swt/META-INF/p2.inf
@@ -34,3 +34,8 @@ requires.7.namespace = org.eclipse.equinox.p2.iu
 requires.7.name = org.eclipse.swt.cocoa.macosx.aarch64
 requires.7.range = [$version$,$version$]
 requires.7.filter = (&(osgi.os=macosx)(osgi.ws=cocoa)(osgi.arch=aarch64)(!(org.eclipse.swt.buildtime=true)))
+
+requires.8.namespace = org.eclipse.equinox.p2.iu
+requires.8.name = org.eclipse.swt.win32.win32.aarch64
+requires.8.range = [$version$,$version$]
+requires.8.filter = (&(osgi.os=win32)(osgi.ws=win32)(osgi.arch=aarch64)(!(org.eclipse.swt.buildtime=true)))

--- a/examples/org.eclipse.swt.examples.ole.win32/META-INF/MANIFEST.MF
+++ b/examples/org.eclipse.swt.examples.ole.win32/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %plugin.SWTOLEExample.name
 Bundle-SymbolicName: org.eclipse.swt.examples.ole.win32; singleton:=true
-Bundle-Version: 3.109.0.qualifier
+Bundle-Version: 3.109.100.qualifier
 Bundle-Activator: org.eclipse.swt.examples.ole.win32.OlePlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/examples/org.eclipse.swt.examples.ole.win32/META-INF/p2.inf
+++ b/examples/org.eclipse.swt.examples.ole.win32/META-INF/p2.inf
@@ -3,3 +3,9 @@ requires.0.namespace = org.eclipse.equinox.p2.iu
 requires.0.name = org.eclipse.swt.win32.win32.x86_64
 #requires.0.range = [$version$,$version$]
 requires.0.filter = (&(osgi.os=win32)(osgi.ws=win32)(osgi.arch=x86_64))
+
+requires.1.namespace = org.eclipse.equinox.p2.iu
+requires.1.name = org.eclipse.swt.win32.win32.aarch64
+#requires.1.range = [$version$,$version$]
+requires.1.filter = (&(osgi.os=win32)(osgi.ws=win32)(osgi.arch=aarch64))
+

--- a/examples/org.eclipse.swt.examples.ole.win32/pom.xml
+++ b/examples/org.eclipse.swt.examples.ole.win32/pom.xml
@@ -21,7 +21,7 @@
   </parent>
   <groupId>org.eclipse.swt</groupId>
   <artifactId>org.eclipse.swt.examples.ole.win32</artifactId>
-  <version>3.109.0-SNAPSHOT</version>
+  <version>3.109.100-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
   <build>


### PR DESCRIPTION
Especially for the `org.eclipse.swt` fragment host, the `win32.aarch64` fragment entry in its `p2.inf` file would help in resolving the SWT classes required during compile of other modules (like `eclipse.platform`, `eclipse.platform.ui`, etc.) for the Windows on Arm64 platform.