### PR TITLE
[win32][arm64] Support Dark Theme on newer Windows builds

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT PI/win32/library/os_custom.c
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/win32/library/os_custom.c
@@ -234,9 +234,17 @@ BOOL Validate_SetPreferredAppMode(const BYTE* functionPtr)
 		(functionPtr[0x06] == 0x87) && (functionPtr[0x07] == 0x0D) &&   // xchg    ecx,dword ptr [uxtheme!g_preferredAppMode]
 		(functionPtr[0x0C] == 0xC3);                                    // ret
 #elif defined(_M_ARM64)
-	if (*(const DWORD*)(&functionPtr[0x1C]) == 0x912F6100) // add x0,x8,#0xBD8
+	const DWORD ldr = *(const DWORD*)(&functionPtr[0x14]);
+	const DWORD add = *(const DWORD*)(&functionPtr[0x1C]);
+
+	if ((ldr & 0xFFC003FF) == 0xB9400113 &&                   // ldr, w19,[x8, arg0]
+		*(const DWORD*)(&functionPtr[0x18]) == 0x2A0003E1 &&  // mov w1,w0
+		(add & 0xFFC003FF) == 0x91000100 &&                   // add x0,x8,arg1
+		*(const DWORD*)(&functionPtr[0x24]) == 0x2A1303E0)    // mov w0,w19
 	{
-		return TRUE;
+		const DWORD arg0 = ((ldr & 0x003FFC00) >> 10) * 4;
+		const DWORD arg1 = ((add & 0x003FFC00) >> 10);
+		return arg0 == arg1;
 	}
 
 	return FALSE;


### PR DESCRIPTION
Continues #1048 #1045

Here's the disassembly:
```
00007FFA2A1D3E10 D503237F             pacibsp  
00007FFA2A1D3E14 F81F0FF3             str         x19,[sp,#-0x10]!  
00007FFA2A1D3E18 A9BF7BFD             stp         fp,lr,[sp,#-0x10]!  
00007FFA2A1D3E1C 910003FD             mov         fp,sp  
00007FFA2A1D3E20 B00007E8             adrp        x8,wil::details::g_enabledStateManager+40h (07FFA2A2D0000h)  
00007FFA2A1D3E24 B94BB913             ldr         w19,[x8,#0xBB8]  
00007FFA2A1D3E28 2A0003E1             mov         w1,w0  
00007FFA2A1D3E2C 912EE100             add         x0,x8,#0xBB8  
00007FFA2A1D3E30 97FF7910             bl          _InterlockedExchange (07FFA2A1B2270h)  
00007FFA2A1D3E34 2A1303E0             mov         w0,w19  
00007FFA2A1D3E38 A8C17BFD             ldp         fp,lr,[sp],#0x10  
00007FFA2A1D3E3C F84107F3             ldr         x19,[sp],#0x10  
00007FFA2A1D3E40 D50323FF             autibsp  
00007FFA2A1D3E44 D65F03C0             ret
```

The `add x0,x8,` instruction changed its parameter. So now the `adrp x8,...` instruction looks more stable because it uses a global variable (Using a global variable is also what is done when validating for the Intel x64 uxtheme.dll)

See https://developer.arm.com/documentation/ddi0602/2024-03/Base-Instructions/ADRP--Form-PC-relative-address-to-4KB-page-
- `functionPtr[0x10] & 0x1F) == 0x08` checks that the destination register is `x8`
- `(functionPtr[0x13] & 0x90) == 0x90` checks that the opcode is ADRP