### PR TITLE
Fix Maven launch config to build SWT binaries

### DIFF
--- a/bundles/org.eclipse.swt/Build-SWT-native-binaries-for-running-platform.launch
+++ b/bundles/org.eclipse.swt/Build-SWT-native-binaries-for-running-platform.launch
@@ -16,9 +16,10 @@
     <stringAttribute key="M2_USER_SETTINGS" value=""/>
     <booleanAttribute key="M2_WORKSPACE_RESOLUTION" value="false"/>
     <booleanAttribute key="org.eclipse.debug.core.ATTR_FORCE_SYSTEM_CONSOLE_ENCODING" value="false"/>
+    <stringAttribute key="org.eclipse.debug.core.ATTR_REFRESH_SCOPE" value="${working_set:&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot;?&gt;&#13;&#10;&lt;resources&gt;&#13;&#10;&lt;item path=&quot;/org.eclipse.swt.cocoa.macosx.aarch64&quot; type=&quot;4&quot;/&gt;&#13;&#10;&lt;item path=&quot;/org.eclipse.swt.cocoa.macosx.x86_64&quot; type=&quot;4&quot;/&gt;&#13;&#10;&lt;item path=&quot;/org.eclipse.swt.gtk.linux.aarch64&quot; type=&quot;4&quot;/&gt;&#13;&#10;&lt;item path=&quot;/org.eclipse.swt.gtk.linux.loongarch64&quot; type=&quot;4&quot;/&gt;&#13;&#10;&lt;item path=&quot;/org.eclipse.swt.gtk.linux.ppc64le&quot; type=&quot;4&quot;/&gt;&#13;&#10;&lt;item path=&quot;/org.eclipse.swt.gtk.linux.x86_64&quot; type=&quot;4&quot;/&gt;&#13;&#10;&lt;item path=&quot;/org.eclipse.swt.win32.win32.aarch64&quot; type=&quot;4&quot;/&gt;&#13;&#10;&lt;item path=&quot;/org.eclipse.swt.win32.win32.x86_64&quot; type=&quot;4&quot;/&gt;&#13;&#10;&lt;/resources&gt;}"/> 
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_ATTR_USE_ARGFILE" value="false"/>
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_SHOW_CODEDETAILS_IN_EXCEPTION_MESSAGES" value="true"/>
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_CLASSPATH_ONLY_JAR" value="false"/>
     <stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17/"/>
-    <stringAttribute key="org.eclipse.jdt.launching.WORKING_DIRECTORY" value="${project_loc:eclipse.platform.swt}/binaries/org.eclipse.swt.${target.ws}.${target.os}.${target.arch}"/>
+    <stringAttribute key="org.eclipse.jdt.launching.WORKING_DIRECTORY" value="${git_work_tree:/org.eclipse.swt}/binaries/org.eclipse.swt.${target.ws}.${target.os}.${target.arch}"/>
 </launchConfiguration>


### PR DESCRIPTION
The path was broken since the projects got moved:

![image](https://github.com/eclipse-platform/eclipse.platform.swt/assets/2205684/906843cb-0512-4b99-b9e0-3b66ac269a61)

But now the path can found:

![image](https://github.com/eclipse-platform/eclipse.platform.swt/assets/2205684/70aad174-f996-4e1b-bfcc-808ed3fbe468)

Also refresh the workspace after running:

![image](https://github.com/eclipse-platform/eclipse.platform.swt/assets/2205684/36258d52-fe47-45ec-a3f4-d80a266792fb)

Adapt the documentation accordingly.