### PR TITLE
Implementation of Pattern to enable multi zoom level support for win32

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/GC.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/GC.java
@@ -198,9 +198,9 @@ void checkGC(int mask) {
 			Pattern pattern = data.foregroundPattern;
 			if (pattern != null) {
 				if(data.alpha == 0xFF) {
-					brush = pattern.handle;
+					brush = pattern.getHandle(getZoom());
 				} else {
-					brush = data.gdipFgPatternBrushAlpha != 0 ? Gdip.Brush_Clone(data.gdipFgPatternBrushAlpha) : createAlphaTextureBrush(pattern.handle, data.alpha);
+					brush = data.gdipFgPatternBrushAlpha != 0 ? Gdip.Brush_Clone(data.gdipFgPatternBrushAlpha) : createAlphaTextureBrush(pattern.getHandle(getZoom()), data.alpha);
 					data.gdipFgPatternBrushAlpha = brush;
 				}
 				if ((data.style & SWT.MIRRORED) != 0) {
@@ -289,9 +289,9 @@ void checkGC(int mask) {
 			Pattern pattern = data.backgroundPattern;
 			if (pattern != null) {
 				if(data.alpha == 0xFF) {
-					data.gdipBrush = pattern.handle;
+					data.gdipBrush = pattern.getHandle(getZoom());
 				} else {
-					long brush = data.gdipBgPatternBrushAlpha != 0 ? Gdip.Brush_Clone(data.gdipBgPatternBrushAlpha) : createAlphaTextureBrush(pattern.handle, data.alpha);
+					long brush = data.gdipBgPatternBrushAlpha != 0 ? Gdip.Brush_Clone(data.gdipBgPatternBrushAlpha) : createAlphaTextureBrush(pattern.getHandle(getZoom()), data.alpha);
 					data.gdipBrush = data.gdipBgBrush /*= data.gdipBgPatternBrushAlpha */ = brush;
 				}
 				if ((data.style & SWT.MIRRORED) != 0) {
@@ -3440,7 +3440,7 @@ public void getClipping (Region region) {
 }
 
 long getFgBrush() {
-	return data.foregroundPattern != null ? data.foregroundPattern.handle : data.gdipFgBrush;
+	return data.foregroundPattern != null ? data.foregroundPattern.getHandle(getZoom()) : data.gdipFgBrush;
 }
 
 /**

--- a/tests/org.eclipse.swt.tests.win32/ManualTests/org/eclipse/swt/widgets/PatternWin32ManualTest.java
+++ b/tests/org.eclipse.swt.tests.win32/ManualTests/org/eclipse/swt/widgets/PatternWin32ManualTest.java
@@ -1,0 +1,71 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Yatta Solutions
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Yatta Solutions - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.swt.widgets;
+
+import org.eclipse.swt.graphics.Color;
+import org.eclipse.swt.graphics.Pattern;
+import org.eclipse.swt.internal.DPIUtil;
+
+/*
+ * This Snippet tests a pattern at multiple zoom levels.
+ *
+ * It is difficult to test the pattern at multiple zoom level automatically since we also need
+ * to test the visual behavior. It is important to make sure that the pattern looks the same
+ * regardless of its size as per the zoom level. On the execution, 2 shells are
+ * opened at 2 different zoom levels. The pattern is a gradient of 2 colors. On both the
+ * shells, the pattern should be uniformly drawn and the size difference of both the patterns
+ * should be clearly visible without any visual difference except for the size. The size
+ * difference should be equal to the scalingFactor in the snippet.
+ *
+ */
+public class PatternWin32ManualTest {
+	private static Display display = Display.getDefault();
+
+	public static void main (String [] args) {
+		int zoom = DPIUtil.getDeviceZoom();
+		int scalingFactor = 3;
+		int scaledZoom = zoom * scalingFactor;
+		int width = 400;
+		int height = 300;
+		final Pattern pat = new Pattern(display, 0, 0, width, height, new Color(null, 200, 200, 200), 0, new Color(null, 255, 0, 0), 255);
+
+		Shell shell1 = createShellWithPattern(width, height, pat, zoom);
+		Shell shell2 = createShellWithPattern(width, height, pat, scaledZoom);
+
+		while (!shell1.isDisposed() || !shell2.isDisposed()) {
+			if (!display.readAndDispatch()) {
+				display.sleep();
+			}
+		}
+		pat.dispose();
+		shell1.dispose();
+		shell2.dispose();
+	}
+
+	private static Shell createShellWithPattern(int width, int height, final Pattern pat, int nativeZoom) {
+		Shell shell = new Shell(display);
+		shell.nativeZoom = nativeZoom;
+		shell.setText("Unscaled shell");
+		shell.setSize(width, height);
+		shell.addPaintListener(e -> {
+			e.gc.setBackground(new Color(null, 100, 200, 0));
+			e.gc.fillRectangle(0, 0, shell.getBounds().width, shell.getBounds().height);
+			e.gc.setBackground(new Color(null, 255, 0, 0));
+			e.gc.setBackgroundPattern(pat);
+			e.gc.fillRectangle(0, 0, shell.getBounds().width, shell.getBounds().height);
+		});
+		shell.open();
+		return shell;
+	}
+}


### PR DESCRIPTION
## Addressed issues
* https://github.com/eclipse-platform/eclipse.platform.swt/issues/62 
* https://github.com/eclipse-platform/eclipse.platform.swt/issues/131

## Requires
* [x] https://github.com/eclipse-platform/eclipse.platform.swt/pull/1236

**Note:** Only the last commit in this PR is to be reviewed. Previous commit(s) belong to the prerequisite PR(s)

## Description

This PR introduces multi zoom level support of pattern using a map which maintains patterns at different zoom level. The map is used by a package protected method which is used in GC in the place where the handle of patterns are needed. Since, testing patterns automatically for how they look visually is a bit difficult, so there's a snippet created for manual testing of the same pattern at different zoom levels.