### PR TITLE
Fix Scrollable.getScrollbarsMode to be consistent #1182

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Scrollable.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Scrollable.java
@@ -303,6 +303,11 @@ public ScrollBar getHorizontalBar () {
  */
 public int getScrollbarsMode () {
 	checkWidget();
+	if (!GTK.GTK4) {
+		if (OS.GTK_OVERLAY_SCROLLING_DISABLED) {
+			return SWT.NONE;
+		}
+	}
 	if (GTK.gtk_scrolled_window_get_overlay_scrolling(scrolledHandle)) {
 		return SWT.SCROLLBAR_OVERLAY;
 	}


### PR DESCRIPTION
Fix Scrollable.getScrollbarsMode to return SWT.NONE when GTK_OVERLAY_SCROLLING=0 setting is present for Linux/GTK3.

Fixes: #1182