### PR TITLE
Add support to display the busy indicator while a Future is running

### DIFF
--- a/binaries/org.eclipse.swt.cocoa.macosx.aarch64/META-INF/MANIFEST.MF
+++ b/binaries/org.eclipse.swt.cocoa.macosx.aarch64/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Fragment-Host: org.eclipse.swt;bundle-version="[3.126.100,4.0.0)"
 Bundle-Name: %fragmentName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.swt.cocoa.macosx.aarch64; singleton:=true
-Bundle-Version: 3.126.100.qualifier
+Bundle-Version: 3.127.0.qualifier
 Bundle-ManifestVersion: 2
 Bundle-Localization: fragment
 Export-Package: 

--- a/binaries/org.eclipse.swt.cocoa.macosx.x86_64/META-INF/MANIFEST.MF
+++ b/binaries/org.eclipse.swt.cocoa.macosx.x86_64/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Fragment-Host: org.eclipse.swt;bundle-version="[3.126.100,4.0.0)"
 Bundle-Name: %fragmentName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.swt.cocoa.macosx.x86_64; singleton:=true
-Bundle-Version: 3.126.100.qualifier
+Bundle-Version: 3.127.0.qualifier
 Bundle-ManifestVersion: 2
 Bundle-Localization: fragment
 Export-Package: 

--- a/binaries/org.eclipse.swt.gtk.linux.aarch64/META-INF/MANIFEST.MF
+++ b/binaries/org.eclipse.swt.gtk.linux.aarch64/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Fragment-Host: org.eclipse.swt;bundle-version="[3.126.100,4.0.0)"
 Bundle-Name: %fragmentName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.swt.gtk.linux.aarch64; singleton:=true
-Bundle-Version: 3.126.100.qualifier
+Bundle-Version: 3.127.0.qualifier
 Bundle-ManifestVersion: 2
 Bundle-Localization: fragment
 Export-Package: 

--- a/binaries/org.eclipse.swt.gtk.linux.loongarch64/META-INF/MANIFEST.MF
+++ b/binaries/org.eclipse.swt.gtk.linux.loongarch64/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Fragment-Host: org.eclipse.swt;bundle-version="[3.126.100,4.0.0)"
 Bundle-Name: %fragmentName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.swt.gtk.linux.loongarch64; singleton:=true
-Bundle-Version: 3.126.100.qualifier
+Bundle-Version: 3.127.0.qualifier
 Bundle-ManifestVersion: 2
 Bundle-Localization: fragment
 Export-Package: 

--- a/binaries/org.eclipse.swt.gtk.linux.ppc64le/META-INF/MANIFEST.MF
+++ b/binaries/org.eclipse.swt.gtk.linux.ppc64le/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Fragment-Host: org.eclipse.swt;bundle-version="[3.126.100,4.0.0)"
 Bundle-Name: %fragmentName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.swt.gtk.linux.ppc64le;singleton:=true
-Bundle-Version: 3.126.100.qualifier
+Bundle-Version: 3.127.0.qualifier
 Bundle-ManifestVersion: 2
 Bundle-Localization: fragment
 Export-Package: 

--- a/binaries/org.eclipse.swt.gtk.linux.x86_64/META-INF/MANIFEST.MF
+++ b/binaries/org.eclipse.swt.gtk.linux.x86_64/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Fragment-Host: org.eclipse.swt;bundle-version="[3.126.100,4.0.0)"
 Bundle-Name: %fragmentName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.swt.gtk.linux.x86_64; singleton:=true
-Bundle-Version: 3.126.100.qualifier
+Bundle-Version: 3.127.0.qualifier
 Bundle-ManifestVersion: 2
 Bundle-Localization: fragment
 Export-Package: 

--- a/binaries/org.eclipse.swt.win32.win32.aarch64/META-INF/MANIFEST.MF
+++ b/binaries/org.eclipse.swt.win32.win32.aarch64/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Fragment-Host: org.eclipse.swt;bundle-version="[3.126.100,4.0.0)"
 Bundle-Name: %fragmentName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.swt.win32.win32.aarch64; singleton:=true
-Bundle-Version: 3.126.100.qualifier
+Bundle-Version: 3.127.0.qualifier
 Bundle-ManifestVersion: 2
 Bundle-Localization: fragment
 Export-Package: 

--- a/binaries/org.eclipse.swt.win32.win32.x86_64/META-INF/MANIFEST.MF
+++ b/binaries/org.eclipse.swt.win32.win32.x86_64/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Fragment-Host: org.eclipse.swt;bundle-version="[3.126.100,4.0.0)"
 Bundle-Name: %fragmentName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.swt.win32.win32.x86_64; singleton:=true
-Bundle-Version: 3.126.100.qualifier
+Bundle-Version: 3.127.0.qualifier
 Bundle-ManifestVersion: 2
 Bundle-Localization: fragment
 Export-Package: 

