### PR TITLE
Implementation of Text Layout to enable multi zoom level support for win32

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/graphics/TextLayoutWin32Tests.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/graphics/TextLayoutWin32Tests.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Yatta Solutions
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Yatta Solutions - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.swt.graphics;
+
+import static org.junit.Assert.assertEquals;
+
+import org.eclipse.swt.internal.*;
+import org.junit.*;
+
+public class TextLayoutWin32Tests extends Win32AutoscaleTestBase {
+	final static String text = "This is a text for testing.";
+
+	@Test
+	public void testGetBoundPublicAPIshouldReturnTheSameValueRegardlessOfZoomLevel() {
+		final TextLayout layout = new TextLayout(display);
+		GCData unscaledData = new GCData();
+		unscaledData.nativeZoom = DPIUtil.getNativeDeviceZoom();
+		GC gc = GC.win32_new(display, unscaledData);
+		layout.draw(gc, 10, 10);
+		Rectangle unscaledBounds = layout.getBounds();
+
+		int scalingFactor = 2;
+		int newZoom = DPIUtil.getNativeDeviceZoom() * scalingFactor;
+		GCData scaledData = new GCData();
+		scaledData.nativeZoom = newZoom;
+		GC scaledGc = GC.win32_new(display, scaledData);
+		layout.draw(scaledGc, 10, 10);
+		Rectangle scaledBounds = layout.getBounds();
+
+		assertEquals("The public API for getBounds should give the same result for any zoom level", scaledBounds, unscaledBounds);
+	}
+
+}

--- a/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/internal/Win32AutoscaleTestBase.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/internal/Win32AutoscaleTestBase.java
@@ -18,7 +18,7 @@ import org.eclipse.swt.widgets.*;
 import org.junit.*;
 
 public abstract class Win32AutoscaleTestBase {
-	private Display display;
+	protected Display display;
 	protected Shell shell;
 	private boolean autoScaleOnRuntime;
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Font.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Font.java
@@ -54,7 +54,7 @@ public final class Font extends Resource {
 	 * The zoom in % of the standard resolution used for conversion of point height to pixel height
 	 * (Warning: This field is platform dependent)
 	 */
-	private int zoom;
+	int zoom;
 /**
  * Prevents uninitialized instances from being created outside the package.
  */

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/FontMetrics.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/FontMetrics.java
@@ -210,27 +210,6 @@ public int hashCode() {
  * </p>
  *
  * @param handle the <code>TEXTMETRIC</code> containing information about a font
- * @return a new font metrics object containing the specified <code>TEXTMETRIC</code>
- *
- * @noreference This method is not intended to be referenced by clients.
- */
-public static FontMetrics win32_new(TEXTMETRIC handle) {
-	FontMetrics fontMetrics = new FontMetrics();
-	fontMetrics.handle = handle;
-	return fontMetrics;
-}
-
-/**
- * Invokes platform specific functionality to allocate a new font metrics.
- * <p>
- * <b>IMPORTANT:</b> This method is <em>not</em> part of the public
- * API for <code>FontMetrics</code>. It is marked public only so that
- * it can be shared within the packages provided by SWT. It is not
- * available on all platforms, and should never be called from
- * application code.
- * </p>
- *
- * @param handle the <code>TEXTMETRIC</code> containing information about a font
  * @param nativeZoom the native zoom of the monitor for which Font Metrics is created
  * @return a new font metrics object containing the specified <code>TEXTMETRIC</code>
  *


### PR DESCRIPTION
## Addressed issues
* https://github.com/eclipse-platform/eclipse.platform.swt/issues/62 
* https://github.com/eclipse-platform/eclipse.platform.swt/issues/131

## Requires
* [x] https://github.com/eclipse-platform/eclipse.platform.swt/pull/1243

**Note:** Only the last commit in this PR is to be reviewed. Previous commit(s) belong to the prerequisite PR(s)

## Description

This pull request is based on the implementations of PR #1243. This commit adds the support of scaling of text layout based on the zoom level of the monitor it is drawn on. It uses the native zoom which is provided by the GCData if available otherwise the zoom level set in the font (since the right font for a zoom level is computed already at the control level, so we always have the consistent zoom information).