### PR TITLE
Scaling of Text Icon for multi zoom level (win 32)

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Display.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Display.java
@@ -271,8 +271,8 @@ public class Display extends Device implements Executor {
 	boolean textUseDarkthemeIcons = false;
 
 	/* Custom icons */
-	long hIconSearch;
-	long hIconCancel;
+	private HashMap<Integer, Long> sizeToSearchIconHandle = new HashMap<>();
+	private HashMap<Integer, Long> sizeToCancelIconHandle = new HashMap<>();
 
 	/* Focus */
 	int focusEvent;
@@ -1186,6 +1186,26 @@ static Image createIcon (Image image) {
 	OS.DeleteObject (hBitmap);
 	OS.DeleteObject (hMask);
 	return Image.win32_new (device, SWT.ICON, hIcon);
+}
+
+long getTextSearchIcon(int size) {
+	if (!sizeToSearchIconHandle.containsKey(size)) {
+		int searchIconResource = textUseDarkthemeIcons ? Text.IDI_SEARCH_DARKTHEME : Text.IDI_SEARCH;
+	    long iconHandle = OS.LoadImage (OS.GetLibraryHandle (), searchIconResource, OS.IMAGE_ICON, size, size, 0);
+	    if (iconHandle == 0) error(SWT.ERROR_NO_HANDLES);
+	    sizeToSearchIconHandle.put(size, iconHandle);
+	}
+    return sizeToSearchIconHandle.get(size);
+}
+
+long getTextCancelIcon(int size) {
+	if (!sizeToCancelIconHandle.containsKey(size)) {
+		int searchIconResource = textUseDarkthemeIcons ? Text.IDI_CANCEL_DARKTHEME : Text.IDI_CANCEL;
+	    long iconHandle = OS.LoadImage (OS.GetLibraryHandle (), searchIconResource, OS.IMAGE_ICON, size, size, 0);
+	    if (iconHandle == 0) error(SWT.ERROR_NO_HANDLES);
+	    sizeToCancelIconHandle.put(size, iconHandle);
+	}
+    return sizeToCancelIconHandle.get(size);
 }
 
 static void deregister (Display display) {
@@ -3795,8 +3815,10 @@ void releaseDisplay () {
 	}
 
 	/* Free custom icons */
-	if (hIconSearch != 0) OS.DestroyIcon (hIconSearch);
-	if (hIconCancel != 0) OS.DestroyIcon (hIconCancel);
+	sizeToSearchIconHandle.values().forEach(handle -> OS.DestroyIcon(handle));
+	sizeToCancelIconHandle.values().forEach(handle -> OS.DestroyIcon(handle));
+	sizeToSearchIconHandle.clear();
+	sizeToCancelIconHandle.clear();
 
 	/* Release XP Themes */
 	resetThemes();

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Text.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Text.java
@@ -337,24 +337,7 @@ void createHandle () {
 			state |= THEME_BACKGROUND;
 		}
 	}
-	addIcons();
-}
-
-private void addIcons() {
 	if ((style & SWT.SEARCH) != 0) {
-		if (display.hIconSearch == 0) {
-			long [] phicon = new long [1];
-
-			int searchIconResource = display.textUseDarkthemeIcons ? IDI_SEARCH_DARKTHEME : IDI_SEARCH;
-			int hresult = OS.LoadIconMetric (OS.GetLibraryHandle (), searchIconResource, OS.LIM_SMALL, phicon);
-			if (hresult != OS.S_OK) error (SWT.ERROR_NO_HANDLES);
-			display.hIconSearch = phicon [0];
-
-			int cancelIconResource = display.textUseDarkthemeIcons ? IDI_CANCEL_DARKTHEME : IDI_CANCEL;
-			hresult = OS.LoadIconMetric (OS.GetLibraryHandle (), cancelIconResource, OS.LIM_SMALL, phicon);
-			if (hresult != OS.S_OK) error (SWT.ERROR_NO_HANDLES);
-			display.hIconCancel = phicon [0];
-		}
 		if ((style & SWT.ICON_SEARCH) != 0) {
 			long hwndSearch = OS.CreateWindowEx (
 				0,
@@ -2770,7 +2753,10 @@ LRESULT WM_DRAWITEM (long wParam, long lParam) {
 		int state = OS.GetKeyState (OS.VK_LBUTTON) < 0 ? OS.PBS_PRESSED : OS.PBS_HOT;
 		OS.DrawThemeBackground (display.hButtonThemeAuto (), struct.hDC, OS.BP_PUSHBUTTON, state, rect, null);
 	}
-	long hIcon = (struct.CtlID == SWT.ICON_SEARCH) ? display.hIconSearch : display.hIconCancel;
+	int width = rect.right - rect.left;
+	int height = rect.bottom - rect.top;
+	int size = Math.min(width, height);
+	long hIcon = (struct.CtlID == SWT.ICON_SEARCH) ? display.getTextSearchIcon(size) : display.getTextCancelIcon(size);
 	int y = (rect.bottom - rect.right) / 2;
 	OS.DrawIconEx (struct.hDC, 0, y, hIcon, 0, 0, 0, 0, OS.DI_NORMAL);
 	return LRESULT.ONE;
@@ -3167,7 +3153,6 @@ private static void handleDPIChange(Widget widget, int newZoom, float scalingFac
 	if (!(widget instanceof Text text)) {
 		return;
 	}
-	text.addIcons();
 	text.setMargins();
 }
 }


### PR DESCRIPTION
This contribution provides the ability to scaling the special icons of Text in win 32, i.e., Search and Cancel icon. The scaled icon is obtained at the draw time in the method Text.WM_DRAWITEM. We get rid of the fields hIconSearch and hIconCancel and we maintain a hashmap of size to icon for both the icons. We use the size as the key since the size of the icon is based on the rectangle it is drawn in. And since the size of the rectangle is determined from the OS directly, the size can be non-uniform sometimes. So we maintain the hashmap for size to handle instead of the zoom.

![image](https://github.com/eclipse-platform/eclipse.platform.swt/assets/46150646/969999d8-7127-445f-970e-d5b15c3d6159)


### How to Test
* Start an eclipse workspace with the arguments metioned below and open the error log view.
```
        -Xms256m
        -Xmx2048m
        -Dswt.autoScale.updateOnRuntime=true
```
* There's a text bar in the view containing a search icon to the left. You need to type in some text in the text bar to make the cancel icon appear to the right.
* Now move around the icon to monitors with different zoom levels. The icons should scale to the respective zoom levels.

contributes to #62 and #127