### PR TITLE
Scaling combo text according to zoom level

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CCombo.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CCombo.java
@@ -2025,4 +2025,20 @@ public boolean traverse(int event){
 	}
 	return super.traverse(event);
 }
+
+/**
+ * The method accepts a combo and a callback which takes
+ * all the child of the CCombo as the argument and executes it.
+ * All children are refreshed after the execution of the callback.
+ *
+ * @noreference This method is not intended to be referenced by clients.
+ * @param combo the Combo to get the children widget from
+ * @param childUpdater the callback which works with the child widgets
+ */
+public static void updateAndRefreshChildren(CCombo combo, Consumer<Widget> childUpdater) {
+	childUpdater.accept(combo.text);
+	childUpdater.accept(combo.list);
+	childUpdater.accept(combo.arrow);
+	childUpdater.accept(combo.popup);
+}
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/CommonWidgetsDPIChangeHandlers.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/CommonWidgetsDPIChangeHandlers.java
@@ -33,6 +33,7 @@ public class CommonWidgetsDPIChangeHandlers {
 	public static void registerCommonHandlers() {
 		DPIZoomChangeRegistry.registerHandler(CommonWidgetsDPIChangeHandlers::handleItemDPIChange, Item.class);
 		DPIZoomChangeRegistry.registerHandler(CommonWidgetsDPIChangeHandlers::handleStyledTextDPIChange, StyledText.class);
+		DPIZoomChangeRegistry.registerHandler(CommonWidgetsDPIChangeHandlers::handleCComboDPIChange, CCombo.class);
 	}
 
 	private static void handleItemDPIChange(Widget widget, int newZoom, float scalingFactor) {
@@ -51,9 +52,16 @@ public class CommonWidgetsDPIChangeHandlers {
 			return;
 		}
 
+
 		StyledText.updateAndRefreshCarets(styledText, caretToRefresh -> {
 			DPIZoomChangeRegistry.applyChange(caretToRefresh, newZoom, scalingFactor);
 			Caret.win32_setHeight(caretToRefresh, styledText.getLineHeight());
 		});
+	}
+	private static void handleCComboDPIChange(Widget widget, int newZoom, float scalingFactor) {
+		if (!(widget instanceof CCombo combo)) {
+			return;
+		}
+		CCombo.updateAndRefreshChildren(combo, childWidget -> DPIZoomChangeRegistry.applyChange(childWidget, newZoom, scalingFactor));
 	}
 }


### PR DESCRIPTION
Registering the comboDpiChange handler and applying change manually to
 text, image and arrow

Contributes to https://github.com/eclipse-platform/eclipse.platform.swt/issues/62 and https://github.com/eclipse-platform/eclipse.platform.swt/issues/127

## HOW TO TEST **(Windows only!)**

- Run the `CustomControlExample` with the following **VM Arguments**
```
-Dswt.autoScale=quarter
-Dswt.autoScale.updateOnRuntime=true
```
- Switch to the tab "CCombo"
- Move the window from 100 to 200 zoom level monitor
- See if scales properly

## EXPECTED BEHAVIOUR

Combo list, text and arrow should be properly scaled.
