### PR TITLE
Fix warning message on Mac about secure coding not enabled

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT PI/cocoa/org/eclipse/swt/internal/cocoa/OS.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/cocoa/org/eclipse/swt/internal/cocoa/OS.java
@@ -156,8 +156,9 @@ public class OS extends C {
 	public static final long sel_setStyle = Selector.sel_setStyle.value;
 	public static final int NSTableViewStylePlain = 4;
 
-    /** 14.0 selector */
-    public static final long sel_setClipsToBounds_ = Selector.sel_setClipsToBounds_.value;
+	/** 14.0 selectors */
+	public static final long sel_setClipsToBounds_ = Selector.sel_setClipsToBounds_.value;
+	public static final long sel_applicationSupportsSecureRestorableState_ = Selector.sel_applicationSupportsSecureRestorableState_.value;
 
 	/* AWT application delegate. Remove these when JavaRuntimeSupport.framework has bridgesupport generated for it. */
 	public static final long class_JRSAppKitAWT = objc_getClass("JRSAppKitAWT");

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/cocoa/org/eclipse/swt/internal/cocoa/Selector.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/cocoa/org/eclipse/swt/internal/cocoa/Selector.java
@@ -82,8 +82,9 @@ public enum Selector {
 	/** 11.0 selector */
 	, sel_setStyle("setStyle:")
 
-	/** 14.0 selector */
+	/** 14.0 selectors */
 	, sel_setClipsToBounds_("setClipsToBounds:")
+	, sel_applicationSupportsSecureRestorableState_("applicationSupportsSecureRestorableState:")
 
 	, sel_awtAppDelegate("awtAppDelegate")
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Display.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Display.java
@@ -1052,6 +1052,7 @@ void createDisplay (DeviceData data) {
 		OS.class_addMethod(cls, OS.sel_application_openUrls_, appProc4, "@:@@");
 		OS.class_addMethod(cls, OS.sel_applicationShouldHandleReopen_hasVisibleWindows_, appProc4, "@:@B");
 		OS.class_addMethod(cls, OS.sel_applicationShouldTerminate_, appProc3, "@:@");
+		OS.class_addMethod(cls, OS.sel_applicationSupportsSecureRestorableState_, appProc3, "@:@");
 		OS.objc_registerClassPair(cls);
 	}
 
@@ -5901,6 +5902,9 @@ static long applicationProc(long id, long sel, long arg0) {
 				}
 			}
 			return 0;
+		}
+		case sel_applicationSupportsSecureRestorableState_: {
+			return 1;
 		}
 		default: {
 			return 0;


### PR DESCRIPTION
- See https://github.com/eclipse-platform/eclipse.platform.swt/issues/1228

- On macOS 14 and later a warning message is written to console:

"WARNING: Secure coding is not enabled for restorable state! Enable secure coding by implementing NSApplicationDelegate.applicationSupportsSecureRestorableState: and returning YES."

- As recommended by Apple, this change adds a new selector for applicationSupportsSecureRestorableState and returns a 1 value (YES) in the callback in the Display class

- However, this only takes care of the NSApplicationDelegate created in the Display class. The warning message will still appear when a splash screen is created in Equinox JNI code so a fix there is also required. See https://github.com/eclipse-equinox/equinox/issues/630

- This implementation for SWT can be tested by using the -noSplash argument when launching Eclipse