### PR TITLE
remove unnecessary casts

### DIFF
--- a/bundles/org.eclipse.swt.tools/JNI Generation/org/eclipse/swt/tools/internal/EmbedMetaData.java
+++ b/bundles/org.eclipse.swt.tools/JNI Generation/org/eclipse/swt/tools/internal/EmbedMetaData.java
@@ -88,7 +88,7 @@ public void generate(JNIMethod method) {
 		ASTParameter param = (ASTParameter)p;
 		//wrap cast with parentheses
 		param.setCast(param.getCast());
-		data = ((AbstractItem)param).flatten();
+		data = param.flatten();
 		if (data != null && data.length() != 0) {
 			tags.add("@param " + param.getName() + " " + data);
 		}

--- a/bundles/org.eclipse.swt.tools/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.swt.tools/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.swt.tools; singleton:=true
-Bundle-Version: 3.110.400.qualifier
+Bundle-Version: 3.110.500.qualifier
 Bundle-ManifestVersion: 2
 Export-Package: org.eclipse.swt.tools.internal; x-internal:=true
 Bundle-ActivationPolicy: lazy

--- a/features/org.eclipse.swt.tools.feature/feature.xml
+++ b/features/org.eclipse.swt.tools.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.swt.tools.feature"
       label="%featureName"
-      version="3.109.400.qualifier"
+      version="3.109.500.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Control.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Control.java
@@ -1026,7 +1026,7 @@ protected void consistencyEvent(final int paramA, final int paramB,
 		shell.pack();
 		shell.open();
 		if(control instanceof Shell) {
-			((Shell)control).pack();
+			control.pack();
 			((Shell)control).open();
 		}
 		final Point[] pt = determineLocations(paramA, paramB, paramC, paramD, method);


### PR DESCRIPTION
When https://github.com/eclipse-jdt/eclipse.jdt.core/pull/2471 is merged, ecj will signal more casts as unnecessary.

With this PR I suggest to remove affected casts before new warnings will show up in the build.