### PR TITLE
Make requirement of o.e.swt for swt.win32.aarch64 temporarily optional

### DIFF
--- a/bundles/org.eclipse.swt/META-INF/p2.inf
+++ b/bundles/org.eclipse.swt/META-INF/p2.inf
@@ -37,5 +37,6 @@ requires.7.filter = (&(osgi.os=macosx)(osgi.ws=cocoa)(osgi.arch=aarch64)(!(org.e
 
 requires.8.namespace = org.eclipse.equinox.p2.iu
 requires.8.name = org.eclipse.swt.win32.win32.aarch64
+requires.8.optional = true
 requires.8.range = [$version$,$version$]
 requires.8.filter = (&(osgi.os=win32)(osgi.ws=win32)(osgi.arch=aarch64)(!(org.eclipse.swt.buildtime=true)))

--- a/examples/org.eclipse.swt.examples.ole.win32/META-INF/p2.inf
+++ b/examples/org.eclipse.swt.examples.ole.win32/META-INF/p2.inf
@@ -6,6 +6,6 @@ requires.0.filter = (&(osgi.os=win32)(osgi.ws=win32)(osgi.arch=x86_64))
 
 requires.1.namespace = org.eclipse.equinox.p2.iu
 requires.1.name = org.eclipse.swt.win32.win32.aarch64
+requires.1.optional = true
 #requires.1.range = [$version$,$version$]
 requires.1.filter = (&(osgi.os=win32)(osgi.ws=win32)(osgi.arch=aarch64))
-


### PR DESCRIPTION
As long org.eclipse.swt.win32.aarch64 is not included in the 'eclipse' repository it cannot be mandatory.

See https://github.com/eclipse-platform/eclipse.platform.ui/pull/1789#issuecomment-2031249051.