### PR TITLE
Remove macos-large image from GitHub Actions configuration

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -31,7 +31,7 @@ jobs:
         config: 
           - { name: Linux, os: ubuntu-latest, native: gtk.linux.x86_64 }
           - { name: Windows, os: windows-latest, native: win32.win32.x86_64 }
-          - { name: MacOS x86, os: macos-latest-large, native: cocoa.macosx.x86_64 }
+          - { name: MacOS 13 x86, os: macos-13, native: cocoa.macosx.x86_64 }
           - { name: MacOS ARM, os: macos-latest, native: cocoa.macosx.aarch64 }
     name: Verify ${{ matrix.config.name }} with Java-${{ matrix.java }}
     steps:


### PR DESCRIPTION
The macos-large-* images currently produce costs which is why we are asked not to use them.

See mail by Frederic Gurr.