### PR TITLE
Extend GitHub actions configuration matrix for MacOS AArch64 build

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -31,7 +31,8 @@ jobs:
         config: 
           - { name: Linux, os: ubuntu-latest, native: gtk.linux.x86_64 }
           - { name: Windows, os: windows-latest, native: win32.win32.x86_64 }
-          - { name: MacOS, os: macos-latest-large, native: cocoa.macosx.x86_64 }
+          - { name: MacOS x86, os: macos-latest-large, native: cocoa.macosx.x86_64 }
+          - { name: MacOS ARM, os: macos-latest, native: cocoa.macosx.aarch64 }
     name: Verify ${{ matrix.config.name }} with Java-${{ matrix.java }}
     steps:
     - name: checkout swt

--- a/pom.xml
+++ b/pom.xml
@@ -100,12 +100,7 @@
                 <environment>
                   <os>macosx</os>
                   <ws>cocoa</ws>
-                  <arch>x86_64</arch>
-                </environment>
-                <environment>
-                  <os>macosx</os>
-                  <ws>cocoa</ws>
-                  <arch>aarch64</arch>
+                  <arch>${os.arch}</arch>
                 </environment>
               </environments>
             </configuration>


### PR DESCRIPTION
GitHub provides aarch64 runners for MacOS and has recently made them even the default runners for MacOS. In order to also validate on aarch64 in addition to x86_64, this change extends the build configuration matrix to also be executed on a MacOS aarch64 runner.