### PR TITLE
Remove API filter for 4.32 release

### DIFF
--- a/binaries/org.eclipse.swt.cocoa.macosx.aarch64/.settings/.api_filters
+++ b/binaries/org.eclipse.swt.cocoa.macosx.aarch64/.settings/.api_filters
@@ -550,12 +550,4 @@
             </message_arguments>
         </filter>
     </resource>
-    <resource path="Eclipse SWT/common/org/eclipse/swt/widgets/TypedListener.java" type="org.eclipse.swt.widgets.TypedListener">
-        <filter comment="Class declared as internal in its JavaDoc since ever." id="336744520">
-            <message_arguments>
-                <message_argument value="@noextend"/>
-                <message_argument value="org.eclipse.swt.widgets.TypedListener"/>
-            </message_arguments>
-        </filter>
-    </resource>
 </component>

--- a/binaries/org.eclipse.swt.cocoa.macosx.x86_64/.settings/.api_filters
+++ b/binaries/org.eclipse.swt.cocoa.macosx.x86_64/.settings/.api_filters
@@ -550,12 +550,4 @@
             </message_arguments>
         </filter>
     </resource>
-    <resource path="Eclipse SWT/common/org/eclipse/swt/widgets/TypedListener.java" type="org.eclipse.swt.widgets.TypedListener">
-        <filter comment="Class declared as internal in its JavaDoc since ever." id="336744520">
-            <message_arguments>
-                <message_argument value="@noextend"/>
-                <message_argument value="org.eclipse.swt.widgets.TypedListener"/>
-            </message_arguments>
-        </filter>
-    </resource>
 </component>

--- a/binaries/org.eclipse.swt.gtk.linux.aarch64/.settings/.api_filters
+++ b/binaries/org.eclipse.swt.gtk.linux.aarch64/.settings/.api_filters
@@ -448,14 +448,6 @@
             </message_arguments>
         </filter>
     </resource>
-    <resource path="Eclipse SWT/common/org/eclipse/swt/widgets/TypedListener.java" type="org.eclipse.swt.widgets.TypedListener">
-        <filter comment="Class declared as internal in its JavaDoc since ever." id="336744520">
-            <message_arguments>
-                <message_argument value="@noextend"/>
-                <message_argument value="org.eclipse.swt.widgets.TypedListener"/>
-            </message_arguments>
-        </filter>
-    </resource>
     <resource path="Eclipse SWT/gtk/org/eclipse/swt/widgets/Composite.java" type="org.eclipse.swt.widgets.Composite">
         <filter id="576778288">
             <message_arguments>

--- a/binaries/org.eclipse.swt.gtk.linux.loongarch64/.settings/.api_filters
+++ b/binaries/org.eclipse.swt.gtk.linux.loongarch64/.settings/.api_filters
@@ -448,14 +448,6 @@
             </message_arguments>
         </filter>
     </resource>
-    <resource path="Eclipse SWT/common/org/eclipse/swt/widgets/TypedListener.java" type="org.eclipse.swt.widgets.TypedListener">
-        <filter comment="Class declared as internal in its JavaDoc since ever." id="336744520">
-            <message_arguments>
-                <message_argument value="@noextend"/>
-                <message_argument value="org.eclipse.swt.widgets.TypedListener"/>
-            </message_arguments>
-        </filter>
-    </resource>
     <resource path="Eclipse SWT/gtk/org/eclipse/swt/widgets/Composite.java" type="org.eclipse.swt.widgets.Composite">
         <filter id="576778288">
             <message_arguments>

--- a/binaries/org.eclipse.swt.gtk.linux.ppc64le/.settings/.api_filters
+++ b/binaries/org.eclipse.swt.gtk.linux.ppc64le/.settings/.api_filters
@@ -448,14 +448,6 @@
             </message_arguments>
         </filter>
     </resource>
