### PR TITLE
FileDialog & DirectoryDialog hang after closing them with opened menu

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/DirectoryDialog.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/DirectoryDialog.java
@@ -254,6 +254,7 @@ Optional<String> openNativeChooserDialog () {
 		result = Optional.ofNullable(selectedPath);
 	}
 	display.removeIdleProc ();
+	OS.g_object_unref(handle);
 	if (result.isPresent() || response == GTK.GTK_RESPONSE_CANCEL) {
 		return result;
 	}

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/FileDialog.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/FileDialog.java
@@ -412,6 +412,7 @@ Optional<String> openNativeChooserDialog () {
 		result = Optional.ofNullable(computeResultChooserDialog ());
 	}
 	display.removeIdleProc ();
+	OS.g_object_unref(handle);
 	if (result.isPresent() || response == GTK.GTK_RESPONSE_CANCEL) {
 		return result;
 	}

--- a/tests/org.eclipse.swt.tests.gtk/ManualTests/org/eclipse/swt/tests/gtk/snippets/Issue1062_FileChooserNativeDialog.java
+++ b/tests/org.eclipse.swt.tests.gtk/ManualTests/org/eclipse/swt/tests/gtk/snippets/Issue1062_FileChooserNativeDialog.java
@@ -1,0 +1,74 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Andrey Loskutov (loskutov@gmx.de) and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Andrey Loskutov (loskutov@gmx.de) - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.swt.tests.gtk.snippets;
+
+/*
+ * A handy snippet to test hanging File/Directory dialogs
+ */
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.events.SelectionAdapter;
+import org.eclipse.swt.events.SelectionEvent;
+import org.eclipse.swt.layout.FillLayout;
+import org.eclipse.swt.widgets.Button;
+import org.eclipse.swt.widgets.DirectoryDialog;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.FileDialog;
+import org.eclipse.swt.widgets.Label;
+import org.eclipse.swt.widgets.Shell;
+
+public class Issue1062_FileChooserNativeDialog {
+
+	public static void main(String[] args) {
+		Display display = new Display();
+		Shell shell = new Shell(display);
+		shell.setText("Issue1062_FileChooserNativeDialog");
+		shell.setLayout(new FillLayout(SWT.VERTICAL));
+		Label label = new Label(shell, SWT.WRAP);
+		label.setText("Click to open dialog, then right click on some file to open a menu and after that close dialog."
+				+ " The shell should not 'hang' after closing dialogs.");
+
+		Button button = new Button(shell, 0);
+		button.setText("Open File Dialog");
+		button.addSelectionListener(new SelectionAdapter() {
+			@Override
+			public void widgetSelected(SelectionEvent e) {
+				FileDialog dialog = new FileDialog(shell, SWT.OPEN);
+				dialog.setText("Right click to open a menu and after that try to close dialog");
+				String string = dialog.open();
+				System.out.println("Selected: " + string);
+			}
+		});
+
+		button = new Button(shell, 0);
+		button.setText("Open Directory Dialog");
+		button.addSelectionListener(new SelectionAdapter() {
+			@Override
+			public void widgetSelected(SelectionEvent e) {
+				DirectoryDialog dialog = new DirectoryDialog(shell, SWT.OPEN);
+				dialog.setText("Right click to open a menu and after that try to close dialog");
+				String string = dialog.open();
+				System.out.println("Selected: " + string);
+			}
+		});
+
+		shell.setSize(400, 200);
+		shell.open();
+		while (!shell.isDisposed()) {
+			if (!display.readAndDispatch())
+				display.sleep();
+		}
+		display.dispose();
+	}
+
+}


### PR DESCRIPTION
`gtk_file_chooser_native_new handle()` should be dereferenced after use as proposed in https://docs.gtk.org/gtk3/class.FileChooserNative.html.

Otherwise `gtk_native_dialog_run()` seem to continue to run (probably because the opened menu still references the dialog), with the effect that: `the recursive main loop gives the effect of a modal dialog (it prevents the user from interacting with other windows in the same window group while the dialog is run)`.

See https://docs.gtk.org/gtk3/method.NativeDialog.run.html

Fixes https://github.com/eclipse-platform/eclipse.platform.swt/issues/1062