### PR TITLE
Adapt GitHub Actions configuration to execute MacOS on x86_64 image

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -31,7 +31,7 @@ jobs:
         config: 
           - { name: Linux, os: ubuntu-latest, native: gtk.linux.x86_64 }
           - { name: Windows, os: windows-latest, native: win32.win32.x86_64 }
-          - { name: MacOS, os: macos-latest, native: cocoa.macosx.x86_64 }
+          - { name: MacOS, os: macos-latest-large, native: cocoa.macosx.x86_64 }
     name: Verify ${{ matrix.config.name }} with Java-${{ matrix.java }}
     steps:
     - name: checkout swt


### PR DESCRIPTION
<s>GitHub Actions changed their latest images for MacOS to use the AArch64 instead of the x86_64 architecture. The SWT tests are currently failing because they still assume `macos-latest` to be an x86_64 architecture and therefore use the according SWT binaries.

With this change, the proper SWT binaries (AArch64) are used for the MacOS image.

As an alternative, we could use the `macos-latest-large` image, which uses latest x86_64, but since for Mac devices AArch64 is becoming kind of the new normal, I would propose to stick to `macos-latest` and use the according binaries instead. Feel free to share your opinion on this.</s>

GitHub Actions changed their latest images for MacOS to use the aarch64 instead of the x86_64 architecture. The SWT tests are currently failing because they still assume macos-latest to be an x86_64 architecture and therefore use the according SWT binaries.

With this change, the used GitHub actions runner is changed from macos-latest to macos-latest-large to ensure that still the x86_64 build is used. This is supposed to restore the existing purpose of the configuration. Changing to or adding an aarch64 runner for MacOS can be done subsequently.

See also https://github.com/actions/runner-images