### PR TITLE
Multi Zoom Support for region for win32

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/graphics/RegionWin32Tests.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/graphics/RegionWin32Tests.java
@@ -1,0 +1,52 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Yatta Solutions
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Yatta Solutions - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.swt.graphics;
+
+import static org.junit.Assert.assertEquals;
+
+import org.eclipse.swt.internal.*;
+import org.eclipse.swt.internal.win32.*;
+import org.junit.jupiter.api.*;
+
+class RegionWin32Tests extends Win32AutoscaleTestBase {
+
+	@Test
+	public void testRegionMustBeScaledOnHandleOfScaledZoomLevel() {
+		int zoom = DPIUtil.getDeviceZoom();
+		int scalingFactor = 2;
+
+		Region region = new Region(display);
+		region.add(0, 0, 5, 10);
+		region.subtract(0,0,1,1);
+		region.translate(0, 5);
+		region.intersect(1,1,1,1);
+
+		long handle = Region.win32_getHandle(region, zoom);
+		long scaledRegionHandle = Region.win32_getHandle(region, zoom * scalingFactor);
+
+		RECT rect = new RECT();
+		OS.GetRgnBox(handle, rect);
+		Rectangle bounds = new Rectangle(rect.left, rect.top, rect.right - rect.left, rect.bottom - rect.top);
+
+		rect = new RECT();
+		OS.GetRgnBox(scaledRegionHandle, rect);
+		Rectangle scaledBounds = new Rectangle(rect.left, rect.top, rect.right - rect.left, rect.bottom - rect.top);
+
+		assertEquals("scaled region's height should be double of unscaled region", bounds.height * scalingFactor, scaledBounds.height);
+		assertEquals("scaled region's width should be double of unscaled region", bounds.width * scalingFactor, scaledBounds.width);
+		assertEquals("scaled region's x position should be double of unscaled region", bounds.x * scalingFactor, scaledBounds.x);
+		assertEquals("scaled region's y position should be double of unscaled region", bounds.y * scalingFactor, scaledBounds.y);
+	}
+
+}

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/GC.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/GC.java
@@ -3386,7 +3386,7 @@ public void getClipping (Region region) {
 			Gdip.Graphics_SetPixelOffsetMode(gdipGraphics, Gdip.PixelOffsetModeNone);
 			Gdip.Graphics_GetVisibleClipBounds(gdipGraphics, rect);
 			Gdip.Graphics_SetPixelOffsetMode(gdipGraphics, Gdip.PixelOffsetModeHalf);
-			OS.SetRectRgn(region.handle, rect.X, rect.Y, rect.X + rect.Width, rect.Y + rect.Height);
+			OS.SetRectRgn(Region.win32_getHandle(region, getZoom()), rect.X, rect.Y, rect.X + rect.Width, rect.Y + rect.Height);
 		} else {
 			long matrix = Gdip.Matrix_new(1, 0, 0, 1, 0, 0);
 			long identity = Gdip.Matrix_new(1, 0, 0, 1, 0, 0);
@@ -3399,7 +3399,7 @@ public void getClipping (Region region) {
 			POINT pt = new POINT ();
 			OS.GetWindowOrgEx (handle, pt);
 			OS.OffsetRgn (hRgn, pt.x, pt.y);
-			OS.CombineRgn(region.handle, hRgn, 0, OS.RGN_COPY);
+			OS.CombineRgn(Region.win32_getHandle(region, getZoom()), hRgn, 0, OS.RGN_COPY);
 			OS.DeleteObject(hRgn);
 		}
 		Gdip.Region_delete(rgn);
@@ -3407,18 +3407,18 @@ public void getClipping (Region region) {
 	}
 	POINT pt = new POINT ();
 	OS.GetWindowOrgEx (handle, pt);
-	int result = OS.GetClipRgn (handle, region.handle);
+	int result = OS.GetClipRgn (handle, Region.win32_getHandle(region, getZoom()));
 	if (result != 1) {
 		RECT rect = new RECT();
 		OS.GetClipBox(handle, rect);
-		OS.SetRectRgn(region.handle, rect.left, rect.top, rect.right, rect.bottom);
+		OS.SetRectRgn(Region.win32_getHandle(region, getZoom()), rect.left, rect.top, rect.right, rect.bottom);
 	} else {
-		OS.OffsetRgn (region.handle, pt.x, pt.y);
+		OS.OffsetRgn (Region.win32_getHandle(region, getZoom()), pt.x, pt.y);
 	}
 	long metaRgn = OS.CreateRectRgn (0, 0, 0, 0);
 	if (OS.GetMetaRgn (handle, metaRgn) != 0) {
 		OS.OffsetRgn (metaRgn, pt.x, pt.y);
-		OS.CombineRgn (region.handle, metaRgn, region.handle, OS.RGN_AND);
+		OS.CombineRgn (Region.win32_getHandle(region, getZoom()), metaRgn, Region.win32_getHandle(region, getZoom()), OS.RGN_AND);
 	}
 	OS.DeleteObject(metaRgn);
 	long hwnd = data.hwnd;
@@ -3435,7 +3435,7 @@ public void getClipping (Region region) {
 			}
 			OS.MapWindowPoints (0, hwnd, pt, 1);
 			OS.OffsetRgn (sysRgn, pt.x, pt.y);
-			OS.CombineRgn (region.handle, sysRgn, region.handle, OS.RGN_AND);
+			OS.CombineRgn (Region.win32_getHandle(region, getZoom()), sysRgn, Region.win32_getHandle(region, getZoom()), OS.RGN_AND);
 		}
 		OS.DeleteObject(sysRgn);
 	}
