### PR TITLE
Revert "Make requirement of o.e.swt for swt.win32.aarch64 temporarily optional"

### DIFF
--- a/bundles/org.eclipse.swt/META-INF/p2.inf
+++ b/bundles/org.eclipse.swt/META-INF/p2.inf
@@ -37,6 +37,5 @@ requires.7.filter = (&(osgi.os=macosx)(osgi.ws=cocoa)(osgi.arch=aarch64)(!(org.e
 
 requires.8.namespace = org.eclipse.equinox.p2.iu
 requires.8.name = org.eclipse.swt.win32.win32.aarch64
-requires.8.optional = true
 requires.8.range = [$version$,$version$]
 requires.8.filter = (&(osgi.os=win32)(osgi.ws=win32)(osgi.arch=aarch64)(!(org.eclipse.swt.buildtime=true)))

--- a/examples/org.eclipse.swt.examples.ole.win32/META-INF/p2.inf
+++ b/examples/org.eclipse.swt.examples.ole.win32/META-INF/p2.inf
@@ -6,6 +6,5 @@ requires.0.filter = (&(osgi.os=win32)(osgi.ws=win32)(osgi.arch=x86_64))
 
 requires.1.namespace = org.eclipse.equinox.p2.iu
 requires.1.name = org.eclipse.swt.win32.win32.aarch64
-requires.1.optional = true
 #requires.1.range = [$version$,$version$]
 requires.1.filter = (&(osgi.os=win32)(osgi.ws=win32)(osgi.arch=aarch64))


### PR DESCRIPTION
Now that an Equinox launcher is  available for Windows on ARM and the win32.aarch64 environment is activated in the Eclipse Maven build (see https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/1917), the requirement don't need to be optional anymore.

This reverts commit 5a79f9f370c4b378f46ef58b9e09e82f8729f7d9.

Part of https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/577

@chirontt FYI