### PR TITLE
Implementation of FontMetrics to enable multi zoom level support for win32

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/FontMetrics.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/FontMetrics.java
@@ -43,6 +43,8 @@ public final class FontMetrics {
 	 */
 	public TEXTMETRIC handle;
 
+	private int nativeZoom;
+
 /**
  * Prevents instances from being created outside the package.
  */
@@ -95,7 +97,7 @@ public boolean equals (Object object) {
  * @return the ascent of the font
  */
 public int getAscent() {
-	return DPIUtil.autoScaleDown(handle.tmAscent - handle.tmInternalLeading);
+	return DPIUtil.scaleDown(handle.tmAscent - handle.tmInternalLeading, getZoom());
 }
 
 /**
@@ -118,7 +120,7 @@ public double getAverageCharacterWidth() {
  */
 @Deprecated
 public int getAverageCharWidth() {
-	return DPIUtil.autoScaleDown(handle.tmAveCharWidth);
+	return DPIUtil.scaleDown(handle.tmAveCharWidth, getZoom());
 }
 
 /**
@@ -130,7 +132,7 @@ public int getAverageCharWidth() {
  * @return the descent of the font
  */
 public int getDescent() {
-	return DPIUtil.autoScaleDown(handle.tmDescent);
+	return DPIUtil.scaleDown(handle.tmDescent, getZoom());
 }
 
 /**
@@ -145,7 +147,7 @@ public int getDescent() {
  * @see #getLeading
  */
 public int getHeight() {
-	return DPIUtil.autoScaleDown(handle.tmHeight);
+	return DPIUtil.scaleDown(handle.tmHeight, getZoom());
 }
 
 /**
@@ -170,6 +172,10 @@ public int getLeading() {
 	 * value here:
 	 */
 	return getHeight() - getAscent() - getDescent();
+}
+
+private int getZoom() {
+	return DPIUtil.getZoomForAutoscaleProperty(nativeZoom);
 }
 
 /**
@@ -211,6 +217,29 @@ public int hashCode() {
 public static FontMetrics win32_new(TEXTMETRIC handle) {
 	FontMetrics fontMetrics = new FontMetrics();
 	fontMetrics.handle = handle;
+	return fontMetrics;
+}
+
+/**
+ * Invokes platform specific functionality to allocate a new font metrics.
+ * <p>
+ * <b>IMPORTANT:</b> This method is <em>not</em> part of the public
+ * API for <code>FontMetrics</code>. It is marked public only so that
+ * it can be shared within the packages provided by SWT. It is not
+ * available on all platforms, and should never be called from
+ * application code.
+ * </p>
+ *
+ * @param handle the <code>TEXTMETRIC</code> containing information about a font
+ * @param nativeZoom the native zoom of the monitor for which Font Metrics is created
+ * @return a new font metrics object containing the specified <code>TEXTMETRIC</code>
+ *
+ * @noreference This method is not intended to be referenced by clients.
+ */
+public static FontMetrics win32_new(TEXTMETRIC handle, int nativeZoom) {
+	FontMetrics fontMetrics = new FontMetrics();
+	fontMetrics.handle = handle;
+	fontMetrics.nativeZoom = nativeZoom;
 	return fontMetrics;
 }
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/GC.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/GC.java
@@ -3493,7 +3493,7 @@ public FontMetrics getFontMetrics() {
 	checkGC(FONT);
 	TEXTMETRIC lptm = new TEXTMETRIC();
 	OS.GetTextMetrics(handle, lptm);
-	return FontMetrics.win32_new(lptm);
+	return FontMetrics.win32_new(lptm, data.nativeZoom);
 }
 
 /**

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Composite.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Composite.java
@@ -1527,7 +1527,7 @@ LRESULT WM_PAINT (long wParam, long lParam) {
 				Control control = findBackgroundControl ();
 				if (control == null) control = this;
 				data.background = control.getBackgroundPixel ();
-				data.font = Font.win32_new(display, OS.SendMessage (handle, OS.WM_GETFONT, 0, 0));
+				data.font = Font.win32_new(display, OS.SendMessage (handle, OS.WM_GETFONT, 0, 0), nativeZoom);
 				data.uiState = (int)OS.SendMessage (handle, OS.WM_QUERYUISTATE, 0, 0);
 				if ((style & SWT.NO_BACKGROUND) != 0) {
 					/* This code is intentionally commented because it may be slow to copy bits from the screen */


### PR DESCRIPTION
## Addressed issues
* https://github.com/eclipse-platform/eclipse.platform.swt/issues/62 
* https://github.com/eclipse-platform/eclipse.platform.swt/issues/131

## Requires
* [x] https://github.com/eclipse-platform/eclipse.platform.swt/pull/1214

**Note:** Only the last commit in this PR is to be reviewed. Previous commit(s) belong to the prerequisite PR(s)

## Unlocks
* https://github.com/eclipse-platform/eclipse.platform.swt/pull/1244

## Description

This pull request is based on the implementations of PR #1214. It provides the native zoom to the font metrics which can further be utilized by GC and Text Layout using Public APIs, since fonts are scaled to native zoom. (based on PR #1214 ).