@@ -4374,7 +4374,7 @@ public void setClipping (Rectangle rect) {
 public void setClipping (Region region) {
 	if (handle == 0) SWT.error(SWT.ERROR_GRAPHIC_DISPOSED);
 	if (region != null && region.isDisposed()) SWT.error(SWT.ERROR_INVALID_ARGUMENT);
-	setClipping(region != null ? region.handle : 0);
+	setClipping(region != null ? Region.win32_getHandle(region, getZoom()) : 0);
 }
 
 /**

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Control.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Control.java
@@ -3690,7 +3690,7 @@ public void setRegion (Region region) {
 	long hRegion = 0;
 	if (region != null) {
 		hRegion = OS.CreateRectRgn (0, 0, 0, 0);
-		OS.CombineRgn (hRegion, region.handle, hRegion, OS.RGN_OR);
+		OS.CombineRgn (hRegion, Region.win32_getHandle(region, getZoom()), hRegion, OS.RGN_OR);
 	}
 	OS.SetWindowRgn (handle, hRegion, true);
 	this.region = region;
@@ -5814,6 +5814,9 @@ private static void handleDPIChange(Widget widget, int newZoom, float scalingFac
 		} else {
 			control.setBackgroundImage(image);
 		}
+	}
+	if (control.getRegion() != null) {
+		control.setRegion(control.getRegion());
 	}
 }
 

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Shell.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Shell.java
@@ -712,7 +712,7 @@ private void logUnlessEquals(Appendable log, String message, Rectangle expected,
 	}
 }
 
-//TODO This test was not hooked for running with the runTest override. It fails on GTK/Cocoa. Investigate.
+@Test
 public void a_test_setRegion() {
 	Region region = new Region();
 	region.add(new Rectangle(10, 20, 100, 200));
@@ -727,7 +727,7 @@ public void a_test_setRegion() {
 	Shell shell2 = new Shell(display, SWT.NO_TRIM);
 	assertNull(":d:", shell2.getRegion());
 	shell2.setRegion(region);
-	assertEquals(":e:", region.handle, shell2.getRegion().handle);
+	assertEquals(":e:", region, shell2.getRegion());
 	region.dispose();
 	assertTrue(":f:", shell2.getRegion().isDisposed());
 	shell2.setRegion(null);


### PR DESCRIPTION
## Addressed issues
* https://github.com/eclipse-platform/eclipse.platform.swt/issues/62 
* https://github.com/eclipse-platform/eclipse.platform.swt/issues/131

## Requires
* [x] https://github.com/eclipse-platform/eclipse.platform.swt/pull/1214

**Note:** Only the last commit in this PR is to be reviewed. Previous commit(s) belong to the prerequisite PR(s)

## Description

This pull request is based on the implementations of PR #1214. It extends to the native zoom which is provided within widget and propagated to GC. In this PR, the multiple zoom level functionality is attained by using a map to maintain the handle of the region scale as per zoom level. The handle can then be obtained by the method win32_getHandle by passing the zoom information from the client.

contributes to #62 and #127