### PR TITLE
Snippets: reduce warnings

### DIFF
--- a/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet123.java
+++ b/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet123.java
@@ -28,6 +28,7 @@ package org.eclipse.swt.snippets;
  * http://www.eclipse.org/swt/snippets/
  */
 import org.eclipse.swt.*;
+import org.eclipse.swt.internal.*;
 import org.eclipse.swt.internal.ole.win32.*;
 import org.eclipse.swt.internal.win32.*;
 import org.eclipse.swt.layout.*;
@@ -192,11 +193,11 @@ class EventDispatch {
 		COM.MoveMemory(guid, riid, GUID.sizeof);
 
 		if (COM.IsEqualGUID(guid, COM.IIDIUnknown) || COM.IsEqualGUID(guid, COM.IIDIDispatch)) {
-			COM.MoveMemory(ppvObject, new long /*int*/[] {iDispatch.getAddress()}, OS.PTR_SIZEOF);
+			OS.MoveMemory(ppvObject, new long /*int*/[] {iDispatch.getAddress()}, C.PTR_SIZEOF);
 			AddRef();
 			return COM.S_OK;
 		}
-		COM.MoveMemory(ppvObject, new long /*int*/[] {0}, OS.PTR_SIZEOF);
+		OS.MoveMemory(ppvObject, new long /*int*/[] {0}, C.PTR_SIZEOF);
 		return COM.E_NOINTERFACE;
 	}
 	int Release() {

--- a/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet186.java
+++ b/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet186.java
@@ -25,11 +25,13 @@ package org.eclipse.swt.snippets;
  * http://www.eclipse.org/swt/snippets/
  */
 import org.eclipse.swt.*;
+import org.eclipse.swt.internal.*;
 import org.eclipse.swt.internal.win32.*;
 import org.eclipse.swt.layout.*;
 import org.eclipse.swt.ole.win32.*;
 import org.eclipse.swt.widgets.*;
 
+@SuppressWarnings("restriction")
 public class Snippet186 {
 
 static int CodePage = OS.GetACP();
@@ -144,7 +146,7 @@ static String readSafeArray(Variant variantByRef) {
 		OS.MoveMemory(vt_type, pVariant[0], 2);
 		if (vt_type[0] == (short)(OLE.VT_ARRAY | OLE.VT_UI1)) {
 			long /*int*/ [] pSafearray = new long /*int*/[1];
-			OS.MoveMemory(pSafearray, pVariant[0] + 8, OS.PTR_SIZEOF);
+			OS.MoveMemory(pSafearray, pVariant[0] + 8, C.PTR_SIZEOF);
 			SAFEARRAY safeArray = new SAFEARRAY();
 			OS.MoveMemory(safeArray, pSafearray[0], SAFEARRAY.sizeof);
 			for (int i = 0; i < safeArray.cDims; i++) {
@@ -195,7 +197,7 @@ static Variant writeSafeArray (String string) {
 	long /*int*/ pVariant = OS.GlobalAlloc(OS.GMEM_FIXED | OS.GMEM_ZEROINIT, Variant.sizeof);
 	short vt = (short)(OLE.VT_ARRAY | OLE.VT_UI1);
 	OS.MoveMemory(pVariant, new short[] {vt}, 2);
-	OS.MoveMemory(pVariant + 8, new long /*int*/[]{pSafeArray}, OS.PTR_SIZEOF);
+	OS.MoveMemory(pVariant + 8, new long /*int*/[]{pSafeArray}, C.PTR_SIZEOF);
 	// Create a by ref variant
 	Variant variantByRef = new Variant(pVariant, (short)(OLE.VT_BYREF | OLE.VT_VARIANT));
 	return variantByRef;

--- a/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet337.java
+++ b/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet337.java
@@ -40,7 +40,7 @@ public static void main(String args[]) {
 	display = new Display();
 	EventQueue.invokeLater(() -> {
 		JFrame mainFrame = new JFrame("Main Window");
-		mainFrame.setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
+		mainFrame.setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
 		mainFrame.addWindowListener(new Snippet337.CloseListener());
 		JPanel mainPanel = new JPanel();
 		mainPanel.setLayout(new FlowLayout());

--- a/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet81.java
+++ b/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet81.java
@@ -26,6 +26,7 @@ import org.eclipse.swt.internal.ole.win32.*;
 import org.eclipse.swt.ole.win32.*;
 import org.eclipse.swt.widgets.*;
 
+@SuppressWarnings("restriction")
 public class Snippet81 {
 
 public static void main(String[] args) {

--- a/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet83.java
+++ b/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet83.java
@@ -24,9 +24,11 @@ package org.eclipse.swt.snippets;
 import org.eclipse.swt.*;
 import org.eclipse.swt.dnd.*;
 import org.eclipse.swt.internal.ole.win32.*;
+import org.eclipse.swt.internal.win32.*;
 import org.eclipse.swt.layout.*;
 import org.eclipse.swt.widgets.*;
 
+@SuppressWarnings("restriction")
 public class Snippet83 extends ByteArrayTransfer {
 
 private static Snippet83 _instance = new Snippet83();
@@ -112,7 +114,7 @@ static String getNameFromId(int id) {
 	String name = null;
 	int maxSize = 128;
 	char [] buffer = new char [maxSize];
-	int size = COM.GetClipboardFormatName(id, buffer, maxSize);
+	int size = OS.GetClipboardFormatName(id, buffer, maxSize);
 	if (size != 0) {
 		name = new String (buffer, 0, size);
 	} else {


### PR DESCRIPTION
* The static method should be accessed directly
* The static field should be accessed directly
* discouraged access