### PR TITLE
Incorrect scaling for TreeItem font

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TreeItem.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TreeItem.java
@@ -1388,9 +1388,10 @@ public void setFont (Font font){
 		error (SWT.ERROR_INVALID_ARGUMENT);
 	}
 	Font oldFont = this.font;
-	if (oldFont == font) return;
 	Shell shell = parent.getShell();
-	this.font = (font == null ? font : Font.win32_new(font, shell.nativeZoom));
+	Font newFont = (font == null ? font : Font.win32_new(font, shell.nativeZoom));
+	if (oldFont == newFont) return;
+	this.font = newFont;
 	if (oldFont != null && oldFont.equals (font)) return;
 	if (font != null) parent.customDraw = true;
 	if ((parent.style & SWT.VIRTUAL) != 0) cached = true;


### PR DESCRIPTION
Incorrect scaling for TreeItem font when moving through different zoom levels.

Contributes to https://github.com/eclipse-platform/eclipse.platform.swt/issues/62 and https://github.com/eclipse-platform/eclipse.platform.swt/issues/127

## HOW TO TEST

- Run the `ControlExample` with the following **VM Arguments**
```
-Dswt.autoScale=quarter
-Dswt.autoScale.updateOnRuntime=true
```
- Switch to the tab "Tree"
- Set any font from the side bar window
- Move the window from 100 to 200 zoom level monitor
- See if scales properly

## EXPECTED BEHAVIOUR

The list font should be scaled properly
