### PR TITLE
[win32][fix] apply dpi change to menus attribute for Decorations in windows

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/DPIZoomChangeRegistry.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/DPIZoomChangeRegistry.java
@@ -44,6 +44,9 @@ public class DPIZoomChangeRegistry {
 	 * @param scalingFactor factor as division between new zoom and old zoom, e.g. 1.5 for a scaling from 100% to 150%
 	 */
 	public static void applyChange(Widget widget, int newZoom, float scalingFactor) {
+		if (widget == null) {
+			return;
+		}
 		for (Entry<Class<? extends Widget>, DPIZoomChangeHandler> entry : dpiZoomChangeHandlers.entrySet()) {
 			Class<? extends Widget> clazz = entry.getKey();
 			DPIZoomChangeHandler handler = entry.getValue();

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Decorations.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Decorations.java
@@ -1703,9 +1703,12 @@ private static void handleDPIChange(Widget widget, int newZoom, float scalingFac
 		decorations.setImages(images);
 	}
 
-	Menu menuBar = decorations.getMenuBar();
-	if (menuBar != null) {
-		DPIZoomChangeRegistry.applyChange(menuBar, newZoom, scalingFactor);
+	DPIZoomChangeRegistry.applyChange(decorations.getMenuBar(), newZoom, scalingFactor);
+
+	if (decorations.menus != null) {
+		for (Menu menu : decorations.menus) {
+			DPIZoomChangeRegistry.applyChange(menu, newZoom, scalingFactor);
+		}
 	}
 }
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Menu.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Menu.java
@@ -430,6 +430,7 @@ void fixMenus (Decorations newParent) {
 	parent.removeMenu (this);
 	newParent.addMenu (this);
 	this.parent = newParent;
+	this.nativeZoom = newParent.nativeZoom;
 }
 
 /**

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/MenuItem.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/MenuItem.java
@@ -280,6 +280,7 @@ boolean fillAccel (ACCEL accel) {
 }
 
 void fixMenus (Decorations newParent) {
+	this.nativeZoom = newParent.nativeZoom;
 	if (menu != null && !menu.isDisposed() && !newParent.isDisposed()) menu.fixMenus (newParent);
 }
 


### PR DESCRIPTION
**Note:** issue can only occur in windows with flag swt.autoScale.updateOnRuntime set to true

This commit applies dpi changes to all menus in this menus attribute in Decorations as well in windows, so pop-up menus are no longer opened on the wrong location.

## Requires

- [x] https://github.com/eclipse-platform/eclipse.platform.swt/pull/1251

## How to reproduce

1. Have two monitors with different zoom settings
2. Start IDE
3. Move Java Editors on both of the monitors
4. Right-click on multiple positions in the editor on the non-primary monitor -> in some places they are opened at the mouse location in some places not