### PR TITLE
Init nativeZoom of Tray on creation

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/Tray.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/Tray.java
@@ -43,6 +43,7 @@ public class Tray extends Widget {
 
 Tray (Display display, int style) {
 	this.display = display;
+	this.nativeZoom = display.getDeviceZoom();
 	reskinWidget ();
 }
 


### PR DESCRIPTION
As the constructor of Tray is not calling the super constructor, the nativeZoom attribute must be set here as well. As it only has the display as reference, the zoom of the display (currently equal to primary monitor zoom) will be used

Contributes to #62 and #131