### PR TITLE
Update coactions to use NodeJS v20

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -60,7 +60,7 @@ jobs:
       with:
         maven-version: 3.9.6
     - name: Build with Maven
-      uses: coactions/setup-xvfb@b6b4fcfb9f5a895edadc3bc76318fae0ac17c8b3 # v1.0.1
+      uses: coactions/setup-xvfb@90473c3ebc69533a1a6e0505c36511b69c8c3135 # v1.0.1
       with:
        run: >-
         mvn --batch-mode -V -U -e
@@ -76,7 +76,7 @@ jobs:
         clean install
     - name: Performance tests
       if: contains(github.event.pull_request.labels.*.name, 'performance')
-      uses: coactions/setup-xvfb@b6b4fcfb9f5a895edadc3bc76318fae0ac17c8b3 # v1.0.1
+      uses: coactions/setup-xvfb@90473c3ebc69533a1a6e0505c36511b69c8c3135 # v1.0.1
       with:
        run: >-
         mvn --batch-mode -V -U -e


### PR DESCRIPTION
GH Actions transitioned to Node 20 in Septmber 2023 and all projects should transition too (see:
https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/)

This gets rid of the warnings in the runs of GH Actions.