### PR TITLE
Scale up magic number for radio Buttons with Image

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Button.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Button.java
@@ -365,7 +365,7 @@ int computeLeftMargin () {
 				if (length == 0) {
 					height = Math.max (height, lptm.tmHeight);
 				} else {
-					extra = Math.max (MARGIN * 2, lptm.tmAveCharWidth);
+					extra = Math.max (DPIUtil.autoScaleUp(MARGIN * 2, getZoom()), lptm.tmAveCharWidth);
 					char [] buffer = text.toCharArray ();
 					RECT rect = new RECT ();
 					int flags = OS.DT_CALCRECT | OS.DT_SINGLELINE;

--- a/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet164.java
+++ b/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet164.java
@@ -37,8 +37,9 @@ public static void main (String[] args) {
 	Button button1 = new Button (shell, SWT.PUSH);
 	button1.setText ("&Typical button");
 
-	Button button2 = new Button (shell, SWT.PUSH);
+	Button button2 = new Button (shell, SWT.RADIO);
 	button2.setImage (image);
+	button2.setText("text");
 	button2.getAccessible ().addAccessibleListener (new AccessibleAdapter() {
 		@Override
 		public void getName (AccessibleEvent e) {


### PR DESCRIPTION
The modification of the magic number allows for scaling up or down through DPIUtil. This only affects Radio or Check Buttons with an image. There is no visual difference between using the magic number and DPIUtil.

These Screenshots are from Sbippet164, i changed 2 rows of the code to test the changes. 
![image](https://github.com/eclipse-platform/eclipse.platform.swt/assets/66252366/45c92339-e3fd-4b08-8189-c10157d618ae)

Without the change on 100% zoom 
![image](https://github.com/eclipse-platform/eclipse.platform.swt/assets/66252366/55df84b1-d1ad-4513-8395-247305522e97)

With the change on 100% zoom 
![image](https://github.com/eclipse-platform/eclipse.platform.swt/assets/66252366/e61e33fd-89ff-4e01-8fce-46529a792764)

Without the change on 200% zoom 
![image](https://github.com/eclipse-platform/eclipse.platform.swt/assets/66252366/7f7e86d5-e2e9-4327-b22f-61efcb3b80aa)

With the change on 200% zoom 
![image](https://github.com/eclipse-platform/eclipse.platform.swt/assets/66252366/698fb88d-31df-46f0-a5f7-a371d5f82dfd)

Without the change on 100% zoom, move it to 200%.
![image](https://github.com/eclipse-platform/eclipse.platform.swt/assets/66252366/a0e3f345-5b33-491d-993f-3eee18d21781)

With the change on 100% zoom, move it to 200%.
![image](https://github.com/eclipse-platform/eclipse.platform.swt/assets/66252366/11bf45f6-c847-4f3f-82da-09926196f239)

Contributes to https://github.com/vi-eclipse/Eclipse-Platform/issues/72