### PR TITLE
fix IllegalArgumentException when deleting text while IME open #1162

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/DefaultContent.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/DefaultContent.java
@@ -581,7 +581,7 @@ public int getLineCount(){
  */
 @Override
 public int getLineAtOffset(int charPosition){
-	if ((charPosition > getCharCount()) || (charPosition < 0)) error(SWT.ERROR_INVALID_ARGUMENT);
+	int charCount = getCharCount();	if ((charPosition > charCount) || (charPosition < 0)) SWT.error(SWT.ERROR_INVALID_ARGUMENT, null, ". charPosition=" + charPosition + " charCount=" + charCount);
 	int position;
 	if (charPosition < gapStart) {
 		// position is before the gap

--- a/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/StyledTextRenderer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/StyledTextRenderer.java
@@ -1292,7 +1292,7 @@ TextLayout getTextLayout(int lineIndex, int orientation, int width, int lineSpac
 	if (styledText != null && styledText.ime != null) {
 		IME ime = styledText.ime;
 		int compositionOffset = ime.getCompositionOffset();
-		if (compositionOffset != -1) {
+		if (compositionOffset != -1 && compositionOffset <= content.getCharCount()) {
 			int commitCount = ime.getCommitCount();
 			int compositionLength = ime.getText().length();
 			if (compositionLength != commitCount) {


### PR DESCRIPTION
If text is deleted while the IME assistent is open the start of the open IME has to be adjusted accordingly

https://github.com/eclipse-platform/eclipse.platform.swt/issues/1162