### PR TITLE
Fix usage of re-scaled fonts in Control:setFont for windows

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/graphics/GCWin32Tests.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/graphics/GCWin32Tests.java
@@ -15,34 +15,15 @@ package org.eclipse.swt.graphics;
 
 import static org.junit.Assert.assertEquals;
 
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.*;
 
-import org.eclipse.swt.SWT;
-import org.eclipse.swt.internal.DPITestUtil;
-import org.eclipse.swt.internal.DPIUtil;
-import org.eclipse.swt.widgets.Display;
-import org.eclipse.swt.widgets.Event;
-import org.eclipse.swt.widgets.Shell;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.eclipse.swt.*;
+import org.eclipse.swt.internal.*;
+import org.eclipse.swt.widgets.*;
+import org.junit.*;
 
-public class GCWin32Tests {
-	private Display display;
-	private boolean autoScaleOnRuntime;
-
-	@Before
-	public void setUp() {
-		autoScaleOnRuntime = DPIUtil.isAutoScaleOnRuntimeActive();
-		DPITestUtil.setAutoScaleOnRunTime(true);
-		display = Display.getDefault();
-	}
-
-	@After
-	public void tearDown() {
-		DPITestUtil.setAutoScaleOnRunTime(autoScaleOnRuntime);
-	}
+public class GCWin32Tests extends Win32AutoscaleTestBase {
 
 	@Test
 	public void gcZoomLevelMustChangeOnShellZoomChange() {
@@ -50,7 +31,6 @@ public class GCWin32Tests {
 		CompletableFuture<Integer> scaledGcNativeZoom = new CompletableFuture<>();
 		int zoom = DPIUtil.getDeviceZoom();
 		AtomicBoolean isScaled = new AtomicBoolean(false);
-		Shell shell = new Shell(display);
 		shell.addListener(SWT.Paint, event -> {
 			if (isScaled.get()) {
 				scaledGcNativeZoom.complete(event.gc.getGCData().nativeZoom);
@@ -79,7 +59,6 @@ public class GCWin32Tests {
 	public void drawnElementsShouldScaleUpToTheRightZoomLevel() {
 		int zoom = DPIUtil.getDeviceZoom();
 		int scalingFactor = 2;
-		Shell shell = new Shell(display);
 		GC gc = GC.win32_new(shell, new GCData());
 		gc.getGCData().nativeZoom = zoom * scalingFactor;
 		gc.getGCData().lineWidth = 10;

--- a/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/internal/DPITestUtil.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/internal/DPITestUtil.java
@@ -6,4 +6,7 @@ public class DPITestUtil {
 		DPIUtil.setAutoScaleOnRuntimeActive(value);
 	}
 
+	public static boolean isAutoScaleOnRuntimeActive() {
+		return DPIUtil.isAutoScaleOnRuntimeActive();
+	}
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/internal/Win32AutoscaleTestBase.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/internal/Win32AutoscaleTestBase.java
@@ -1,0 +1,60 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Yatta Solutions
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Yatta Solutions - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.swt.internal;
+
+import org.eclipse.swt.*;
+import org.eclipse.swt.widgets.*;
+import org.junit.*;
+
+public abstract class Win32AutoscaleTestBase {
+	private Display display;
+	protected Shell shell;
+	private boolean autoScaleOnRuntime;
+
+	@BeforeClass
+	public static void assumeIsFittingPlatform() {
+		PlatformSpecificExecution.assumeIsFittingPlatform();
+	}
+
+	@Before
+	public void setUpTest() {
+		autoScaleOnRuntime = DPITestUtil.isAutoScaleOnRuntimeActive();
+		display = Display.getDefault();
+		autoScaleOnRuntime(true);
+		shell = new Shell(display);
+	}
+
+	@After
+	public void tearDownTest() {
+		if (shell != null) {
+			shell.dispose();
+		}
+		autoScaleOnRuntime(autoScaleOnRuntime);
+	}
+
+	protected void autoScaleOnRuntime (boolean autoScaleOnRuntime) {
+		DPITestUtil.setAutoScaleOnRunTime(autoScaleOnRuntime);
+		// dispose a existing font registry for the default display
+		SWTFontProvider.disposeFontRegistry(display);
+	}
+
+	protected void changeDPIZoom (int nativeZoom) {
+		Event event = new Event();
+		event.type = SWT.ZoomChanged;
+		event.widget = shell;
+		event.detail = nativeZoom;
+		event.doit = true;
+		shell.notifyListeners(SWT.ZoomChanged, event);
+	}
+}

--- a/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/widgets/ControlWin32Tests.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/widgets/ControlWin32Tests.java
@@ -1,0 +1,80 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Yatta Solutions
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Yatta Solutions - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.swt.widgets;
+
+
+import static org.junit.Assert.*;
+
+import org.eclipse.swt.*;
+import org.eclipse.swt.graphics.*;
+import org.eclipse.swt.internal.*;
+import org.junit.*;
+
+/**
+ * Automated Tests for class org.eclipse.swt.widgets.Control
+ * for Windows specific behavior
+ *
+ * @see org.eclipse.swt.widgets.Control
+ */
+public class ControlWin32Tests extends Win32AutoscaleTestBase {
+
+	@Test
+	public void testScaleFontCorrectlyInAutoScaleSzenario() {
+		assertTrue("Autoscale property is not set to true", DPITestUtil.isAutoScaleOnRuntimeActive());
+
+		int scalingFactor = 2;
+		Control control = new Composite(shell, SWT.NONE);
+		int zoom = DPIUtil.getDeviceZoom();
+		int newZoom = zoom * scalingFactor;
+		try {
+			Font oldFont = control.getFont();
+			changeDPIZoom(newZoom);
+			control.setFont(oldFont);
+			Font newFont = control.getFont();
+			FontData fontData = oldFont.getFontData()[0];
+			FontData currentFontData = newFont.getFontData()[0];
+			int heightInPixels = fontData.data.lfHeight;
+			int currentHeightInPixels = currentFontData.data.lfHeight;
+			assertEquals("Font height in points is different on different zoom levels", fontData.getHeight(), currentFontData.getHeight());
+			assertEquals("Font height in pixels is not adjusted according to the scale factor", heightInPixels * scalingFactor, currentHeightInPixels);
+		} finally {
+			control.dispose();
+		}
+	}
+
+	@Test
+	public void testDoNotScaleFontCorrectlyInNoAutoScaleSzenario() {
+		autoScaleOnRuntime(false);
+		assertFalse("Autoscale property is not set to false", DPITestUtil.isAutoScaleOnRuntimeActive());
+
+		int scalingFactor = 2;
+		Control control = new Composite(shell, SWT.NONE);
+		int zoom = DPIUtil.getDeviceZoom();
+		int newZoom = zoom * scalingFactor;
+		try {
+			Font oldFont = control.getFont();
+			changeDPIZoom(newZoom);
+			control.setFont(oldFont);
+			Font newFont = control.getFont();
+			FontData fontData = oldFont.getFontData()[0];
+			FontData currentFontData = newFont.getFontData()[0];
+			int heightInPixels = fontData.data.lfHeight;
+			int currentHeightInPixels = currentFontData.data.lfHeight;
+			assertEquals("Font height in points is different on different zoom levels", fontData.getHeight(), currentFontData.getHeight());
+			assertEquals("Font height in pixels is different when setting the same font again", heightInPixels, currentHeightInPixels);
+		} finally {
+			control.dispose();
+		}
+	}
+}

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Control.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Control.java
@@ -3420,11 +3420,11 @@ public void setFont (Font font) {
 		newFont = Font.win32_new(newFont, getShell().nativeZoom);
 	}
 	long hFont = 0;
-	if (font != null) {
-		if (font.isDisposed()) error(SWT.ERROR_INVALID_ARGUMENT);
-		hFont = font.handle;
+	if (newFont != null) {
+		if (newFont.isDisposed()) error(SWT.ERROR_INVALID_ARGUMENT);
+		hFont = newFont.handle;
 	}
-	this.font = font;
+	this.font = newFont;
 	if (hFont == 0) hFont = defaultFont ();
 	OS.SendMessage (handle, OS.WM_SETFONT, hFont, 1);
 }


### PR DESCRIPTION
In Control::setFont the passed font and not the font from the SWTFontProvider is used. This has only an effect when the ScaledFontRegistry is used and a font is passed, that does not match the current zoom of the control.

Contributes to https://github.com/eclipse-platform/eclipse.platform.swt/issues/62 and https://github.com/eclipse-platform/eclipse.platform.swt/issues/127