### PR TITLE
fix boundary condition in StyledText#getTextBounds

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/StyledText.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/StyledText.java
@@ -4892,7 +4892,7 @@ public Rectangle getTextBounds(int start, int end) {
 	Rectangle rect;
 	int y = getLinePixel(lineStart);
 	int height = 0;
-	int left = 0x7fffffff, right = 0;
+	int left = Integer.MAX_VALUE, right = 0;
 	for (int i = lineStart; i <= lineEnd; i++) {
 		int lineOffset = content.getOffsetAtLine(i);
 		TextLayout layout = renderer.getTextLayout(i);
@@ -4917,6 +4917,9 @@ public Rectangle getTextBounds(int start, int end) {
 			height += renderer.getLineHeight();
 		}
 		renderer.disposeTextLayout(layout);
+	}
+	if (left == Integer.MAX_VALUE) {
+		left = 0;
 	}
 	rect = new Rectangle (left, y, right-left, height);
 	rect.x += leftMargin - horizontalScrollOffset;

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_custom_StyledText.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_custom_StyledText.java
@@ -181,6 +181,30 @@ public void test_ConstructorLorg_eclipse_swt_widgets_CompositeI(){
 }
 
 @Test
+public void test_getTextBounds() {
+	StyledText text = new StyledText(shell,SWT.BORDER);
+	try {
+		text.setText("\r\n\r\ntext");
+		int firstLineOffset = text.getOffsetAtLine(0);
+		Rectangle r = text.getTextBounds(firstLineOffset, firstLineOffset);
+		assertEquals(0,r.x);
+		assertEquals(0,r.y);
+		assertEquals(0,r.width);
+		assertTrue(r.height > 0);
+
+		text.setText("\r\n\r\ntext");
+		int thirdLineOffset = text.getOffsetAtLine(2);
+		r = text.getTextBounds(thirdLineOffset, thirdLineOffset);
+		assertEquals(0, r.x);
+		assertTrue(r.y > 0);
+		assertTrue(r.width > 0);
+		assertTrue(r.height > 0);
+	}finally {
+		text.dispose();
+	}
+}
+
+@Test
 public void test_addExtendedModifyListenerLorg_eclipse_swt_custom_ExtendedModifyListener() {
 	final String line = "Line1";
 	ExtendedModifyListener listener = event -> {


### PR DESCRIPTION
StyledText#getTextBounds returns 0x7fffffff as x value if input parameters start and end have the same value and line at the given offset is empty. This looks not correct from my point of view. 
This has the effect that code minings in org.eclipse.jface.text.examples.codemining.CodeMiningDemo are not drawn correctly. Two LineHeaderCodeMinings to be drawn on the same line are then drawn on top of each other (see screenshot at https://github.com/eclipse-platform/eclipse.platform.ui/pull/2024).