### PR TITLE
Bump minor version of o.e.swt bundle to align it with its fragments

### DIFF
--- a/binaries/org.eclipse.swt.cocoa.macosx.aarch64/META-INF/MANIFEST.MF
+++ b/binaries/org.eclipse.swt.cocoa.macosx.aarch64/META-INF/MANIFEST.MF
@@ -1,5 +1,5 @@
 Manifest-Version: 1.0
-Fragment-Host: org.eclipse.swt;bundle-version="[3.126.100,4.0.0)"
+Fragment-Host: org.eclipse.swt;bundle-version="[3.127.0,4.0.0)"
 Bundle-Name: %fragmentName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.swt.cocoa.macosx.aarch64; singleton:=true

--- a/binaries/org.eclipse.swt.cocoa.macosx.x86_64/META-INF/MANIFEST.MF
+++ b/binaries/org.eclipse.swt.cocoa.macosx.x86_64/META-INF/MANIFEST.MF
@@ -1,5 +1,5 @@
 Manifest-Version: 1.0
-Fragment-Host: org.eclipse.swt;bundle-version="[3.126.100,4.0.0)"
+Fragment-Host: org.eclipse.swt;bundle-version="[3.127.0,4.0.0)"
 Bundle-Name: %fragmentName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.swt.cocoa.macosx.x86_64; singleton:=true

--- a/binaries/org.eclipse.swt.gtk.linux.aarch64/META-INF/MANIFEST.MF
+++ b/binaries/org.eclipse.swt.gtk.linux.aarch64/META-INF/MANIFEST.MF
@@ -1,5 +1,5 @@
 Manifest-Version: 1.0
-Fragment-Host: org.eclipse.swt;bundle-version="[3.126.100,4.0.0)"
+Fragment-Host: org.eclipse.swt;bundle-version="[3.127.0,4.0.0)"
 Bundle-Name: %fragmentName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.swt.gtk.linux.aarch64; singleton:=true

--- a/binaries/org.eclipse.swt.gtk.linux.loongarch64/META-INF/MANIFEST.MF
+++ b/binaries/org.eclipse.swt.gtk.linux.loongarch64/META-INF/MANIFEST.MF
@@ -1,5 +1,5 @@
 Manifest-Version: 1.0
-Fragment-Host: org.eclipse.swt;bundle-version="[3.126.100,4.0.0)"
+Fragment-Host: org.eclipse.swt;bundle-version="[3.127.0,4.0.0)"
 Bundle-Name: %fragmentName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.swt.gtk.linux.loongarch64; singleton:=true

--- a/binaries/org.eclipse.swt.gtk.linux.ppc64le/META-INF/MANIFEST.MF
+++ b/binaries/org.eclipse.swt.gtk.linux.ppc64le/META-INF/MANIFEST.MF
@@ -1,5 +1,5 @@
 Manifest-Version: 1.0
-Fragment-Host: org.eclipse.swt;bundle-version="[3.126.100,4.0.0)"
+Fragment-Host: org.eclipse.swt;bundle-version="[3.127.0,4.0.0)"
 Bundle-Name: %fragmentName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.swt.gtk.linux.ppc64le;singleton:=true

--- a/binaries/org.eclipse.swt.gtk.linux.x86_64/META-INF/MANIFEST.MF
+++ b/binaries/org.eclipse.swt.gtk.linux.x86_64/META-INF/MANIFEST.MF
@@ -1,5 +1,5 @@
 Manifest-Version: 1.0
-Fragment-Host: org.eclipse.swt;bundle-version="[3.126.100,4.0.0)"
+Fragment-Host: org.eclipse.swt;bundle-version="[3.127.0,4.0.0)"
 Bundle-Name: %fragmentName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.swt.gtk.linux.x86_64; singleton:=true

--- a/binaries/org.eclipse.swt.win32.win32.aarch64/META-INF/MANIFEST.MF
+++ b/binaries/org.eclipse.swt.win32.win32.aarch64/META-INF/MANIFEST.MF
@@ -1,5 +1,5 @@
 Manifest-Version: 1.0
-Fragment-Host: org.eclipse.swt;bundle-version="[3.126.100,4.0.0)"
+Fragment-Host: org.eclipse.swt;bundle-version="[3.127.0,4.0.0)"
 Bundle-Name: %fragmentName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.swt.win32.win32.aarch64; singleton:=true

