### PR TITLE
Migrate win32 unit tests to JUnit 5 and reduce test visibility #1298

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/graphics/GCWin32Tests.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/graphics/GCWin32Tests.java
@@ -21,9 +21,9 @@ import java.util.concurrent.atomic.*;
 import org.eclipse.swt.*;
 import org.eclipse.swt.internal.*;
 import org.eclipse.swt.widgets.*;
-import org.junit.*;
+import org.junit.jupiter.api.*;
 
-public class GCWin32Tests extends Win32AutoscaleTestBase {
+class GCWin32Tests extends Win32AutoscaleTestBase {
 
 	@Test
 	public void gcZoomLevelMustChangeOnShellZoomChange() {

--- a/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/graphics/PathWin32Tests.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/graphics/PathWin32Tests.java
@@ -19,9 +19,9 @@ import java.util.*;
 
 import org.eclipse.swt.internal.*;
 import org.eclipse.swt.internal.gdip.*;
-import org.junit.*;
+import org.junit.jupiter.api.*;
 
-public class PathWin32Tests extends Win32AutoscaleTestBase {
+class PathWin32Tests extends Win32AutoscaleTestBase {
 
 	int zoom = 100;
 	int scaledZoom = 200;

--- a/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/graphics/TextLayoutWin32Tests.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/graphics/TextLayoutWin32Tests.java
@@ -16,9 +16,9 @@ package org.eclipse.swt.graphics;
 import static org.junit.Assert.assertEquals;
 
 import org.eclipse.swt.internal.*;
-import org.junit.*;
+import org.junit.jupiter.api.*;
 
-public class TextLayoutWin32Tests extends Win32AutoscaleTestBase {
+class TextLayoutWin32Tests extends Win32AutoscaleTestBase {
 	final static String text = "This is a text for testing.";
 
 	@Test

--- a/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/graphics/TransformWin32Tests.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/graphics/TransformWin32Tests.java
@@ -13,15 +13,14 @@
  *******************************************************************************/
 package org.eclipse.swt.graphics;
 
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 
 import org.eclipse.swt.internal.*;
 import org.eclipse.swt.internal.gdip.*;
-import org.junit.*;
+import org.junit.jupiter.api.*;
 
-public class TransformWin32Tests extends Win32AutoscaleTestBase {
+class TransformWin32Tests extends Win32AutoscaleTestBase {
 
 	@Test
 	public void testShouldHaveDifferentHandlesAtDifferentZoomLevels() {

--- a/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/internal/DefaultSWTFontRegistryTests.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/internal/DefaultSWTFontRegistryTests.java
@@ -16,32 +16,28 @@ package org.eclipse.swt.internal;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-import org.eclipse.swt.SWT;
-import org.eclipse.swt.graphics.Font;
-import org.eclipse.swt.graphics.FontData;
-import org.eclipse.swt.widgets.Display;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.eclipse.swt.*;
+import org.eclipse.swt.graphics.*;
+import org.eclipse.swt.widgets.*;
+import org.junit.jupiter.api.*;
 
-public class DefaultSWTFontRegistryTests {
+class DefaultSWTFontRegistryTests {
 	private static String TEST_FONT = "Helvetica";
 	private Display display;
 	private SWTFontRegistry fontRegistry;
 
-	@BeforeClass
+	@BeforeAll
 	public static void assumeIsFittingPlatform() {
 		PlatformSpecificExecution.assumeIsFittingPlatform();
 	}
 
-	@Before
+	@BeforeEach
 	public void setUp() {
 		this.display = Display.getDefault();
 		this.fontRegistry = new DefaultSWTFontRegistry(display);
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() {
 		if (this.fontRegistry != null) {
 			this.fontRegistry.dispose();

--- a/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/internal/ScalingSWTFontRegistryTests.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/internal/ScalingSWTFontRegistryTests.java
@@ -13,34 +13,28 @@
  *******************************************************************************/
 package org.eclipse.swt.internal;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
-import org.eclipse.swt.SWT;
-import org.eclipse.swt.graphics.Font;
-import org.eclipse.swt.graphics.FontData;
-import org.eclipse.swt.widgets.Display;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.eclipse.swt.*;
+import org.eclipse.swt.graphics.*;
+import org.eclipse.swt.widgets.*;
+import org.junit.jupiter.api.*;
 
-public class ScalingSWTFontRegistryTests {
+class ScalingSWTFontRegistryTests {
 	private static String TEST_FONT = "Helvetica";
 	private SWTFontRegistry fontRegistry;
 
-	@BeforeClass
+	@BeforeAll
 	public static void assumeIsFittingPlatform() {
 		PlatformSpecificExecution.assumeIsFittingPlatform();
 	}
 
-	@Before
+	@BeforeEach
 	public void setUp() {
 		this.fontRegistry = new ScalingSWTFontRegistry(Display.getDefault());
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() {
 		if (this.fontRegistry != null) {
 			this.fontRegistry.dispose();

--- a/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/internal/Win32AutoscaleTestBase.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/internal/Win32AutoscaleTestBase.java
@@ -15,19 +15,19 @@ package org.eclipse.swt.internal;
 
 import org.eclipse.swt.*;
 import org.eclipse.swt.widgets.*;
-import org.junit.*;
+import org.junit.jupiter.api.*;
 
 public abstract class Win32AutoscaleTestBase {
 	protected Display display;
 	protected Shell shell;
 	private boolean autoScaleOnRuntime;
 
-	@BeforeClass
+	@BeforeAll
 	public static void assumeIsFittingPlatform() {
 		PlatformSpecificExecution.assumeIsFittingPlatform();
 	}
 
-	@Before
+	@BeforeEach
 	public void setUpTest() {
 		autoScaleOnRuntime = DPITestUtil.isAutoScaleOnRuntimeActive();
 		display = Display.getDefault();
@@ -35,7 +35,7 @@ public abstract class Win32AutoscaleTestBase {
 		shell = new Shell(display);
 	}
 
-	@After
+	@AfterEach
 	public void tearDownTest() {
 		if (shell != null) {
 			shell.dispose();

--- a/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/widgets/ControlWin32Tests.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/widgets/ControlWin32Tests.java
@@ -13,13 +13,12 @@
  *******************************************************************************/
 package org.eclipse.swt.widgets;
 
-
 import static org.junit.Assert.*;
 
 import org.eclipse.swt.*;
 import org.eclipse.swt.graphics.*;
 import org.eclipse.swt.internal.*;
-import org.junit.*;
+import org.junit.jupiter.api.*;
 
 /**
  * Automated Tests for class org.eclipse.swt.widgets.Control
@@ -27,7 +26,7 @@ import org.junit.*;
  *
  * @see org.eclipse.swt.widgets.Control
  */
-public class ControlWin32Tests extends Win32AutoscaleTestBase {
+class ControlWin32Tests extends Win32AutoscaleTestBase {
 
 	@Test
 	public void testScaleFontCorrectlyInAutoScaleSzenario() {

--- a/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/widgets/WidgetWin32Tests.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/widgets/WidgetWin32Tests.java
@@ -4,9 +4,9 @@ import static org.junit.Assert.assertEquals;
 
 import org.eclipse.swt.*;
 import org.eclipse.swt.internal.*;
-import org.junit.*;
+import org.junit.jupiter.api.*;
 
-public class WidgetWin32Tests extends Win32AutoscaleTestBase {
+class WidgetWin32Tests extends Win32AutoscaleTestBase {
 
 	@Test
 	public void testWidgetZoomShouldChangeOnZoomLevelChange() {


### PR DESCRIPTION
This migrates the unit tests placed in the SWT win32 production fragments to JUnit 5. The visibility of the test classes is reduced to `packaged protected` as allowed by JUnit 5.

This resolves the API errors as reported in #1298.

Fixes https://github.com/eclipse-platform/eclipse.platform.swt/issues/1298