### PR TITLE
Reduce Win32 FontRegistries visibility and move tests inside fragment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 bin/
+bin_test/
 *.log
 target/
 /.project

--- a/binaries/.classpath_win32
+++ b/binaries/.classpath_win32
@@ -25,5 +25,11 @@
 	<classpathentry kind="src" path="Eclipse SWT Browser/win32"/>
 	<classpathentry kind="src" path="Eclipse SWT OpenGL/win32"/>
 	<classpathentry kind="src" path="Eclipse SWT OpenGL/common"/>
+	<classpathentry kind="src" output="bin_test" path="Eclipse SWT Tests/win32">
+		<attributes>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/5"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/binaries/org.eclipse.swt.win32.win32.aarch64/.project
+++ b/binaries/org.eclipse.swt.win32.win32.aarch64/.project
@@ -107,6 +107,12 @@
 			<type>2</type>
 			<locationURI>SWT_HOST_PLUGIN/Eclipse%20SWT%20WebKit</locationURI>
 		</link>
+		<link>
+			<name>Eclipse SWT Tests</name>
+			<type>2</type>
+			<!-- Once Tycho supports custom variables, SWT_HOST_PLUGIN should be used here: https://github.com/eclipse-tycho/tycho/issues/3820 -->
+			<locationURI>PARENT-2-PROJECT_LOC/bundles/org.eclipse.swt/Eclipse%20SWT%20Tests</locationURI>
+		</link>
 	</linkedResources>
 	<variableList>
 		<variable>

--- a/binaries/org.eclipse.swt.win32.win32.x86_64/.project
+++ b/binaries/org.eclipse.swt.win32.win32.x86_64/.project
@@ -107,6 +107,12 @@
 			<type>2</type>
 			<locationURI>SWT_HOST_PLUGIN/Eclipse%20SWT%20WebKit</locationURI>
 		</link>
+		<link>
+			<name>Eclipse SWT Tests</name>
+			<type>2</type>
+			<!-- Once Tycho supports custom variables, SWT_HOST_PLUGIN should be used here: https://github.com/eclipse-tycho/tycho/issues/3820 -->
+			<locationURI>PARENT-2-PROJECT_LOC/bundles/org.eclipse.swt/Eclipse%20SWT%20Tests</locationURI>
+		</link>
 	</linkedResources>
 	<variableList>
 		<variable>

--- a/binaries/pom.xml
+++ b/binaries/pom.xml
@@ -45,6 +45,25 @@
 	<build>
 		<plugins>
 			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<dependencies>
+					<dependency>
+						<groupId>org.apache.maven.surefire</groupId>
+						<artifactId>surefire-junit-platform</artifactId>
+						<version>3.2.5</version>
+					</dependency>
+				</dependencies>
+				<executions>
+					<execution>
+						<id>execute-tests</id>
+						<goals>
+							<goal>test</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
 				<groupId>org.eclipse.tycho</groupId>
 				<artifactId>tycho-apitools-plugin</artifactId>
 				<version>${tycho.version}</version>

