### PR TITLE
[win32] Consider monitor zoom when calculating bounds if autoScaleOnRuntime is active

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Display.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Display.java
@@ -2146,10 +2146,6 @@ Monitor getMonitor (long hmonitor) {
 	OS.GetMonitorInfo (hmonitor, lpmi);
 	Monitor monitor = new Monitor ();
 	monitor.handle = hmonitor;
-	Rectangle boundsInPixels = new Rectangle (lpmi.rcMonitor_left, lpmi.rcMonitor_top, lpmi.rcMonitor_right - lpmi.rcMonitor_left,lpmi.rcMonitor_bottom - lpmi.rcMonitor_top);
-	monitor.setBounds (DPIUtil.autoScaleDown (boundsInPixels));
-	Rectangle clientAreaInPixels = new Rectangle (lpmi.rcWork_left, lpmi.rcWork_top, lpmi.rcWork_right - lpmi.rcWork_left, lpmi.rcWork_bottom - lpmi.rcWork_top);
-	monitor.setClientArea (DPIUtil.autoScaleDown (clientAreaInPixels));
 	int [] dpiX = new int[1];
 	int [] dpiY = new int[1];
 	int result = OS.GetDpiForMonitor (monitor.handle, OS.MDT_EFFECTIVE_DPI, dpiX, dpiY);
@@ -2163,6 +2159,19 @@ Monitor getMonitor (long hmonitor) {
 	 * to scaling issue on OS Win8.1 and above, for more details refer bug 537614.
 	 */
 	monitor.zoom = result;
+
+	// Calculate bounds and client area of the monitor
+	Rectangle boundsInPixels = new Rectangle(lpmi.rcMonitor_left, lpmi.rcMonitor_top, lpmi.rcMonitor_right - lpmi.rcMonitor_left,lpmi.rcMonitor_bottom - lpmi.rcMonitor_top);
+	Rectangle clientAreaInPixels = new Rectangle(lpmi.rcWork_left, lpmi.rcWork_top, lpmi.rcWork_right - lpmi.rcWork_left, lpmi.rcWork_bottom - lpmi.rcWork_top);
+	int autoscaleZoom;
+	if (DPIUtil.isAutoScaleOnRuntimeActive()) {
+		autoscaleZoom = DPIUtil.getZoomForAutoscaleProperty(result);
+	} else {
+		autoscaleZoom = DPIUtil.getDeviceZoom();
+	}
+	monitor.setBounds(DPIUtil.scaleDown(boundsInPixels, autoscaleZoom));
+	monitor.setClientArea(DPIUtil.scaleDown(clientAreaInPixels, autoscaleZoom));
+
 	return monitor;
 }
 


### PR DESCRIPTION
Currently the monitor bounds are calculated using the static DPIUtil.deviceZoom attribute as zoom. In multi monitor setup with different zooms, this will result in wrong bounds for the non primary monitor.

There are two scenarios:

1. isAutoScaleOnRuntimeActive == false: This should behave as before, thefore DPIUtil.getDeviceZoom() is used 
2. isAutoScaleOnRuntimeActive == true: As the zoom of shell is now tied to the zoom of its monitor, it is important that each monitor bounds (in points) are based on there own zoom as well.

One example where you can construct an effect of it is with the CompletionProposalPopup. There, the clientArea of the monitor is used to make sure, maximum of 25% of the monitor is used by the popup. If the monitor is calculated with the wrong zoom, the popup will get bigger as expected, see
![Screenshot 2024-06-26 132107](https://github.com/eclipse-platform/eclipse.platform.swt/assets/119662019/649a38e3-38b3-4e49-9eb3-dee9086a3b0c)
vs.
![Screenshot 2024-06-26 132134](https://github.com/eclipse-platform/eclipse.platform.swt/assets/119662019/af01b06b-49c4-45cf-a7c9-0955fc7fbd2a)

if the Monitor e.g. has 2160 pixels on a zoom of 200%, the primary monitor has a zoom of 100%. If the primary monitor zoom is used, the 2160 pixels will used as 2160 points. 25% of it is 540. As the popup will be initialized (correctly) with the zoom of 200% it will convert the 540 points back to 1080 pixels => that is bigger than it should be.

Conclusion: monitor zoom must be treated the same of the zoom of widgets.