--- a/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet130.java
+++ b/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet130.java
@@ -44,6 +44,17 @@ public class Snippet130 {
 		AtomicInteger nextId = new AtomicInteger();
 		Button b = new Button(shell, SWT.PUSH);
 		b.setText("invoke long running job");
+		Button b2 = new Button(shell, SWT.PUSH);
+		b2.setText("wait for predefined future");
+		CompletableFuture<String> future = CompletableFuture.supplyAsync(()->{
+			try {
+				TimeUnit.SECONDS.sleep(30);
+				System.out.println("Future is done!");
+			} catch (InterruptedException e) {
+				return "Task is interrupted";
+			}
+			return "Text computed in the background";
+		});
 		b.addSelectionListener(widgetSelectedAdapter(e -> {
 			int id = nextId.incrementAndGet();
 			text.append("\nStart long running task " + id);
@@ -60,6 +71,16 @@ public class Snippet130 {
 				text.append("\nCompleted long running task " + id);
 			}, display);
 
+		}));
+		b2.addSelectionListener(widgetSelectedAdapter(e -> {
+			text.append("\nWaiting for Background Work to complete...");
+			b2.setEnabled(false);
+			BusyIndicator.showWhile(future);
+			if (text.isDisposed() || b2.isDisposed()) {
+				return;
+			}
+			b2.setEnabled(true);
+			text.append("\nBackground work has completed");
 		}));
 		shell.setSize(500, 300);
 		shell.open();

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/AllWidgetTests.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/AllWidgetTests.java
@@ -50,7 +50,8 @@ import org.junit.runners.Suite;
 		Test_org_eclipse_swt_custom_StyledText_multiCaretsSelections.class,
 		Test_org_eclipse_swt_custom_StyledTextLineSpacingProvider.class,
 		Test_org_eclipse_swt_custom_CTabFolder.class, Test_org_eclipse_swt_widgets_Spinner.class,
-		Test_org_eclipse_swt_widgets_ScrolledComposite.class})
+		Test_org_eclipse_swt_widgets_ScrolledComposite.class,
+		Test_org_eclipse_swt_custom_BusyIndicator.class})
 public class AllWidgetTests {
 	public static void main(String[] args) {
 		JUnitCore.main(AllWidgetTests.class.getName());

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_custom_BusyIndicator.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_custom_BusyIndicator.java
@@ -1,0 +1,134 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Christoph Läubrich and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.swt.tests.junit;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.custom.BusyIndicator;
+import org.eclipse.swt.graphics.Cursor;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Shell;
+import org.junit.Test;
+
+public class Test_org_eclipse_swt_custom_BusyIndicator {
+
+	@Test
+	public void testShowWhile() {
+		Shell shell = new Shell();
+		Display display = shell.getDisplay();
+		Cursor busyCursor = display.getSystemCursor(SWT.CURSOR_WAIT);
+		CountDownLatch latch = new CountDownLatch(1);
+		CompletableFuture<?> future = CompletableFuture.runAsync(() -> {
+			try {
+				latch.await(10, TimeUnit.SECONDS);
+			} catch (InterruptedException e) {
+			}
+		});
+
+		CountDownLatch latchNested = new CountDownLatch(1);
+		CompletableFuture<?> futureNested = CompletableFuture.runAsync(() -> {
+			try {
+				latchNested.await(10, TimeUnit.SECONDS);
+			} catch (InterruptedException e) {
+			}
+		});
+
+		assertNotEquals(busyCursor, shell.getCursor());
+
+		// This it proves that events on the display are executed
+		display.asyncExec(() -> {
+			// This will happen during the showWhile(future) from below.
+			BusyIndicator.showWhile(futureNested);
+		});
+
+		Cursor[] cursorInAsync = new Cursor[2];
+
+		// this serves two purpose:
+		// 1) it proves that events on the display are executed
+		// 2) it checks that the shell has the busy cursor during the nest showWhile.
+		display.asyncExec(() -> {
+			cursorInAsync[0] = shell.getCursor();
+			latchNested.countDown();
+		});
+
+		// this serves two purpose:
+		// 1) it proves that events on the display are executed
+		// 2) it checks that the shell has the busy cursor even after the termination of
+		// the nested showWhile.
+		display.asyncExec(() -> {
+			cursorInAsync[1] = shell.getCursor();
+			latch.countDown();
+		});
+
+		BusyIndicator.showWhile(future);
+		assertTrue(future.isDone());
+		assertEquals(busyCursor, cursorInAsync[0]);
+		assertEquals(busyCursor, cursorInAsync[1]);
+		shell.dispose();
+		while (!display.isDisposed() && display.readAndDispatch()) {
+		}
+	}
+
+	@Test
+	public void testShowWhileWithFuture() {
+		ExecutorService executor = Executors.newSingleThreadExecutor();
+		try {
+			Shell shell = new Shell();
+			Display display = shell.getDisplay();
+			Cursor busyCursor = display.getSystemCursor(SWT.CURSOR_WAIT);
+			Cursor[] cursorInAsync = new Cursor[1];
+			CountDownLatch latch = new CountDownLatch(1);
+			Future<?> future = executor.submit(() -> {
+				try {
+					latch.await(10, TimeUnit.SECONDS);
+				} catch (InterruptedException e) {
+				}
+			});
+			// this serves two purpose:
+			// 1) it proves that events on the display are executed
+			// 2) it checks that the shell has the busy cursor during the nest showWhile.
+			display.asyncExec(() -> {
+				cursorInAsync[0] = shell.getCursor();
+				latch.countDown();
+			});
+			//External trigger for minimal latency as advised in the javadoc
+			executor.submit(()->{
+				try {
+					future.get();
+				} catch (Exception e) {
+				}
+				display.wake();
+			});
+			BusyIndicator.showWhile(future);
+			assertTrue(future.isDone());
+			assertEquals(busyCursor, cursorInAsync[0]);
+			shell.dispose();
+			while (!display.isDisposed() && display.readAndDispatch()) {
+			}
+		} finally {
+			executor.shutdownNow();
+		}
+	}
+
+}


### PR DESCRIPTION
While the methods to perform an operation with busy indication are already a great help to write responsive UI there is one case missing where a (Completable)Future is already present, this can for example be used to cache some heavy work.

This now adds a new BusyIndicator.showWhile(Future) method that covers the use case of an externally provided future computation so the caller can be sure that while it takes place the UI shows an indicator.

Beside that the Snippet30 was enhanced to demonstrate the new function.