### PR TITLE
Scale up magic number

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Button.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Button.java
@@ -361,10 +361,10 @@ int computeLeftMargin () {
 					Rectangle rect = DPIUtil.scaleBounds(image.getBounds(), this.getZoom(), 100);
 					width = rect.width;
 					if (hasText && text.length () != 0) {
-						width += MARGIN * 2;
+						width += DPIUtil.scaleUp(MARGIN * 2, getZoom());;
 					}
 					height = rect.height;
-					extra = MARGIN * 2;
+					extra = DPIUtil.scaleUp(MARGIN * 2, getZoom());;
 				}
 			}
 			if (hasText) {
@@ -378,7 +378,7 @@ int computeLeftMargin () {
 				if (length == 0) {
 					height = Math.max (height, lptm.tmHeight);
 				} else {
-					extra = Math.max (MARGIN * 2, lptm.tmAveCharWidth);
+					extra = Math.max (DPIUtil.scaleUp(MARGIN * 2, getZoom()), lptm.tmAveCharWidth);
 					char [] buffer = text.toCharArray ();
 					RECT rect = new RECT ();
 					int flags = OS.DT_CALCRECT | OS.DT_SINGLELINE;


### PR DESCRIPTION
The modification of the magic number allows for scaling up or down through DPIUtil. This only affects Radio or Check Buttons. There is no visual difference between using the magic number and DPIUtil.

These Screenshots are from the genral preferences. 

Without the change on 100% zoom 
![image](https://github.com/eclipse-platform/eclipse.platform.swt/assets/66252366/5e0c0377-538b-4f39-a42c-57e409bbe82c)
 
With the change on 100% zoom 
![image](https://github.com/eclipse-platform/eclipse.platform.swt/assets/66252366/9efefcfe-1a55-4d2f-b807-d71fa216f931)

Without the change on 200% zoom 
![image](https://github.com/eclipse-platform/eclipse.platform.swt/assets/66252366/f2c7a7f0-f33f-4f42-8303-f4af1b94a8a3)

With the change on 200% zoom 
![image](https://github.com/eclipse-platform/eclipse.platform.swt/assets/66252366/1a22634f-43d9-4d95-8fab-ca0d12772eea)
 
Without the change on 100% zoom, move it to 200%.
![image](https://github.com/eclipse-platform/eclipse.platform.swt/assets/66252366/e80414dd-4b63-4705-b6a8-7787225b1fa9)

With the change on 100% zoom, move it to 200%.
![image](https://github.com/eclipse-platform/eclipse.platform.swt/assets/66252366/5d19d522-39bf-4557-96a5-1db4958e8fc4)

Contributes to https://github.com/vi-eclipse/Eclipse-Platform/issues/72