### PR TITLE
Add missing copyright headers to win32 test classes

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/internal/DPITestUtil.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/internal/DPITestUtil.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Yatta Solutions
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
 package org.eclipse.swt.internal;
 
 public class DPITestUtil {

--- a/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/internal/PlatformSpecificExecution.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/internal/PlatformSpecificExecution.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Vector Informatik GmbH
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
 package org.eclipse.swt.internal;
 
 import static org.junit.Assume.assumeTrue;

--- a/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/widgets/WidgetWin32Tests.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/widgets/WidgetWin32Tests.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Yatta Solutions
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
 package org.eclipse.swt.widgets;
 
 import static org.junit.Assert.assertEquals;


### PR DESCRIPTION
Some recently added files miss copyright headers. This adds proper headers according to the contributors.