### PR TITLE
LineHeaderCodeMining not rendered properly with DPIUtil#deviceZoom=200

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/StyledTextRenderer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/StyledTextRenderer.java
@@ -21,6 +21,7 @@ import java.util.List;
 
 import org.eclipse.swt.*;
 import org.eclipse.swt.graphics.*;
+import org.eclipse.swt.internal.*;
 import org.eclipse.swt.widgets.*;
 
 /**
@@ -304,7 +305,7 @@ void calculate(int startLine, int lineCount) {
 		LineSizeInfo line = getLineSize(i);
 		if (line.needsRecalculateSize()) {
 			TextLayout layout = getTextLayout(i);
-			Rectangle rect = layout.getBounds();
+			Rectangle rect = getBoundsWithoutLineVerticalIndentScaling(layout,i);
 			line.width = rect.width + hTrim;
 			line.height = rect.height;
 			averageLineHeight += (line.height - Math.round(averageLineHeight)) / ++linesInAverageLineHeight;
@@ -315,6 +316,15 @@ void calculate(int startLine, int lineCount) {
 			maxWidthLineIndex = i;
 		}
 	}
+}
+private Rectangle getBoundsWithoutLineVerticalIndentScaling(TextLayout layout,int lineIndex) {
+	int lineVerticalIndent = getLineVerticalIndent(lineIndex);
+	Rectangle rect = layout.getBounds();
+	if (lineVerticalIndent>0) {
+		rect.height -= DPIUtil.autoScaleUp(styledText, lineVerticalIndent);
+		rect.height += lineVerticalIndent;
+	}
+	return rect;
 }
 LineSizeInfo getLineSize(int i) {
 	if (lineSizes[i] == null) {
@@ -466,7 +476,7 @@ private LineDrawInfo makeLineDrawInfo(int lineIndex) {
 	TextLayout layout = getTextLayout(lineIndex);
 	String text = content.getLine(lineIndex);
 	int offset = content.getOffsetAtLine(lineIndex);
-	int height = layout.getBounds().height;
+	int height = getBoundsWithoutLineVerticalIndentScaling(layout,lineIndex).height;
 	return new LineDrawInfo(lineIndex, layout, text, offset, height);
 }
 


### PR DESCRIPTION
LineHeaderCodeMinings are not properly rendered on my windows machine when DPIUtil#deviceZoom is set to value 200.

Here a screenshot how it looks like:
![vertical_line_indent_1](https://github.com/eclipse-platform/eclipse.platform.swt/assets/10373336/8de6b2b2-d955-41c9-88c6-fcdccdaf68ff)
The height of line 7 and 13 is not correct from my point of view, the height is twice as high as it should be. Over these 2 lines the minings are rendered. 

After applying the changes in this pull request, it looks much better:
![vertical_line_indent_2](https://github.com/eclipse-platform/eclipse.platform.swt/assets/10373336/2ece2853-1aeb-49eb-b49f-c5f379663455)

TextLayout#getBounds() calls DPIUtil.autoScaleUp for the lineVerticalIndent value which then makes the height of the given line too high. 
Removing the DPIUtil.autoScaleUp for the lineVerticalIndent is not a solution, text rendering is then destroyed for all editor lines. 
It would be great if an expert could take a look into this issue and maybe find a much better solution than mine. It feels more like a workaround what I have done here.

