### PR TITLE
Updating the control example by adding option to make Table and Tree Widgets editable

### DIFF
--- a/examples/org.eclipse.swt.examples/src/examples_control.properties
+++ b/examples/org.eclipse.swt.examples/src/examples_control.properties
@@ -111,6 +111,7 @@ Header_Visible		= Header Visible
 Sort_Indicator		= Sort Indicator
 Header_Images		= Header Images
 Sub_Images			= Sub Images
+Editable			= Editable
 Lines_Visible		= Lines Visible
 Moveable_Columns	= Moveable Columns
 Resizable_Columns	= Resizable Columns


### PR DESCRIPTION
Updating the example by adding option to make Table and Tree Widgets editable

This commit is part of testing the custom controls for multi-monitor support.

**HOW TO TEST**

* Run the _Runtime Workspace_ launch configuration
* Open the _SWT Controls_ view
* Switch to the tab "Tree"/"Table"
* Check the "Editable" option under "Other"
* Edit the content of the tree/table

Contributes to #62 and #127