### PR TITLE
Extend DPIUtil to provide scale up and down methods with target zoom as parameter

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/DPIUtil.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/DPIUtil.java
@@ -11,6 +11,7 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *     Daniel Kruegler - #420 - [High DPI] "swt.autoScale" should add new "half" option
+ *     Yatta Solutions - #131 - Additional methods to specify target zoom directly
  *******************************************************************************/
 package org.eclipse.swt.internal;
 
@@ -116,13 +117,13 @@ public class DPIUtil {
  */
 public static ImageData autoScaleDown (Device device, final ImageData imageData) {
 	if (deviceZoom == 100 || imageData == null || (device != null && !device.isAutoScalable())) return imageData;
-	float scaleFactor = 1.0f / getScalingFactor ();
+	float scaleFactor = 1.0f / getScalingFactor (deviceZoom);
 	return autoScaleImageData(device, imageData, scaleFactor);
 }
 
 public static int[] autoScaleDown(int[] pointArray) {
 	if (deviceZoom == 100 || pointArray == null) return pointArray;
-	float scaleFactor = getScalingFactor ();
+	float scaleFactor = getScalingFactor (deviceZoom);
 	int [] returnArray = new int[pointArray.length];
 	for (int i = 0; i < pointArray.length; i++) {
 		returnArray [i] =  Math.round (pointArray [i] / scaleFactor);
@@ -138,9 +139,13 @@ public static int[] autoScaleDown(Drawable drawable, int[] pointArray) {
 /**
  * Auto-scale down float array dimensions.
  */
-public static float[] autoScaleDown (float size[]) {
-	if (deviceZoom == 100 || size == null) return size;
-	float scaleFactor = getScalingFactor ();
+public static float[] autoScaleDown(float size[]) {
+	return scaleDown(size, deviceZoom);
+}
+
+public static float[] scaleDown(float size[], int zoom) {
+	if (zoom == 100 || size == null) return size;
+	float scaleFactor = getScalingFactor (zoom);
 	float scaledSize[] = new float[size.length];
 	for (int i = 0; i < scaledSize.length; i++) {
 		scaledSize[i] = size[i] / scaleFactor;
@@ -151,50 +156,75 @@ public static float[] autoScaleDown (float size[]) {
 /**
  * Auto-scale down float array dimensions if enabled for Drawable class.
  */
-public static float[] autoScaleDown (Drawable drawable, float size[]) {
-	if (drawable != null && !drawable.isAutoScalable ()) return size;
-	return autoScaleDown (size);
+public static float[] autoScaleDown(Drawable drawable, float size[]) {
+	return scaleDown(drawable, size, deviceZoom);
+}
+
+public static float[] scaleDown(Drawable drawable, float size[], int zoom) {
+	if (drawable != null && !drawable.isAutoScalable()) return size;
+	return scaleDown(size, zoom);
 }
 
 /**
  * Auto-scale down int dimensions.
  */
-public static int autoScaleDown (int size) {
-	if (deviceZoom == 100 || size == SWT.DEFAULT) return size;
-	float scaleFactor = getScalingFactor ();
+public static int autoScaleDown(int size) {
+	return scaleDown(size, deviceZoom);
+}
+
+public static int scaleDown(int size, int zoom) {
+	if (zoom == 100 || size == SWT.DEFAULT) return size;
+	float scaleFactor = getScalingFactor (zoom);
 	return Math.round (size / scaleFactor);
 }
+
 /**
  * Auto-scale down int dimensions if enabled for Drawable class.
  */
-public static int autoScaleDown (Drawable drawable, int size) {
-	if (drawable != null && !drawable.isAutoScalable ()) return size;
-	return autoScaleDown (size);
+public static int autoScaleDown(Drawable drawable, int size) {
+	return scaleDown(drawable, size, deviceZoom);
+}
+
+public static int scaleDown(Drawable drawable, int size, int zoom) {
+	if (drawable != null && !drawable.isAutoScalable()) return size;
+	return scaleDown (size, zoom);
 }
 
 /**
  * Auto-scale down float dimensions.
  */
-public static float autoScaleDown (float size) {
-	if (deviceZoom == 100 || size == SWT.DEFAULT) return size;
-	float scaleFactor = getScalingFactor ();
+public static float autoScaleDown(float size) {
+	return scaleDown(size, deviceZoom);
+}
+
+public static float scaleDown(float size, int zoom) {
+	if (zoom == 100 || size == SWT.DEFAULT) return size;
+	float scaleFactor = getScalingFactor (zoom);
 	return (size / scaleFactor);
 }
 
 /**
  * Auto-scale down float dimensions if enabled for Drawable class.
  */
-public static float autoScaleDown (Drawable drawable, float size) {
-	if (drawable != null && !drawable.isAutoScalable ()) return size;
-	return autoScaleDown (size);
+public static float autoScaleDown(Drawable drawable, float size) {
+	return scaleDown (drawable, size, deviceZoom);
+}
+
+public static float scaleDown(Drawable drawable, float size, int zoom) {
+	if (drawable != null && !drawable.isAutoScalable()) return size;
+	return scaleDown (size, zoom);
 }
 
 /**
  * Returns a new scaled down Point.
  */
-public static Point autoScaleDown (Point point) {
-	if (deviceZoom == 100 || point == null) return point;
-	float scaleFactor = getScalingFactor ();
+public static Point autoScaleDown(Point point) {
+	return scaleDown(point, deviceZoom);
+}
+
+public static Point scaleDown(Point point, int zoom) {
+	if (zoom == 100 || point == null) return point;
+	float scaleFactor = getScalingFactor(zoom);
 	Point scaledPoint = new Point (0,0);
 	scaledPoint.x = Math.round (point.x / scaleFactor);
 	scaledPoint.y = Math.round (point.y / scaleFactor);
@@ -204,19 +234,27 @@ public static Point autoScaleDown (Point point) {
 /**
  * Returns a new scaled down Point if enabled for Drawable class.
  */
-public static Point autoScaleDown (Drawable drawable, Point point) {
-	if (drawable != null && !drawable.isAutoScalable ()) return point;
-	return autoScaleDown (point);
+public static Point autoScaleDown(Drawable drawable, Point point) {
+	return scaleDown(drawable, point, deviceZoom);
+}
+
+public static Point scaleDown(Drawable drawable, Point point, int zoom) {
+	if (drawable != null && !drawable.isAutoScalable()) return point;
+	return scaleDown (point, zoom);
 }
 
 /**
  * Returns a new scaled down Rectangle.
  */
-public static Rectangle autoScaleDown (Rectangle rect) {
-	if (deviceZoom == 100 || rect == null) return rect;
+public static Rectangle autoScaleDown(Rectangle rect) {
+	return scaleDown(rect, deviceZoom);
+}
+
+public static Rectangle scaleDown(Rectangle rect, int zoom) {
+	if (zoom == 100 || rect == null) return rect;
 	Rectangle scaledRect = new Rectangle (0,0,0,0);
-	Point scaledTopLeft = DPIUtil.autoScaleDown (new Point (rect.x, rect.y));
-	Point scaledBottomRight = DPIUtil.autoScaleDown (new Point (rect.x + rect.width, rect.y + rect.height));
+	Point scaledTopLeft = DPIUtil.scaleDown(new Point (rect.x, rect.y), zoom);
+	Point scaledBottomRight = DPIUtil.scaleDown(new Point (rect.x + rect.width, rect.y + rect.height), zoom);
 
 	scaledRect.x = scaledTopLeft.x;
 	scaledRect.y = scaledTopLeft.y;
@@ -227,9 +265,14 @@ public static Rectangle autoScaleDown (Rectangle rect) {
 /**
  * Returns a new scaled down Rectangle if enabled for Drawable class.
  */
-public static Rectangle autoScaleDown (Drawable drawable, Rectangle rect) {
-	if (drawable != null && !drawable.isAutoScalable ()) return rect;
-	return autoScaleDown (rect);
+public static Rectangle autoScaleDown(Drawable drawable, Rectangle rect) {
+	if (drawable != null && !drawable.isAutoScalable()) return rect;
+	return scaleDown(rect, deviceZoom);
+}
+
+public static Rectangle scaleDown(Drawable drawable, Rectangle rect, int zoom) {
+	if (drawable != null && !drawable.isAutoScalable()) return rect;
+	return scaleDown (rect, zoom);
 }
 
 /**
@@ -311,9 +354,13 @@ public static ImageData autoScaleUp (Device device, final ElementAtZoom<ImageDat
 }
 
 public static int[] autoScaleUp(int[] pointArray) {
-	if (deviceZoom == 100 || pointArray == null) return pointArray;
-	float scaleFactor = getScalingFactor ();
-	int [] returnArray = new int[pointArray.length];
+	return autoScaleUp(pointArray, deviceZoom);
+}
+
+public static int[] autoScaleUp(int[] pointArray, int zoom) {
+	if (zoom == 100 || pointArray == null) return pointArray;
+	float scaleFactor = getScalingFactor(zoom);
+	int[] returnArray = new int[pointArray.length];
 	for (int i = 0; i < pointArray.length; i++) {
 		returnArray [i] =  Math.round (pointArray [i] * scaleFactor);
 	}
@@ -321,24 +368,26 @@ public static int[] autoScaleUp(int[] pointArray) {
 }
 
 public static int[] autoScaleUp(Drawable drawable, int[] pointArray) {
-	if (drawable != null && !drawable.isAutoScalable ()) return pointArray;
-	return autoScaleUp (pointArray);
+	return autoScaleUp(drawable, pointArray, deviceZoom);
 }
 
+public static int[] autoScaleUp(Drawable drawable, int[] pointArray, int zoom) {
+	if (drawable != null && !drawable.isAutoScalable()) return pointArray;
+	return autoScaleUp (pointArray, zoom);
+}
 /**
  * Auto-scale up int dimensions.
  */
-public static int autoScaleUp (int size) {
-	if (deviceZoom == 100 || size == SWT.DEFAULT) return size;
-	float scaleFactor = getScalingFactor ();
-	return Math.round (size * scaleFactor);
+public static int autoScaleUp(int size) {
+	return autoScaleUp(size, deviceZoom);
 }
 
 /**
  * Auto-scale up int dimensions to match the given zoom level
  */
-public static int autoScaleUp (int size, int zoom) {
-	float scaleFactor = getScalingFactor (zoom);
+public static int autoScaleUp(int size, int zoom) {
+	if (zoom == 100 || size == SWT.DEFAULT) return size;
+	float scaleFactor = getScalingFactor(zoom);
 	return Math.round (size * scaleFactor);
 }
 
@@ -354,29 +403,45 @@ public static int autoScaleUpUsingNativeDPI (int size) {
 /**
  * Auto-scale up int dimensions if enabled for Drawable class.
  */
-public static int autoScaleUp (Drawable drawable, int size) {
-	if (drawable != null && !drawable.isAutoScalable ()) return size;
-	return autoScaleUp (size);
+public static int autoScaleUp(Drawable drawable, int size) {
+	return autoScaleUp(drawable, size, deviceZoom);
+}
+
+public static int autoScaleUp(Drawable drawable, int size, int zoom) {
+	if (drawable != null && !drawable.isAutoScalable()) return size;
+	return autoScaleUp (size, zoom);
 }
 
 public static float autoScaleUp(float size) {
-	if (deviceZoom == 100 || size == SWT.DEFAULT) return size;
-	float scaleFactor = getScalingFactor ();
+	return autoScaleUp(size, deviceZoom);
+}
+
+public static float autoScaleUp(float size, int zoom) {
+	if (zoom == 100 || size == SWT.DEFAULT) return size;
+	float scaleFactor = getScalingFactor(zoom);
 	return (size * scaleFactor);
 }
 
 public static float autoScaleUp(Drawable drawable, float size) {
-	if (drawable != null && !drawable.isAutoScalable ()) return size;
-	return autoScaleUp (size);
+	return autoScaleUp(drawable, size, deviceZoom);
+}
+
+public static float autoScaleUp(Drawable drawable, float size, int zoom) {
+	if (drawable != null && !drawable.isAutoScalable()) return size;
+	return autoScaleUp (size, zoom);
 }
 
 /**
  * Returns a new scaled up Point.
  */
-public static Point autoScaleUp (Point point) {
-	if (deviceZoom == 100 || point == null) return point;
-	float scaleFactor = getScalingFactor ();
-	Point scaledPoint = new Point (0,0);
+public static Point autoScaleUp(Point point) {
+	return autoScaleUp(point, deviceZoom);
+}
+
+public static Point autoScaleUp(Point point, int zoom) {
+	if (zoom == 100 || point == null) return point;
+	float scaleFactor = getScalingFactor(zoom);
+	Point scaledPoint = new Point(0,0);
 	scaledPoint.x = Math.round (point.x * scaleFactor);
 	scaledPoint.y = Math.round (point.y * scaleFactor);
 	return scaledPoint;
@@ -385,19 +450,27 @@ public static Point autoScaleUp (Point point) {
 /**
  * Returns a new scaled up Point if enabled for Drawable class.
  */
-public static Point autoScaleUp (Drawable drawable, Point point) {
-	if (drawable != null && !drawable.isAutoScalable ()) return point;
-	return autoScaleUp (point);
+public static Point autoScaleUp(Drawable drawable, Point point) {
+	return autoScaleUp (drawable, point, deviceZoom);
+}
+
+public static Point autoScaleUp(Drawable drawable, Point point, int zoom) {
+	if (drawable != null && !drawable.isAutoScalable()) return point;
+	return autoScaleUp (point, zoom);
 }
 
 /**
  * Returns a new scaled up Rectangle.
  */
-public static Rectangle autoScaleUp (Rectangle rect) {
-	if (deviceZoom == 100 || rect == null) return rect;
-	Rectangle scaledRect = new Rectangle (0,0,0,0);
-	Point scaledTopLeft = DPIUtil.autoScaleUp (new Point (rect.x, rect.y));
-	Point scaledBottomRight = DPIUtil.autoScaleUp (new Point (rect.x + rect.width, rect.y + rect.height));
+public static Rectangle autoScaleUp(Rectangle rect) {
+	return autoScaleUp(rect, deviceZoom);
+}
+
+public static Rectangle autoScaleUp(Rectangle rect, int zoom) {
+	if (zoom == 100 || rect == null) return rect;
+	Rectangle scaledRect = new Rectangle(0,0,0,0);
+	Point scaledTopLeft = DPIUtil.autoScaleUp (new Point(rect.x, rect.y), zoom);
+	Point scaledBottomRight = DPIUtil.autoScaleUp (new Point(rect.x + rect.width, rect.y + rect.height), zoom);
 
 	scaledRect.x = scaledTopLeft.x;
 	scaledRect.y = scaledTopLeft.y;
@@ -409,28 +482,27 @@ public static Rectangle autoScaleUp (Rectangle rect) {
 /**
  * Returns a new scaled up Rectangle if enabled for Drawable class.
  */
-public static Rectangle autoScaleUp (Drawable drawable, Rectangle rect) {
-	if (drawable != null && !drawable.isAutoScalable ()) return rect;
-	return autoScaleUp (rect);
+public static Rectangle autoScaleUp(Drawable drawable, Rectangle rect) {
+	return autoScaleUp(drawable, rect, deviceZoom);
 }
 
-/**
- * Returns Scaling factor from the display
- * @return float scaling factor
- */
-private static float getScalingFactor () {
-	return getScalingFactor(deviceZoom);
+public static Rectangle autoScaleUp(Drawable drawable, Rectangle rect, int zoom) {
+	if (drawable != null && !drawable.isAutoScalable()) return rect;
+	return autoScaleUp (rect, zoom);
 }
 
 /**
  * Returns scaling factor from the given device zoom
  * @return float scaling factor
  */
-private static float getScalingFactor (int shellDeviceZoom) {
+private static float getScalingFactor(int zoom) {
 	if (useCairoAutoScale) {
 		return 1;
 	}
-	return shellDeviceZoom / 100f;
+	if (zoom <= 0) {
+		zoom = deviceZoom;
+	}
+	return zoom / 100f;
 }
 
 /**

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/AllNonBrowserTests.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/AllNonBrowserTests.java
@@ -45,7 +45,8 @@ import org.junit.runners.Suite;
 		Test_org_eclipse_swt_accessibility_Accessible.class,
 		Test_org_eclipse_swt_accessibility_AccessibleControlEvent.class,
 		Test_org_eclipse_swt_accessibility_AccessibleEvent.class,
-		Test_org_eclipse_swt_accessibility_AccessibleTextEvent.class })
+		Test_org_eclipse_swt_accessibility_AccessibleTextEvent.class,
+		DPIUtilTests.class})
 public class AllNonBrowserTests {
 	private static List<Error> leakedResources;
 

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/DPIUtilTests.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/DPIUtilTests.java
@@ -1,0 +1,326 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Yatta Solutions
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Yatta Solutions - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.swt.tests.junit;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+
+import org.eclipse.swt.graphics.Device;
+import org.eclipse.swt.graphics.Point;
+import org.eclipse.swt.graphics.Rectangle;
+import org.eclipse.swt.internal.DPIUtil;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Automated Test Suite for class org.eclipse.swt.internal.DPIUtil
+ *
+ * @see org.eclipse.swt.internal.DPIUtil
+ */
+public class DPIUtilTests {
+
+	private int deviceZoom;
+	private boolean useCairoAutoScale;
+
+	@Before
+	public void setup() {
+		deviceZoom = DPIUtil.getDeviceZoom();
+		useCairoAutoScale = DPIUtil.useCairoAutoScale();
+		DPIUtil.setDeviceZoom(200);
+		DPIUtil.setUseCairoAutoScale(false);
+	}
+
+	@After
+	public void tearDown() {
+		DPIUtil.setUseCairoAutoScale(useCairoAutoScale);
+		DPIUtil.setDeviceZoom(deviceZoom);
+	}
+
+	@Test
+	public void scaleDownFloatArray() {
+		float[] valueAt200 = new float[] { 2, 3, 4 };
+		float[] valueAt150 = new float[] { 1.5f, 2.25f, 3 };
+		float[] valueAt100 = new float[] { 1, 1.5f, 2 };
+
+		float[] scaledValue = DPIUtil.autoScaleDown(valueAt200);
+		assertArrayEquals(String.format("Scaling down float array from device zoom (%d) to 100 failed",
+				DPIUtil.getDeviceZoom()), valueAt100, scaledValue, .001f);
+		scaledValue = DPIUtil.autoScaleDown((Device) null, valueAt200);
+		assertArrayEquals(String.format("Scaling down float array from device zoom (%d) to 100 with device failed",
+				DPIUtil.getDeviceZoom()), valueAt100, scaledValue, .001f);
+
+		scaledValue = DPIUtil.scaleDown(valueAt200, 200);
+		assertArrayEquals("Scaling down float array from 200 failed", valueAt100, scaledValue, .001f);
+		scaledValue = DPIUtil.scaleDown((Device) null, valueAt200, 200);
+		assertArrayEquals("Scaling down float array from 200 with device failed", valueAt100, scaledValue, .001f);
+		scaledValue = DPIUtil.scaleDown(valueAt150, 150);
+		assertArrayEquals("Scaling down float array from 150 failed", valueAt100, scaledValue, .001f);
+		scaledValue = DPIUtil.scaleDown((Device) null, valueAt150, 150);
+		assertArrayEquals("Scaling down float array from 150 with device failed", valueAt100, scaledValue, .001f);
+		scaledValue = DPIUtil.scaleDown(valueAt100, 100);
+		assertSame("Scaling down float array without zoom change failed", valueAt100, scaledValue);
+		scaledValue = DPIUtil.scaleDown((Device) null, valueAt100, 100);
+		assertSame("Scaling down float array without zoom change with device failed", valueAt100, scaledValue);
+	}
+
+	@Test
+	public void scaleDownInteger() {
+		int valueAt200 = 10;
+		int valueAt150 = 7;
+		int valueAt100 = 5;
+
+		int scaledValue = DPIUtil.autoScaleDown(valueAt200);
+		assertEquals(
+				String.format("Scaling down integer from device zoom (%d) to 100 failed", DPIUtil.getDeviceZoom()),
+				valueAt100, scaledValue);
+		scaledValue = DPIUtil.autoScaleDown((Device) null, valueAt200);
+		assertEquals(String.format("Scaling down integer from device zoom (%d) to 100 with device failed",
+				DPIUtil.getDeviceZoom()), valueAt100, scaledValue);
+
+		scaledValue = DPIUtil.scaleDown(valueAt200, 200);
+		assertEquals("Scaling down integer from 200 failed", valueAt100, scaledValue);
+		scaledValue = DPIUtil.scaleDown((Device) null, valueAt200, 200);
+		assertEquals("Scaling down integer from 200 with device failed", valueAt100, scaledValue);
+		scaledValue = DPIUtil.scaleDown(valueAt150, 150);
+		assertEquals("Scaling down integer from 150 failed", valueAt100, scaledValue);
+		scaledValue = DPIUtil.scaleDown((Device) null, valueAt150, 150);
+		assertEquals("Scaling down integer from 150 with device failed", valueAt100, scaledValue);
+		scaledValue = DPIUtil.scaleDown(valueAt100, 100);
+		assertSame("Scaling down integer without zoom change failed", valueAt100, scaledValue);
+		scaledValue = DPIUtil.scaleDown((Device) null, valueAt100, 100);
+		assertSame("Scaling down integer without zoom change with device failed", valueAt100, scaledValue);
+	}
+
+	@Test
+	public void scaleDownFloat() {
+		float valueAt200 = 10f;
+		float valueAt150 = 7.5f;
+		float valueAt100 = 5f;
+
+		float scaledValue = DPIUtil.autoScaleDown(valueAt200);
+		assertEquals(
+				String.format("Scaling down float from device zoom (%d) to 100 failed", DPIUtil.getDeviceZoom()),
+				valueAt100, scaledValue, .001f);
+		scaledValue = DPIUtil.autoScaleDown((Device) null, valueAt200);
+		assertEquals(String.format("Scaling down float from device zoom (%d) to 100 with device failed",
+				DPIUtil.getDeviceZoom()), valueAt100, scaledValue, .001f);
+
+		scaledValue = DPIUtil.scaleDown(valueAt200, 200);
+		assertEquals("Scaling down float from 200 failed", valueAt100, scaledValue, .001f);
+		scaledValue = DPIUtil.scaleDown((Device) null, valueAt200, 200);
+		assertEquals("Scaling down float from 200 with device failed", valueAt100, scaledValue, .001f);
+		scaledValue = DPIUtil.scaleDown(valueAt150, 150);
+		assertEquals("Scaling down float from 150 failed", valueAt100, scaledValue, .001f);
+		scaledValue = DPIUtil.scaleDown((Device) null, valueAt150, 150);
+		assertEquals("Scaling down float from 150 with device failed", valueAt100, scaledValue, .001f);
+		scaledValue = DPIUtil.scaleDown(valueAt100, 100);
+		assertEquals("Scaling down float without zoom change failed", valueAt100, scaledValue, .001f);
+		scaledValue = DPIUtil.scaleDown((Device) null, valueAt100, 100);
+		assertEquals("Scaling down float without zoom change with device failed", valueAt100, scaledValue, .001f);
+	}
+
+	@Test
+	public void scaleDownPoint() {
+		Point valueAt200 = new Point(10, 14);
+		Point valueAt150 = new Point(7, 10);
+		Point valueAt100 = new Point(5, 7);
+
+		Point scaledValue = DPIUtil.autoScaleDown(valueAt200);
+		assertEquals(
+				String.format("Scaling down Point from device zoom (%d) to 100 failed", DPIUtil.getDeviceZoom()),
+				valueAt100, scaledValue);
+		scaledValue = DPIUtil.autoScaleDown((Device) null, valueAt200);
+		assertEquals(String.format("Scaling down Point from device zoom (%d) to 100 with device failed",
+				DPIUtil.getDeviceZoom()), valueAt100, scaledValue);
+
+		scaledValue = DPIUtil.scaleDown(valueAt200, 200);
+		assertEquals("Scaling down Point from 200 failed", valueAt100, scaledValue);
+		scaledValue = DPIUtil.scaleDown((Device) null, valueAt200, 200);
+		assertEquals("Scaling down Point from 200 with device failed", valueAt100, scaledValue);
+		scaledValue = DPIUtil.scaleDown(valueAt150, 150);
+		assertEquals("Scaling down Point from 150 failed", valueAt100, scaledValue);
+		scaledValue = DPIUtil.scaleDown((Device) null, valueAt150, 150);
+		assertEquals("Scaling down Point from 150 with device failed", valueAt100, scaledValue);
+		scaledValue = DPIUtil.scaleDown(valueAt100, 100);
+		assertSame("Scaling down Point without zoom change failed", valueAt100, scaledValue);
+		scaledValue = DPIUtil.scaleDown((Device) null, valueAt100, 100);
+		assertSame("Scaling down Point without zoom change with device failed", valueAt100, scaledValue);
+	}
+
+	@Test
+	public void scaleDownRectangle() {
+		Rectangle valueAt200 = new Rectangle(100, 150, 10, 14);
+		Rectangle valueAt150 = new Rectangle(75, 113, 7, 10);
+		Rectangle valueAt100 = new Rectangle(50, 75, 5, 7);
+
+		Rectangle scaledValue = DPIUtil.autoScaleDown(valueAt200);
+		assertEquals(String.format("Scaling down Rectangle from device zoom (%d) to 100 failed",
+				DPIUtil.getDeviceZoom()), valueAt100, scaledValue);
+		scaledValue = DPIUtil.autoScaleDown((Device) null, valueAt200);
+		assertEquals(String.format("Scaling down Rectangle from device zoom (%d) to 100 with device failed",
+				DPIUtil.getDeviceZoom()), valueAt100, scaledValue);
+
+		scaledValue = DPIUtil.scaleDown(valueAt200, 200);
+		assertEquals("Scaling down Rectangle from 200 failed", valueAt100, scaledValue);
+		scaledValue = DPIUtil.scaleDown((Device) null, valueAt200, 200);
+		assertEquals("Scaling down Rectangle from 200 with device failed", valueAt100, scaledValue);
+		scaledValue = DPIUtil.scaleDown(valueAt150, 150);
+		assertEquals("Scaling down Rectangle from 150 failed", valueAt100, scaledValue);
+		scaledValue = DPIUtil.scaleDown((Device) null, valueAt150, 150);
+		assertEquals("Scaling down Rectangle from 150 with device failed", valueAt100, scaledValue);
+		scaledValue = DPIUtil.scaleDown(valueAt100, 100);
+		assertSame("Scaling down Rectangle without zoom change failed", valueAt100, scaledValue);
+		scaledValue = DPIUtil.scaleDown((Device) null, valueAt100, 100);
+		assertSame("Scaling down Rectangle without zoom change with device failed", valueAt100, scaledValue);
+	}
+
+	@Test
+	public void scaleUpIntArray() {
+		int[] valueAt200 = new int[] { 10, 12, 14 };
+		int[] valueAt150 = new int[] { 8, 9, 11 };
+		int[] valueAt100 = new int[] { 5, 6, 7 };
+
+		int[] scaledValue = DPIUtil.autoScaleUp(valueAt100);
+		assertArrayEquals(
+				String.format("Scaling up int array to device zoom (%d) to 100 failed", DPIUtil.getDeviceZoom()),
+				valueAt200, scaledValue);
+		scaledValue = DPIUtil.autoScaleUp((Device) null, valueAt100);
+		assertArrayEquals(String.format("Scaling up int array to device zoom (%d) to 100 with device failed",
+				DPIUtil.getDeviceZoom()), valueAt200, scaledValue);
+
+		scaledValue = DPIUtil.autoScaleUp(valueAt100, 200);
+		assertArrayEquals("Scaling up int array to 200 failed", valueAt200, scaledValue);
+		scaledValue = DPIUtil.autoScaleUp((Device) null, valueAt100, 200);
+		assertArrayEquals("Scaling up int array to 200 with device failed", valueAt200, scaledValue);
+		scaledValue = DPIUtil.autoScaleUp(valueAt100, 150);
+		assertArrayEquals("Scaling up int array to 150 failed", valueAt150, scaledValue);
+		scaledValue = DPIUtil.autoScaleUp((Device) null, valueAt100, 150);
+		assertArrayEquals("Scaling up int array to 150 with device failed", valueAt150, scaledValue);
+		scaledValue = DPIUtil.autoScaleUp(valueAt100, 100);
+		assertSame("Scaling up int array without zoom change failed", valueAt100, scaledValue);
+		scaledValue = DPIUtil.autoScaleUp((Device) null, valueAt100, 100);
+		assertSame("Scaling up int array without zoom change with device failed", valueAt100, scaledValue);
+	}
+
+	@Test
+	public void scaleUpInteger() {
+		int valueAt200 = 10;
+		int valueAt150 = 8;
+		int valueAt100 = 5;
+
+		int scaledValue = DPIUtil.autoScaleUp(valueAt100);
+		assertEquals(String.format("Scaling up integer to device zoom (%d) to 100 failed", DPIUtil.getDeviceZoom()),
+				valueAt200, scaledValue);
+		scaledValue = DPIUtil.autoScaleUp((Device) null, valueAt100);
+		assertEquals(String.format("Scaling up integer to device zoom (%d) to 100 with device failed",
+				DPIUtil.getDeviceZoom()), valueAt200, scaledValue);
+
+		scaledValue = DPIUtil.autoScaleUp(valueAt100, 200);
+		assertEquals("Scaling up integer to 200 failed", valueAt200, scaledValue);
+		scaledValue = DPIUtil.autoScaleUp((Device) null, valueAt100, 200);
+		assertEquals("Scaling up integer to 200 with device failed", valueAt200, scaledValue);
+		scaledValue = DPIUtil.autoScaleUp(valueAt100, 150);
+		assertEquals("Scaling up integer to 150 failed", valueAt150, scaledValue);
+		scaledValue = DPIUtil.autoScaleUp((Device) null, valueAt100, 150);
+		assertEquals("Scaling up integer to 150 with device failed", valueAt150, scaledValue);
+		scaledValue = DPIUtil.autoScaleUp(valueAt100, 100);
+		assertSame("Scaling up integer without zoom change failed", valueAt100, scaledValue);
+		scaledValue = DPIUtil.autoScaleUp((Device) null, valueAt100, 100);
+		assertSame("Scaling up integer without zoom change with device failed", valueAt100, scaledValue);
+	}
+
+	@Test
+	public void scaleUpFloat() {
+		float valueAt200 = 10;
+		float valueAt150 = 7.5f;
+		float valueAt100 = 5;
+
+		float scaledValue = DPIUtil.autoScaleUp(valueAt100);
+		assertEquals(String.format("Scaling up integer to device zoom (%d) to 100 failed", DPIUtil.getDeviceZoom()),
+				valueAt200, scaledValue, 0.001f);
+		scaledValue = DPIUtil.autoScaleUp((Device) null, valueAt100);
+		assertEquals(String.format("Scaling up integer to device zoom (%d) to 100 with device failed",
+				DPIUtil.getDeviceZoom()), valueAt200, scaledValue, 0.001f);
+
+		scaledValue = DPIUtil.autoScaleUp(valueAt100, 200);
+		assertEquals("Scaling up integer to 200 failed", valueAt200, scaledValue, 0.001f);
+		scaledValue = DPIUtil.autoScaleUp((Device) null, valueAt100, 200);
+		assertEquals("Scaling up integer to 200 with device failed", valueAt200, scaledValue, 0.001f);
+		scaledValue = DPIUtil.autoScaleUp(valueAt100, 150);
+		assertEquals("Scaling up integer to 150 failed", valueAt150, scaledValue, 0.001f);
+		scaledValue = DPIUtil.autoScaleUp((Device) null, valueAt100, 150);
+		assertEquals("Scaling up integer to 150 with device failed", valueAt150, scaledValue, 0.001f);
+		scaledValue = DPIUtil.autoScaleUp(valueAt100, 100);
+		assertEquals("Scaling up integer without zoom change failed", valueAt100, scaledValue, 0.001f);
+		scaledValue = DPIUtil.autoScaleUp((Device) null, valueAt100, 100);
+		assertEquals("Scaling up integer without zoom change with device failed", valueAt100, scaledValue, 0.001f);
+	}
+
+	@Test
+	public void scaleUpPoint() {
+		Point valueAt200 = new Point(10, 14);
+		Point valueAt150 = new Point(8, 11);
+		Point valueAt100 = new Point(5, 7);
+
+		Point scaledValue = DPIUtil.autoScaleUp(valueAt100);
+		assertEquals(String.format("Scaling up Point to device zoom (%d) to 100 failed", DPIUtil.getDeviceZoom()),
+				valueAt200, scaledValue);
+		scaledValue = DPIUtil.autoScaleUp((Device) null, valueAt100);
+		assertEquals(String.format("Scaling up Point to device zoom (%d) to 100 with device failed",
+				DPIUtil.getDeviceZoom()), valueAt200, scaledValue);
+
+		scaledValue = DPIUtil.autoScaleUp(valueAt100, 200);
+		assertEquals("Scaling up Point to 200 failed", valueAt200, scaledValue);
+		scaledValue = DPIUtil.autoScaleUp((Device) null, valueAt100, 200);
+		assertEquals("Scaling up Point to 200 with device failed", valueAt200, scaledValue);
+		scaledValue = DPIUtil.autoScaleUp(valueAt100, 150);
+		assertEquals("Scaling up Point to 150 failed", valueAt150, scaledValue);
+		scaledValue = DPIUtil.autoScaleUp((Device) null, valueAt100, 150);
+		assertEquals("Scaling up Point to 150 with device failed", valueAt150, scaledValue);
+		scaledValue = DPIUtil.autoScaleUp(valueAt100, 100);
+		assertSame("Scaling up Point without zoom change failed", valueAt100, scaledValue);
+		scaledValue = DPIUtil.autoScaleUp((Device) null, valueAt100, 100);
+		assertSame("Scaling up Point without zoom change with device failed", valueAt100, scaledValue);
+	}
+
+	@Test
+	public void scaleUpRectangle() {
+		Rectangle valueAt200 = new Rectangle(100, 150, 10, 14);
+		Rectangle valueAt150 = new Rectangle(75, 113, 8, 10);
+		Rectangle valueAt100 = new Rectangle(50, 75, 5, 7);
+
+		Rectangle scaledValue = DPIUtil.autoScaleUp(valueAt100);
+		assertEquals(
+				String.format("Scaling up Rectangle to device zoom (%d) to 100 failed", DPIUtil.getDeviceZoom()),
+				valueAt200, scaledValue);
+		scaledValue = DPIUtil.autoScaleUp((Device) null, valueAt100);
+		assertEquals(String.format("Scaling up Rectangle to device zoom (%d) to 100 with device failed",
+				DPIUtil.getDeviceZoom()), valueAt200, scaledValue);
+
+		scaledValue = DPIUtil.autoScaleUp(valueAt100, 200);
+		assertEquals("Scaling up Rectangle to 200 failed", valueAt200, scaledValue);
+		scaledValue = DPIUtil.autoScaleUp((Device) null, valueAt100, 200);
+		assertEquals("Scaling up Rectangle to 200 with device failed", valueAt200, scaledValue);
+		scaledValue = DPIUtil.autoScaleUp(valueAt100, 150);
+		assertEquals("Scaling up Rectangle to 150 failed", valueAt150, scaledValue);
+		scaledValue = DPIUtil.autoScaleUp((Device) null, valueAt100, 150);
+		assertEquals("Scaling up Rectangle to 150 with device failed", valueAt150, scaledValue);
+		scaledValue = DPIUtil.autoScaleUp(valueAt100, 100);
+		assertSame("Scaling up Rectangle without zoom change failed", valueAt100, scaledValue);
+		scaledValue = DPIUtil.autoScaleUp((Device) null, valueAt100, 100);
+		assertSame("Scaling up Rectangle without zoom change with device failed", valueAt100, scaledValue);
+	}
+}


### PR DESCRIPTION
For our ongoing work to improve the HiDPI support in the Windows implementation, we are currently working on #131. We need adaptions on DPIUtil to be able to directly pass the target zoom for the up and down scaling utility methods. To provide small PRs for different components, I'd like to contribute our changes on DPIUtil seperately and in advance because they will be needed in all following PRs.
In summary, this contribution adds additional methods to scale different datatypes up or down by passing the target zoom level as parameter. All existing methods will delegate to the added methods and pass DPIUtil::deviceZoom as zoom.