### PR TITLE
Multi zoom level path

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/graphics/PathWin32Tests.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/graphics/PathWin32Tests.java
@@ -1,0 +1,66 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Yatta Solutions
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Yatta Solutions - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.swt.graphics;
+
+import static org.junit.Assert.assertTrue;
+
+import java.util.*;
+
+import org.eclipse.swt.internal.*;
+import org.eclipse.swt.internal.gdip.*;
+import org.junit.*;
+
+public class PathWin32Tests extends Win32AutoscaleTestBase {
+
+	int zoom = 100;
+	int scaledZoom = 200;
+
+	@Test
+	public void testPathMustBeScaledOnZoomLevelChange() {
+		Path path = new Path(display);
+		path.addArc(0, 0, 10, 10, 0, 90);
+		PathData pathData = path.getPathData();
+		DPIUtil.setDeviceZoom(scaledZoom);
+		Path scaledPath = new Path(display, pathData);
+		PathData scaledPathData = scaledPath.getPathData();
+		assertTrue("PathData types don't change on zoom level change", Arrays.equals(pathData.types, scaledPathData.types));
+		assertTrue("PathData points don't change on zoom level change", Arrays.equals(pathData.points, scaledPathData.points));
+	}
+
+	@Test
+	public void testHandlesExistForEachZoomLevelInHashMap() {
+		DPIUtil.setDeviceZoom(zoom);
+		Path path = new Path(display);
+		path.addArc(0, 0, 10, 10, 0, 90);
+		path.getHandle(scaledZoom);
+		assertTrue("zoomLevelToHandle contains scaled handle", path.toString().contains(scaledZoom + "="));
+		assertTrue("zoomLevelToHandle contains initial zoom's handle", path.toString().contains(zoom + "="));
+	}
+
+	@Test
+	public void testBoundsAreScaledWRTZoomLevel() {
+		DPIUtil.setDeviceZoom(zoom);
+		int scalingFactor = scaledZoom/zoom;
+		Path path = new Path(display);
+		path.addArc(0, 0, 10, 10, 0, 90);
+		RectF bounds = new RectF();
+		RectF scaledBounds = new RectF();
+		Gdip.GraphicsPath_GetBounds(path.getHandle(zoom), bounds, 0, 0);
+		Gdip.GraphicsPath_GetBounds(path.getHandle(scaledZoom), scaledBounds, 0, 0);
+		assertTrue("X coordinate is scaled up wrt the scalingFactor", bounds.X * scalingFactor == scaledBounds.X);
+		assertTrue("X coordinate is scaled up wrt the scalingFactor", bounds.Y * scalingFactor == scaledBounds.Y);
+		assertTrue("Height is scaled up wrt the scalingFactor", bounds.Height * scalingFactor == scaledBounds.Height);
+		assertTrue("Height is scaled up wrt the scalingFactor", bounds.Width * scalingFactor == scaledBounds.Width);
+	}
+}

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/GC.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/GC.java
@@ -1746,12 +1746,13 @@ void drawOvalInPixels (int x, int y, int width, int height) {
 public void drawPath (Path path) {
 	if (handle == 0) SWT.error(SWT.ERROR_GRAPHIC_DISPOSED);
 	if (path == null) SWT.error(SWT.ERROR_NULL_ARGUMENT);
-	if (path.handle == 0) SWT.error(SWT.ERROR_INVALID_ARGUMENT);
+	long pathHandle = path.getHandle(getZoom());
+	if (pathHandle == 0) SWT.error(SWT.ERROR_INVALID_ARGUMENT);
 	initGdip();
 	checkGC(DRAW);
 	long gdipGraphics = data.gdipGraphics;
 	Gdip.Graphics_TranslateTransform(gdipGraphics, data.gdipXOffset, data.gdipYOffset, Gdip.MatrixOrderPrepend);
-	Gdip.Graphics_DrawPath(gdipGraphics, data.gdipPen, path.handle);
+	Gdip.Graphics_DrawPath(gdipGraphics, data.gdipPen, pathHandle);
 	Gdip.Graphics_TranslateTransform(gdipGraphics, -data.gdipXOffset, -data.gdipYOffset, Gdip.MatrixOrderPrepend);
 }
 
@@ -2930,12 +2931,13 @@ void fillOvalInPixels (int x, int y, int width, int height) {
 public void fillPath (Path path) {
 	if (handle == 0) SWT.error(SWT.ERROR_GRAPHIC_DISPOSED);
 	if (path == null) SWT.error(SWT.ERROR_NULL_ARGUMENT);
-	if (path.handle == 0) SWT.error(SWT.ERROR_INVALID_ARGUMENT);
+	final long pathHandle = path.getHandle(getZoom());
+	if (pathHandle == 0) SWT.error(SWT.ERROR_INVALID_ARGUMENT);
 	initGdip();
 	checkGC(FILL);
 	int mode = OS.GetPolyFillMode(handle) == OS.WINDING ? Gdip.FillModeWinding : Gdip.FillModeAlternate;
-	Gdip.GraphicsPath_SetFillMode(path.handle, mode);
-	Gdip.Graphics_FillPath(data.gdipGraphics, data.gdipBrush, path.handle);
+	Gdip.GraphicsPath_SetFillMode(pathHandle, mode);
+	Gdip.Graphics_FillPath(data.gdipGraphics, data.gdipBrush, pathHandle);
 }
 
 /**
@@ -4323,8 +4325,9 @@ public void setClipping (Path path) {
 	if (path != null) {
 		initGdip();
 		int mode = OS.GetPolyFillMode(handle) == OS.WINDING ? Gdip.FillModeWinding : Gdip.FillModeAlternate;
-		Gdip.GraphicsPath_SetFillMode(path.handle, mode);
-		Gdip.Graphics_SetClipPath(data.gdipGraphics, path.handle);
+		final long pathHandle = path.getHandle(getZoom());
+		Gdip.GraphicsPath_SetFillMode(pathHandle, mode);
+		Gdip.Graphics_SetClipPath(data.gdipGraphics, pathHandle);
 	}
 }
 


### PR DESCRIPTION
## Addressed issues
* https://github.com/eclipse-platform/eclipse.platform.swt/issues/62 
* https://github.com/eclipse-platform/eclipse.platform.swt/issues/131

## Requires
* [x] https://github.com/eclipse-platform/eclipse.platform.swt/pull/1214

**Note:** Only the last commit in this PR is to be reviewed. Previous commit(s) belong to the prerequisite PR(s)

## Description

This pull request is based on the implementations of PR #1214. It extends to the native zoom which is provided within widget and propagated to GC. In this PR, the multiple zoom level functionality is attained by using a map to maintain the handle of the path scaled as per the zoom level. The handle can then be obtained by the method win32_getHandle by passing the zoom information from the client.

contributes to #62 and #127