### PR TITLE
Re-calculating the indent size for Tree on zoom change

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Tree.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Tree.java
@@ -5371,7 +5371,7 @@ public void setTopItem (TreeItem item) {
  * In a Tree without imageList, the indent also controls the chevron (glyph) size.
  */
 private void calculateAndApplyIndentSize() {
-	int indent = DPIUtil.autoScaleUpUsingNativeDPI(DEFAULT_INDENT);
+	int indent = DPIUtil.scaleUp(DEFAULT_INDENT, nativeZoom);
 	OS.SendMessage(handle, OS.TVM_SETINDENT, indent, 0);
 }
 
@@ -8297,6 +8297,7 @@ private static void handleDPIChange(Widget widget, int newZoom, float scalingFac
 		DPIZoomChangeRegistry.applyChange(item, newZoom, scalingFactor);
 	}
 
+	tree.calculateAndApplyIndentSize();
 	tree.updateOrientation();
 	tree.setScrollWidth();
 	// Reset of CheckBox Size required (if SWT.Check is not set, this is a no-op)


### PR DESCRIPTION
The method calculateAndApplyIndentSize in `Tree ` class is called again and scaled according to the zoom level when moving the shell across different zoom level screens. 

Before the fix: (100 -> 200)

![image](https://github.com/eclipse-platform/eclipse.platform.swt/assets/49493944/0b49892b-8ec7-416a-ad07-7006587f987b)

After the fix:  (100 -> 200)

![image](https://github.com/eclipse-platform/eclipse.platform.swt/assets/49493944/5f77cc5b-a68e-4523-8d82-036fdbfb4454)

## HOW TO TEST

- Run the `ControlExample` with the following **VM Arguments**
```
-Dswt.autoScale=quarter
-Dswt.autoScale.updateOnRuntime=true
```
- Switch to the tab "Tree"
- Move the window from 100 to 200 zoom level monitor
- See if the indentation looks normal

## EXPECTED BEHAVIOUR

The list should be indented properly.

Note: There is a visible issue with other zoom level changes as well. i.e. 200 -> 100




