### PR TITLE
Implementation of transform to enable Multi Zoom Level Support for Win32

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/graphics/TransformWin32Tests.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/graphics/TransformWin32Tests.java
@@ -1,0 +1,49 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Yatta Solutions
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Yatta Solutions - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.swt.graphics;
+
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+import org.eclipse.swt.internal.*;
+import org.eclipse.swt.internal.gdip.*;
+import org.junit.*;
+
+public class TransformWin32Tests extends Win32AutoscaleTestBase {
+
+	@Test
+	public void testShouldHaveDifferentHandlesAtDifferentZoomLevels() {
+		int zoom = DPIUtil.getDeviceZoom();
+		Transform transform = new Transform(display);
+		long scaledHandle = transform.getHandle(zoom * 2);
+		assertNotEquals("There should be different handles for different zoom levels", scaledHandle, transform.getHandle(zoom));
+		long scaledHandle2 = transform.getHandle(zoom * 3);
+		assertNotEquals("There should be different handles for different zoom levels", scaledHandle, scaledHandle2);
+	}
+
+	@Test
+	public void testScaledTrasformMustHaveScaledValues() {
+		int zoom = DPIUtil.getDeviceZoom();
+		Transform transform = new Transform(display, 0, 0, 0, 0, 4, 2);
+		float[] elements = new float[6];
+		transform.getElements(elements);
+		long scaledHandle = transform.getHandle(zoom * 2);
+		float[] scaledElements = new float[6];
+		Gdip.Matrix_GetElements(scaledHandle, scaledElements);
+		assertEquals(elements[4] * 2, scaledElements[4], 0);
+		assertEquals(elements[5] * 2, scaledElements[5], 0);
+	}
+
+}

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/GC.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/GC.java
@@ -3790,10 +3790,10 @@ public void getTransform(Transform transform) {
 	if (transform.isDisposed()) SWT.error(SWT.ERROR_INVALID_ARGUMENT);
 	long gdipGraphics = data.gdipGraphics;
 	if (gdipGraphics != 0) {
-		Gdip.Graphics_GetTransform(gdipGraphics, transform.handle);
+		Gdip.Graphics_GetTransform(gdipGraphics, transform.getHandle(getZoom()));
 		long identity = identity();
 		Gdip.Matrix_Invert(identity);
-		Gdip.Matrix_Multiply(transform.handle, identity, Gdip.MatrixOrderAppend);
+		Gdip.Matrix_Multiply(transform.getHandle(getZoom()), identity, Gdip.MatrixOrderAppend);
 		Gdip.Matrix_delete(identity);
 	} else {
 		transform.setElements(1, 0, 0, 1, 0, 0);
@@ -4928,7 +4928,7 @@ public void setTransform(Transform transform) {
 	initGdip();
 	long identity = identity();
 	if (transform != null) {
-		Gdip.Matrix_Multiply(identity, transform.handle, Gdip.MatrixOrderPrepend);
+		Gdip.Matrix_Multiply(identity, transform.getHandle(getZoom()), Gdip.MatrixOrderPrepend);
 	}
 	Gdip.Graphics_SetTransform(data.gdipGraphics, identity);
 	Gdip.Matrix_delete(identity);


### PR DESCRIPTION
## Addressed issues
* https://github.com/eclipse-platform/eclipse.platform.swt/issues/62 
* https://github.com/eclipse-platform/eclipse.platform.swt/issues/131

## Requires
* [x] https://github.com/eclipse-platform/eclipse.platform.swt/pull/1214

**Note:** Only the last commit in this PR is to be reviewed. Previous commit(s) belong to the prerequisite PR(s)

## Description

This pull request is based on the implementations of PR #1214. It extends to the native zoom which is provided within widget and propagated to GC. In this PR, we provide a map of different handles to Transform for different zoom levels as required by different monitors. The method win32_getHandle provides the appropriate handle for the scaled transform as per requested by the client. So far, Transform is only used by GC in the project, so all the calls from GC has been adapted to use the new method to obtasin the right handle.