### PR TITLE
[win][edge] add focus delegate to browser

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Browser/win32/org/eclipse/swt/browser/Edge.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Browser/win32/org/eclipse/swt/browser/Edge.java
@@ -426,6 +426,9 @@ public void create(Composite parent, int style) {
 	handler = newCallback(this::handleMoveFocusRequested);
 	controller.add_MoveFocusRequested(handler, token);
 	handler.Release();
+	handler = newCallback(this::handleGotFocus);
+	controller.add_GotFocus(handler, token);
+	handler.Release();
 	if (webView_2 != null) {
 		handler = newCallback(this::handleDOMContentLoaded);
 		webView_2.add_DOMContentLoaded(handler, token);
@@ -783,6 +786,11 @@ int handleNewWindowRequested(long pView, long pArgs) {
 			inNewWindow = false;
 		}
 	});
+	return COM.S_OK;
+}
+
+int handleGotFocus(long pView, long pArg) {
+	this.browser.forceFocus();
 	return COM.S_OK;
 }
 


### PR DESCRIPTION
Currently when the ICoreWebView2Controller gets the focus this is not reflected on the browser widget.
This adds a GotFocus handler and forces the focus on the browser widget.

Fixes #1139 