### PR TITLE
Fix usage of re-scaled fonts in TableItem::setFont for Windows

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TableItem.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TableItem.java
@@ -936,7 +936,7 @@ public void setFont (int index, Font font) {
 	}
 	Font oldFont = cellFont [index];
 	if (oldFont == font) return;
-	cellFont [index] = font;
+	cellFont [index] = font == null ? font : Font.win32_new(font, nativeZoom);
 	if (oldFont != null && oldFont.equals (font)) return;
 	if (font != null) parent.setCustomDraw (true);
 	if ((parent.style & SWT.VIRTUAL) != 0) cached = true;


### PR DESCRIPTION
In TableItem::setFont with the index specified, the passed font and not the font from the SWTFontProvider is used. This has only an effect when the ScaledFontRegistry is used and a font is passed, that does not match the current zoom of the table item.

Contributes to #62 and #127

## How to reproduce

1. Adapt the VM argument of the ControlExample
```
-Dswt.autoScale=quarter
-Dswt.autoScale.updateOnRuntime=true
```
2. Have two monitors with different zoom, e.g. 100% and 150%
3. Start the ControlExample on 100%
4. Move it to the monitor with 150%
5.  Change column font 
![image](https://github.com/eclipse-platform/eclipse.platform.swt/assets/119662019/bcc63e35-be07-4bcc-893a-ca66e3b86fe5)
6.  -> The font will have the wrong size: 
![image](https://github.com/eclipse-platform/eclipse.platform.swt/assets/119662019/611a4949-26a6-41e2-9816-22d84cf28e4b)
top after -> bottom before
