### PR TITLE
[win32] Init nativeZoom of taskbar on creation

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TaskBar.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TaskBar.java
@@ -65,6 +65,7 @@ public class TaskBar extends Widget {
 
 TaskBar (Display display, int style) {
 	this.display = display;
+	this.nativeZoom = display.getDeviceZoom();
 	createHandle ();
 	reskinWidget ();
 }
@@ -166,14 +167,14 @@ IShellLink createShellLink (MenuItem item) {
 				ImageData data;
 				if (item.hBitmap != 0) {
 					Image image2 = Image.win32_new (display, SWT.BITMAP, item.hBitmap);
-					data = image2.getImageData (DPIUtil.getDeviceZoom ());
+					data = image2.getImageData (getZoom());
 					/*
 					 * image2 instance doesn't own the handle and shall not be disposed. Make it
 					 * appear disposed to cause leak trackers to ignore it.
 					 */
 					image2.handle = 0;
 				} else {
-					data = image.getImageData (DPIUtil.getDeviceZoom ());
+					data = image.getImageData (getZoom());
 				}
 				ImageLoader loader = new ImageLoader ();
 				loader.data = new ImageData [] {data};


### PR DESCRIPTION
As the constructor of TaskBar is not calling the super constructor the nativeZoom attribute must be set here as well. As it only has the display as reference, the zoom of the display (currently equal to primary monitor zoom) will be used

Contributes to #62 and #131