--- a/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/internal/DefaultSWTFontRegistryTests.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/internal/DefaultSWTFontRegistryTests.java
@@ -22,12 +22,18 @@ import org.eclipse.swt.graphics.FontData;
 import org.eclipse.swt.widgets.Display;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 public class DefaultSWTFontRegistryTests {
 	private static String TEST_FONT = "Helvetica";
 	private Display display;
 	private SWTFontRegistry fontRegistry;
+
+	@BeforeClass
+	public static void assumeIsFittingPlatform() {
+		PlatformSpecificExecution.assumeIsFittingPlatform();
+	}
 
 	@Before
 	public void setUp() {

--- a/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/internal/PlatformSpecificExecution.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/internal/PlatformSpecificExecution.java
@@ -1,0 +1,28 @@
+package org.eclipse.swt.internal;
+
+import static org.junit.Assume.assumeTrue;
+
+import java.net.*;
+
+public final class PlatformSpecificExecution {
+	private PlatformSpecificExecution()  {
+	}
+
+	public static void assumeIsFittingPlatform() {
+		assumeTrue("test is specific for Windows", isFittingOS());
+		assumeTrue("architecture of platform does not match", isFittingArchitecture());
+	}
+
+	private static boolean isFittingOS() {
+		return Library.os().equals("win32");
+	}
+
+	private static boolean isFittingArchitecture() {
+		Class<?> thisClass = PlatformSpecificExecution.class;
+		String thisClassResourcePath = thisClass.getName().replace('.', '/')  + ".class";
+		URL thisClassURL = thisClass.getClassLoader().getResource(thisClassResourcePath); //$NON-NLS-1$
+		return thisClassURL.toString().contains(Library.arch());
+	}
+
+}
+

--- a/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/internal/ScalingSWTFontRegistryTests.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/internal/ScalingSWTFontRegistryTests.java
@@ -23,11 +23,17 @@ import org.eclipse.swt.graphics.FontData;
 import org.eclipse.swt.widgets.Display;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 public class ScalingSWTFontRegistryTests {
 	private static String TEST_FONT = "Helvetica";
 	private SWTFontRegistry fontRegistry;
+
+	@BeforeClass
+	public static void assumeIsFittingPlatform() {
+		PlatformSpecificExecution.assumeIsFittingPlatform();
+	}
 
 	@Before
 	public void setUp() {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/DefaultSWTFontRegistry.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/DefaultSWTFontRegistry.java
@@ -25,16 +25,13 @@ import org.eclipse.swt.internal.win32.*;
  * As this class is only intended to be used internally via {@code SWTFontProvider},
  * it should neither be instantiated nor referenced in a client application.
  * The behavior can change any time in a future release.
- *
- * @noreference This class is not intended to be referenced by clients.
- * @noinstantiate This class is not intended to be instantiated by clients.
  */
-public final class DefaultSWTFontRegistry implements SWTFontRegistry {
+final class DefaultSWTFontRegistry implements SWTFontRegistry {
 	private static FontData KEY_SYSTEM_FONTS = new FontData();
 	private Map<FontData, Font> fontsMap = new HashMap<>();
 	private Device device;
 
-	public DefaultSWTFontRegistry(Device device) {
+	DefaultSWTFontRegistry(Device device) {
 		this.device = device;
 	}
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/ScalingSWTFontRegistry.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/ScalingSWTFontRegistry.java
@@ -26,11 +26,8 @@ import org.eclipse.swt.internal.win32.*;
  * As this class is only intended to be used internally via {@code SWTFontProvider},
  * it should neither be instantiated nor referenced in a client application.
  * The behavior can change any time in a future release.
- *
- * @noreference This class is not intended to be referenced by clients.
- * @noinstantiate This class is not intended to be instantiated by clients.
  */
-public final class ScalingSWTFontRegistry implements SWTFontRegistry {
+final class ScalingSWTFontRegistry implements SWTFontRegistry {
 	private class ScaledFontContainer {
 		// the first (unknown) font to be requested as scaled variant
 		// usually it is scaled to the primary monitor zoom, but that is not guaranteed
@@ -72,7 +69,7 @@ public final class ScalingSWTFontRegistry implements SWTFontRegistry {
 	private Map<FontData, ScaledFontContainer> fontKeyMap = new HashMap<>();
 	private Device device;
 
-	public ScalingSWTFontRegistry(Device device) {
+	ScalingSWTFontRegistry(Device device) {
 		this.device = device;
 	}
 

--- a/tests/org.eclipse.swt.tests.win32/JUnit Tests/org/eclipse/swt/tests/win32/AllWin32Tests.java
+++ b/tests/org.eclipse.swt.tests.win32/JUnit Tests/org/eclipse/swt/tests/win32/AllWin32Tests.java
@@ -15,20 +15,15 @@
 package org.eclipse.swt.tests.win32;
 
 import org.eclipse.swt.graphics.ImageWin32Tests;
-import org.eclipse.swt.internal.DefaultSWTFontRegistryTests;
-import org.eclipse.swt.internal.ScalingSWTFontRegistryTests;
 import org.eclipse.swt.tests.win32.widgets.TestTreeColumn;
 import org.eclipse.swt.tests.win32.widgets.Test_org_eclipse_swt_widgets_Display;
 import org.junit.runner.JUnitCore;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 
-
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
-	DefaultSWTFontRegistryTests.class,
 	ImageWin32Tests.class,
-	ScalingSWTFontRegistryTests.class,
 	Test_org_eclipse_swt_dnd_DND.class,
 	Test_org_eclipse_swt_events_KeyEvent.class,
 	Test_org_eclipse_swt_widgets_Display.class,


### PR DESCRIPTION
The classes DefaultSWTFontRegistry and ScalingSWTFontRegistry are currently public only to make them testable from a test bundle. There is currently no pre-configured way to implement unit tests for classes that are not directly accessible via public API.

With this change, the SWT Win32 fragments are extended by a configuration for providing fragment-internal unit tests executed with plain Maven surefire, which can access the classes under test even with reduced visibility. Due to current limitations in Tycho (see https://github.com/eclipse-tycho/tycho/issues/3803), an according temporary extension to the Maven configuration for the binaries projects is made. This configuration is applied to the tests for the DefaultSWTFontRegistry and ScalingSWTFontRegistry, such that their visibilities can properly be reduced to package visibility.