### PR TITLE
[win32] Update shell zoom on location change

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Display.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Display.java
@@ -5229,4 +5229,15 @@ static char [] withCrLf (char [] string) {
 static boolean isActivateShellOnForceFocus() {
 	return "true".equals(System.getProperty("org.eclipse.swt.internal.activateShellOnForceFocus", "true")); //$NON-NLS-1$
 }
+
+Monitor getContainingMonitor(int x, int y) {
+	Monitor[] monitors = getMonitors();
+	for (Monitor current : monitors) {
+		Rectangle clientArea = current.getClientArea();
+		if (clientArea.contains(x, y)) {
+			return current;
+		}
+	}
+	return getPrimaryMonitor();
+}
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Display.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Display.java
@@ -2146,18 +2146,25 @@ Monitor getMonitor (long hmonitor) {
 	OS.GetMonitorInfo (hmonitor, lpmi);
 	Monitor monitor = new Monitor ();
 	monitor.handle = hmonitor;
-	Rectangle boundsInPixels = new Rectangle (lpmi.rcMonitor_left, lpmi.rcMonitor_top, lpmi.rcMonitor_right - lpmi.rcMonitor_left,lpmi.rcMonitor_bottom - lpmi.rcMonitor_top);
-	monitor.setBounds (DPIUtil.autoScaleDown (boundsInPixels));
-	Rectangle clientAreaInPixels = new Rectangle (lpmi.rcWork_left, lpmi.rcWork_top, lpmi.rcWork_right - lpmi.rcWork_left, lpmi.rcWork_bottom - lpmi.rcWork_top);
-	monitor.setClientArea (DPIUtil.autoScaleDown (clientAreaInPixels));
+	Rectangle boundsInPixels = new Rectangle(lpmi.rcMonitor_left, lpmi.rcMonitor_top, lpmi.rcMonitor_right - lpmi.rcMonitor_left,lpmi.rcMonitor_bottom - lpmi.rcMonitor_top);
+	Rectangle clientAreaInPixels = new Rectangle(lpmi.rcWork_left, lpmi.rcWork_top, lpmi.rcWork_right - lpmi.rcWork_left, lpmi.rcWork_bottom - lpmi.rcWork_top);
 	int [] dpiX = new int[1];
 	int [] dpiY = new int[1];
 	int result = OS.GetDpiForMonitor (monitor.handle, OS.MDT_EFFECTIVE_DPI, dpiX, dpiY);
 	result = (result == OS.S_OK) ? DPIUtil.mapDPIToZoom (dpiX[0]) : 100;
+
+	int autoscaleZoom;
+	if (DPIUtil.isAutoScaleOnRuntimeActive()) {
+		autoscaleZoom = DPIUtil.getZoomForAutoscaleProperty(result);
+	} else {
+		autoscaleZoom = DPIUtil.getDeviceZoom();
+	}
 	if (result == 0) {
 		System.err.println("***WARNING: GetDpiForMonitor: SWT could not get valid monitor scaling factor.");
 		result = 100;
 	}
+	monitor.setBounds(DPIUtil.scaleDown(boundsInPixels, autoscaleZoom));
+	monitor.setClientArea(DPIUtil.scaleDown(clientAreaInPixels, autoscaleZoom));
 	/*
 	 * Always return true monitor zoom value as fetched from native, else will lead
 	 * to scaling issue on OS Win8.1 and above, for more details refer bug 537614.

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Shell.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Shell.java
@@ -1571,6 +1571,40 @@ public void setAlpha (int alpha) {
 	}
 }
 
+private void updateNativeZoomBeforePositionChange(int x, int y) {
+	if (DPIUtil.isAutoScaleOnRuntimeActive()) {
+		Monitor monitor = display.getContainingMonitor(x, y);
+		this.nativeZoom = monitor.zoom;
+		System.out.println("Update shell zoom (" + handle + ") " + monitor.zoom);
+	}
+}
+
+@Override
+public void setLocation(Point location) {
+	if (location == null) error (SWT.ERROR_NULL_ARGUMENT);
+	updateNativeZoomBeforePositionChange(location.x, location.y);
+	super.setLocation(location);
+}
+
+@Override
+public void setLocation(int x, int y) {
+	updateNativeZoomBeforePositionChange(x, y);
+	super.setLocation(x, y);
+}
+
+@Override
+public void setBounds(Rectangle rect) {
+	if (rect == null) error (SWT.ERROR_NULL_ARGUMENT);
+	updateNativeZoomBeforePositionChange(rect.x, rect.y);
+	super.setBounds(rect);
+}
+
+@Override
+public void setBounds(int x, int y, int width, int height) {
+	updateNativeZoomBeforePositionChange(x, y);
+	super.setBounds(x, y, width, height);
+}
+
 @Override
 void setBoundsInPixels (int x, int y, int width, int height, int flags, boolean defer) {
 	if (fullScreen) setFullScreen (false);


### PR DESCRIPTION
## Prerequisites

- [ ] https://github.com/eclipse-platform/eclipse.platform.swt/pull/1312

## Description
When a Shell is moved to a new position, the new position can be located on a different monitor. If autoScaleOnRuntimeActive is active and the monitor has a different zoom than the previous one, this would lead to a wrong positioning of the shell due to the stored zoom of the shell. Therefor the Shell nativeZoom must update BEFORE the location change will be applied.

## How to reproduce
**Note:** This only has affect, when swt.autoScale.updateOnRuntime-flag is set to true

1. Have to monitors, one with 200% (primary monitor) and one with 100% zoom on the right of the primary monitor.
2. Execute the following snippet with swt.autoScale.updateOnRuntime-flag on true (You could test it as well with the Eclipse IDE and _Window -> New Window_, but that tests only one of the overwritten methods)

```
public final class CreateAndPositionNewShellsInHiDPIScenarios {

	private static Shell newShell() {
		Shell newShell = new Shell();
		newShell.setLayout(new GridLayout(1, true));
		Label label = new Label(newShell, SWT.NONE);
		label.setText("I am a new Shell");
		newShell.pack();
		return newShell;
	}

	public static void main(String[] args) {
		final Display display = Display.getDefault();
		final Shell shell = new Shell(display);
		shell.setLayout(new GridLayout(2, true));

		Label l1 = new Label(shell, SWT.NONE);
		l1.setText("Create Shell and position with setLocation(x, y)");
		Button b1 = new Button(shell, SWT.NONE);
		b1.setText("New shell");
		b1.addMouseListener(new MouseAdapter() {
			@Override
			public void mouseUp(MouseEvent e) {
				Shell newShell = newShell();
				Point location = shell.getLocation();
				newShell.setLocation(location.x, location.y);
				newShell.open();
			}
		});

		Label l2 = new Label(shell, SWT.NONE);
		l2.setText("Create Shell and position with setLocation(Point)");
		Button b2 = new Button(shell, SWT.NONE);
		b2.setText("New shell");
		b2.addMouseListener(new MouseAdapter() {
			@Override
			public void mouseUp(MouseEvent e) {
				Shell newShell = newShell();
				newShell.setLocation(shell.getLocation());
				newShell.open();
			}
		});

		Label l3 = new Label(shell, SWT.NONE);
		l3.setText("Create Shell and position with setBounds(Rectangle)");
		Button b3 = new Button(shell, SWT.NONE);
		b3.setText("New shell");
		b3.addMouseListener(new MouseAdapter() {
			@Override
			public void mouseUp(MouseEvent e) {
				Shell newShell = newShell();
				newShell.setBounds(shell.getBounds());
				newShell.open();
			}
		});

		Label l4 = new Label(shell, SWT.NONE);
		l4.setText("Create Shell and position with setBounds(x, y)");
		Button b4 = new Button(shell, SWT.NONE);
		b4.setText("New shell");
		b4.addMouseListener(new MouseAdapter() {
			@Override
			public void mouseUp(MouseEvent e) {
				Shell newShell = newShell();
				Rectangle bounds= shell.getBounds();
				newShell.setBounds(bounds.x, bounds.y, bounds.width, bounds.height);
				newShell.open();
			}
		});
		shell.pack();
		shell.open();

		while (!shell.isDisposed()) {
			if (!display.readAndDispatch()) {
				display.sleep();
			}
		}

		display.dispose();
	}
}
```
3. Move the opened Shell from 200% to 100%
4. Open a new Shell with one of the buttons
5. Move the **new** Shell back to the 200% monitor
6. Open a second (or more) new Shell(s) with the buttons
7. Without this PR this Shell will be positioned wrong, probably even out of the visible area