### PR TITLE
Removal of region constructor with handle param

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Region.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Region.java
@@ -90,17 +90,6 @@ public Region (Device device) {
 }
 
 /**
- * Constructs a new region given a handle to the operating
- * system resources that it should represent.
- *
- * @param handle the handle for the result
- */
-Region(Device device, int handle) {
-	super(device);
-	this.handle = handle;
-}
-
-/**
  * Adds the given polygon to the collection of polygons
  * the receiver maintains to describe its area.
  *
@@ -628,26 +617,6 @@ public void translate (Point pt) {
 public String toString () {
 	if (isDisposed()) return "Region {*DISPOSED*}";
 	return "Region {" + handle + "}";
-}
-
-/**
- * Invokes platform specific functionality to allocate a new region.
- * <p>
- * <b>IMPORTANT:</b> This method is <em>not</em> part of the public
- * API for <code>Region</code>. It is marked public only so that it
- * can be shared within the packages provided by SWT. It is not
- * available on all platforms, and should never be called from
- * application code.
- * </p>
- *
- * @param device the device on which to allocate the region
- * @param handle the handle for the region
- * @return a new region object containing the specified device and handle
- *
- * @noreference This method is not intended to be referenced by clients.
- */
-public static Region win32_new(Device device, int handle) {
-	return new Region(device, handle);
 }
 
 }


### PR DESCRIPTION
This commit removes the constructor and the following method win32_new and hereby confirm that none of the clients consume them.

contributes to #62 and #127