### PR TITLE
Fix for #1288: No exception when creating GC with image from another thread

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Image.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Image.java
@@ -2190,7 +2190,7 @@ public long internal_new_GC (GCData data) {
 		data.device = device;
 		data.nativeZoom = initialNativeZoom;
 		data.image = this;
-		data.font = Font.win32_new(device.getSystemFont(), DPIUtil.getNativeDeviceZoom());
+		data.font = SWTFontProvider.getSystemFont(device, DPIUtil.getNativeDeviceZoom());
 	}
 	return imageDC;
 }

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_GC.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_GC.java
@@ -23,8 +23,11 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Color;
@@ -765,6 +768,27 @@ public void test_drawLine_noSingularitiesIn45DregreeRotation() {
 		gc.dispose();
 		image.dispose();
 	}
+}
+
+/**
+ * @see <a href="https://github.com/eclipse-platform/eclipse.platform.swt/issues/1288">Issue 1288</a>
+ */
+@Test
+public void test_bug1288_createGCFromImageFromNonDisplayThread() throws InterruptedException {
+	AtomicReference<Exception> exceptionReference = new AtomicReference<>();
+	Thread thread = new Thread(() -> {
+		try {
+			Image image = new Image(null, 100, 100);
+			GC gc = new GC(image);
+			gc.dispose();
+			image.dispose();
+		} catch(Exception e) {
+			exceptionReference.set(e);
+		}
+	});
+	thread.start();
+	thread.join();
+	assertNull("Creating a GC from an Image without a device threw an exception", exceptionReference.get());
 }
 
 /* custom */


### PR DESCRIPTION
This commit fixes an issue when creating a GC from an Image using a device bound to another thread as the GC is currently created in. 