### PR TITLE
Add Scrollable.setScrollbarsMode for changing overlay mode

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/os.c
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/os.c
@@ -6878,6 +6878,16 @@ JNIEXPORT void JNICALL GTK_NATIVE(gtk_1scrolled_1window_1set_1hadjustment)
 }
 #endif
 
+#ifndef NO_gtk_1scrolled_1window_1set_1overlay_1scrolling
+JNIEXPORT void JNICALL GTK_NATIVE(gtk_1scrolled_1window_1set_1overlay_1scrolling)
+	(JNIEnv *env, jclass that, jlong arg0, jboolean arg1)
+{
+	GTK_NATIVE_ENTER(env, that, gtk_1scrolled_1window_1set_1overlay_1scrolling_FUNC);
+	gtk_scrolled_window_set_overlay_scrolling((GtkScrolledWindow *)arg0, arg1);
+	GTK_NATIVE_EXIT(env, that, gtk_1scrolled_1window_1set_1overlay_1scrolling_FUNC);
+}
+#endif
+
 #ifndef NO_gtk_1scrolled_1window_1set_1policy
 JNIEXPORT void JNICALL GTK_NATIVE(gtk_1scrolled_1window_1set_1policy)
 	(JNIEnv *env, jclass that, jlong arg0, jint arg1, jint arg2)

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/os_stats.h
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/os_stats.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2023 IBM Corporation and others. All rights reserved.
+ * Copyright (c) 2000, 2024 IBM Corporation and others. All rights reserved.
  * The contents of this file are made available under the terms
  * of the GNU Lesser General Public License (LGPL) Version 2.1 that
  * accompanies this distribution (lgpl-v21.txt).  The LGPL is also
@@ -553,6 +553,7 @@ typedef enum {
 	gtk_1scrolled_1window_1get_1vadjustment_FUNC,
 	gtk_1scrolled_1window_1get_1vscrollbar_FUNC,
 	gtk_1scrolled_1window_1set_1hadjustment_FUNC,
+	gtk_1scrolled_1window_1set_1overlay_1scrolling_FUNC,
 	gtk_1scrolled_1window_1set_1policy_FUNC,
 	gtk_1scrolled_1window_1set_1vadjustment_FUNC,
 	gtk_1search_1entry_1new_FUNC,

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/org/eclipse/swt/internal/gtk/GTK.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/org/eclipse/swt/internal/gtk/GTK.java
@@ -1469,6 +1469,8 @@ public class GTK extends OS {
 	public static final native void gtk_scrolled_window_set_policy(long scrolled_window, int hscrollbar_policy, int vscrollbar_policy);
 	/** @param scrolled_window cast=(GtkScrolledWindow *) */
 	public static final native boolean gtk_scrolled_window_get_overlay_scrolling(long scrolled_window);
+	/** @param scrolled_window cast=(GtkScrolledWindow *) */
+	public static final native void gtk_scrolled_window_set_overlay_scrolling(long scrolled_window, boolean overlay_scrolling);
 	/**
 	 * @param scrolled_window cast=(GtkScrolledWindow *)
 	 * @param adjustment cast=(GtkAdjustment *)

--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Scrollable.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Scrollable.java
@@ -253,6 +253,30 @@ public int getScrollbarsMode () {
 }
 
 /**
+ * Sets the mode of the receiver's scrollbars. This will be
+ * <em>bitwise</em> OR of one or more of the constants defined in class
+ * <code>SWT</code>.<br>
+ * <ul>
+ * <li><code>SWT.SCROLLBAR_OVERLAY</code> - if receiver
+ * uses overlay scrollbars</li>
+ * <li><code>SWT.NONE</code> - otherwise</li>
+ * </ul>
+ *
+ * @exception SWTException <ul>
+ * <li>ERROR_WIDGET_DISPOSED - if the receiver has been
+ * disposed</li>
+ * <li>ERROR_THREAD_INVALID_ACCESS - if not called from the
+ * thread that created the receiver</li>
+ * </ul>
+ *
+ * @see SWT#SCROLLBAR_OVERLAY
+ * @since 3.126
+ */
+public void setScrollbarsMode (int mode) {
+	checkWidget();
+}
+
+/**
  * Returns the receiver's vertical scroll bar if it has
  * one, and null if it does not.
  *

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Scrollable.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Scrollable.java
@@ -314,6 +314,31 @@ public int getScrollbarsMode () {
 	return SWT.NONE;
 }
 /**
+ * Sets the mode of the receiver's scrollbars. This will be
+ * <em>bitwise</em> OR of one or more of the constants defined in class
+ * <code>SWT</code>.<br>
+ * <ul>
+ * <li><code>SWT.SCROLLBAR_OVERLAY</code> - if receiver
+ * uses overlay scrollbars</li>
+ * <li><code>SWT.NONE</code> - otherwise</li>
+ * </ul>
+ *
+ * @exception SWTException <ul>
+ * <li>ERROR_WIDGET_DISPOSED - if the receiver has been
+ * disposed</li>
+ * <li>ERROR_THREAD_INVALID_ACCESS - if not called from the
+ * thread that created the receiver</li>
+ * </ul>
+ *
+ * @see SWT#SCROLLBAR_OVERLAY
+ * @since 3.126
+ */
+public void setScrollbarsMode (int mode) {
+	checkWidget();
+	boolean overlayScrolling = (mode & SWT.SCROLLBAR_OVERLAY) != 0;
+	GTK.gtk_scrolled_window_set_overlay_scrolling(scrolledHandle, overlayScrolling);
+}
+/**
  * Returns the receiver's vertical scroll bar if it has
  * one, and null if it does not.
  *

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Scrollable.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Scrollable.java
@@ -277,6 +277,31 @@ public int getScrollbarsMode () {
 }
 
 /**
+ * Sets the mode of the receiver's scrollbars. This will be
+ * <em>bitwise</em> OR of one or more of the constants defined in class
+ * <code>SWT</code>.<br>
+ * <ul>
+ * <li><code>SWT.SCROLLBAR_OVERLAY</code> - if receiver
+ * uses overlay scrollbars</li>
+ * <li><code>SWT.NONE</code> - otherwise</li>
+ * </ul>
+ *
+ * @exception SWTException <ul>
+ * <li>ERROR_WIDGET_DISPOSED - if the receiver has been
+ * disposed</li>
+ * <li>ERROR_THREAD_INVALID_ACCESS - if not called from the
+ * thread that created the receiver</li>
+ * </ul>
+ *
+ * @see SWT#SCROLLBAR_OVERLAY
+ *
+ * @since 3.126
+ */
+public void setScrollbarsMode (int mode) {
+	checkWidget();
+}
+
+/**
  * Returns the receiver's vertical scroll bar if it has
  * one, and null if it does not.
  *


### PR DESCRIPTION
eclipse-platform#1184

Add Scrollable.setScrollbarsMode(int) method to provide the possibility to disable/enable overlay scrollbars.

Fixes: eclipse-platform#1184