--- a/binaries/org.eclipse.swt.win32.win32.x86_64/META-INF/MANIFEST.MF
+++ b/binaries/org.eclipse.swt.win32.win32.x86_64/META-INF/MANIFEST.MF
@@ -1,5 +1,5 @@
 Manifest-Version: 1.0
-Fragment-Host: org.eclipse.swt;bundle-version="[3.126.100,4.0.0)"
+Fragment-Host: org.eclipse.swt;bundle-version="[3.127.0,4.0.0)"
 Bundle-Name: %fragmentName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.swt.win32.win32.x86_64; singleton:=true

--- a/bundles/org.eclipse.swt/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.swt/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.swt; singleton:=true
-Bundle-Version: 3.126.100.qualifier
+Bundle-Version: 3.127.0.qualifier
 Bundle-ManifestVersion: 2
 Bundle-Localization: plugin
 DynamicImport-Package: org.eclipse.swt.accessibility2

--- a/bundles/org.eclipse.swt/pom.xml
+++ b/bundles/org.eclipse.swt/pom.xml
@@ -21,7 +21,7 @@
     </parent>
     <groupId>org.eclipse.swt</groupId>
     <artifactId>org.eclipse.swt</artifactId>
-    <version>3.126.100-SNAPSHOT</version>
+    <version>3.127.0-SNAPSHOT</version>
     <packaging>eclipse-plugin</packaging>
 
     <properties>


### PR DESCRIPTION
This was forgotten in https://github.com/eclipse-platform/eclipse.platform.swt/pull/1266

Also require the bumped minor version of the o.e.swt host in the fragments.

Because it was forgotten the [I-build 4.33#31](https://ci.eclipse.org/releng/job/Builds/job/I-build-4.33/31/) broke because the o.e.swt host requires a fragment for that platform with the exact same version.
```
 [ERROR] Cannot resolve dependencies of project org.eclipse.platform:org.eclipse.jface:eclipse-plugin:3.35.0-SNAPSHOT
 [ERROR]  with context {osgi.os=linux, org.eclipse.update.install.features=true, osgi.arch=x86_64, org.eclipse.update.install.sources=true, osgi.ws=gtk, org.eclipse.jdt.buildtime=true}
 [ERROR]   Software being installed: org.eclipse.jface 3.35.0.qualifier
 [ERROR]   Missing requirement for filter properties ~= $0: org.eclipse.swt 3.126.100.qualifier requires 'org.eclipse.equinox.p2.iu; org.eclipse.swt.gtk.linux.x86_64 [3.126.100.qualifier,3.126.100.qualifier], filter=(&(osgi.arch=x86_64)(osgi.os=linux)(osgi.ws=gtk)(!(org.eclipse.swt.buildtime=true)))' but it could not be found
 [ERROR]   Cannot satisfy dependency: org.eclipse.jface 3.35.0.qualifier depends on: osgi.bundle; org.eclipse.swt [3.126.0,4.0.0): See log for details
 [ERROR] -> [Help 1]
 org.apache.maven.lifecycle.LifecycleExecutionException: Cannot resolve dependencies of project org.eclipse.platform:org.eclipse.jface:eclipse-plugin:3.35.0-SNAPSHOT
  with context {osgi.os=linux, org.eclipse.update.install.features=true, osgi.arch=x86_64, org.eclipse.update.install.sources=true, osgi.ws=gtk, org.eclipse.jdt.buildtime=true}
   Software being installed: org.eclipse.jface 3.35.0.qualifier
   Missing requirement for filter properties ~= $0: org.eclipse.swt 3.126.100.qualifier requires 'org.eclipse.equinox.p2.iu; org.eclipse.swt.gtk.linux.x86_64 [3.126.100.qualifier,3.126.100.qualifier], filter=(&(osgi.arch=x86_64)(osgi.os=linux)(osgi.ws=gtk)(!(org.eclipse.swt.buildtime=true)))' but it could not be found
   Cannot satisfy dependency: org.eclipse.jface 3.35.0.qualifier depends on: osgi.bundle; org.eclipse.swt [3.126.0,4.0.0)
```

In general I think we should install some safety nets to ensure this is captured in verification builds.