### PR TITLE
Fix API errors in SWT due to tests

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/Win32AutoscaleTestBase.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/Win32AutoscaleTestBase.java
@@ -11,12 +11,15 @@
  * Contributors:
  *     Yatta Solutions - initial API and implementation
  *******************************************************************************/
-package org.eclipse.swt.internal;
+package org.eclipse.swt;
 
-import org.eclipse.swt.*;
+import org.eclipse.swt.internal.*;
 import org.eclipse.swt.widgets.*;
 import org.junit.*;
 
+/**
+ * @since 3.127
+ */
 public abstract class Win32AutoscaleTestBase {
 	protected Display display;
 	protected Shell shell;

--- a/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/graphics/GCWin32Tests.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/graphics/GCWin32Tests.java
@@ -23,6 +23,9 @@ import org.eclipse.swt.internal.*;
 import org.eclipse.swt.widgets.*;
 import org.junit.*;
 
+/**
+ * @since 3.127
+ */
 public class GCWin32Tests extends Win32AutoscaleTestBase {
 
 	@Test

--- a/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/graphics/PathWin32Tests.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/graphics/PathWin32Tests.java
@@ -17,10 +17,14 @@ import static org.junit.Assert.assertTrue;
 
 import java.util.*;
 
+import org.eclipse.swt.*;
 import org.eclipse.swt.internal.*;
 import org.eclipse.swt.internal.gdip.*;
 import org.junit.*;
 
+/**
+ * @since 3.127
+ */
 public class PathWin32Tests extends Win32AutoscaleTestBase {
 
 	int zoom = 100;

--- a/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/graphics/TextLayoutWin32Tests.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/graphics/TextLayoutWin32Tests.java
@@ -15,9 +15,13 @@ package org.eclipse.swt.graphics;
 
 import static org.junit.Assert.assertEquals;
 
+import org.eclipse.swt.*;
 import org.eclipse.swt.internal.*;
 import org.junit.*;
 
+/**
+ * @since 3.127
+ */
 public class TextLayoutWin32Tests extends Win32AutoscaleTestBase {
 	final static String text = "This is a text for testing.";
 

--- a/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/graphics/TransformWin32Tests.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/graphics/TransformWin32Tests.java
@@ -17,10 +17,14 @@ package org.eclipse.swt.graphics;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 
+import org.eclipse.swt.*;
 import org.eclipse.swt.internal.*;
 import org.eclipse.swt.internal.gdip.*;
 import org.junit.*;
 
+/**
+ * @since 3.127
+ */
 public class TransformWin32Tests extends Win32AutoscaleTestBase {
 
 	@Test

--- a/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/widgets/ControlWin32Tests.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/widgets/ControlWin32Tests.java
@@ -26,6 +26,7 @@ import org.junit.*;
  * for Windows specific behavior
  *
  * @see org.eclipse.swt.widgets.Control
+ * @since 3.127
  */
 public class ControlWin32Tests extends Win32AutoscaleTestBase {
 

--- a/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/widgets/WidgetWin32Tests.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/widgets/WidgetWin32Tests.java
@@ -6,6 +6,9 @@ import org.eclipse.swt.*;
 import org.eclipse.swt.internal.*;
 import org.junit.*;
 
+/**
+ * @since 3.127
+ */
 public class WidgetWin32Tests extends Win32AutoscaleTestBase {
 
 	@Test


### PR DESCRIPTION
- Move Win32AutoscaleTestBase to package org.eclipse.swt
- Increase minor version in manifest
- Add missing `@since` tags in extending test classes

Fixes https://github.com/eclipse-platform/eclipse.platform.swt/issues/1298