### PR TITLE
Adapt GetSystemMetrics call to be DPI dependent

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Button.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Button.java
@@ -54,24 +54,13 @@ public class Button extends Control {
 	ImageList imageList;
 	boolean ignoreMouse, grayed, useDarkModeExplorerTheme;
 	static final int MARGIN = 4;
-	static final int CHECK_WIDTH, CHECK_HEIGHT;
+	private final int checkWidth, checkHeight;
 	static final int ICON_WIDTH = 128, ICON_HEIGHT = 128;
 	static /*final*/ boolean COMMAND_LINK = false;
 	static final char[] STRING_WITH_ZERO_CHAR = new char[] {'0'};
 	static final long ButtonProc;
 	static final TCHAR ButtonClass = new TCHAR (0, "BUTTON", true);
 	static {
-		long hBitmap = OS.LoadBitmap (0, OS.OBM_CHECKBOXES);
-		if (hBitmap == 0) {
-			CHECK_WIDTH = OS.GetSystemMetrics (OS.SM_CXVSCROLL);
-			CHECK_HEIGHT = OS.GetSystemMetrics (OS.SM_CYVSCROLL);
-		} else {
-			BITMAP bitmap = new BITMAP ();
-			OS.GetObject (hBitmap, BITMAP.sizeof, bitmap);
-			OS.DeleteObject (hBitmap);
-			CHECK_WIDTH = bitmap.bmWidth / 4;
-			CHECK_HEIGHT =  bitmap.bmHeight / 3;
-		}
 		WNDCLASS lpWndClass = new WNDCLASS ();
 		OS.GetClassInfo (0, ButtonClass, lpWndClass);
 		ButtonProc = lpWndClass.lpfnWndProc;
@@ -119,6 +108,17 @@ public class Button extends Control {
  */
 public Button (Composite parent, int style) {
 	super (parent, checkStyle (style));
+	long hBitmap = OS.LoadBitmap (0, OS.OBM_CHECKBOXES);
+	if (hBitmap == 0) {
+		checkWidth = getSystemMetrics(OS.SM_CXVSCROLL);
+		checkHeight = getSystemMetrics (OS.SM_CYVSCROLL);
+	} else {
+		BITMAP bitmap = new BITMAP ();
+		OS.GetObject (hBitmap, BITMAP.sizeof, bitmap);
+		OS.DeleteObject (hBitmap);
+		checkWidth = bitmap.bmWidth / 4;
+		checkHeight =  bitmap.bmHeight / 3;
+	}
 }
 
 void _setImage (Image image) {
@@ -315,11 +315,11 @@ int computeLeftMargin () {
 	int width = 0, height = 0, border = getBorderWidthInPixels ();
 	if ((style & SWT.ARROW) != 0) {
 		if ((style & (SWT.UP | SWT.DOWN)) != 0) {
-			width += OS.GetSystemMetrics (OS.SM_CXVSCROLL);
-			height += OS.GetSystemMetrics (OS.SM_CYVSCROLL);
+			width += getSystemMetrics (OS.SM_CXVSCROLL);
+			height += getSystemMetrics (OS.SM_CYVSCROLL);
 		} else {
-			width += OS.GetSystemMetrics (OS.SM_CXHSCROLL);
-			height += OS.GetSystemMetrics (OS.SM_CYHSCROLL);
+			width += getSystemMetrics (OS.SM_CXHSCROLL);
+			height += getSystemMetrics (OS.SM_CYHSCROLL);
 		}
 	} else {
 		if ((style & SWT.COMMAND) != 0) {
@@ -373,7 +373,7 @@ int computeLeftMargin () {
 						flags = OS.DT_CALCRECT | OS.DT_WORDBREAK;
 						rect.right = wHint - width - 2 * border;
 						if (isRadioOrCheck()) {
-							rect.right -= CHECK_WIDTH + 3;
+							rect.right -= checkWidth + 3;
 						} else {
 							rect.right -= 6;
 						}
@@ -392,8 +392,8 @@ int computeLeftMargin () {
 				OS.ReleaseDC (handle, hDC);
 			}
 			if (isRadioOrCheck()) {
-				width += CHECK_WIDTH + extra;
-				height = Math.max (height, CHECK_HEIGHT + 3);
+				width += checkWidth + extra;
+				height = Math.max (height, checkHeight + 3);
 			}
 			if ((style & (SWT.PUSH | SWT.TOGGLE)) != 0) {
 				width += 12;  height += 10;

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Combo.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Combo.java
@@ -655,8 +655,8 @@ public void clearSelection () {
 		width += pcbi.itemLeft + (pcbi.buttonRight - pcbi.buttonLeft);
 		height = (pcbi.buttonBottom - pcbi.buttonTop) + pcbi.buttonTop * 2;
 	} else {
-		int border = OS.GetSystemMetrics (OS.SM_CXEDGE);
-		width += OS.GetSystemMetrics (OS.SM_CXVSCROLL) + border * 2;
+		int border = getSystemMetrics (OS.SM_CXEDGE);
+		width += getSystemMetrics (OS.SM_CXVSCROLL) + border * 2;
 		int textHeight = (int)OS.SendMessage (handle, OS.CB_GETITEMHEIGHT, -1, 0);
 		if ((style & SWT.DROP_DOWN) != 0) {
 			height = textHeight + 6;
@@ -665,7 +665,7 @@ public void clearSelection () {
 		}
 	}
 	if ((style & SWT.SIMPLE) != 0 && (style & SWT.H_SCROLL) != 0) {
-		height += OS.GetSystemMetrics (OS.SM_CYHSCROLL);
+		height += getSystemMetrics (OS.SM_CYHSCROLL);
 	}
 	return new Point (width, height);
 }
@@ -2188,7 +2188,7 @@ void setScrollWidth (int scrollWidth) {
 		OS.SendMessage (handle, OS.CB_SETDROPPEDWIDTH, 0, 0);
 		OS.SendMessage (handle, OS.CB_SETHORIZONTALEXTENT, scrollWidth, 0);
 	} else {
-		scrollWidth += OS.GetSystemMetrics (OS.SM_CYHSCROLL);
+		scrollWidth += getSystemMetrics (OS.SM_CYHSCROLL);
 		OS.SendMessage (handle, OS.CB_SETDROPPEDWIDTH, scrollWidth, 0);
 		OS.SendMessage (handle, OS.CB_SETHORIZONTALEXTENT, 0, 0);
 	}

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Composite.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Composite.java
@@ -1854,7 +1854,7 @@ LRESULT wmNCPaint (long hwnd, long wParam, long lParam) {
 				rect.right -= rect.left;
 				rect.bottom -= rect.top;
 				rect.left = rect.top = 0;
-				int border = OS.GetSystemMetrics (OS.SM_CXEDGE);
+				int border = getSystemMetrics (OS.SM_CXEDGE);
 				OS.ExcludeClipRect (hDC, border, border, rect.right - border, rect.bottom - border);
 				OS.DrawThemeBackground (display.hEditTheme (), hDC, OS.EP_EDITTEXT, OS.ETS_NORMAL, rect, null);
 				OS.ReleaseDC (hwnd, hDC);

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Control.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Control.java
@@ -680,7 +680,7 @@ void createHandle () {
 }
 
 void checkGesture () {
-	int value = OS.GetSystemMetrics (OS.SM_DIGITIZER);
+	int value =getSystemMetrics (OS.SM_DIGITIZER);
 	if ((value & (OS.NID_READY | OS.NID_MULTI_INPUT)) != 0) {
 		/*
 		 * Feature in Windows 7: All gestures are enabled by default except GID_ROTATE.
@@ -1161,8 +1161,8 @@ public int getBorderWidth () {
 int getBorderWidthInPixels () {
 	long borderHandle = borderHandle ();
 	int bits1 = OS.GetWindowLong (borderHandle, OS.GWL_EXSTYLE);
-	if ((bits1 & OS.WS_EX_CLIENTEDGE) != 0) return OS.GetSystemMetrics (OS.SM_CXEDGE);
-	if ((bits1 & OS.WS_EX_STATICEDGE) != 0) return OS.GetSystemMetrics (OS.SM_CXBORDER);
+	if ((bits1 & OS.WS_EX_CLIENTEDGE) != 0) return getSystemMetrics (OS.SM_CXEDGE);
+	if ((bits1 & OS.WS_EX_STATICEDGE) != 0) return getSystemMetrics (OS.SM_CXBORDER);
 	int bits2 = OS.GetWindowLong (borderHandle, OS.GWL_STYLE);
 
 	if ((bits2 & OS.WS_BORDER) != 0) {
@@ -1172,9 +1172,9 @@ int getBorderWidthInPixels () {
 		 * saves screen space, but could break some layouts.
 		 */
 		if (isUseWsBorder ())
-			return OS.GetSystemMetrics (OS.SM_CXEDGE);
+			return getSystemMetrics (OS.SM_CXEDGE);
 
-		return OS.GetSystemMetrics (OS.SM_CXBORDER);
+		return getSystemMetrics (OS.SM_CXBORDER);
 	}
 
 	return 0;
@@ -2284,10 +2284,10 @@ void printWidget (long hwnd, long hdc, GC gc) {
 			hwndInsertAfter = OS.HWND_TOP;
 		}
 		if (fixPrintWindow) {
-			int x = OS.GetSystemMetrics (OS.SM_XVIRTUALSCREEN);
-			int y = OS.GetSystemMetrics (OS.SM_YVIRTUALSCREEN);
-			int width = OS.GetSystemMetrics (OS.SM_CXVIRTUALSCREEN);
-			int height = OS.GetSystemMetrics (OS.SM_CYVIRTUALSCREEN);
+			int x =getSystemMetrics (OS.SM_XVIRTUALSCREEN);
+			int y =getSystemMetrics (OS.SM_YVIRTUALSCREEN);
+			int width =getSystemMetrics (OS.SM_CXVIRTUALSCREEN);
+			int height =getSystemMetrics (OS.SM_CYVIRTUALSCREEN);
 			int flags = OS.SWP_NOSIZE | OS.SWP_NOZORDER | OS.SWP_NOACTIVATE | OS.SWP_DRAWFRAME;
 			if ((bits1 & OS.WS_VISIBLE) != 0) {
 				OS.DefWindowProc (hwnd, OS.WM_SETREDRAW, 0, 0);

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/DateTime.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/DateTime.java
@@ -238,7 +238,7 @@ protected void checkSubclass () {
 			width = size.cx;
 			height = size.cy;
 			// TODO: Can maybe use DTM_GETDATETIMEPICKERINFO for this
-			int upDownHeight = OS.GetSystemMetrics (OS.SM_CYVSCROLL) + 7;
+			int upDownHeight = getSystemMetrics (OS.SM_CYVSCROLL) + 7;
 			height = Math.max (height, upDownHeight);
 		}
 	}

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Decorations.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Decorations.java
@@ -316,8 +316,8 @@ Control computeTabRoot () {
 	OS.AdjustWindowRectEx (rect, bits1, hasMenu, bits2);
 
 	/* Get the size of the scroll bars */
-	if (horizontalBar != null) rect.bottom += OS.GetSystemMetrics (OS.SM_CYHSCROLL);
-	if (verticalBar != null) rect.right += OS.GetSystemMetrics (OS.SM_CXVSCROLL);
+	if (horizontalBar != null) rect.bottom += getSystemMetrics (OS.SM_CYHSCROLL);
+	if (verticalBar != null) rect.right += getSystemMetrics (OS.SM_CXVSCROLL);
 
 	/* Compute the height of the menu bar */
 	if (hasMenu) {
@@ -326,7 +326,7 @@ Control computeTabRoot () {
 		OS.SendMessage (handle, OS.WM_NCCALCSIZE, 0, testRect);
 		while ((testRect.bottom - testRect.top) < height) {
 			if (testRect.bottom - testRect.top == 0) break;
-			rect.top -= OS.GetSystemMetrics (OS.SM_CYMENU) - OS.GetSystemMetrics (OS.SM_CYBORDER);
+			rect.top -= getSystemMetrics (OS.SM_CYMENU) - getSystemMetrics (OS.SM_CYBORDER);
 			OS.SetRect (testRect, 0, 0, rect.right - rect.left, rect.bottom - rect.top);
 			OS.SendMessage (handle, OS.WM_NCCALCSIZE, 0, testRect);
 		}
@@ -466,8 +466,8 @@ void fixDecorations (Decorations newDecorations, Control control, Menu [] menus)
 		* the window restored.  There is no fix for this problem at
 		* this time.
 		*/
-		if (horizontalBar != null) width -= OS.GetSystemMetrics (OS.SM_CYHSCROLL);
-		if (verticalBar != null) height -= OS.GetSystemMetrics (OS.SM_CXVSCROLL);
+		if (horizontalBar != null) width -= getSystemMetrics (OS.SM_CYHSCROLL);
+		if (verticalBar != null) height -= getSystemMetrics (OS.SM_CXVSCROLL);
 		RECT rect = new RECT ();
 		int bits1 = OS.GetWindowLong (handle, OS.GWL_STYLE);
 		int bits2 = OS.GetWindowLong (handle, OS.GWL_EXSTYLE);
@@ -902,11 +902,11 @@ void setImages (Image image, Image [] images) {
 					datas [i] = images [i].getImageData (getZoom());
 				}
 				images = bestImages;
-				sort (images, datas, OS.GetSystemMetrics (OS.SM_CXSMICON), OS.GetSystemMetrics (OS.SM_CYSMICON), depth);
+				sort (images, datas, getSystemMetrics (OS.SM_CXSMICON), getSystemMetrics (OS.SM_CYSMICON), depth);
 			}
 			smallIcon = images [0];
 			if (images.length > 1) {
-				sort (images, datas, OS.GetSystemMetrics (OS.SM_CXICON), OS.GetSystemMetrics (OS.SM_CYICON), depth);
+				sort (images, datas, getSystemMetrics (OS.SM_CXICON), getSystemMetrics (OS.SM_CYICON), depth);
 			}
 			largeIcon = images [0];
 		}

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Label.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Label.java
@@ -135,7 +135,7 @@ static int checkStyle (int style) {
 	checkWidget ();
 	int width = 0, height = 0, border = getBorderWidthInPixels ();
 	if ((style & SWT.SEPARATOR) != 0) {
-		int lineWidth = OS.GetSystemMetrics (OS.SM_CXBORDER);
+		int lineWidth = getSystemMetrics (OS.SM_CXBORDER);
 		if ((style & SWT.HORIZONTAL) != 0) {
 			width = DEFAULT_WIDTH;  height = lineWidth * 2;
 		} else {
@@ -535,7 +535,7 @@ void wmDrawChildSeparator(DRAWITEMSTRUCT struct) {
 	if ((style & SWT.SHADOW_NONE) != 0) return;
 
 	RECT rect = new RECT ();
-	int lineWidth = OS.GetSystemMetrics (OS.SM_CXBORDER);
+	int lineWidth = getSystemMetrics (OS.SM_CXBORDER);
 	int flags = (style & SWT.SHADOW_IN) != 0 ? OS.EDGE_SUNKEN : OS.EDGE_ETCHED;
 	if ((style & SWT.HORIZONTAL) != 0) {
 		int bottom = struct.top + Math.max (lineWidth * 2, (struct.bottom - struct.top) / 2);

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/List.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/List.java
@@ -260,10 +260,10 @@ static int checkStyle (int style) {
 	width += border * 2 + INSET;
 	height += border * 2;
 	if ((style & SWT.V_SCROLL) != 0) {
-		width += OS.GetSystemMetrics (OS.SM_CXVSCROLL);
+		width += getSystemMetrics (OS.SM_CXVSCROLL);
 	}
 	if ((style & SWT.H_SCROLL) != 0) {
-		height += OS.GetSystemMetrics (OS.SM_CYHSCROLL);
+		height += getSystemMetrics (OS.SM_CYHSCROLL);
 	}
 	return new Point (width, height);
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Menu.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Menu.java
@@ -1354,7 +1354,7 @@ LRESULT wmTimer (long wParam, long lParam) {
 			if (!success) return null;
 			if (OS.PtInRect (rect, pt)) {
 				// Mouse cursor is within the bounds of menu item
-				selectedMenuItem.showTooltip (pt.x, pt.y + OS.GetSystemMetrics(OS.SM_CYCURSOR) / 2 + 5);
+				selectedMenuItem.showTooltip (pt.x, pt.y + getSystemMetrics(OS.SM_CYCURSOR) / 2 + 5);
 			} else {
 				/*
 				 * Mouse cursor is outside the bounds of the menu item:

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ProgressBar.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ProgressBar.java
@@ -123,11 +123,11 @@ static int checkStyle (int style) {
 	int border = getBorderWidthInPixels ();
 	int width = border * 2, height = border * 2;
 	if ((style & SWT.HORIZONTAL) != 0) {
-		width += OS.GetSystemMetrics (OS.SM_CXHSCROLL) * 10;
-		height += OS.GetSystemMetrics (OS.SM_CYHSCROLL);
+		width += getSystemMetrics (OS.SM_CXHSCROLL) * 10;
+		height += getSystemMetrics (OS.SM_CYHSCROLL);
 	} else {
-		width += OS.GetSystemMetrics (OS.SM_CXVSCROLL);
-		height += OS.GetSystemMetrics (OS.SM_CYVSCROLL) * 10;
+		width += getSystemMetrics (OS.SM_CXVSCROLL);
+		height += getSystemMetrics (OS.SM_CYVSCROLL) * 10;
 	}
 	if (wHint != SWT.DEFAULT) width = wHint + (border * 2);
 	if (hHint != SWT.DEFAULT) height = hHint + (border * 2);

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Scale.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Scale.java
@@ -150,13 +150,13 @@ static int checkStyle (int style) {
 	RECT rect = new RECT ();
 	OS.SendMessage (handle, OS.TBM_GETTHUMBRECT, 0, rect);
 	if ((style & SWT.HORIZONTAL) != 0) {
-		width += OS.GetSystemMetrics (OS.SM_CXHSCROLL) * 10;
-		int scrollY = OS.GetSystemMetrics (OS.SM_CYHSCROLL);
+		width += getSystemMetrics (OS.SM_CXHSCROLL) * 10;
+		int scrollY = getSystemMetrics (OS.SM_CYHSCROLL);
 		height += (rect.top * 2) + scrollY + (scrollY / 3);
 	} else {
-		int scrollX = OS.GetSystemMetrics (OS.SM_CXVSCROLL);
+		int scrollX = getSystemMetrics (OS.SM_CXVSCROLL);
 		width += (rect.left * 2) + scrollX + (scrollX / 3);
-		height += OS.GetSystemMetrics (OS.SM_CYVSCROLL) * 10;
+		height += getSystemMetrics (OS.SM_CYVSCROLL) * 10;
 	}
 	if (wHint != SWT.DEFAULT) width = wHint + (border * 2);
 	if (hHint != SWT.DEFAULT) height = hHint + (border * 2);

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ScrollBar.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ScrollBar.java
@@ -199,10 +199,10 @@ Rectangle getBounds () {
 	if ((style & SWT.HORIZONTAL) != 0) {
 		y = rect.bottom - rect.top;
 		width = rect.right - rect.left;
-		height = OS.GetSystemMetrics (OS.SM_CYHSCROLL);
+		height = getSystemMetrics (OS.SM_CYHSCROLL);
 	} else {
 		x = rect.right - rect.left;
-		width = OS.GetSystemMetrics (OS.SM_CXVSCROLL);
+		width = getSystemMetrics (OS.SM_CXVSCROLL);
 		height = rect.bottom - rect.top;
 	}
 	return new Rectangle (x, y, width, height);
@@ -365,9 +365,9 @@ Point getSizeInPixels () {
 	int width, height;
 	if ((style & SWT.HORIZONTAL) != 0) {
 		width = rect.right - rect.left;
-		height = OS.GetSystemMetrics (OS.SM_CYHSCROLL);
+		height = getSystemMetrics (OS.SM_CYHSCROLL);
 	} else {
-		width = OS.GetSystemMetrics (OS.SM_CXVSCROLL);
+		width = getSystemMetrics (OS.SM_CXVSCROLL);
 		height = rect.bottom - rect.top;
 	}
 	return new Point (width, height);
@@ -468,7 +468,7 @@ Rectangle getThumbTrackBoundsInPixels () {
 	int x = 0, y = 0, width, height;
 	if ((style & SWT.HORIZONTAL) != 0) {
 		OS.GetScrollBarInfo(parent.handle, OS.OBJID_HSCROLL, info);
-		int size = OS.GetSystemMetrics (OS.SM_CYHSCROLL);
+		int size = getSystemMetrics (OS.SM_CYHSCROLL);
 		y = info.rcScrollBar.top;
 		width = info.rcScrollBar.right - info.rcScrollBar.left;
 		height = size;
@@ -481,7 +481,7 @@ Rectangle getThumbTrackBoundsInPixels () {
 		}
 	} else {
 		OS.GetScrollBarInfo(parent.handle, OS.OBJID_VSCROLL, info);
-		int size = OS.GetSystemMetrics (OS.SM_CYVSCROLL);
+		int size = getSystemMetrics (OS.SM_CYVSCROLL);
 		x = info.rcScrollBar.left;
 		width = size;
 		height = info.rcScrollBar.bottom - info.rcScrollBar.top;

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Scrollable.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Scrollable.java
@@ -135,8 +135,8 @@ Rectangle computeTrimInPixels (int x, int y, int width, int height) {
 	int bits1 = OS.GetWindowLong (scrolledHandle, OS.GWL_STYLE);
 	int bits2 = OS.GetWindowLong (scrolledHandle, OS.GWL_EXSTYLE);
 	OS.AdjustWindowRectEx (rect, bits1, false, bits2);
-	if (horizontalBar != null) rect.bottom += OS.GetSystemMetrics (OS.SM_CYHSCROLL);
-	if (verticalBar != null) rect.right += OS.GetSystemMetrics (OS.SM_CXVSCROLL);
+	if (horizontalBar != null) rect.bottom += getSystemMetrics (OS.SM_CYHSCROLL);
+	if (verticalBar != null) rect.right += getSystemMetrics (OS.SM_CXVSCROLL);
 	int nWidth = rect.right - rect.left, nHeight = rect.bottom - rect.top;
 	return new Rectangle (rect.left, rect.top, nWidth, nHeight);
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Shell.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Shell.java
@@ -1063,12 +1063,12 @@ Point getMaximumSizeInPixels () {
 	int width = Math.min (Integer.MAX_VALUE, maxWidth);
 	int trim = SWT.TITLE | SWT.CLOSE | SWT.MIN | SWT.MAX;
 	if ((style & SWT.NO_TRIM) == 0 && (style & trim) != 0) {
-		width = Math.min (width, OS.GetSystemMetrics (OS.SM_CXMAXTRACK));
+		width = Math.min (width, getSystemMetrics (OS.SM_CXMAXTRACK));
 	}
 	int height = Math.min (Integer.MAX_VALUE, maxHeight);
 	if ((style & SWT.NO_TRIM) == 0 && (style & trim) != 0) {
 		if ((style & SWT.RESIZE) != 0) {
-			height = Math.min (height, OS.GetSystemMetrics (OS.SM_CYMAXTRACK));
+			height = Math.min (height, getSystemMetrics (OS.SM_CYMAXTRACK));
 		} else {
 			RECT rect = new RECT ();
 			int bits1 = OS.GetWindowLong (handle, OS.GWL_STYLE);
@@ -1104,12 +1104,12 @@ Point getMinimumSizeInPixels () {
 	int width = Math.max (0, minWidth);
 	int trim = SWT.TITLE | SWT.CLOSE | SWT.MIN | SWT.MAX;
 	if ((style & SWT.NO_TRIM) == 0 && (style & trim) != 0) {
-		width = Math.max (width, OS.GetSystemMetrics (OS.SM_CXMINTRACK));
+		width = Math.max (width, getSystemMetrics (OS.SM_CXMINTRACK));
 	}
 	int height = Math.max (0, minHeight);
 	if ((style & SWT.NO_TRIM) == 0 && (style & trim) != 0) {
 		if ((style & SWT.RESIZE) != 0) {
-			height = Math.max (height, OS.GetSystemMetrics (OS.SM_CYMINTRACK));
+			height = Math.max (height, getSystemMetrics (OS.SM_CYMINTRACK));
 		} else {
 			RECT rect = new RECT ();
 			int bits1 = OS.GetWindowLong (handle, OS.GWL_STYLE);
@@ -1775,9 +1775,9 @@ void setMaximumSizeInPixels (int width, int height) {
 	int widthLimit = 0, heightLimit = 0;
 	int trim = SWT.TITLE | SWT.CLOSE | SWT.MIN | SWT.MAX;
 	if ((style & SWT.NO_TRIM) == 0 && (style & trim) != 0) {
-		widthLimit = OS.GetSystemMetrics (OS.SM_CXMAXTRACK);
+		widthLimit = getSystemMetrics (OS.SM_CXMAXTRACK);
 		if ((style & SWT.RESIZE) != 0) {
-			heightLimit = OS.GetSystemMetrics (OS.SM_CYMAXTRACK);
+			heightLimit = getSystemMetrics (OS.SM_CYMAXTRACK);
 		} else {
 			RECT rect = new RECT ();
 			int bits1 = OS.GetWindowLong (handle, OS.GWL_STYLE);
@@ -1821,9 +1821,9 @@ void setMinimumSizeInPixels (int width, int height) {
 	int widthLimit = 0, heightLimit = 0;
 	int trim = SWT.TITLE | SWT.CLOSE | SWT.MIN | SWT.MAX;
 	if ((style & SWT.NO_TRIM) == 0 && (style & trim) != 0) {
-		widthLimit = OS.GetSystemMetrics (OS.SM_CXMINTRACK);
+		widthLimit = getSystemMetrics (OS.SM_CXMINTRACK);
 		if ((style & SWT.RESIZE) != 0) {
-			heightLimit = OS.GetSystemMetrics (OS.SM_CYMINTRACK);
+			heightLimit = getSystemMetrics (OS.SM_CYMINTRACK);
 		} else {
 			RECT rect = new RECT ();
 			int bits1 = OS.GetWindowLong (handle, OS.GWL_STYLE);
@@ -2628,12 +2628,12 @@ LRESULT WM_WINDOWPOSCHANGING (long wParam, long lParam) {
 		lpwp.cx = Math.max (lpwp.cx, minWidth);
 		int trim = SWT.TITLE | SWT.CLOSE | SWT.MIN | SWT.MAX;
 		if ((style & SWT.NO_TRIM) == 0 && (style & trim) != 0) {
-			lpwp.cx = Math.max (lpwp.cx, OS.GetSystemMetrics (OS.SM_CXMINTRACK));
+			lpwp.cx = Math.max (lpwp.cx, getSystemMetrics (OS.SM_CXMINTRACK));
 		}
 		lpwp.cy = Math.max (lpwp.cy, minHeight);
 		if ((style & SWT.NO_TRIM) == 0 && (style & trim) != 0) {
 			if ((style & SWT.RESIZE) != 0) {
-				lpwp.cy = Math.max (lpwp.cy, OS.GetSystemMetrics (OS.SM_CYMINTRACK));
+				lpwp.cy = Math.max (lpwp.cy, getSystemMetrics (OS.SM_CYMINTRACK));
 			} else {
 				RECT rect = new RECT ();
 				int bits1 = OS.GetWindowLong (handle, OS.GWL_STYLE);

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Slider.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Slider.java
@@ -181,11 +181,11 @@ static int checkStyle (int style) {
 	int border = getBorderWidthInPixels ();
 	int width = border * 2, height = border * 2;
 	if ((style & SWT.HORIZONTAL) != 0) {
-		width += OS.GetSystemMetrics (OS.SM_CXHSCROLL) * 10;
-		height += OS.GetSystemMetrics (OS.SM_CYHSCROLL);
+		width += getSystemMetrics (OS.SM_CXHSCROLL) * 10;
+		height += getSystemMetrics (OS.SM_CYHSCROLL);
 	} else {
-		width += OS.GetSystemMetrics (OS.SM_CXVSCROLL);
-		height += OS.GetSystemMetrics (OS.SM_CYVSCROLL) * 10;
+		width += getSystemMetrics (OS.SM_CXVSCROLL);
+		height += getSystemMetrics (OS.SM_CYVSCROLL) * 10;
 	}
 	if (wHint != SWT.DEFAULT) width = wHint + (border * 2);
 	if (hHint != SWT.DEFAULT) height = hHint + (border * 2);

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Spinner.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Spinner.java
@@ -296,7 +296,7 @@ void addVerifyListener (VerifyListener listener) {
 		height = hHint;
 	else {
 		int borderAdjustment = (style & SWT.BORDER) != 0 ? -1 : 3;
-		int upDownHeight = OS.GetSystemMetrics (OS.SM_CYVSCROLL);
+		int upDownHeight = getSystemMetrics (OS.SM_CYVSCROLL);
 		height = Math.max(height, upDownHeight + borderAdjustment);
 	}
 
@@ -339,7 +339,7 @@ void addVerifyListener (VerifyListener listener) {
 		width += 2;
 		height += 2;
 	}
-	width += OS.GetSystemMetrics (OS.SM_CXVSCROLL);
+	width += getSystemMetrics (OS.SM_CXVSCROLL);
 	return new Rectangle (x, y, width, height);
 }
 
@@ -1216,7 +1216,7 @@ LRESULT WM_SIZE (long wParam, long lParam) {
 	LRESULT result = super.WM_SIZE (wParam, lParam);
 	if (isDisposed ()) return result;
 	int width = OS.LOWORD (lParam), height = OS.HIWORD (lParam);
-	int upDownWidth = OS.GetSystemMetrics (OS.SM_CXVSCROLL) - 1;
+	int upDownWidth = getSystemMetrics (OS.SM_CXVSCROLL) - 1;
 	int textWidth = width - upDownWidth;
 
 	/*
@@ -1226,7 +1226,7 @@ LRESULT WM_SIZE (long wParam, long lParam) {
 	 */
 	int borderAdjustment = 0;
 	if (((style & SWT.BORDER) != 0) && !display.useWsBorderText) {
-		borderAdjustment = OS.GetSystemMetrics (OS.SM_CYEDGE) - OS.GetSystemMetrics (OS.SM_CYBORDER);
+		borderAdjustment = getSystemMetrics (OS.SM_CYEDGE) - getSystemMetrics (OS.SM_CYBORDER);
 		/* There is an unexplained 1px additional offset in Windows */
 		borderAdjustment++;
 	}

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Table.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Table.java
@@ -1479,10 +1479,10 @@ public void clearAll () {
 	int border = getBorderWidthInPixels ();
 	width += border * 2;  height += border * 2;
 	if ((style & SWT.V_SCROLL) != 0) {
-		width += OS.GetSystemMetrics (OS.SM_CXVSCROLL);
+		width += getSystemMetrics (OS.SM_CXVSCROLL);
 	}
 	if ((style & SWT.H_SCROLL) != 0) {
-		height += OS.GetSystemMetrics (OS.SM_CYHSCROLL);
+		height += getSystemMetrics (OS.SM_CYHSCROLL);
 	}
 	return new Point (width, height);
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Text.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Text.java
@@ -789,8 +789,8 @@ public void clearSelection () {
 
 		// When WS_BORDER is used instead of WS_EX_CLIENTEDGE, compensate the size difference
 		if (isUseWsBorder ()) {
-			int dx = OS.GetSystemMetrics (OS.SM_CXEDGE) - OS.GetSystemMetrics (OS.SM_CXBORDER);
-			int dy = OS.GetSystemMetrics (OS.SM_CYEDGE) - OS.GetSystemMetrics (OS.SM_CYBORDER);
+			int dx = getSystemMetrics (OS.SM_CXEDGE) - getSystemMetrics (OS.SM_CXBORDER);
+			int dy = getSystemMetrics (OS.SM_CYEDGE) - getSystemMetrics (OS.SM_CYBORDER);
 			rect.x -= dx;
 			rect.y -= dy;
 			rect.width += 2*dx;
@@ -969,15 +969,6 @@ void fixAlignment () {
 
 @Override int getBorderWidthInPixels () {
 	checkWidget ();
-	/*
-	* Feature in Windows 2000 and XP.  Despite the fact that WS_BORDER
-	* is set when the edit control is created, the style bit is cleared.
-	* The fix is to avoid the check for WS_BORDER and use the SWT widget
-	* style bits instead.
-	*/
-//	if ((style & SWT.BORDER) != 0 && (style & SWT.FLAT) != 0) {
-//		return OS.GetSystemMetrics (OS.SM_CXBORDER);
-//	}
 	return super.getBorderWidthInPixels ();
 }
 
@@ -2095,7 +2086,7 @@ void setMargins () {
 		if ((style & SWT.ICON_SEARCH) != 0) flags |= fLeading;
 		if ((style & SWT.ICON_CANCEL) != 0) flags |= fTrailing;
 		if (flags != 0) {
-			int iconWidth = OS.GetSystemMetrics (OS.SM_CXSMICON);
+			int iconWidth = getSystemMetrics (OS.SM_CXSMICON);
 			OS.SendMessage (handle, OS.EM_SETMARGINS, flags, OS.MAKELPARAM(iconWidth, iconWidth));
 		}
 	}
@@ -2958,7 +2949,7 @@ LRESULT WM_SIZE(long wParam, long lParam) {
 		long hwndTrailing = OS.GetDlgItem (handle, rtl ? SWT.ICON_SEARCH : SWT.ICON_CANCEL);
 		int width = OS.LOWORD (lParam);
 		int height = OS.HIWORD (lParam);
-		int iconWidth = OS.GetSystemMetrics (OS.SM_CXSMICON);
+		int iconWidth = getSystemMetrics (OS.SM_CXSMICON);
 		int flags = OS.SWP_NOZORDER | OS.SWP_NOACTIVATE | OS.SWP_NOCOPYBITS;
 		if (hwndLeading != 0) OS.SetWindowPos (hwndLeading, 0, 0, 0, iconWidth, height, flags);
 		if (hwndTrailing != 0) OS.SetWindowPos (hwndTrailing, 0, width - iconWidth, 0, iconWidth, height, flags);

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Tree.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Tree.java
@@ -1860,10 +1860,10 @@ long CompareFunc (long lParam1, long lParam2, long lParamSort) {
 	width += border * 2;
 	height += border * 2;
 	if ((style & SWT.V_SCROLL) != 0) {
-		width += OS.GetSystemMetrics (OS.SM_CXVSCROLL);
+		width += getSystemMetrics (OS.SM_CXVSCROLL);
 	}
 	if ((style & SWT.H_SCROLL) != 0) {
-		height += OS.GetSystemMetrics (OS.SM_CYHSCROLL);
+		height += getSystemMetrics (OS.SM_CYHSCROLL);
 	}
 	return new Point (width, height);
 }
@@ -5050,7 +5050,7 @@ void setScrollWidth (int width) {
 	if (playout.prc != 0) OS.HeapFree (hHeap, 0, playout.prc);
 	if (playout.pwpos != 0) OS.HeapFree (hHeap, 0, playout.pwpos);
 	OS.SetWindowPos (hwndHeader, OS.HWND_TOP, pos.x - left, pos.y, pos.cx + left, pos.cy, OS.SWP_NOACTIVATE);
-	int w = pos.cx + (columnCount == 0 && width == 0 ? 0 : OS.GetSystemMetrics (OS.SM_CXVSCROLL));
+	int w = pos.cx + (columnCount == 0 && width == 0 ? 0 : getSystemMetrics (OS.SM_CXVSCROLL));
 	int h = rect.bottom - rect.top - pos.cy;
 	boolean oldIgnore = ignoreResize;
 	ignoreResize = true;
@@ -8057,7 +8057,7 @@ LRESULT wmNotifyHeader (NMHDR hdr, long wParam, long lParam) {
 					int newX = rect.left + deltaX;
 					rect.right = Math.max (rect.right, rect.left + Math.abs (deltaX));
 					if (explorerTheme || (findImageControl () != null || hooks (SWT.MeasureItem) || hooks (SWT.EraseItem) || hooks (SWT.PaintItem))) {
-						rect.left -= OS.GetSystemMetrics (OS.SM_CXFOCUSBORDER);
+						rect.left -= getSystemMetrics (OS.SM_CXFOCUSBORDER);
 						OS.InvalidateRect (handle, rect, true);
 						OS.OffsetRect (rect, deltaX, 0);
 						OS.InvalidateRect (handle, rect, true);

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TreeColumn.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TreeColumn.java
@@ -392,7 +392,7 @@ public void pack () {
 		if (hwndHeader != 0) {
 			margin = (int)OS.SendMessage (hwndHeader, OS.HDM_GETBITMAPMARGIN, 0, 0);
 		} else {
-			margin = OS.GetSystemMetrics (OS.SM_CXEDGE) * 3;
+			margin = getSystemMetrics (OS.SM_CXEDGE) * 3;
 		}
 		headerWidth += margin * 2;
 	}

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Widget.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Widget.java
@@ -2344,7 +2344,7 @@ LRESULT wmPrint (long hwnd, long wParam, long lParam) {
 				rect.right -= rect.left;
 				rect.bottom -= rect.top;
 				rect.left = rect.top = 0;
-				int border = OS.GetSystemMetrics (OS.SM_CXEDGE);
+				int border = getSystemMetrics (OS.SM_CXEDGE);
 				OS.ExcludeClipRect (wParam, border, border, rect.right - border, rect.bottom - border);
 				OS.DrawThemeBackground (display.hEditTheme (), wParam, OS.EP_EDITTEXT, OS.ETS_NORMAL, rect, null);
 				return new LRESULT (code);
@@ -2659,4 +2659,16 @@ int getZoom() {
 private static void handleDPIChange(Widget widget, int newZoom, float scalingFactor) {
 	widget.nativeZoom = newZoom;
 }
+
+int getSystemMetrics(int nIndex) {
+	/*
+	 * DPI dependent metrics were introduced after 2016 version of windows 10
+	 */
+	if (OS.WIN32_BUILD >= OS.WIN32_BUILD_WIN10_1607) {
+		return OS.GetSystemMetricsForDpi(nIndex, DPIUtil.mapZoomToDPI(getZoom()));
+	}
+	return OS.GetSystemMetrics(nIndex);
+}
+
+
 }


### PR DESCRIPTION
**NOTE: these changes affect only _Windows_**

## What it does

Writing GetSystemMetrics method in Widget class so that the child controls can use it to get System Metrics to be DPI dependent. There are some visible affected areas (before and after zooming to 200 from 100) for which screenshots are attached. 

The OS.getSystemMetrics call had a slight issue in some of the controls i.e. Combo, List and Table. The values returned for scroll i.e. `OS.SM_CXVSCROLL` were independent of DPI. So moving the shell from smaller zoom level to higher zoom level we can see the visible difference in the scroll bar which is not visible in the latter part. 

If a scrollbar is shown or not could perhaps be a side effect in some scenarios, but the main reason for that change is that the correct value for scroolbar sizes are used when the size for the table is calculated. You'll see the effect in the following screenshot:

![image](https://github.com/eclipse-platform/eclipse.platform.swt/assets/49493944/2ed5e66c-3fd6-41b9-bf0a-e74d0227fb90)

Both are started on 100% and moved to 200% (That is when the screenshots were made). The left one uses OS.GetSystemMetrics, the right one uses OS.GetSystemMetricsForDpi. You'll see the left table is smaller, because it still uses the scrollbar sizes for the primary monitor (=OS.GetSystemMetrics)

## HOW TO TEST **(Windows only!)**

- Run the ControlExample 
- Add these lines in your vm arguments  
`-Dswt.autoScale=quarter`
`-Dswt.autoScale.updateOnRuntime=true`
- Open the SWT Controls view
- Switch to the tab "Combo"/"List"/"Table" 
- Change the size to 50x50 from Size section
- Move the window from 100 to 200 zoom level monitor
- See if gives more spacing to widget itself rather than scrollbar than before 

## EXPECTED BEHAVIOUR

None of the widgets should look out of order when changing the zoom level.

Contributes to #62 and #127: