### PR TITLE
Revert "Set the selection to 1st CTabItem when it is created."

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CTabFolder.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CTabFolder.java
@@ -768,7 +768,6 @@ void createItem (CTabItem item, int index) {
 	priority = newPriority;
 
 	if (items.length == 1) {
-		setSelection(0);
 		updateFolder(UPDATE_TAB_HEIGHT | REDRAW);
 	} else {
 		updateFolder(REDRAW_TABS);


### PR DESCRIPTION
This reverts commit 49c04a7f17f50cd667c20c6400099e1e5e06a717 because it introduces regressions in client code.

See https://github.com/eclipse-platform/eclipse.platform.swt/issues/46#issuecomment-2107616850