### PR TITLE
Store nativeDeviceZoom in widgets instead of zoom for win32

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/GC.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/GC.java
@@ -996,7 +996,7 @@ public void drawImage (Image image, int srcX, int srcY, int srcWidth, int srcHei
 
 void drawImage(Image srcImage, int srcX, int srcY, int srcWidth, int srcHeight, int destX, int destY, int destWidth, int destHeight, boolean simple) {
 	/* Refresh Image as per zoom level, if required. */
-	srcImage.handleDPIChange(DPIUtil.getDeviceZoom());
+	srcImage.handleDPIChange(DPIUtil.getNativeDeviceZoom());
 	if (data.gdipGraphics != 0) {
 		//TODO - cache bitmap
 		long [] gdipImage = srcImage.createGdipImage();

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Caret.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Caret.java
@@ -475,7 +475,7 @@ public void setFont (Font font) {
 		error (SWT.ERROR_INVALID_ARGUMENT);
 	}
 	Shell shell = parent.getShell();
-	this.font = font == null ? null : Font.win32_new(font, shell.getNativeZoom());
+	this.font = font == null ? null : Font.win32_new(font, shell.nativeZoom);
 	if (hasFocus ()) setIMEFont ();
 }
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Control.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Control.java
@@ -717,7 +717,7 @@ int defaultBackground () {
 }
 
 long defaultFont() {
-	return display.getSystemFont(getShell().getNativeZoom()).handle;
+	return display.getSystemFont(getShell().nativeZoom).handle;
 }
 
 int defaultForeground () {
@@ -1309,7 +1309,7 @@ public Font getFont () {
 	if (font != null) return font;
 	long hFont = OS.SendMessage (handle, OS.WM_GETFONT, 0, 0);
 	if (hFont == 0) hFont = defaultFont ();
-	return Font.win32_new (display, hFont, getShell().getNativeZoom());
+	return Font.win32_new (display, hFont, getShell().nativeZoom);
 }
 
 /**
@@ -3314,7 +3314,7 @@ public void setCursor (Cursor cursor) {
 }
 
 void setDefaultFont () {
-	long hFont = display.getSystemFont (getShell().getNativeZoom()).handle;
+	long hFont = display.getSystemFont (getShell().nativeZoom).handle;
 	OS.SendMessage (handle, OS.WM_SETFONT, hFont, 0);
 }
 
@@ -3416,7 +3416,7 @@ public void setFont (Font font) {
 	Font newFont = font;
 	if (newFont != null) {
 		if (newFont.isDisposed()) error(SWT.ERROR_INVALID_ARGUMENT);
-		newFont = Font.win32_new(newFont, getShell().getNativeZoom());
+		newFont = Font.win32_new(newFont, getShell().nativeZoom);
 	}
 	long hFont = 0;
 	if (font != null) {
@@ -4686,9 +4686,9 @@ public boolean setParent (Composite parent) {
 	if (OS.SetParent (topHandle, parent.handle) == 0) return false;
 	this.parent = parent;
 	// If parent changed, zoom level might need to be adjusted
-	if (parent.getZoom() != getZoom()) {
-		int oldZoom = getZoom();
-		int newZoom = parent.getZoom();
+	if (parent.nativeZoom != nativeZoom) {
+		int oldZoom = nativeZoom;
+		int newZoom = parent.nativeZoom;
 		float scalingFactor = 1f * newZoom / oldZoom;
 		DPIZoomChangeRegistry.applyChange(this, newZoom, scalingFactor);
 	}
@@ -4884,21 +4884,19 @@ LRESULT WM_DESTROY (long wParam, long lParam) {
 
 LRESULT WM_DPICHANGED (long wParam, long lParam) {
 	// Map DPI to Zoom and compare
-	int nativeZoom = DPIUtil.mapDPIToZoom (OS.HIWORD (wParam));
-	int newSWTZoom = DPIUtil.getZoomForAutoscaleProperty (nativeZoom);
-	int oldSWTZoom = getShell().getZoom();
+	int newNativeZoom = DPIUtil.mapDPIToZoom (OS.HIWORD (wParam));
+	int oldNativeZoom = getShell().nativeZoom;
 
 	// Throw the DPI change event if zoom value changes
-	if (newSWTZoom != oldSWTZoom) {
+	if (newNativeZoom != oldNativeZoom) {
 		Event event = new Event();
 		event.type = SWT.ZoomChanged;
 		event.widget = this;
-		event.detail = newSWTZoom;
+		event.detail = newNativeZoom;
 		event.doit = true;
 
 		if (DPIUtil.isAutoScaleOnRuntimeActive()) {
-			DPIUtil.setDeviceZoom (nativeZoom);
-			getShell().setNativeZoom(nativeZoom);
+			DPIUtil.setDeviceZoom (newNativeZoom);
 		}
 
 		notifyListeners(SWT.ZoomChanged, event);
@@ -5791,7 +5789,7 @@ private static void handleDPIChange(Widget widget, int newZoom, float scalingFac
 	if (!(widget instanceof Control control)) {
 		return;
 	}
-	resizeFont(control, control.getShell().getNativeZoom());
+	resizeFont(control, control.getShell().nativeZoom);
 
 	Image image = control.getBackgroundImage();
 	if (image != null) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Shell.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Shell.java
@@ -125,7 +125,6 @@ public class Shell extends Decorations {
 	ToolTip [] toolTips;
 	long hwndMDIClient, lpstrTip, toolTipHandle, balloonTipHandle, menuItemToolTipHandle;
 	int minWidth = SWT.DEFAULT, minHeight = SWT.DEFAULT, maxWidth = SWT.DEFAULT, maxHeight = SWT.DEFAULT;
-	private int nativeZoom;
 	long [] brushes;
 	boolean showWithParent, fullScreen, wasMaximized, modified, center;
 	String toolTitle, balloonTitle;
@@ -301,18 +300,14 @@ Shell (Display display, Shell parent, int style, long handle, boolean embedded) 
 		state |= FOREIGN_HANDLE;
 	}
 
-	int shellZoom;
 	int shellNativeZoom;
 	if (parent != null) {
-		shellZoom = parent.getZoom();
-		shellNativeZoom = parent.getNativeZoom();
+		shellNativeZoom = parent.nativeZoom;
 	} else {
 		int mappedDPIZoom = getMonitor().getZoom();
-		shellZoom = DPIUtil.getZoomForAutoscaleProperty(mappedDPIZoom);
 		shellNativeZoom = mappedDPIZoom;
 	}
-	this.setZoom(shellZoom);
-	this.setNativeZoom(shellNativeZoom);
+	this.nativeZoom = shellNativeZoom;
 
 	reskinWidget();
 	createWidget ();
@@ -2650,20 +2645,10 @@ LRESULT WM_WINDOWPOSCHANGING (long wParam, long lParam) {
 	return result;
 }
 
-/**
- * The native zoom in % of the standard resolution the shell is scaled for
- */
-int getNativeZoom() {
-	return nativeZoom;
-}
-
-void setNativeZoom(int nativeZoom) {
-	this.nativeZoom = nativeZoom;
-}
-
 private void handleZoomEvent(Event event) {
-	float scalingFactor = 1f * event.detail / getZoom();
-	DPIZoomChangeRegistry.applyChange(this, event.detail, scalingFactor);
+	int newNativeZoom = event.detail;
+	float scalingFactor = 1f * DPIUtil.getZoomForAutoscaleProperty(newNativeZoom) / getZoom();
+	DPIZoomChangeRegistry.applyChange(this, newNativeZoom, scalingFactor);
 }
 
 private static void handleDPIChange(Widget widget, int newZoom, float scalingFactor) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TableItem.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TableItem.java
@@ -871,7 +871,7 @@ public void setFont (Font font){
 	}
 	Font oldFont = this.font;
 	Shell shell = parent.getShell();
-	Font newFont = (font == null ? font : Font.win32_new(font, shell.getNativeZoom()));
+	Font newFont = (font == null ? font : Font.win32_new(font, shell.nativeZoom));
 	if (oldFont == newFont) return;
 	this.font = newFont;
 	if (oldFont != null && oldFont.equals (newFont)) return;
@@ -1293,7 +1293,7 @@ private static void handleDPIChange(Widget widget, int newZoom, float scalingFac
 		Shell shell = tableItem.parent.getShell();
 		for (int index = 0; index < cellFonts.length; index++) {
 			Font cellFont = cellFonts[index];
-			cellFonts[index] = cellFont == null ? null : Font.win32_new(cellFont, shell.getNativeZoom());
+			cellFonts[index] = cellFont == null ? null : Font.win32_new(cellFont, shell.nativeZoom);
 		}
 	}
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TreeItem.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TreeItem.java
@@ -1390,7 +1390,7 @@ public void setFont (Font font){
 	Font oldFont = this.font;
 	if (oldFont == font) return;
 	Shell shell = parent.getShell();
-	this.font = (font == null ? font : Font.win32_new(font, shell.getNativeZoom()));
+	this.font = (font == null ? font : Font.win32_new(font, shell.nativeZoom));
 	if (oldFont != null && oldFont.equals (font)) return;
 	if (font != null) parent.customDraw = true;
 	if ((parent.style & SWT.VIRTUAL) != 0) cached = true;
@@ -1445,7 +1445,7 @@ public void setFont (int index, Font font) {
 	Font oldFont = cellFont [index];
 	if (oldFont == font) return;
 	Shell shell = parent.getShell();
-	cellFont [index] = font == null ? font : Font.win32_new(font, shell.getNativeZoom());
+	cellFont [index] = font == null ? font : Font.win32_new(font, shell.nativeZoom);
 	if (oldFont != null && oldFont.equals (font)) return;
 	if (font != null) parent.customDraw = true;
 	if ((parent.style & SWT.VIRTUAL) != 0) cached = true;
@@ -1838,7 +1838,7 @@ private static void handleDPIChange(Widget widget, int newZoom, float scalingFac
 		Shell shell = treeItem.parent.getShell();
 		for (int index = 0; index < cellFonts.length; index++) {
 			Font cellFont = cellFonts[index];
-			cellFonts[index] = cellFont == null ? null : Font.win32_new(cellFont, shell.getNativeZoom());
+			cellFonts[index] = cellFont == null ? null : Font.win32_new(cellFont, shell.nativeZoom);
 		}
 	}
 	for (TreeItem item : treeItem.getItems()) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Widget.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Widget.java
@@ -52,7 +52,19 @@ import org.eclipse.swt.internal.win32.*;
  */
 public abstract class Widget {
 
-	private int zoom;
+	/**
+	 * the native zoom of the monitor in percent
+	 * (Warning: This field is platform dependent)
+	 * <p>
+	 * <b>IMPORTANT:</b> This field is <em>not</em> part of the SWT
+	 * public API. It is marked public only so that it can be shared
+	 * within the packages provided by SWT. It is not available on all
+	 * platforms and should never be accessed from application code.
+	 * </p>
+	 *
+	 * @noreference This field is not intended to be referenced by clients.
+	 */
+	protected int nativeZoom;
 	int style, state;
 	Display display;
 	EventTable eventTable;
@@ -169,7 +181,7 @@ public Widget (Widget parent, int style) {
 	checkSubclass ();
 	checkParent (parent);
 	this.style = style;
-	this.zoom = parent != null ? parent.getZoom() : DPIUtil.getDeviceZoom();
+	this.nativeZoom = parent != null ? parent.nativeZoom : DPIUtil.getNativeDeviceZoom();
 	display = parent.display;
 	reskinWidget ();
 	notifyCreationTracker();
@@ -2635,19 +2647,11 @@ void notifyDisposalTracker() {
 	}
 }
 
-
-/**
- * The current DPI zoom level the widget is scaled for
- */
 int getZoom() {
-	return zoom;
-}
-
-void setZoom(int zoom) {
-	this.zoom = zoom;
+	return DPIUtil.getZoomForAutoscaleProperty(nativeZoom);
 }
 
 private static void handleDPIChange(Widget widget, int newZoom, float scalingFactor) {
-	widget.setZoom(newZoom);
+	widget.nativeZoom = newZoom;
 }
 }


### PR DESCRIPTION
## Addressed issues
* https://github.com/eclipse-platform/eclipse.platform.swt/issues/62 
* https://github.com/eclipse-platform/eclipse.platform.swt/issues/127

## Unlocks
* https://github.com/eclipse-platform/eclipse.platform.swt/pull/1214

## Description

This contribution is to provide the nativeDeviceZoom to all the widgets so that it can be used later on for e.g. font scaling and more. Currently, the nativeDeviceZoom is only available via the shell, which is not sufficient later when there is no shell available, e.g. GC.

In this following PR https://github.com/eclipse-platform/eclipse.platform.swt/pull/1214 , we had discussed that instead of storing zoom for widgets, we should store nativeDeviceZoom, to make it more accessible where shell is not present. Because in some cases, there was no nativeDeviceZoom present because of the previous implementation and we discussed if a fallback might be necessary. This implementation makes sure that in those scenarios, nativeDeviceZoom would always be available for further usage.

The consumers can now have deviceZoom wherever necessary by using the utility method to translate nativeDeviceZoom to deviceZoom, which is available in DPIUtil.