### PR TITLE
selection background drawn with the line spacing for multiline selection

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/graphics/TextLayout.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/graphics/TextLayout.java
@@ -498,6 +498,9 @@ public void draw(GC gc, int x, int y, int selectionStart, int selectionEnd, Colo
 					rect.y += pt.y;
 					if (fixedLineMetrics != null) rect.height = fixedLineMetrics.height;
 					rect.height = Math.max(rect.height, ascent + descent);
+					if ((flags & (SWT.FULL_SELECTION | SWT.DELIMITER_SELECTION)) != 0 && (/*hasSelection ||*/ (flags & SWT.LAST_LINE_SELECTION) != 0)) {
+						rect.height += spacing;
+					}
 					path.appendBezierPathWithRect(rect);
 				}
 			}
@@ -506,8 +509,8 @@ public void draw(GC gc, int x, int y, int selectionStart, int selectionEnd, Colo
 				NSRect bounds = lineBounds[lineBounds.length - 1];
 				rect.x = pt.x + bounds.x + bounds.width;
 				rect.y = y + bounds.y;
-				rect.width = (flags & SWT.FULL_SELECTION) != 0 ? 0x7fffffff : bounds.height / 3;
-				rect.height = Math.max(bounds.height, ascent + descent);
+				rect.width = (flags & SWT.FULL_SELECTION) != 0 ? 0x7fffffff : (bounds.height + spacing) / 3;
+				rect.height = Math.max(bounds.height + spacing, ascent + descent);
 				path.appendBezierPathWithRect(rect);
 			}
 			selectionColor.setFill();

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/TextLayout.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/TextLayout.java
@@ -842,10 +842,10 @@ void drawInPixels (GC gc, int x, int y, int selectionStart, int selectionEnd, Co
 		int drawY = y + DPIUtil.scaleUp(getDevice(), lineY[line], getZoom(gc));
 		StyleItem[] lineRuns = runs[line];
 		int lineHeight = DPIUtil.scaleUp(getDevice(), lineY[line+1] - lineY[line] - lineSpacingInPoints, getZoom(gc));
-
+		int lineHeightWithSpacing = DPIUtil.scaleUp(getDevice(), lineY[line+1] - lineY[line], getZoom(gc));
 		//Draw last line selection
+		boolean extents = false;
 		if ((flags & (SWT.FULL_SELECTION | SWT.DELIMITER_SELECTION)) != 0 && (hasSelection || (flags & SWT.LAST_LINE_SELECTION) != 0)) {
-			boolean extents = false;
 			if (line == runs.length - 1 && (flags & SWT.LAST_LINE_SELECTION) != 0) {
 				extents = true;
 			} else {
@@ -864,13 +864,13 @@ void drawInPixels (GC gc, int x, int y, int selectionStart, int selectionEnd, Co
 				if ((flags & SWT.FULL_SELECTION) != 0) {
 					width = 0x6FFFFFF;
 				} else {
-					width = lineHeight / 3;
+					width = lineHeightWithSpacing / 3;
 				}
 				if (gdip) {
-					Gdip.Graphics_FillRectangle(gdipGraphics, gdipSelBackground, drawX + lineWidthInPixels[line], drawY, width, lineHeight);
+					Gdip.Graphics_FillRectangle(gdipGraphics, gdipSelBackground, drawX + lineWidthInPixels[line], drawY, width, lineHeightWithSpacing);
 				} else {
 					OS.SelectObject(hdc, selBackground);
-					OS.PatBlt(hdc, drawX + lineWidthInPixels[line], drawY, width, lineHeight, OS.PATCOPY);
+					OS.PatBlt(hdc, drawX + lineWidthInPixels[line], drawY, width, lineHeightWithSpacing, OS.PATCOPY);
 				}
 			}
 		}
@@ -884,7 +884,11 @@ void drawInPixels (GC gc, int x, int y, int selectionStart, int selectionEnd, Co
 			if (drawX > clip.x + clip.width) break;
 			if (drawX + run.width >= clip.x) {
 				if (!run.lineBreak || run.softBreak) {
-					OS.SetRect(rect, drawX, drawY, drawX + run.width, drawY + lineHeight);
+					if (extents) {
+						OS.SetRect(rect, drawX, drawY, drawX + run.width, drawY + lineHeightWithSpacing);
+					}else {
+						OS.SetRect(rect, drawX, drawY, drawX + run.width, drawY + lineHeight);
+					}
 					if (gdip) {
 						drawRunBackgroundGDIP(run, gdipGraphics, rect, selectionStart, selectionEnd, alpha, gdipSelBackground, hasSelection);
 					} else {


### PR DESCRIPTION
Line selection background is drawn without the line spacing value in the StyledText control. For a multiline selection, a zebra effect occurs which looks questionable from my point of view. In this change, the line spacing height is included when drawing the selection background. 

Before with line spacing value 60%:
![multiline_selection_line_spacing_before](https://github.com/eclipse-platform/eclipse.platform.swt/assets/10373336/7cb55d7b-6f59-401a-ada7-eace4375f1b1)


After with line spacing value 60%:
![multiline_selection_line_spacing_after](https://github.com/eclipse-platform/eclipse.platform.swt/assets/10373336/a7982cf8-40ba-4ac4-bb78-211a5129e7e2)
