### PR TITLE
Update tree item height correctly on DPI change

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Tree.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Tree.java
@@ -8280,11 +8280,12 @@ private static void handleDPIChange(Widget widget, int newZoom, float scalingFac
 		tree.imageList = null;
 	}
 
-	if (tree.hooks(SWT.MeasureItem)) {
-		// with the measure item hook, the height must be programmatically recalculated
-		var itemHeight = tree.getItemHeightInPixels();
-		tree.setItemHeight(Math.round(itemHeight * scalingFactor));
-	}
+	// if the item height was set at least once programmatically with TVM_SETITEMHEIGHT,
+	// the item height of the tree is not managed by the OS anymore e.g. when the zoom
+	// on the monitor is changed, the height of the item will stay at the fixed size.
+	// Resetting it will re-enable the default behavior again
+	tree.setItemHeight(-1);
+
 	for (TreeColumn treeColumn : tree.getColumns()) {
 		DPIZoomChangeRegistry.applyChange(treeColumn, newZoom, scalingFactor);
 	}


### PR DESCRIPTION
With the current implementation of the handler on DPI zoom changes, not all rescaling cases are covered correctly. If the item height was set at least once programmatically (currently done in Tree::setItemHeight), it will never be done by the OS anymore. With the current implementation a double scale up can happen (once scaled up from the OS and once from the handler), see:

![image](https://github.com/eclipse-platform/eclipse.platform.swt/assets/119662019/f5cf5e7e-08a5-410a-8f20-3b272f7ece3b)

To make it failsafe a new internal flag is used to evaluate whether the item height was set programmatically or not.

## How to reproduce

1. Adapt the VM argument of e.g. the Eclipse IDE by adding
```
-Dswt.autoScale=quarter
-Dswt.autoScale.updateOnRuntime=true
```
2. Have two monitors with different zoom, e.g. 100% and 150%
3. Start the IDE on 100%
4. Open the Outline view
5. Move it to the monitor with 150%  -> The item height will be too big as in the screenshot
