### PR TITLE
GC Data image scaling Bugfix

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/GC.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/GC.java
@@ -3930,7 +3930,7 @@ void init(Drawable drawable, GCData data, long hDC) {
 	}
 	Image image = data.image;
 	if (image != null) {
-		data.hNullBitmap = OS.SelectObject(hDC, Image.win32_getHandle(image, data.nativeZoom));
+		data.hNullBitmap = OS.SelectObject(hDC, Image.win32_getHandle(image, DPIUtil.getZoomForAutoscaleProperty(data.nativeZoom)));
 		image.memGC = this;
 	}
 	int layout = data.layout;


### PR DESCRIPTION
This PR fixes the image scaling bug in GC data. The image was scaled with the native zoom of the GC Data instead of the zoom. This leads to the the problem of no image drawn but just a white background. The image is only visible when the zoom and nativeZoom are the same. This behavior can be seen if the IDE is started at i.e. 125% zoom level on the default monitor. Hence, in this case the zoom is set to 100 and nativeZoom is 125. And due to wrong scaling, the lineNumberRulerColumn and minimize and maximize button images are not visible but rather just a white background is visible. 

![image](https://github.com/eclipse-platform/eclipse.platform.swt/assets/46150646/a33af276-fff0-4bd4-915c-055bf3754d4f)


This fix provides the right scaling to the image in the GC Data using the zoom but not the nativeZoom level as per the standard.

Contributes to #62 and #127