-    <resource path="Eclipse SWT/common/org/eclipse/swt/widgets/TypedListener.java" type="org.eclipse.swt.widgets.TypedListener">
-        <filter comment="Class declared as internal in its JavaDoc since ever." id="336744520">
-            <message_arguments>
-                <message_argument value="@noextend"/>
-                <message_argument value="org.eclipse.swt.widgets.TypedListener"/>
-            </message_arguments>
-        </filter>
-    </resource>
     <resource path="Eclipse SWT/gtk/org/eclipse/swt/widgets/Composite.java" type="org.eclipse.swt.widgets.Composite">
         <filter id="576778288">
             <message_arguments>

--- a/binaries/org.eclipse.swt.gtk.linux.x86_64/.settings/.api_filters
+++ b/binaries/org.eclipse.swt.gtk.linux.x86_64/.settings/.api_filters
@@ -448,14 +448,6 @@
             </message_arguments>
         </filter>
     </resource>
-    <resource path="Eclipse SWT/common/org/eclipse/swt/widgets/TypedListener.java" type="org.eclipse.swt.widgets.TypedListener">
-        <filter comment="Class declared as internal in its JavaDoc since ever." id="336744520">
-            <message_arguments>
-                <message_argument value="@noextend"/>
-                <message_argument value="org.eclipse.swt.widgets.TypedListener"/>
-            </message_arguments>
-        </filter>
-    </resource>
     <resource path="Eclipse SWT/gtk/org/eclipse/swt/widgets/Composite.java" type="org.eclipse.swt.widgets.Composite">
         <filter id="576778288">
             <message_arguments>

--- a/binaries/org.eclipse.swt.win32.win32.aarch64/.settings/.api_filters
+++ b/binaries/org.eclipse.swt.win32.win32.aarch64/.settings/.api_filters
@@ -575,14 +575,6 @@
             </message_arguments>
         </filter>
     </resource>
-    <resource path="Eclipse SWT/common/org/eclipse/swt/widgets/TypedListener.java" type="org.eclipse.swt.widgets.TypedListener">
-        <filter comment="Class declared as internal in its JavaDoc since ever." id="336744520">
-            <message_arguments>
-                <message_argument value="@noextend"/>
-                <message_argument value="org.eclipse.swt.widgets.TypedListener"/>
-            </message_arguments>
-        </filter>
-    </resource>
     <resource path="Eclipse SWT/win32/org/eclipse/swt/graphics/GCData.java" type="org.eclipse.swt.graphics.GCData">
         <filter id="627060751">
             <message_arguments>

--- a/binaries/org.eclipse.swt.win32.win32.x86_64/.settings/.api_filters
+++ b/binaries/org.eclipse.swt.win32.win32.x86_64/.settings/.api_filters
@@ -575,14 +575,6 @@
             </message_arguments>
         </filter>
     </resource>
-    <resource path="Eclipse SWT/common/org/eclipse/swt/widgets/TypedListener.java" type="org.eclipse.swt.widgets.TypedListener">
-        <filter comment="Class declared as internal in its JavaDoc since ever." id="336744520">
-            <message_arguments>
-                <message_argument value="@noextend"/>
-                <message_argument value="org.eclipse.swt.widgets.TypedListener"/>
-            </message_arguments>
-        </filter>
-    </resource>
     <resource path="Eclipse SWT/win32/org/eclipse/swt/graphics/GCData.java" type="org.eclipse.swt.graphics.GCData">
         <filter id="627060751">
             <message_arguments>


### PR DESCRIPTION
For the 4.32 release, an API filter for the TypedListener being annotated with `@noextend` has been introduced (see https://github.com/eclipse-platform/eclipse.platform.swt/pull/1101). After having switched to the 4.33 stream, this filter now became obsolete and is thus removed with this change.

This resolves the warning for an unused API filter:
![image](https://github.com/eclipse-platform/eclipse.platform.swt/assets/755472/4427b93d-f0e0-49d8-99be-dc0aacdbf8f6)
I would actually expect that we can remove the other API filters as well, but since the build validation currently only complains about the `TypedListener`, this change only removes exactly that filter.

@HannesWell I just took over from you (https://github.com/eclipse-platform/eclipse.platform.swt/pull/1253#issuecomment-2150956767), as we would like to merge some finalized PRs tomorrow and would thus like to resolve the new warnings before.

