### PR TITLE
Refactoring autoScaleUp with zoom to scaleUp

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/DPIUtil.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/DPIUtil.java
@@ -257,8 +257,8 @@ public static Rectangle autoScaleDown(Rectangle rect) {
 public static Rectangle scaleDown(Rectangle rect, int zoom) {
 	if (zoom == 100 || rect == null) return rect;
 	Rectangle scaledRect = new Rectangle (0,0,0,0);
-	Point scaledTopLeft = DPIUtil.scaleDown(new Point (rect.x, rect.y), zoom);
-	Point scaledBottomRight = DPIUtil.scaleDown(new Point (rect.x + rect.width, rect.y + rect.height), zoom);
+	Point scaledTopLeft = scaleDown(new Point (rect.x, rect.y), zoom);
+	Point scaledBottomRight = scaleDown(new Point (rect.x + rect.width, rect.y + rect.height), zoom);
 
 	scaledRect.x = scaledTopLeft.x;
 	scaledRect.y = scaledTopLeft.y;
@@ -308,14 +308,14 @@ private static ImageData autoScaleImageData (Device device, final ImageData imag
 		Image resultImage = new Image (device, (ImageDataProvider) zoom -> resultData);
 		GC gc = new GC (resultImage);
 		gc.setAntialias (SWT.ON);
-		gc.drawImage (original, 0, 0, DPIUtil.autoScaleDown (width), DPIUtil.autoScaleDown (height),
+		gc.drawImage (original, 0, 0, autoScaleDown (width), autoScaleDown (height),
 				/* E.g. destWidth here is effectively DPIUtil.autoScaleDown (scaledWidth), but avoiding rounding errors.
 				 * Nevertheless, we still have some rounding errors due to the point-based API GC#drawImage(..).
 				 */
-				0, 0, Math.round (DPIUtil.autoScaleDown (width * scaleFactor)), Math.round (DPIUtil.autoScaleDown (height * scaleFactor)));
+				0, 0, Math.round (autoScaleDown (width * scaleFactor)), Math.round (autoScaleDown (height * scaleFactor)));
 		gc.dispose ();
 		original.dispose ();
-		ImageData result = resultImage.getImageData (DPIUtil.getDeviceZoom ());
+		ImageData result = resultImage.getImageData (getDeviceZoom ());
 		resultImage.dispose ();
 		yield result;
 	}
@@ -326,7 +326,7 @@ private static ImageData autoScaleImageData (Device device, final ImageData imag
 /**
  * Returns a new rectangle as per the scaleFactor.
  */
-public static Rectangle autoScaleBounds (Rectangle rect, int targetZoom, int currentZoom) {
+public static Rectangle scaleBounds (Rectangle rect, int targetZoom, int currentZoom) {
 	if (rect == null || targetZoom == currentZoom) return rect;
 	float scaleFactor = ((float)targetZoom) / (float)currentZoom;
 	Rectangle returnRect = new Rectangle (0,0,0,0);
@@ -358,10 +358,10 @@ public static ImageData autoScaleUp (Device device, final ElementAtZoom<ImageDat
 }
 
 public static int[] autoScaleUp(int[] pointArray) {
-	return autoScaleUp(pointArray, deviceZoom);
+	return scaleUp(pointArray, deviceZoom);
 }
 
-public static int[] autoScaleUp(int[] pointArray, int zoom) {
+public static int[] scaleUp(int[] pointArray, int zoom) {
 	if (zoom == 100 || pointArray == null) return pointArray;
 	float scaleFactor = getScalingFactor(zoom);
 	int[] returnArray = new int[pointArray.length];
@@ -372,24 +372,24 @@ public static int[] autoScaleUp(int[] pointArray, int zoom) {
 }
 
 public static int[] autoScaleUp(Drawable drawable, int[] pointArray) {
-	return autoScaleUp(drawable, pointArray, deviceZoom);
+	return scaleUp(drawable, pointArray, deviceZoom);
 }
 
-public static int[] autoScaleUp(Drawable drawable, int[] pointArray, int zoom) {
+public static int[] scaleUp(Drawable drawable, int[] pointArray, int zoom) {
 	if (drawable != null && !drawable.isAutoScalable()) return pointArray;
-	return autoScaleUp (pointArray, zoom);
+	return scaleUp (pointArray, zoom);
 }
 /**
  * Auto-scale up int dimensions.
  */
 public static int autoScaleUp(int size) {
-	return autoScaleUp(size, deviceZoom);
+	return scaleUp(size, deviceZoom);
 }
 
 /**
  * Auto-scale up int dimensions to match the given zoom level
  */
-public static int autoScaleUp(int size, int zoom) {
+public static int scaleUp(int size, int zoom) {
 	if (zoom == 100 || size == SWT.DEFAULT) return size;
 	float scaleFactor = getScalingFactor(zoom);
 	return Math.round (size * scaleFactor);
@@ -408,41 +408,41 @@ public static int autoScaleUpUsingNativeDPI (int size) {
  * Auto-scale up int dimensions if enabled for Drawable class.
  */
 public static int autoScaleUp(Drawable drawable, int size) {
-	return autoScaleUp(drawable, size, deviceZoom);
+	return scaleUp(drawable, size, deviceZoom);
 }
 
-public static int autoScaleUp(Drawable drawable, int size, int zoom) {
+public static int scaleUp(Drawable drawable, int size, int zoom) {
 	if (drawable != null && !drawable.isAutoScalable()) return size;
-	return autoScaleUp (size, zoom);
+	return scaleUp (size, zoom);
 }
 
 public static float autoScaleUp(float size) {
-	return autoScaleUp(size, deviceZoom);
+	return scaleUp(size, deviceZoom);
 }
 
-public static float autoScaleUp(float size, int zoom) {
+public static float scaleUp(float size, int zoom) {
 	if (zoom == 100 || size == SWT.DEFAULT) return size;
 	float scaleFactor = getScalingFactor(zoom);
 	return (size * scaleFactor);
 }
 
 public static float autoScaleUp(Drawable drawable, float size) {
-	return autoScaleUp(drawable, size, deviceZoom);
+	return scaleUp(drawable, size, deviceZoom);
 }
 
-public static float autoScaleUp(Drawable drawable, float size, int zoom) {
+public static float scaleUp(Drawable drawable, float size, int zoom) {
 	if (drawable != null && !drawable.isAutoScalable()) return size;
-	return autoScaleUp (size, zoom);
+	return scaleUp (size, zoom);
 }
 
 /**
  * Returns a new scaled up Point.
  */
 public static Point autoScaleUp(Point point) {
-	return autoScaleUp(point, deviceZoom);
+	return scaleUp(point, deviceZoom);
 }
 
-public static Point autoScaleUp(Point point, int zoom) {
+public static Point scaleUp(Point point, int zoom) {
 	if (zoom == 100 || point == null) return point;
 	float scaleFactor = getScalingFactor(zoom);
 	Point scaledPoint = new Point(0,0);
@@ -455,26 +455,26 @@ public static Point autoScaleUp(Point point, int zoom) {
  * Returns a new scaled up Point if enabled for Drawable class.
  */
 public static Point autoScaleUp(Drawable drawable, Point point) {
-	return autoScaleUp (drawable, point, deviceZoom);
+	return scaleUp (drawable, point, deviceZoom);
 }
 
-public static Point autoScaleUp(Drawable drawable, Point point, int zoom) {
+public static Point scaleUp(Drawable drawable, Point point, int zoom) {
 	if (drawable != null && !drawable.isAutoScalable()) return point;
-	return autoScaleUp (point, zoom);
+	return scaleUp (point, zoom);
 }
 
 /**
  * Returns a new scaled up Rectangle.
  */
 public static Rectangle autoScaleUp(Rectangle rect) {
-	return autoScaleUp(rect, deviceZoom);
+	return scaleUp(rect, deviceZoom);
 }
 
-public static Rectangle autoScaleUp(Rectangle rect, int zoom) {
+public static Rectangle scaleUp(Rectangle rect, int zoom) {
 	if (zoom == 100 || rect == null) return rect;
 	Rectangle scaledRect = new Rectangle(0,0,0,0);
-	Point scaledTopLeft = DPIUtil.autoScaleUp (new Point(rect.x, rect.y), zoom);
-	Point scaledBottomRight = DPIUtil.autoScaleUp (new Point(rect.x + rect.width, rect.y + rect.height), zoom);
+	Point scaledTopLeft = scaleUp (new Point(rect.x, rect.y), zoom);
+	Point scaledBottomRight = scaleUp (new Point(rect.x + rect.width, rect.y + rect.height), zoom);
 
 	scaledRect.x = scaledTopLeft.x;
 	scaledRect.y = scaledTopLeft.y;
@@ -487,12 +487,12 @@ public static Rectangle autoScaleUp(Rectangle rect, int zoom) {
  * Returns a new scaled up Rectangle if enabled for Drawable class.
  */
 public static Rectangle autoScaleUp(Drawable drawable, Rectangle rect) {
-	return autoScaleUp(drawable, rect, deviceZoom);
+	return scaleUp(drawable, rect, deviceZoom);
 }
 
-public static Rectangle autoScaleUp(Drawable drawable, Rectangle rect, int zoom) {
+public static Rectangle scaleUp(Drawable drawable, Rectangle rect, int zoom) {
 	if (drawable != null && !drawable.isAutoScalable()) return rect;
-	return autoScaleUp (rect, zoom);
+	return scaleUp (rect, zoom);
 }
 
 /**

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/GC.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/GC.java
@@ -456,8 +456,8 @@ void checkGC(int mask) {
  */
 public void copyArea (Image image, int x, int y) {
 	int deviceZoom = getZoom();
-	x = DPIUtil.autoScaleUp(drawable, x, deviceZoom);
-	y = DPIUtil.autoScaleUp(drawable, y, deviceZoom);
+	x = DPIUtil.scaleUp(drawable, x, deviceZoom);
+	y = DPIUtil.scaleUp(drawable, y, deviceZoom);
 	copyAreaInPixels(image, x, y);
 }
 
@@ -513,12 +513,12 @@ public void copyArea (int srcX, int srcY, int width, int height, int destX, int 
  */
 public void copyArea (int srcX, int srcY, int width, int height, int destX, int destY, boolean paint) {
 	int deviceZoom = getZoom();
-	srcX = DPIUtil.autoScaleUp(drawable, srcX, deviceZoom);
-	srcY = DPIUtil.autoScaleUp(drawable, srcY, deviceZoom);
-	width = DPIUtil.autoScaleUp(drawable, width, deviceZoom);
-	height = DPIUtil.autoScaleUp(drawable, height, deviceZoom);
-	destX = DPIUtil.autoScaleUp(drawable, destX, deviceZoom);
-	destY = DPIUtil.autoScaleUp(drawable, destY, deviceZoom);
+	srcX = DPIUtil.scaleUp(drawable, srcX, deviceZoom);
+	srcY = DPIUtil.scaleUp(drawable, srcY, deviceZoom);
+	width = DPIUtil.scaleUp(drawable, width, deviceZoom);
+	height = DPIUtil.scaleUp(drawable, height, deviceZoom);
+	destX = DPIUtil.scaleUp(drawable, destX, deviceZoom);
+	destY = DPIUtil.scaleUp(drawable, destY, deviceZoom);
 	copyAreaInPixels(srcX, srcY, width, height, destX, destY, paint);
 }
 
@@ -760,10 +760,10 @@ void disposeGdip() {
  */
 public void drawArc (int x, int y, int width, int height, int startAngle, int arcAngle) {
 	int deviceZoom = getZoom();
-	x = DPIUtil.autoScaleUp(drawable, x, deviceZoom);
-	y = DPIUtil.autoScaleUp(drawable, y, deviceZoom);
-	width = DPIUtil.autoScaleUp(drawable, width, deviceZoom);
-	height = DPIUtil.autoScaleUp(drawable, height, deviceZoom);
+	x = DPIUtil.scaleUp(drawable, x, deviceZoom);
+	y = DPIUtil.scaleUp(drawable, y, deviceZoom);
+	width = DPIUtil.scaleUp(drawable, width, deviceZoom);
+	height = DPIUtil.scaleUp(drawable, height, deviceZoom);
 	drawArcInPixels(x, y, width, height, startAngle, arcAngle);
 }
 
@@ -844,10 +844,10 @@ void drawArcInPixels (int x, int y, int width, int height, int startAngle, int a
  */
 public void drawFocus (int x, int y, int width, int height) {
 	int deviceZoom = getZoom();
-	x = DPIUtil.autoScaleUp (drawable, x, deviceZoom);
-	y = DPIUtil.autoScaleUp (drawable, y, deviceZoom);
-	width = DPIUtil.autoScaleUp (drawable, width, deviceZoom);
-	height = DPIUtil.autoScaleUp (drawable, height, deviceZoom);
+	x = DPIUtil.scaleUp (drawable, x, deviceZoom);
+	y = DPIUtil.scaleUp (drawable, y, deviceZoom);
+	width = DPIUtil.scaleUp (drawable, width, deviceZoom);
+	height = DPIUtil.scaleUp (drawable, height, deviceZoom);
 	drawFocusInPixels(x, y, width, height);
 }
 
@@ -923,8 +923,8 @@ void drawFocusInPixels (int x, int y, int width, int height) {
  */
 public void drawImage (Image image, int x, int y) {
 	int deviceZoom = getZoom();
-	x = DPIUtil.autoScaleUp(drawable, x, deviceZoom);
-	y = DPIUtil.autoScaleUp(drawable, y, deviceZoom);
+	x = DPIUtil.scaleUp(drawable, x, deviceZoom);
+	y = DPIUtil.scaleUp(drawable, y, deviceZoom);
 	drawImageInPixels(image, x, y);
 }
 
@@ -977,8 +977,8 @@ public void drawImage (Image image, int srcX, int srcY, int srcWidth, int srcHei
 	if (image.isDisposed()) SWT.error(SWT.ERROR_INVALID_ARGUMENT);
 
 	int deviceZoom = getZoom();
-	Rectangle src = DPIUtil.autoScaleUp(drawable, new Rectangle(srcX, srcY, srcWidth, srcHeight), deviceZoom);
-	Rectangle dest = DPIUtil.autoScaleUp(drawable, new Rectangle(destX, destY, destWidth, destHeight), deviceZoom);
+	Rectangle src = DPIUtil.scaleUp(drawable, new Rectangle(srcX, srcY, srcWidth, srcHeight), deviceZoom);
+	Rectangle dest = DPIUtil.scaleUp(drawable, new Rectangle(destX, destY, destWidth, destHeight), deviceZoom);
 	if (deviceZoom != 100) {
 		/*
 		 * This is a HACK! Due to rounding errors at fractional scale factors,
@@ -1644,10 +1644,10 @@ void drawBitmapColor(Image srcImage, int srcX, int srcY, int srcWidth, int srcHe
  */
 public void drawLine (int x1, int y1, int x2, int y2) {
 	int deviceZoom = getZoom();
-	x1 = DPIUtil.autoScaleUp (drawable, x1, deviceZoom);
-	x2 = DPIUtil.autoScaleUp (drawable, x2, deviceZoom);
-	y1 = DPIUtil.autoScaleUp (drawable, y1, deviceZoom);
-	y2 = DPIUtil.autoScaleUp (drawable, y2, deviceZoom);
+	x1 = DPIUtil.scaleUp (drawable, x1, deviceZoom);
+	x2 = DPIUtil.scaleUp (drawable, x2, deviceZoom);
+	y1 = DPIUtil.scaleUp (drawable, y1, deviceZoom);
+	y2 = DPIUtil.scaleUp (drawable, y2, deviceZoom);
 	drawLineInPixels(x1, y1, x2, y2);
 }
 
@@ -1697,10 +1697,10 @@ void drawLineInPixels (int x1, int y1, int x2, int y2) {
  */
 public void drawOval (int x, int y, int width, int height) {
 	int deviceZoom = getZoom();
-	x = DPIUtil.autoScaleUp (drawable, x, deviceZoom);
-	y = DPIUtil.autoScaleUp (drawable, y, deviceZoom);
-	width = DPIUtil.autoScaleUp (drawable, width, deviceZoom);
-	height = DPIUtil.autoScaleUp (drawable, height, deviceZoom);
+	x = DPIUtil.scaleUp (drawable, x, deviceZoom);
+	y = DPIUtil.scaleUp (drawable, y, deviceZoom);
+	width = DPIUtil.scaleUp (drawable, width, deviceZoom);
+	height = DPIUtil.scaleUp (drawable, height, deviceZoom);
 	drawOvalInPixels(x, y, width, height);
 }
 
@@ -1775,8 +1775,8 @@ public void drawPath (Path path) {
  */
 public void drawPoint (int x, int y) {
 	int deviceZoom = getZoom();
-	x = DPIUtil.autoScaleUp (drawable, x, deviceZoom);
-	y = DPIUtil.autoScaleUp (drawable, y, deviceZoom);
+	x = DPIUtil.scaleUp (drawable, x, deviceZoom);
+	y = DPIUtil.scaleUp (drawable, y, deviceZoom);
 	drawPointInPixels(x, y);
 }
 
@@ -1809,7 +1809,7 @@ void drawPointInPixels (int x, int y) {
  */
 public void drawPolygon (int[] pointArray) {
 	if (pointArray == null) SWT.error(SWT.ERROR_NULL_ARGUMENT);
-	drawPolygonInPixels(DPIUtil.autoScaleUp(drawable, pointArray, getZoom()));
+	drawPolygonInPixels(DPIUtil.scaleUp(drawable, pointArray, getZoom()));
 }
 
 void drawPolygonInPixels(int[] pointArray) {
@@ -1857,7 +1857,7 @@ void drawPolygonInPixels(int[] pointArray) {
  * </ul>
  */
 public void drawPolyline (int[] pointArray) {
-	drawPolylineInPixels(DPIUtil.autoScaleUp(drawable, pointArray, getZoom()));
+	drawPolylineInPixels(DPIUtil.scaleUp(drawable, pointArray, getZoom()));
 }
 
 void drawPolylineInPixels(int[] pointArray) {
@@ -1911,10 +1911,10 @@ void drawPolylineInPixels(int[] pointArray) {
  */
 public void drawRectangle (int x, int y, int width, int height) {
 	int deviceZoom = getZoom();
-	x = DPIUtil.autoScaleUp (drawable, x, deviceZoom);
-	y = DPIUtil.autoScaleUp (drawable, y, deviceZoom);
-	width = DPIUtil.autoScaleUp (drawable, width, deviceZoom);
-	height = DPIUtil.autoScaleUp (drawable, height, deviceZoom);
+	x = DPIUtil.scaleUp (drawable, x, deviceZoom);
+	y = DPIUtil.scaleUp (drawable, y, deviceZoom);
+	width = DPIUtil.scaleUp (drawable, width, deviceZoom);
+	height = DPIUtil.scaleUp (drawable, height, deviceZoom);
 	drawRectangleInPixels(x, y, width, height);
 }
 
@@ -1970,7 +1970,7 @@ void drawRectangleInPixels (int x, int y, int width, int height) {
  */
 public void drawRectangle (Rectangle rect) {
 	if (rect == null) SWT.error(SWT.ERROR_NULL_ARGUMENT);
-	rect = DPIUtil.autoScaleUp(drawable, rect, getZoom());
+	rect = DPIUtil.scaleUp(drawable, rect, getZoom());
 	drawRectangleInPixels(rect.x, rect.y, rect.width, rect.height);
 }
 
@@ -1997,12 +1997,12 @@ public void drawRectangle (Rectangle rect) {
  */
 public void drawRoundRectangle (int x, int y, int width, int height, int arcWidth, int arcHeight) {
 	int deviceZoom = getZoom();
-	x = DPIUtil.autoScaleUp (drawable, x, deviceZoom);
-	y = DPIUtil.autoScaleUp (drawable, y, deviceZoom);
-	width = DPIUtil.autoScaleUp (drawable, width, deviceZoom);
-	height = DPIUtil.autoScaleUp (drawable, height, deviceZoom);
-	arcWidth = DPIUtil.autoScaleUp (drawable, arcWidth, deviceZoom);
-	arcHeight = DPIUtil.autoScaleUp (drawable, arcHeight, deviceZoom);
+	x = DPIUtil.scaleUp (drawable, x, deviceZoom);
+	y = DPIUtil.scaleUp (drawable, y, deviceZoom);
+	width = DPIUtil.scaleUp (drawable, width, deviceZoom);
+	height = DPIUtil.scaleUp (drawable, height, deviceZoom);
+	arcWidth = DPIUtil.scaleUp (drawable, arcWidth, deviceZoom);
+	arcHeight = DPIUtil.scaleUp (drawable, arcHeight, deviceZoom);
 	drawRoundRectangleInPixels(x, y, width, height, arcWidth, arcHeight);
 }
 
@@ -2095,8 +2095,8 @@ void drawRoundRectangleGdip (long gdipGraphics, long pen, int x, int y, int widt
  */
 public void drawString (String string, int x, int y) {
 	int deviceZoom = getZoom();
-	x = DPIUtil.autoScaleUp(drawable, x, deviceZoom);
-	y = DPIUtil.autoScaleUp(drawable, y, deviceZoom);
+	x = DPIUtil.scaleUp(drawable, x, deviceZoom);
+	y = DPIUtil.scaleUp(drawable, y, deviceZoom);
 	drawStringInPixels(string, x, y, false);
 }
 
@@ -2129,8 +2129,8 @@ public void drawString (String string, int x, int y) {
  */
 public void drawString (String string, int x, int y, boolean isTransparent) {
 	int deviceZoom = getZoom();
-	x = DPIUtil.autoScaleUp(drawable, x, deviceZoom);
-	y = DPIUtil.autoScaleUp(drawable, y, deviceZoom);
+	x = DPIUtil.scaleUp(drawable, x, deviceZoom);
+	y = DPIUtil.scaleUp(drawable, y, deviceZoom);
 	drawStringInPixels(string, x, y, isTransparent);
 }
 
@@ -2221,8 +2221,8 @@ void drawStringInPixels (String string, int x, int y, boolean isTransparent) {
  */
 public void drawText (String string, int x, int y) {
 	int deviceZoom = getZoom();
-	x = DPIUtil.autoScaleUp(drawable, x, deviceZoom);
-	y = DPIUtil.autoScaleUp(drawable, y, deviceZoom);
+	x = DPIUtil.scaleUp(drawable, x, deviceZoom);
+	y = DPIUtil.scaleUp(drawable, y, deviceZoom);
 	drawTextInPixels(string, x, y);
 }
 
@@ -2256,8 +2256,8 @@ void drawTextInPixels (String string, int x, int y) {
  */
 public void drawText (String string, int x, int y, boolean isTransparent) {
 	int deviceZoom = getZoom();
-	x = DPIUtil.autoScaleUp(drawable, x, deviceZoom);
-	y = DPIUtil.autoScaleUp(drawable, y, deviceZoom);
+	x = DPIUtil.scaleUp(drawable, x, deviceZoom);
+	y = DPIUtil.scaleUp(drawable, y, deviceZoom);
 	drawTextInPixels(string, x, y, isTransparent);
 }
 
@@ -2308,8 +2308,8 @@ void drawTextInPixels (String string, int x, int y, boolean isTransparent) {
  */
 public void drawText (String string, int x, int y, int flags) {
 	int deviceZoom = getZoom();
-	x = DPIUtil.autoScaleUp(drawable, x, deviceZoom);
-	y = DPIUtil.autoScaleUp(drawable, y, deviceZoom);
+	x = DPIUtil.scaleUp(drawable, x, deviceZoom);
+	y = DPIUtil.scaleUp(drawable, y, deviceZoom);
 	drawTextInPixels(string, x, y, flags);
 }
 
@@ -2688,10 +2688,10 @@ public boolean equals (Object object) {
  */
 public void fillArc (int x, int y, int width, int height, int startAngle, int arcAngle) {
 	int deviceZoom = getZoom();
-	x = DPIUtil.autoScaleUp (drawable, x, deviceZoom);
-	y = DPIUtil.autoScaleUp (drawable, y, deviceZoom);
-	width = DPIUtil.autoScaleUp (drawable, width, deviceZoom);
-	height = DPIUtil.autoScaleUp (drawable, height, deviceZoom);
+	x = DPIUtil.scaleUp (drawable, x, deviceZoom);
+	y = DPIUtil.scaleUp (drawable, y, deviceZoom);
+	width = DPIUtil.scaleUp (drawable, width, deviceZoom);
+	height = DPIUtil.scaleUp (drawable, height, deviceZoom);
 	fillArcInPixels(x, y, width, height, startAngle, arcAngle);
 }
 
@@ -2768,10 +2768,10 @@ void fillArcInPixels (int x, int y, int width, int height, int startAngle, int a
  */
 public void fillGradientRectangle (int x, int y, int width, int height, boolean vertical) {
 	int deviceZoom = getZoom();
-	x = DPIUtil.autoScaleUp (drawable, x, deviceZoom);
-	y = DPIUtil.autoScaleUp (drawable, y, deviceZoom);
-	width = DPIUtil.autoScaleUp (drawable, width, deviceZoom);
-	height = DPIUtil.autoScaleUp (drawable, height, deviceZoom);
+	x = DPIUtil.scaleUp (drawable, x, deviceZoom);
+	y = DPIUtil.scaleUp (drawable, y, deviceZoom);
+	width = DPIUtil.scaleUp (drawable, width, deviceZoom);
+	height = DPIUtil.scaleUp (drawable, height, deviceZoom);
 	fillGradientRectangleInPixels(x, y, width, height, vertical);
 }
 
@@ -2887,10 +2887,10 @@ void fillGradientRectangleInPixels(int x, int y, int width, int height, boolean 
  */
 public void fillOval (int x, int y, int width, int height) {
 	int deviceZoom = getZoom();
-	x = DPIUtil.autoScaleUp (drawable, x, deviceZoom);
-	y = DPIUtil.autoScaleUp (drawable, y, deviceZoom);
-	width = DPIUtil.autoScaleUp (drawable, width, deviceZoom);
-	height = DPIUtil.autoScaleUp (drawable, height, deviceZoom);
+	x = DPIUtil.scaleUp (drawable, x, deviceZoom);
+	y = DPIUtil.scaleUp (drawable, y, deviceZoom);
+	width = DPIUtil.scaleUp (drawable, width, deviceZoom);
+	height = DPIUtil.scaleUp (drawable, height, deviceZoom);
 	fillOvalInPixels(x, y, width, height);
 }
 
@@ -2961,7 +2961,7 @@ public void fillPath (Path path) {
  */
 public void fillPolygon (int[] pointArray) {
 	if (pointArray == null) SWT.error(SWT.ERROR_NULL_ARGUMENT);
-	fillPolygonInPixels(DPIUtil.autoScaleUp(drawable, pointArray, getZoom()));
+	fillPolygonInPixels(DPIUtil.scaleUp(drawable, pointArray, getZoom()));
 }
 
 void fillPolygonInPixels (int[] pointArray) {
@@ -3011,10 +3011,10 @@ void fillPolygonInPixels (int[] pointArray) {
  */
 public void fillRectangle (int x, int y, int width, int height) {
 	int deviceZoom = getZoom();
-	x = DPIUtil.autoScaleUp (drawable, x, deviceZoom);
-	y = DPIUtil.autoScaleUp (drawable, y, deviceZoom);
-	width = DPIUtil.autoScaleUp (drawable, width, deviceZoom);
-	height = DPIUtil.autoScaleUp (drawable, height, deviceZoom);
+	x = DPIUtil.scaleUp (drawable, x, deviceZoom);
+	y = DPIUtil.scaleUp (drawable, y, deviceZoom);
+	width = DPIUtil.scaleUp (drawable, width, deviceZoom);
+	height = DPIUtil.scaleUp (drawable, height, deviceZoom);
 	fillRectangleInPixels(x, y, width, height);
 }
 
@@ -3054,7 +3054,7 @@ void fillRectangleInPixels (int x, int y, int width, int height) {
  */
 public void fillRectangle (Rectangle rect) {
 	if (rect == null) SWT.error(SWT.ERROR_NULL_ARGUMENT);
-	rect = DPIUtil.autoScaleUp(drawable, rect, getZoom());
+	rect = DPIUtil.scaleUp(drawable, rect, getZoom());
 	fillRectangleInPixels(rect.x, rect.y, rect.width, rect.height);
 }
 
@@ -3077,12 +3077,12 @@ public void fillRectangle (Rectangle rect) {
  */
 public void fillRoundRectangle (int x, int y, int width, int height, int arcWidth, int arcHeight) {
 	int deviceZoom = getZoom();
-	x = DPIUtil.autoScaleUp (drawable, x, deviceZoom);
-	y = DPIUtil.autoScaleUp (drawable, y, deviceZoom);
-	width = DPIUtil.autoScaleUp (drawable, width, deviceZoom);
-	height = DPIUtil.autoScaleUp (drawable, height, deviceZoom);
-	arcWidth = DPIUtil.autoScaleUp (drawable, arcWidth, deviceZoom);
-	arcHeight = DPIUtil.autoScaleUp (drawable, arcHeight, deviceZoom);
+	x = DPIUtil.scaleUp (drawable, x, deviceZoom);
+	y = DPIUtil.scaleUp (drawable, y, deviceZoom);
+	width = DPIUtil.scaleUp (drawable, width, deviceZoom);
+	height = DPIUtil.scaleUp (drawable, height, deviceZoom);
+	arcWidth = DPIUtil.scaleUp (drawable, arcWidth, deviceZoom);
+	arcHeight = DPIUtil.scaleUp (drawable, arcHeight, deviceZoom);
 	fillRoundRectangleInPixels(x, y, width, height, arcWidth, arcHeight);
 }
 
@@ -4278,10 +4278,10 @@ void setClipping(long clipRgn) {
  */
 public void setClipping (int x, int y, int width, int height) {
 	int deviceZoom = getZoom();
-	x = DPIUtil.autoScaleUp(drawable, x, deviceZoom);
-	y = DPIUtil.autoScaleUp(drawable, y, deviceZoom);
-	width = DPIUtil.autoScaleUp(drawable, width, deviceZoom);
-	height = DPIUtil.autoScaleUp(drawable, height, deviceZoom);
+	x = DPIUtil.scaleUp(drawable, x, deviceZoom);
+	y = DPIUtil.scaleUp(drawable, y, deviceZoom);
+	width = DPIUtil.scaleUp(drawable, width, deviceZoom);
+	height = DPIUtil.scaleUp(drawable, height, deviceZoom);
 	setClippingInPixels(x, y, width, height);
 }
 
@@ -4350,7 +4350,7 @@ public void setClipping (Rectangle rect) {
 		setClipping(0);
 	}
 	else {
-		rect = DPIUtil.autoScaleUp(drawable, rect, getZoom());
+		rect = DPIUtil.scaleUp(drawable, rect, getZoom());
 		setClippingInPixels(rect.x, rect.y, rect.width, rect.height);
 	}
 }
@@ -4556,7 +4556,7 @@ public void setInterpolation(int interpolation) {
  */
 public void setLineAttributes (LineAttributes attributes) {
 	if (attributes == null) SWT.error(SWT.ERROR_NULL_ARGUMENT);
-	attributes.width = DPIUtil.autoScaleUp(drawable, attributes.width, getZoom());
+	attributes.width = DPIUtil.scaleUp(drawable, attributes.width, getZoom());
 	setLineAttributesInPixels(attributes);
 }
 
@@ -4621,7 +4621,7 @@ void setLineAttributesInPixels (LineAttributes attributes) {
 			float[] newDashes = new float[dashes.length];
 			int deviceZoom = getZoom();
 			for (int i = 0; i < newDashes.length; i++) {
-				newDashes[i] = DPIUtil.autoScaleUp(drawable, dashes[i], deviceZoom);
+				newDashes[i] = DPIUtil.scaleUp(drawable, dashes[i], deviceZoom);
 			}
 			dashes = newDashes;
 			mask |= LINE_STYLE;
@@ -4712,7 +4712,7 @@ public void setLineDash(int[] dashes) {
 		int deviceZoom = getZoom();
 		for (int i = 0; i < dashes.length; i++) {
 			if (dashes[i] <= 0) SWT.error(SWT.ERROR_INVALID_ARGUMENT);
-			newDashes[i] = DPIUtil.autoScaleUp(drawable, (float) dashes[i], deviceZoom);
+			newDashes[i] = DPIUtil.scaleUp(drawable, (float) dashes[i], deviceZoom);
 			if (!changed && lineDashes[i] != newDashes[i]) changed = true;
 		}
 		if (!changed) return;
@@ -4813,7 +4813,7 @@ public void setLineStyle(int lineStyle) {
  * </ul>
  */
 public void setLineWidth(int lineWidth) {
-	lineWidth = DPIUtil.autoScaleUp (drawable, lineWidth, getZoom());
+	lineWidth = DPIUtil.scaleUp (drawable, lineWidth, getZoom());
 	setLineWidthInPixels(lineWidth);
 }
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Image.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Image.java
@@ -462,7 +462,7 @@ public Image(Device device, Rectangle bounds) {
 	super(device);
 	if (bounds == null) SWT.error(SWT.ERROR_NULL_ARGUMENT);
 	initialNativeZoom = DPIUtil.getNativeDeviceZoom();
-	bounds = DPIUtil.autoScaleUp (bounds, getZoom());
+	bounds = DPIUtil.scaleUp (bounds, getZoom());
 	init(bounds.width, bounds.height);
 	init();
 }
@@ -1270,7 +1270,7 @@ Rectangle getBounds(int zoom) {
 	// Read the bounds in pixels from native layer.
 	Rectangle bounds = getBoundsInPixelsFromNative();
 	if (bounds != null && zoom != getZoom()) {
-		bounds = DPIUtil.autoScaleBounds(bounds, zoom, getZoom());
+		bounds = DPIUtil.scaleBounds(bounds, zoom, getZoom());
 	}
 	return bounds;
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Path.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Path.java
@@ -206,10 +206,10 @@ private Path(Device device, PathData data, int zoom) {
 public void addArc (float x, float y, float width, float height, float startAngle, float arcAngle) {
 	if (width == 0 || height == 0 || arcAngle == 0) return;
 	Drawable drawable = getDevice();
-	x = DPIUtil.autoScaleUp(drawable, x, initialZoom);
-	y = DPIUtil.autoScaleUp(drawable, y, initialZoom);
-	width = DPIUtil.autoScaleUp(drawable, width, initialZoom);
-	height = DPIUtil.autoScaleUp(drawable, height, initialZoom);
+	x = DPIUtil.scaleUp(drawable, x, initialZoom);
+	y = DPIUtil.scaleUp(drawable, y, initialZoom);
+	width = DPIUtil.scaleUp(drawable, width, initialZoom);
+	height = DPIUtil.scaleUp(drawable, height, initialZoom);
 	addArcInPixels(x, y, width, height, startAngle, arcAngle);
 }
 
@@ -309,8 +309,8 @@ void addRectangleInPixels(float x, float y, float width, float height) {
  */
 public void addString (String string, float x, float y, Font font) {
 	Drawable drawable = getDevice();
-	x = DPIUtil.autoScaleUp(drawable, x, initialZoom);
-	y = DPIUtil.autoScaleUp(drawable, y, initialZoom);
+	x = DPIUtil.scaleUp(drawable, x, initialZoom);
+	y = DPIUtil.scaleUp(drawable, y, initialZoom);
 	addStringInPixels(string, x, y, font);
 }
 void addStringInPixels(String string, float x, float y, Font font) {
@@ -381,8 +381,8 @@ public void close() {
  */
 public boolean contains (float x, float y, GC gc, boolean outline) {
 	Drawable drawable = getDevice();
-	x = DPIUtil.autoScaleUp(drawable, x, initialZoom);
-	y = DPIUtil.autoScaleUp(drawable, y, initialZoom);
+	x = DPIUtil.scaleUp(drawable, x, initialZoom);
+	y = DPIUtil.scaleUp(drawable, y, initialZoom);
 	return containsInPixels(x, y, gc, outline);
 }
 boolean containsInPixels(float x, float y, GC gc, boolean outline) {
@@ -417,12 +417,12 @@ boolean containsInPixels(float x, float y, GC gc, boolean outline) {
  */
 public void cubicTo (float cx1, float cy1, float cx2, float cy2, float x, float y) {
 	Drawable drawable = getDevice();
-	cx1 = DPIUtil.autoScaleUp(drawable, cx1, initialZoom);
-	cy1 = DPIUtil.autoScaleUp(drawable, cy1, initialZoom);
-	cx2 = DPIUtil.autoScaleUp(drawable, cx2, initialZoom);
-	cy2 = DPIUtil.autoScaleUp(drawable, cy2, initialZoom);
-	x = DPIUtil.autoScaleUp(drawable, x, initialZoom);
-	y = DPIUtil.autoScaleUp(drawable, y, initialZoom);
+	cx1 = DPIUtil.scaleUp(drawable, cx1, initialZoom);
+	cy1 = DPIUtil.scaleUp(drawable, cy1, initialZoom);
+	cx2 = DPIUtil.scaleUp(drawable, cx2, initialZoom);
+	cy2 = DPIUtil.scaleUp(drawable, cy2, initialZoom);
+	x = DPIUtil.scaleUp(drawable, x, initialZoom);
+	y = DPIUtil.scaleUp(drawable, y, initialZoom);
 	cubicToInPixels(cx1, cy1, cx2, cy2, x, y);
 }
 
@@ -575,7 +575,7 @@ PathData getPathDataInPixels() {
  */
 public void lineTo (float x, float y) {
 	Drawable drawable = getDevice();
-	lineToInPixels(DPIUtil.autoScaleUp(drawable, x, initialZoom), DPIUtil.autoScaleUp(drawable, y, initialZoom));
+	lineToInPixels(DPIUtil.scaleUp(drawable, x, initialZoom), DPIUtil.scaleUp(drawable, y, initialZoom));
 }
 
 void lineToInPixels(float x, float y) {
@@ -640,7 +640,7 @@ public boolean isDisposed() {
  */
 public void moveTo (float x, float y) {
 	Drawable drawable = getDevice();
-	moveToInPixels(DPIUtil.autoScaleUp(drawable, x, initialZoom), DPIUtil.autoScaleUp(drawable, y, initialZoom));
+	moveToInPixels(DPIUtil.scaleUp(drawable, x, initialZoom), DPIUtil.scaleUp(drawable, y, initialZoom));
 }
 
 void moveToInPixels(float x, float y) {
@@ -664,10 +664,10 @@ void moveToInPixels(float x, float y) {
  */
 public void quadTo (float cx, float cy, float x, float y) {
 	Drawable drawable = getDevice();
-	cx = DPIUtil.autoScaleUp(drawable, cx, initialZoom);
-	cy = DPIUtil.autoScaleUp(drawable, cy, initialZoom);
-	x = DPIUtil.autoScaleUp(drawable, x, initialZoom);
-	y = DPIUtil.autoScaleUp(drawable, y, initialZoom);
+	cx = DPIUtil.scaleUp(drawable, cx, initialZoom);
+	cy = DPIUtil.scaleUp(drawable, cy, initialZoom);
+	x = DPIUtil.scaleUp(drawable, x, initialZoom);
+	y = DPIUtil.scaleUp(drawable, y, initialZoom);
 	quadToInPixels(cx, cy, x, y);
 }
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Pattern.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Pattern.java
@@ -198,10 +198,10 @@ long getHandle(int zoom) {
 
 private void initializeSize(int zoom) {
 	long handle;
-	float x1 = DPIUtil.autoScaleUp(this.baseX1, zoom);
-	float y1 = DPIUtil.autoScaleUp(this.baseY1, zoom);
-	float x2 = DPIUtil.autoScaleUp(this.baseX2, zoom);
-	float y2 = DPIUtil.autoScaleUp(this.baseY2, zoom);
+	float x1 = DPIUtil.scaleUp(this.baseX1, zoom);
+	float y1 = DPIUtil.scaleUp(this.baseY1, zoom);
+	float x2 = DPIUtil.scaleUp(this.baseX2, zoom);
+	float y2 = DPIUtil.scaleUp(this.baseY2, zoom);
 	if (color1 == null) SWT.error(SWT.ERROR_NULL_ARGUMENT);
 	if (color1.isDisposed()) SWT.error(SWT.ERROR_INVALID_ARGUMENT);
 	if (color2 == null) SWT.error(SWT.ERROR_NULL_ARGUMENT);

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Region.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Region.java
@@ -191,7 +191,7 @@ public void add (Region region) {
  */
 public boolean contains (int x, int y) {
 	if (isDisposed()) SWT.error(SWT.ERROR_GRAPHIC_DISPOSED);
-	return containsInPixels(DPIUtil.autoScaleUp(x, initialZoom), DPIUtil.autoScaleUp(y, initialZoom));
+	return containsInPixels(DPIUtil.scaleUp(x, initialZoom), DPIUtil.scaleUp(y, initialZoom));
 }
 
 boolean containsInPixels (int x, int y) {
@@ -216,7 +216,7 @@ boolean containsInPixels (int x, int y) {
 public boolean contains (Point pt) {
 	if (isDisposed()) SWT.error(SWT.ERROR_GRAPHIC_DISPOSED);
 	if (pt == null) SWT.error(SWT.ERROR_NULL_ARGUMENT);
-	Point p = DPIUtil.autoScaleUp(pt, initialZoom);
+	Point p = DPIUtil.scaleUp(pt, initialZoom);
 	return containsInPixels(p.x, p.y);
 }
 
@@ -375,7 +375,7 @@ public void intersect (Region region) {
  */
 public boolean intersects (int x, int y, int width, int height) {
 	if (isDisposed()) SWT.error(SWT.ERROR_GRAPHIC_DISPOSED);
-	return 	intersectsInPixels(DPIUtil.autoScaleUp(x, initialZoom), DPIUtil.autoScaleUp(y, initialZoom), DPIUtil.autoScaleUp(width, initialZoom), DPIUtil.autoScaleUp(height, initialZoom));
+	return 	intersectsInPixels(DPIUtil.scaleUp(x, initialZoom), DPIUtil.scaleUp(y, initialZoom), DPIUtil.scaleUp(width, initialZoom), DPIUtil.scaleUp(height, initialZoom));
 }
 
 boolean intersectsInPixels (int x, int y, int width, int height) {
@@ -404,7 +404,7 @@ boolean intersectsInPixels (int x, int y, int width, int height) {
 public boolean intersects (Rectangle rect) {
 	if (isDisposed()) SWT.error(SWT.ERROR_GRAPHIC_DISPOSED);
 	if (rect == null) SWT.error(SWT.ERROR_NULL_ARGUMENT);
-	Rectangle r = DPIUtil.autoScaleUp(rect, initialZoom);
+	Rectangle r = DPIUtil.scaleUp(rect, initialZoom);
 	return intersectsInPixels(r.x, r.y, r.width, r.height);
 }
 
@@ -705,7 +705,7 @@ private class OperationWithRectangle extends Operation {
 	}
 
 	private Rectangle getScaledRectangle(int zoom) {
-		return DPIUtil.autoScaleUp(data, zoom);
+		return DPIUtil.scaleUp(data, zoom);
 	}
 
 }
@@ -754,7 +754,7 @@ private class OperationWithArray extends Operation {
 	}
 
 	private int[] getScaledPoints(int zoom) {
-		return DPIUtil.autoScaleUp(data, zoom);
+		return DPIUtil.scaleUp(data, zoom);
 	}
 }
 
@@ -784,7 +784,7 @@ private class OperationWithPoint extends Operation {
 
 	@Override
 	void translate(long handle, int zoom) {
-		Point pt = DPIUtil.autoScaleUp((Point) data, zoom);
+		Point pt = DPIUtil.scaleUp((Point) data, zoom);
 		OS.OffsetRgn (handle, pt.x, pt.y);
 	}
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/TextLayout.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/TextLayout.java
@@ -379,10 +379,10 @@ void computeRuns (GC gc) {
 	}
 	SCRIPT_LOGATTR logAttr = new SCRIPT_LOGATTR();
 	SCRIPT_PROPERTIES properties = new SCRIPT_PROPERTIES();
-	int wrapIndentInPixels = DPIUtil.autoScaleUp(wrapIndent, getZoom(gc));
-	int indentInPixels = DPIUtil.autoScaleUp(indent, getZoom(gc));
-	int wrapWidthInPixels = DPIUtil.autoScaleUp(wrapWidth, getZoom(gc));
-	int[] tabsInPixels = DPIUtil.autoScaleUp(tabs, getZoom(gc));
+	int wrapIndentInPixels = DPIUtil.scaleUp(wrapIndent, getZoom(gc));
+	int indentInPixels = DPIUtil.scaleUp(indent, getZoom(gc));
+	int wrapWidthInPixels = DPIUtil.scaleUp(wrapWidth, getZoom(gc));
+	int[] tabsInPixels = DPIUtil.scaleUp(tabs, getZoom(gc));
 	int lineWidth = indentInPixels, lineStart = 0, lineCount = 1;
 	for (int i=0; i<allRuns.length - 1; i++) {
 		StyleItem run = allRuns[i];
@@ -705,7 +705,7 @@ long createGdipBrush(Color color, int alpha) {
  */
 public void draw (GC gc, int x, int y) {
 	checkLayout();
-	drawInPixels(gc, DPIUtil.autoScaleUp(getDevice(), x, getZoom(gc)), DPIUtil.autoScaleUp(getDevice(), y, getZoom(gc)));
+	drawInPixels(gc, DPIUtil.scaleUp(getDevice(), x, getZoom(gc)), DPIUtil.scaleUp(getDevice(), y, getZoom(gc)));
 }
 
 /**
@@ -729,7 +729,7 @@ public void draw (GC gc, int x, int y) {
  */
 public void draw (GC gc, int x, int y, int selectionStart, int selectionEnd, Color selectionForeground, Color selectionBackground) {
 	checkLayout();
-	drawInPixels(gc, DPIUtil.autoScaleUp(getDevice(), x, getZoom(gc)), DPIUtil.autoScaleUp(getDevice(), y, getZoom(gc)), selectionStart, selectionEnd, selectionForeground, selectionBackground);
+	drawInPixels(gc, DPIUtil.scaleUp(getDevice(), x, getZoom(gc)), DPIUtil.scaleUp(getDevice(), y, getZoom(gc)), selectionStart, selectionEnd, selectionForeground, selectionBackground);
 }
 
 void drawInPixels (GC gc, int x, int y, int selectionStart, int selectionEnd, Color selectionForeground, Color selectionBackground) {
@@ -765,7 +765,7 @@ void drawInPixels (GC gc, int x, int y, int selectionStart, int selectionEnd, Co
  */
 public void draw (GC gc, int x, int y, int selectionStart, int selectionEnd, Color selectionForeground, Color selectionBackground, int flags) {
 	checkLayout();
-	drawInPixels(gc, DPIUtil.autoScaleUp(getDevice(), x, getZoom(gc)), DPIUtil.autoScaleUp(getDevice(), y, getZoom(gc)), selectionStart, selectionEnd, selectionForeground, selectionBackground, flags);
+	drawInPixels(gc, DPIUtil.scaleUp(getDevice(), x, getZoom(gc)), DPIUtil.scaleUp(getDevice(), y, getZoom(gc)), selectionStart, selectionEnd, selectionForeground, selectionBackground, flags);
 }
 
 private int getNativeZoom(GC gc) {
@@ -839,9 +839,9 @@ void drawInPixels (GC gc, int x, int y, int selectionStart, int selectionEnd, Co
 	OS.SetBkMode(hdc, OS.TRANSPARENT);
 	for (int line=0; line<runs.length; line++) {
 		int drawX = x + getLineIndentInPixel(line);
-		int drawY = y + DPIUtil.autoScaleUp(getDevice(), lineY[line], getZoom(gc));
+		int drawY = y + DPIUtil.scaleUp(getDevice(), lineY[line], getZoom(gc));
 		StyleItem[] lineRuns = runs[line];
-		int lineHeight = DPIUtil.autoScaleUp(getDevice(), lineY[line+1] - lineY[line] - lineSpacingInPoints, getZoom(gc));
+		int lineHeight = DPIUtil.scaleUp(getDevice(), lineY[line+1] - lineY[line] - lineSpacingInPoints, getZoom(gc));
 
 		//Draw last line selection
 		if ((flags & (SWT.FULL_SELECTION | SWT.DELIMITER_SELECTION)) != 0 && (hasSelection || (flags & SWT.LAST_LINE_SELECTION) != 0)) {
@@ -896,10 +896,10 @@ void drawInPixels (GC gc, int x, int y, int selectionStart, int selectionEnd, Co
 		}
 
 		//Draw the text, underline, strikeout, and border of the runs in the line
-		int baselineInPixels = Math.max(0, DPIUtil.autoScaleUp(getDevice(), ascent, getZoom(gc)));
+		int baselineInPixels = Math.max(0, DPIUtil.scaleUp(getDevice(), ascent, getZoom(gc)));
 		int lineUnderlinePos = 0;
 		for (StyleItem run : lineRuns) {
-			baselineInPixels = Math.max(baselineInPixels, DPIUtil.autoScaleUp(getDevice(), run.ascentInPoints, getZoom(gc)));
+			baselineInPixels = Math.max(baselineInPixels, DPIUtil.scaleUp(getDevice(), run.ascentInPoints, getZoom(gc)));
 			lineUnderlinePos = Math.min(lineUnderlinePos, run.underlinePos);
 		}
 		RECT borderClip = null, underlineClip = null, strikeoutClip = null, pRect = null;
@@ -1179,7 +1179,7 @@ RECT drawRunText(GC gc, long hdc, StyleItem run, RECT rect, int baselineInPixels
 	boolean partialSelection = hasSelection && !fullSelection && !(selectionStart > end || run.start > selectionEnd);
 	int offset = (orientation & SWT.RIGHT_TO_LEFT) != 0 ? -1 : 0;
 	int x = rect.left + offset;
-	int y = rect.top + (baselineInPixels - DPIUtil.autoScaleUp(getDevice(), run.ascentInPoints, getZoom(gc)));
+	int y = rect.top + (baselineInPixels - DPIUtil.scaleUp(getDevice(), run.ascentInPoints, getZoom(gc)));
 	long hFont = getItemFont(run, gc);
 	OS.SelectObject(hdc, hFont);
 	if (fullSelection) {
@@ -1210,7 +1210,7 @@ RECT drawRunTextGDIP(GC gc, long graphics, StyleItem run, RECT rect, long gdipFo
 	// rendering (such as ScriptTextOut()) which put top of the character
 	// at requested position.
 	int drawY = rect.top + baselineInPixels;
-	if (run.style != null && run.style.rise != 0) drawY -= DPIUtil.autoScaleUp(getDevice(), run.style.rise, getZoom(gc));
+	if (run.style != null && run.style.rise != 0) drawY -= DPIUtil.scaleUp(getDevice(), run.style.rise, getZoom(gc));
 
 	int drawX = rect.left;
 	long brush = color;
@@ -1362,7 +1362,7 @@ RECT drawStrikeout(GC gc, long hdc, int x, int baselineInPixels, StyleItem[] lin
 			}
 		}
 		RECT rect = new RECT();
-		int riseInPixels = DPIUtil.autoScaleUp(getDevice(), style.rise, getZoom(gc));
+		int riseInPixels = DPIUtil.scaleUp(getDevice(), style.rise, getZoom(gc));
 		OS.SetRect(rect, x + left, baselineInPixels - run.strikeoutPos - riseInPixels, x + run.x + run.width, baselineInPixels - run.strikeoutPos + run.strikeoutThickness - riseInPixels);
 		long brush = OS.CreateSolidBrush(color);
 		OS.FillRect(hdc, rect, brush);
@@ -1412,7 +1412,7 @@ RECT drawStrikeoutGDIP(GC gc, long graphics, int x, int baselineInPixels, StyleI
 				}
 			}
 		}
-		int riseInPixels = DPIUtil.autoScaleUp(getDevice(), style.rise, getZoom(gc));
+		int riseInPixels = DPIUtil.scaleUp(getDevice(), style.rise, getZoom(gc));
 		if (clipRect != null) {
 			int gstate = Gdip.Graphics_Save(graphics);
 			if (clipRect.left == -1) clipRect.left = 0;
@@ -1470,7 +1470,7 @@ RECT drawUnderline(GC gc, long hdc, int x, int baselineInPixels, int lineUnderli
 			}
 		}
 		RECT rect = new RECT();
-		int riseInPixels = DPIUtil.autoScaleUp(getDevice(), style.rise, getZoom(gc));
+		int riseInPixels = DPIUtil.scaleUp(getDevice(), style.rise, getZoom(gc));
 		OS.SetRect(rect, x + left, baselineInPixels - lineUnderlinePos - riseInPixels, x + run.x + run.width, baselineInPixels - lineUnderlinePos + run.underlineThickness - riseInPixels);
 		if (clipRect != null) {
 			if (clipRect.left == -1) clipRect.left = 0;
@@ -1546,7 +1546,7 @@ RECT drawUnderline(GC gc, long hdc, int x, int baselineInPixels, int lineUnderli
 				int penStyle = style.underlineStyle == UNDERLINE_IME_DASH ? OS.PS_DASH : OS.PS_DOT;
 				long pen = OS.CreatePen(penStyle, 1, color);
 				long oldPen = OS.SelectObject(hdc, pen);
-				int descentInPixels = DPIUtil.autoScaleUp(getDevice(), run.descentInPoints, getZoom(gc));
+				int descentInPixels = DPIUtil.scaleUp(getDevice(), run.descentInPoints, getZoom(gc));
 				OS.SetRect(rect, rect.left, baselineInPixels + descentInPixels, rect.right, baselineInPixels + descentInPixels + run.underlineThickness);
 				OS.MoveToEx(hdc, rect.left, rect.top, 0);
 				OS.LineTo(hdc, rect.right, rect.top);
@@ -1602,7 +1602,7 @@ RECT drawUnderlineGDIP (GC gc, long graphics, int x, int baselineInPixels, int l
 			}
 		}
 		RECT rect = new RECT();
-		int riseInPixels = DPIUtil.autoScaleUp(getDevice(), style.rise, getZoom(gc));
+		int riseInPixels = DPIUtil.scaleUp(getDevice(), style.rise, getZoom(gc));
 		OS.SetRect(rect, x + left, baselineInPixels - lineUnderlinePos - riseInPixels, x + run.x + run.width, baselineInPixels - lineUnderlinePos + run.underlineThickness - riseInPixels);
 		Rect gdipRect = null;
 		if (clipRect != null) {
@@ -1698,7 +1698,7 @@ RECT drawUnderlineGDIP (GC gc, long graphics, int x, int baselineInPixels, int l
 					gstate = Gdip.Graphics_Save(graphics);
 					Gdip.Graphics_SetClip(graphics, gdipRect, Gdip.CombineModeExclude);
 				}
-				int descentInPixels = DPIUtil.autoScaleUp(getDevice(), run.descentInPoints, getZoom(gc));
+				int descentInPixels = DPIUtil.scaleUp(getDevice(), run.descentInPoints, getZoom(gc));
 				Gdip.Graphics_DrawLine(graphics, pen, rect.left, baselineInPixels + descentInPixels, run.width - run.length, baselineInPixels + descentInPixels);
 				if (gdipRect != null) {
 					Gdip.Graphics_Restore(graphics, gstate);
@@ -1857,7 +1857,7 @@ Rectangle getBoundsInPixels (int start, int end) {
 			int cx = 0;
 			if (run.style != null && run.style.metrics != null) {
 				GlyphMetrics metrics = run.style.metrics;
-				cx = DPIUtil.autoScaleUp(getDevice(), metrics.width, nativeZoom) * (start - run.start);
+				cx = DPIUtil.scaleUp(getDevice(), metrics.width, nativeZoom) * (start - run.start);
 			} else if (!run.tab) {
 				int iX = ScriptCPtoX(start - run.start, false, run);
 				cx = isRTL ? run.width - iX : iX;
@@ -1872,7 +1872,7 @@ Rectangle getBoundsInPixels (int start, int end) {
 			int cx = run.width;
 			if (run.style != null && run.style.metrics != null) {
 				GlyphMetrics metrics = run.style.metrics;
-				cx = DPIUtil.autoScaleUp(getDevice(), metrics.width, nativeZoom) * (end - run.start + 1);
+				cx = DPIUtil.scaleUp(getDevice(), metrics.width, nativeZoom) * (end - run.start + 1);
 			} else if (!run.tab) {
 				int iX = ScriptCPtoX(end - run.start, true, run);
 				cx = isRTL ? run.width - iX : iX;
@@ -1889,8 +1889,8 @@ Rectangle getBoundsInPixels (int start, int end) {
 		}
 		left = Math.min(left, runLead);
 		right = Math.max(right, runTrail);
-		top = Math.min(top, DPIUtil.autoScaleUp(lineY[lineIndex], getZoom(null)));
-		bottom = Math.max(bottom, DPIUtil.autoScaleUp(lineY[lineIndex + 1] - lineSpacingInPoints, getZoom(null)));
+		top = Math.min(top, DPIUtil.scaleUp(lineY[lineIndex], getZoom(null)));
+		bottom = Math.max(bottom, DPIUtil.scaleUp(lineY[lineIndex + 1] - lineSpacingInPoints, getZoom(null)));
 	}
 	return new Rectangle(left, top, right - left, bottom - top + getScaledVerticalIndent());
 }
@@ -2023,9 +2023,9 @@ Rectangle getLineBoundsInPixels(int lineIndex) {
 	computeRuns(null);
 	if (!(0 <= lineIndex && lineIndex < runs.length)) SWT.error(SWT.ERROR_INVALID_RANGE);
 	int x = getLineIndentInPixel(lineIndex);
-	int y = DPIUtil.autoScaleUp(getDevice(), lineY[lineIndex], getZoom());
+	int y = DPIUtil.scaleUp(getDevice(), lineY[lineIndex], getZoom());
 	int width = lineWidthInPixels[lineIndex];
-	int height = DPIUtil.autoScaleUp(getDevice(), lineY[lineIndex + 1] - lineY[lineIndex] - lineSpacingInPoints, getZoom());
+	int height = DPIUtil.scaleUp(getDevice(), lineY[lineIndex + 1] - lineY[lineIndex] - lineSpacingInPoints, getZoom());
 	return new Rectangle (x, y, width, height);
 }
 
@@ -2050,14 +2050,14 @@ int getLineIndent(int lineIndex) {
 }
 
 int getLineIndentInPixel (int lineIndex) {
-	int lineIndent = DPIUtil.autoScaleUp(wrapIndent, getZoom());
+	int lineIndent = DPIUtil.scaleUp(wrapIndent, getZoom());
 	if (lineIndex == 0) {
-		lineIndent = DPIUtil.autoScaleUp(indent, getZoom());
+		lineIndent = DPIUtil.scaleUp(indent, getZoom());
 	} else {
 		StyleItem[] previousLine = runs[lineIndex - 1];
 		StyleItem previousRun = previousLine[previousLine.length - 1];
 		if (previousRun.lineBreak && !previousRun.softBreak) {
-			lineIndent = DPIUtil.autoScaleUp(indent, getZoom());
+			lineIndent = DPIUtil.scaleUp(indent, getZoom());
 		}
 	}
 	if (wrapWidth != -1) {
@@ -2071,8 +2071,8 @@ int getLineIndentInPixel (int lineIndex) {
 		if (partialLine) {
 			int lineWidth = this.lineWidthInPixels[lineIndex] + lineIndent;
 			switch (alignment) {
-				case SWT.CENTER: lineIndent += (DPIUtil.autoScaleUp(wrapWidth, getZoom()) - lineWidth) / 2; break;
-				case SWT.RIGHT: lineIndent += DPIUtil.autoScaleUp(wrapWidth, getZoom()) - lineWidth; break;
+				case SWT.CENTER: lineIndent += (DPIUtil.scaleUp(wrapWidth, getZoom()) - lineWidth) / 2; break;
+				case SWT.RIGHT: lineIndent += DPIUtil.scaleUp(wrapWidth, getZoom()) - lineWidth; break;
 			}
 		}
 	}
@@ -2145,10 +2145,10 @@ public FontMetrics getLineMetrics (int lineIndex) {
 			descentInPoints = Math.max(descentInPoints, run.descentInPoints);
 		}
 	}
-	lptm.tmAscent = DPIUtil.autoScaleUp(getDevice(), ascentInPoints, getZoom());
-	lptm.tmDescent = DPIUtil.autoScaleUp(getDevice(), descentInPoints, getZoom());
-	lptm.tmHeight = DPIUtil.autoScaleUp(getDevice(), ascentInPoints + descentInPoints, getZoom());
-	lptm.tmInternalLeading = DPIUtil.autoScaleUp(getDevice(), leadingInPoints, getZoom());
+	lptm.tmAscent = DPIUtil.scaleUp(getDevice(), ascentInPoints, getZoom());
+	lptm.tmDescent = DPIUtil.scaleUp(getDevice(), descentInPoints, getZoom());
+	lptm.tmHeight = DPIUtil.scaleUp(getDevice(), ascentInPoints + descentInPoints, getZoom());
+	lptm.tmInternalLeading = DPIUtil.scaleUp(getDevice(), leadingInPoints, getZoom());
 	lptm.tmAveCharWidth = 0;
 	return FontMetrics.win32_new(lptm, nativeZoom);
 }
@@ -2207,7 +2207,7 @@ Point getLocationInPixels (int offset, boolean trailing) {
 	}
 	line = Math.min(line, runs.length - 1);
 	if (offset == length) {
-		return new Point(getLineIndentInPixel(line) + lineWidthInPixels[line], DPIUtil.autoScaleUp(getDevice(), lineY[line], getZoom()));
+		return new Point(getLineIndentInPixel(line) + lineWidthInPixels[line], DPIUtil.scaleUp(getDevice(), lineY[line], getZoom()));
 	}
 	/* For trailing use the low surrogate and for lead use the high surrogate */
 	char ch = segmentsText.charAt(offset);
@@ -2243,7 +2243,7 @@ Point getLocationInPixels (int offset, boolean trailing) {
 			int width;
 			if (run.style != null && run.style.metrics != null) {
 				GlyphMetrics metrics = run.style.metrics;
-				width = DPIUtil.autoScaleUp(getDevice(), metrics.width, nativeZoom) * (offset - run.start + (trailing ? 1 : 0));
+				width = DPIUtil.scaleUp(getDevice(), metrics.width, nativeZoom) * (offset - run.start + (trailing ? 1 : 0));
 			} else if (run.tab) {
 				width = (trailing || (offset == length)) ? run.width : 0;
 			} else {
@@ -2251,7 +2251,7 @@ Point getLocationInPixels (int offset, boolean trailing) {
 				final int iX = ScriptCPtoX(runOffset, trailing, run);
 				width = (orientation & SWT.RIGHT_TO_LEFT) != 0 ? run.width - iX : iX;
 			}
-			return new Point(run.x + width, DPIUtil.autoScaleUp(getDevice(), lineY[line], getZoom()) + getScaledVerticalIndent());
+			return new Point(run.x + width, DPIUtil.scaleUp(getDevice(), lineY[line], getZoom()) + getScaledVerticalIndent());
 		}
 	}
 	return new Point(0, 0);
@@ -2402,7 +2402,7 @@ int _getOffset(int offset, int movement, boolean forward) {
  */
 public int getOffset (Point point, int[] trailing) {
 	checkLayout();
-	if (point == null) SWT.error (SWT.ERROR_NULL_ARGUMENT);	return getOffsetInPixels(DPIUtil.autoScaleUp(getDevice(), point, getZoom()), trailing);
+	if (point == null) SWT.error (SWT.ERROR_NULL_ARGUMENT);	return getOffsetInPixels(DPIUtil.scaleUp(getDevice(), point, getZoom()), trailing);
 }
 
 int getOffsetInPixels (Point point, int[] trailing) {
@@ -2434,7 +2434,7 @@ int getOffsetInPixels (Point point, int[] trailing) {
  */
 public int getOffset (int x, int y, int[] trailing) {
 	checkLayout();
-	return getOffsetInPixels(DPIUtil.autoScaleUp(getDevice(), x, getZoom()), DPIUtil.autoScaleUp(getDevice(), y, getZoom()), trailing);
+	return getOffsetInPixels(DPIUtil.scaleUp(getDevice(), x, getZoom()), DPIUtil.scaleUp(getDevice(), y, getZoom()), trailing);
 }
 
 int getOffsetInPixels (int x, int y, int[] trailing) {
@@ -2443,7 +2443,7 @@ int getOffsetInPixels (int x, int y, int[] trailing) {
 	int line;
 	int lineCount = runs.length;
 	for (line=0; line<lineCount; line++) {
-		if (DPIUtil.autoScaleUp(getDevice(), lineY[line + 1], getZoom()) > y) break;
+		if (DPIUtil.scaleUp(getDevice(), lineY[line + 1], getZoom()) > y) break;
 	}
 	line = Math.min(line, runs.length - 1);
 	StyleItem[] lineRuns = runs[line];
@@ -2465,7 +2465,7 @@ int getOffsetInPixels (int x, int y, int[] trailing) {
 			if (run.style != null && run.style.metrics != null) {
 				GlyphMetrics metrics = run.style.metrics;
 				if (metrics.width > 0) {
-					final int metricsWidthInPixels = DPIUtil.autoScaleUp(getDevice(), metrics.width, nativeZoom);
+					final int metricsWidthInPixels = DPIUtil.scaleUp(getDevice(), metrics.width, nativeZoom);
 					if (trailing != null) {
 						trailing[0] = (xRun % metricsWidthInPixels < metricsWidthInPixels / 2) ? 0 : 1;
 					}
@@ -2702,7 +2702,7 @@ private int getScaledVerticalIndent() {
 	if (verticalIndentInPoints == 0) {
 		return verticalIndentInPoints;
 	}
-	return DPIUtil.autoScaleUp(getDevice(), verticalIndentInPoints, getZoom());
+	return DPIUtil.scaleUp(getDevice(), verticalIndentInPoints, getZoom());
 }
 
 /**
@@ -3911,7 +3911,7 @@ void shape (GC  gc, final long hdc, final StyleItem run) {
 			 *  equals zero for FFFC (possibly other unicode code points), the fix
 			 *  is to make sure the glyph is at least one pixel wide.
 			 */
-			run.width = DPIUtil.autoScaleUp(getDevice(), metrics.width, nativeZoom) * Math.max (1, run.glyphCount);
+			run.width = DPIUtil.scaleUp(getDevice(), metrics.width, nativeZoom) * Math.max (1, run.glyphCount);
 			run.ascentInPoints = metrics.ascent;
 			run.descentInPoints = metrics.descent;
 			run.leadingInPoints = 0;
@@ -3935,7 +3935,7 @@ void shape (GC  gc, final long hdc, final StyleItem run) {
 		} else {
 			run.underlinePos = 1;
 			run.underlineThickness = 1;
-			run.strikeoutPos = DPIUtil.autoScaleUp(getDevice(), run.ascentInPoints, getZoom(gc)) / 2;
+			run.strikeoutPos = DPIUtil.scaleUp(getDevice(), run.ascentInPoints, getZoom(gc)) / 2;
 			run.strikeoutThickness = 1;
 		}
 		run.ascentInPoints += style.rise;

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Transform.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Transform.java
@@ -141,7 +141,7 @@ public Transform (Device device, float m11, float m12, float m21, float m22, flo
 	initialZoom = DPIUtil.getDeviceZoom();
 	this.device.checkGDIP();
 	long handle = Gdip.Matrix_new(m11, m12, m21, m22,
-			DPIUtil.autoScaleUp(this.device, dx, initialZoom), DPIUtil.autoScaleUp(this.device, dy, initialZoom));
+			DPIUtil.scaleUp(this.device, dx, initialZoom), DPIUtil.scaleUp(this.device, dy, initialZoom));
 	if (handle == 0) SWT.error(SWT.ERROR_NO_HANDLES);
 	zoomLevelToHandle.put(initialZoom, handle);
 	init();
@@ -312,7 +312,7 @@ public void scale(float scaleX, float scaleY) {
 public void setElements(float m11, float m12, float m21, float m22, float dx, float dy) {
 	if (isDisposed()) SWT.error(SWT.ERROR_GRAPHIC_DISPOSED);
 	Drawable drawable = getDevice();
-	Gdip.Matrix_SetElements(getHandle(initialZoom), m11, m12, m21, m22, DPIUtil.autoScaleUp(drawable, dx, initialZoom), DPIUtil.autoScaleUp(drawable, dy, initialZoom));
+	Gdip.Matrix_SetElements(getHandle(initialZoom), m11, m12, m21, m22, DPIUtil.scaleUp(drawable, dx, initialZoom), DPIUtil.scaleUp(drawable, dy, initialZoom));
 }
 
 /**
@@ -353,7 +353,7 @@ public void transform(float[] pointArray) {
 	int length = pointArray.length;
 	Drawable drawable = getDevice();
 	for (int i = 0; i < length; i++) {
-		pointArray[i] = DPIUtil.autoScaleUp(drawable, pointArray[i], initialZoom);
+		pointArray[i] = DPIUtil.scaleUp(drawable, pointArray[i], initialZoom);
 	}
 	Gdip.Matrix_TransformPoints(getHandle(initialZoom), pointArray, length / 2);
 	for (int i = 0; i < length; i++) {
@@ -375,7 +375,7 @@ public void transform(float[] pointArray) {
 public void translate(float offsetX, float offsetY) {
 	if (isDisposed()) SWT.error(SWT.ERROR_GRAPHIC_DISPOSED);
 	Drawable drawable = getDevice();
-	Gdip.Matrix_Translate(getHandle(initialZoom), DPIUtil.autoScaleUp(drawable, offsetX, initialZoom), DPIUtil.autoScaleUp(drawable, offsetY, initialZoom), Gdip.MatrixOrderPrepend);
+	Gdip.Matrix_Translate(getHandle(initialZoom), DPIUtil.scaleUp(drawable, offsetX, initialZoom), DPIUtil.scaleUp(drawable, offsetY, initialZoom), Gdip.MatrixOrderPrepend);
 }
 
 /**
@@ -396,8 +396,8 @@ long getHandle(int zoomLevel) {
 	if(zoomLevelToHandle.get(zoomLevel) == null) {
 		float[] elements = new float[6];
 		getElements(elements);
-		elements[4] = DPIUtil.autoScaleUp(device, DPIUtil.scaleDown(device, elements[4], initialZoom), zoomLevel);
-		elements[5] = DPIUtil.autoScaleUp(device, DPIUtil.scaleDown(device, elements[5], initialZoom), zoomLevel);
+		elements[4] = DPIUtil.scaleUp(device, DPIUtil.scaleDown(device, elements[4], initialZoom), zoomLevel);
+		elements[5] = DPIUtil.scaleUp(device, DPIUtil.scaleDown(device, elements[5], initialZoom), zoomLevel);
 
 		zoomLevelToHandle.put(zoomLevel, Gdip.Matrix_new(elements[0], elements[1], elements[2], elements[3], elements[4], elements[5]));
 	}

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/ImageList.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/ImageList.java
@@ -48,7 +48,7 @@ public int add (Image image) {
 		index++;
 	}
 	if (count == 0) {
-		Rectangle rect = DPIUtil.autoScaleBounds(image.getBounds(), zoom, 100);
+		Rectangle rect = DPIUtil.scaleBounds(image.getBounds(), zoom, 100);
 		OS.ImageList_SetIconSize (handle, rect.width, rect.height);
 	}
 	set (index, image, count);

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Button.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Button.java
@@ -296,7 +296,7 @@ int computeLeftMargin () {
 	if ((style & (SWT.PUSH | SWT.TOGGLE)) == 0) return MARGIN;
 	int margin = 0;
 	if (image != null && text.length () != 0) {
-		Rectangle bounds = DPIUtil.autoScaleBounds(image.getBounds(), this.getZoom(), 100);
+		Rectangle bounds = DPIUtil.scaleBounds(image.getBounds(), this.getZoom(), 100);
 		margin += bounds.width + MARGIN * 2;
 		long oldFont = 0;
 		long hDC = OS.GetDC (handle);
@@ -358,7 +358,7 @@ int computeLeftMargin () {
 			boolean hasImage = image != null, hasText = true;
 			if (hasImage) {
 				if (image != null) {
-					Rectangle rect = DPIUtil.autoScaleBounds(image.getBounds(), this.getZoom(), 100);
+					Rectangle rect = DPIUtil.scaleBounds(image.getBounds(), this.getZoom(), 100);
 					width = rect.width;
 					if (hasText && text.length () != 0) {
 						width += MARGIN * 2;
@@ -1391,7 +1391,7 @@ LRESULT wmNotifyChild (NMHDR hdr, long wParam, long lParam) {
 							GC gc = createNewGC(nmcd.hdc, data);
 
 							int margin = computeLeftMargin();
-							Rectangle imageBounds = DPIUtil.autoScaleBounds(image.getBounds(), this.getZoom(), 100);
+							Rectangle imageBounds = DPIUtil.scaleBounds(image.getBounds(), this.getZoom(), 100);
 							int imageWidth = imageBounds.width;
 							left += (imageWidth + (isRadioOrCheck() ? 2 * MARGIN : MARGIN)); // for SWT.RIGHT_TO_LEFT right and left are inverted
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Canvas.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Canvas.java
@@ -104,10 +104,10 @@ public Canvas (Composite parent, int style) {
  */
 public void drawBackground (GC gc, int x, int y, int width, int height) {
 	int zoom = getZoom();
-	x = DPIUtil.autoScaleUp(x, zoom);
-	y = DPIUtil.autoScaleUp(y, zoom);
-	width = DPIUtil.autoScaleUp(width, zoom);
-	height = DPIUtil.autoScaleUp(height, zoom);
+	x = DPIUtil.scaleUp(x, zoom);
+	y = DPIUtil.scaleUp(y, zoom);
+	width = DPIUtil.scaleUp(width, zoom);
+	height = DPIUtil.scaleUp(height, zoom);
 	drawBackgroundInPixels(gc, x, y, width, height, 0, 0);
 }
 
@@ -201,12 +201,12 @@ void reskinChildren (int flags) {
 public void scroll (int destX, int destY, int x, int y, int width, int height, boolean all) {
 	checkWidget ();
 	int zoom = getZoom();
-	destX = DPIUtil.autoScaleUp(destX, zoom);
-	destY = DPIUtil.autoScaleUp(destY, zoom);
-	x = DPIUtil.autoScaleUp(x, zoom);
-	y = DPIUtil.autoScaleUp(y, zoom);
-	width = DPIUtil.autoScaleUp(width, zoom);
-	height = DPIUtil.autoScaleUp(height, zoom);
+	destX = DPIUtil.scaleUp(destX, zoom);
+	destY = DPIUtil.scaleUp(destY, zoom);
+	x = DPIUtil.scaleUp(x, zoom);
+	y = DPIUtil.scaleUp(y, zoom);
+	width = DPIUtil.scaleUp(width, zoom);
+	height = DPIUtil.scaleUp(height, zoom);
 	scrollInPixels(destX, destY, x, y, width, height, all);
 }
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Caret.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Caret.java
@@ -233,19 +233,19 @@ Point getSizeInPixels () {
 }
 
 private int getWidthInPixels() {
-	return DPIUtil.autoScaleUp(width, getZoom());
+	return DPIUtil.scaleUp(width, getZoom());
 }
 
 private int getHeightInPixels() {
-	return DPIUtil.autoScaleUp(height, getZoom());
+	return DPIUtil.scaleUp(height, getZoom());
 }
 
 private int getXInPixels() {
-	return DPIUtil.autoScaleUp(x, getZoom());
+	return DPIUtil.scaleUp(x, getZoom());
 }
 
 private int getYInPixels() {
-	return DPIUtil.autoScaleUp(y, getZoom());
+	return DPIUtil.scaleUp(y, getZoom());
 }
 
 /**

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Composite.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Composite.java
@@ -219,7 +219,7 @@ Point computeSizeInPixels (int wHint, int hHint, boolean changed) {
 			changed |= (state & LAYOUT_CHANGED) != 0;
 			state &= ~LAYOUT_CHANGED;
 			int zoom = getZoom();
-			size = DPIUtil.autoScaleUp(layout.computeSize (this, DPIUtil.scaleDown(wHint, zoom), DPIUtil.scaleDown(hHint, zoom), changed), zoom);
+			size = DPIUtil.scaleUp(layout.computeSize (this, DPIUtil.scaleDown(wHint, zoom), DPIUtil.scaleDown(hHint, zoom), changed), zoom);
 		} else {
 			size = new Point (wHint, hHint);
 		}
@@ -235,7 +235,7 @@ Point computeSizeInPixels (int wHint, int hHint, boolean changed) {
 	 * call computeTrimInPixels directly.
 	 */
 	int zoom = getZoom();
-	Rectangle trim = DPIUtil.autoScaleUp(computeTrim (0, 0, DPIUtil.scaleDown(size.x, zoom), DPIUtil.scaleDown(size.y, zoom)), zoom);
+	Rectangle trim = DPIUtil.scaleUp(computeTrim (0, 0, DPIUtil.scaleDown(size.x, zoom), DPIUtil.scaleDown(size.y, zoom)), zoom);
 	return new Point (trim.width, trim.height);
 }
 
@@ -356,12 +356,12 @@ int applyThemeBackground () {
 public void drawBackground (GC gc, int x, int y, int width, int height, int offsetX, int offsetY) {
 	checkWidget ();
 	int zoom = getZoom();
-	x = DPIUtil.autoScaleUp(x, zoom);
-	y = DPIUtil.autoScaleUp(y, zoom);
-	width = DPIUtil.autoScaleUp(width, zoom);
-	height = DPIUtil.autoScaleUp(height, zoom);
-	offsetX = DPIUtil.autoScaleUp(offsetX, zoom);
-	offsetY = DPIUtil.autoScaleUp(offsetY, zoom);
+	x = DPIUtil.scaleUp(x, zoom);
+	y = DPIUtil.scaleUp(y, zoom);
+	width = DPIUtil.scaleUp(width, zoom);
+	height = DPIUtil.scaleUp(height, zoom);
+	offsetX = DPIUtil.scaleUp(offsetX, zoom);
+	offsetY = DPIUtil.scaleUp(offsetY, zoom);
 	drawBackgroundInPixels(gc, x, y, width, height, offsetX, offsetY);
 }
 
@@ -882,10 +882,10 @@ Point minimumSize (int wHint, int hHint, boolean changed) {
 	 * call getClientAreaInPixels directly.
 	 */
 	int zoom = getZoom();
-	Rectangle clientArea = DPIUtil.autoScaleUp(getClientArea (), zoom);
+	Rectangle clientArea = DPIUtil.scaleUp(getClientArea (), zoom);
 	int width = 0, height = 0;
 	for (Control element : _getChildren ()) {
-		Rectangle rect = DPIUtil.autoScaleUp(element.getBounds (), zoom);
+		Rectangle rect = DPIUtil.scaleUp(element.getBounds (), zoom);
 		width = Math.max (width, rect.x - clientArea.x + rect.width);
 		height = Math.max (height, rect.y - clientArea.y + rect.height);
 	}

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Control.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Control.java
@@ -615,8 +615,8 @@ public Point computeSize (int wHint, int hHint) {
 public Point computeSize (int wHint, int hHint, boolean changed){
 	checkWidget ();
 	int zoom = getZoom();
-	wHint = (wHint != SWT.DEFAULT ? DPIUtil.autoScaleUp(wHint, zoom) : wHint);
-	hHint = (hHint != SWT.DEFAULT ? DPIUtil.autoScaleUp(hHint, zoom) : hHint);
+	wHint = (wHint != SWT.DEFAULT ? DPIUtil.scaleUp(wHint, zoom) : wHint);
+	hHint = (hHint != SWT.DEFAULT ? DPIUtil.scaleUp(hHint, zoom) : hHint);
 	return DPIUtil.scaleDown(computeSizeInPixels(wHint, hHint, changed), zoom);
 }
 
@@ -779,7 +779,7 @@ public boolean dragDetect (Event event) {
 	if (event == null) error (SWT.ERROR_NULL_ARGUMENT);
 	Point loc = event.getLocation();
 	int zoom = getZoom();
-	return dragDetect (event.button, event.count, event.stateMask, DPIUtil.autoScaleUp(loc.x, zoom), DPIUtil.autoScaleUp(loc.y, zoom));
+	return dragDetect (event.button, event.count, event.stateMask, DPIUtil.scaleUp(loc.x, zoom), DPIUtil.scaleUp(loc.y, zoom));
 }
 
 /**
@@ -822,7 +822,7 @@ public boolean dragDetect (MouseEvent event) {
 	checkWidget ();
 	if (event == null) error (SWT.ERROR_NULL_ARGUMENT);
 	int zoom = getZoom();
-	return dragDetect (event.button, event.count, event.stateMask, DPIUtil.autoScaleUp(event.x, zoom), DPIUtil.autoScaleUp(event.y, zoom)); // To Pixels
+	return dragDetect (event.button, event.count, event.stateMask, DPIUtil.scaleUp(event.x, zoom), DPIUtil.scaleUp(event.y, zoom)); // To Pixels
 }
 
 boolean dragDetect (int button, int count, int stateMask, int x, int y) {
@@ -1975,8 +1975,8 @@ void mapEvent (long hwnd, Event event) {
 		POINT point = new POINT ();
 		Point loc = event.getLocation();
 		int zoom = getZoom();
-		point.x = DPIUtil.autoScaleUp(loc.x, zoom);
-		point.y = DPIUtil.autoScaleUp(loc.y, zoom);
+		point.x = DPIUtil.scaleUp(loc.x, zoom);
+		point.y = DPIUtil.scaleUp(loc.y, zoom);
 		OS.MapWindowPoints (hwnd, handle, point, 1);
 		event.setLocation(DPIUtil.scaleDown(point.x, zoom), DPIUtil.scaleDown(point.y, zoom));
 	}
@@ -2431,10 +2431,10 @@ public void redraw () {
 public void redraw (int x, int y, int width, int height, boolean all) {
 	checkWidget ();
 	int zoom = getZoom();
-	x = DPIUtil.autoScaleUp(x, zoom);
-	y = DPIUtil.autoScaleUp(y, zoom);
-	width = DPIUtil.autoScaleUp(width, zoom);
-	height = DPIUtil.autoScaleUp(height, zoom);
+	x = DPIUtil.scaleUp(x, zoom);
+	y = DPIUtil.scaleUp(y, zoom);
+	width = DPIUtil.scaleUp(width, zoom);
+	height = DPIUtil.scaleUp(height, zoom);
 	if (width <= 0 || height <= 0) return;
 
 	RECT rect = new RECT ();
@@ -3167,10 +3167,10 @@ void setBackgroundPixel (int pixel) {
 public void setBounds(int x, int y, int width, int height) {
 	checkWidget ();
 	int zoom = getZoom();
-	x = DPIUtil.autoScaleUp(x, zoom);
-	y = DPIUtil.autoScaleUp(y, zoom);
-	width = DPIUtil.autoScaleUp(width, zoom);
-	height = DPIUtil.autoScaleUp(height, zoom);
+	x = DPIUtil.scaleUp(x, zoom);
+	y = DPIUtil.scaleUp(y, zoom);
+	width = DPIUtil.scaleUp(width, zoom);
+	height = DPIUtil.scaleUp(height, zoom);
 	setBoundsInPixels(x, y, width, height);
 }
 
@@ -3248,7 +3248,7 @@ void setBoundsInPixels (int x, int y, int width, int height, int flags, boolean 
 public void setBounds (Rectangle rect) {
 	checkWidget ();
 	if (rect == null) error (SWT.ERROR_NULL_ARGUMENT);
-	setBoundsInPixels(DPIUtil.autoScaleUp(rect, getZoom()));
+	setBoundsInPixels(DPIUtil.scaleUp(rect, getZoom()));
 }
 
 void setBoundsInPixels (Rectangle rect) {
@@ -3503,8 +3503,8 @@ public void setLayoutData (Object layoutData) {
 public void setLocation (int x, int y) {
 	checkWidget ();
 	int zoom = getZoom();
-	x = DPIUtil.autoScaleUp(x, zoom);
-	y = DPIUtil.autoScaleUp(y, zoom);
+	x = DPIUtil.scaleUp(x, zoom);
+	y = DPIUtil.scaleUp(y, zoom);
 	setLocationInPixels(x, y);
 }
 
@@ -3530,7 +3530,7 @@ void setLocationInPixels (int x, int y) {
 public void setLocation (Point location) {
 	checkWidget ();
 	if (location == null) error (SWT.ERROR_NULL_ARGUMENT);
-	location = DPIUtil.autoScaleUp(location, getZoom());
+	location = DPIUtil.scaleUp(location, getZoom());
 	setLocationInPixels(location.x, location.y);
 }
 
@@ -3720,8 +3720,8 @@ public void setRegion (Region region) {
 public void setSize (int width, int height) {
 	checkWidget ();
 	int zoom = getZoom();
-	width = DPIUtil.autoScaleUp(width, zoom);
-	height = DPIUtil.autoScaleUp(height, zoom);
+	width = DPIUtil.scaleUp(width, zoom);
+	height = DPIUtil.scaleUp(height, zoom);
 	setSizeInPixels(width, height);
 }
 
@@ -3756,7 +3756,7 @@ void setSizeInPixels (int width, int height) {
 public void setSize (Point size) {
 	checkWidget ();
 	if (size == null) error (SWT.ERROR_NULL_ARGUMENT);
-	size = DPIUtil.autoScaleUp(size, getZoom());
+	size = DPIUtil.scaleUp(size, getZoom());
 	setSizeInPixels(size.x, size.y);
 }
 
@@ -3970,7 +3970,7 @@ void subclass () {
 public Point toControl (int x, int y) {
 	checkWidget ();
 	int zoom = getZoom();
-	return DPIUtil.scaleDown(toControlInPixels(DPIUtil.autoScaleUp(x, zoom), DPIUtil.autoScaleUp(y, zoom)), zoom);
+	return DPIUtil.scaleDown(toControlInPixels(DPIUtil.scaleUp(x, zoom), DPIUtil.scaleUp(y, zoom)), zoom);
 }
 
 Point toControlInPixels (int x, int y) {
@@ -4004,7 +4004,7 @@ public Point toControl (Point point) {
 	checkWidget ();
 	if (point == null) error (SWT.ERROR_NULL_ARGUMENT);
 	int zoom = getZoom();
-	point = DPIUtil.autoScaleUp(point, zoom);
+	point = DPIUtil.scaleUp(point, zoom);
 	return DPIUtil.scaleDown(toControlInPixels(point.x, point.y), zoom);
 }
 
@@ -4031,7 +4031,7 @@ public Point toControl (Point point) {
 public Point toDisplay (int x, int y) {
 	checkWidget ();
 	int zoom = getZoom();
-	return DPIUtil.scaleDown(toDisplayInPixels(DPIUtil.autoScaleUp(x, zoom), DPIUtil.autoScaleUp(y, zoom)), zoom);
+	return DPIUtil.scaleDown(toDisplayInPixels(DPIUtil.scaleUp(x, zoom), DPIUtil.scaleUp(y, zoom)), zoom);
 }
 
 Point toDisplayInPixels (int x, int y) {
@@ -4065,7 +4065,7 @@ public Point toDisplay (Point point) {
 	checkWidget ();
 	if (point == null) error (SWT.ERROR_NULL_ARGUMENT);
 	int zoom = getZoom();
-	point = DPIUtil.autoScaleUp(point, zoom);
+	point = DPIUtil.scaleUp(point, zoom);
 	return DPIUtil.scaleDown(toDisplayInPixels(point.x, point.y), zoom);
 }
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/CoolBar.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/CoolBar.java
@@ -412,7 +412,7 @@ int getMargin (int index) {
 	}
 	if ((style & SWT.FLAT) == 0) {
 		if (!isLastItemOfRow (index)) {
-			margin += DPIUtil.autoScaleUp(SEPARATOR_WIDTH, getZoom());
+			margin += DPIUtil.scaleUp(SEPARATOR_WIDTH, getZoom());
 		}
 	}
 	return margin;
@@ -809,7 +809,7 @@ public void setItemLayout (int [] itemOrder, int [] wrapIndices, Point [] sizes)
 	if (sizes == null) error (SWT.ERROR_NULL_ARGUMENT);
 	Point [] sizesInPoints = new Point [sizes.length];
 	for (int i = 0; i < sizes.length; i++) {
-		sizesInPoints[i] = DPIUtil.autoScaleUp(sizes[i], getZoom());
+		sizesInPoints[i] = DPIUtil.scaleUp(sizes[i], getZoom());
 	}
 	setItemLayoutInPixels (itemOrder, wrapIndices, sizesInPoints);
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/CoolItem.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/CoolItem.java
@@ -186,8 +186,8 @@ protected void checkSubclass () {
 public Point computeSize (int wHint, int hHint) {
 	checkWidget ();
 	int zoom = getZoom();
-	wHint = (wHint != SWT.DEFAULT ? DPIUtil.autoScaleUp(wHint, zoom) : wHint);
-	hHint = (hHint != SWT.DEFAULT ? DPIUtil.autoScaleUp(hHint, zoom) : hHint);
+	wHint = (wHint != SWT.DEFAULT ? DPIUtil.scaleUp(wHint, zoom) : wHint);
+	hHint = (hHint != SWT.DEFAULT ? DPIUtil.scaleUp(hHint, zoom) : hHint);
 	return DPIUtil.scaleDown(computeSizeInPixels(wHint, hHint), zoom);
 }
 Point computeSizeInPixels (int wHint, int hHint) {
@@ -415,7 +415,7 @@ Point getPreferredSizeInPixels () {
 public void setPreferredSize (int width, int height) {
 	checkWidget ();
 	int zoom = getZoom();
-	setPreferredSizeInPixels(DPIUtil.autoScaleUp(width, zoom), DPIUtil.autoScaleUp(height, zoom));
+	setPreferredSizeInPixels(DPIUtil.scaleUp(width, zoom), DPIUtil.scaleUp(height, zoom));
 }
 
 void setPreferredSizeInPixels (int width, int height) {
@@ -464,7 +464,7 @@ void setPreferredSizeInPixels (int width, int height) {
 public void setPreferredSize (Point size) {
 	checkWidget ();
 	if (size == null) error(SWT.ERROR_NULL_ARGUMENT);
-	size = DPIUtil.autoScaleUp(size, getZoom());
+	size = DPIUtil.scaleUp(size, getZoom());
 	setPreferredSizeInPixels(size.x, size.y);
 }
 
@@ -526,7 +526,7 @@ Point getSizeInPixels() {
 public void setSize (int width, int height) {
 	checkWidget ();
 	int zoom = getZoom();
-	setSizeInPixels(DPIUtil.autoScaleUp(width, zoom), DPIUtil.autoScaleUp(height, zoom));
+	setSizeInPixels(DPIUtil.scaleUp(width, zoom), DPIUtil.scaleUp(height, zoom));
 }
 
 void setSizeInPixels (int width, int height) {
@@ -592,7 +592,7 @@ void setSizeInPixels (int width, int height) {
 public void setSize (Point size) {
 	checkWidget ();
 	if (size == null) error(SWT.ERROR_NULL_ARGUMENT);
-	size = DPIUtil.autoScaleUp(size, getZoom());
+	size = DPIUtil.scaleUp(size, getZoom());
 	setSizeInPixels(size.x, size.y);
 }
 
@@ -645,7 +645,7 @@ Point getMinimumSizeInPixels () {
 public void setMinimumSize (int width, int height) {
 	checkWidget ();
 	int zoom = getZoom();
-	setMinimumSizeInPixels(DPIUtil.autoScaleUp(width, zoom), DPIUtil.autoScaleUp(height, zoom));
+	setMinimumSizeInPixels(DPIUtil.scaleUp(width, zoom), DPIUtil.scaleUp(height, zoom));
 }
 
 void setMinimumSizeInPixels (int width, int height) {
@@ -695,7 +695,7 @@ void setMinimumSizeInPixels (int width, int height) {
 public void setMinimumSize (Point size) {
 	checkWidget ();
 	if (size == null) error (SWT.ERROR_NULL_ARGUMENT);
-	size = DPIUtil.autoScaleUp(size, getZoom());
+	size = DPIUtil.scaleUp(size, getZoom());
 	setMinimumSizeInPixels(size.x, size.y);
 }
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Display.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Display.java
@@ -2966,7 +2966,7 @@ public Point map (Control from, Control to, Point point) {
 	checkDevice ();
 	if (point == null) error (SWT.ERROR_NULL_ARGUMENT);
 	int zoom = getZoomLevelForMapping(from, to);
-	point = DPIUtil.autoScaleUp(point, zoom);
+	point = DPIUtil.scaleUp(point, zoom);
 	return DPIUtil.scaleDown(mapInPixels(from, to, point), zoom);
 }
 
@@ -3013,8 +3013,8 @@ Point mapInPixels (Control from, Control to, Point point) {
 public Point map (Control from, Control to, int x, int y) {
 	checkDevice ();
 	int zoom = getZoomLevelForMapping(from, to);
-	x = DPIUtil.autoScaleUp(x, zoom);
-	y = DPIUtil.autoScaleUp(y, zoom);
+	x = DPIUtil.scaleUp(x, zoom);
+	y = DPIUtil.scaleUp(y, zoom);
 	return DPIUtil.scaleDown(mapInPixels(from, to, x, y), zoom);
 }
 
@@ -3080,7 +3080,7 @@ public Rectangle map (Control from, Control to, Rectangle rectangle) {
 	checkDevice ();
 	if (rectangle == null) error (SWT.ERROR_NULL_ARGUMENT);
 	int zoom = getZoomLevelForMapping(from, to);
-	rectangle = DPIUtil.autoScaleUp(rectangle, zoom);
+	rectangle = DPIUtil.scaleUp(rectangle, zoom);
 	return DPIUtil.scaleDown(mapInPixels(from, to, rectangle), zoom);
 }
 
@@ -3129,10 +3129,10 @@ Rectangle mapInPixels (Control from, Control to, Rectangle rectangle) {
 public Rectangle map (Control from, Control to, int x, int y, int width, int height) {
 	checkDevice ();
 	int zoom = getZoomLevelForMapping(from, to);
-	x = DPIUtil.autoScaleUp(x, zoom);
-	y = DPIUtil.autoScaleUp(y, zoom);
-	width = DPIUtil.autoScaleUp(width, zoom);
-	height = DPIUtil.autoScaleUp(height, zoom);
+	x = DPIUtil.scaleUp(x, zoom);
+	y = DPIUtil.scaleUp(y, zoom);
+	width = DPIUtil.scaleUp(width, zoom);
+	height = DPIUtil.scaleUp(height, zoom);
 	return DPIUtil.scaleDown(mapInPixels(from, to, x, y, width, height), zoom);
 }
 
@@ -3601,7 +3601,7 @@ public boolean post (Event event) {
 					int y = OS.GetSystemMetrics (OS.SM_YVIRTUALSCREEN);
 					int width = OS.GetSystemMetrics (OS.SM_CXVIRTUALSCREEN);
 					int height = OS.GetSystemMetrics (OS.SM_CYVIRTUALSCREEN);
-					Point loc = DPIUtil.autoScaleUp(event.getLocation(), getDeviceZoom());
+					Point loc = DPIUtil.scaleUp(event.getLocation(), getDeviceZoom());
 					inputs.dx = ((loc.x - x) * 65535 + width - 2) / (width - 1);
 					inputs.dy = ((loc.y - y) * 65535 + height - 2) / (height - 1);
 				} else {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ExpandBar.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ExpandBar.java
@@ -561,7 +561,7 @@ void setScrollbar () {
  */
 public void setSpacing (int spacing) {
 	checkWidget ();
-	setSpacingInPixels(DPIUtil.autoScaleUp(spacing, getZoom()));
+	setSpacingInPixels(DPIUtil.scaleUp(spacing, getZoom()));
 }
 
 void setSpacingInPixels (int spacing) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ExpandItem.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ExpandItem.java
@@ -490,7 +490,7 @@ public void setExpanded (boolean expanded) {
  */
 public void setHeight (int height) {
 	checkWidget ();
-	setHeightInPixels(DPIUtil.autoScaleUp(height, getZoom()));
+	setHeightInPixels(DPIUtil.scaleUp(height, getZoom()));
 }
 
 void setHeightInPixels (int height) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Label.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Label.java
@@ -147,7 +147,7 @@ static int checkStyle (int style) {
 		return new Point (width, height);
 	}
 	if (isImageMode) {
-		Rectangle rect = DPIUtil.autoScaleBounds(image.getBounds(), this.getZoom(), 100);
+		Rectangle rect = DPIUtil.scaleBounds(image.getBounds(), this.getZoom(), 100);
 		width += rect.width;
 		height += rect.height;
 	} else {
@@ -554,7 +554,7 @@ void wmDrawChildImage(DRAWITEMSTRUCT struct) {
 	if (width == 0 || height == 0) return;
 
 	int zoom = getZoom();
-	Rectangle imageRect = DPIUtil.autoScaleBounds(image.getBounds(), zoom, 100);
+	Rectangle imageRect = DPIUtil.scaleBounds(image.getBounds(), zoom, 100);
 
 	int x = 0;
 	if ((style & SWT.CENTER) != 0) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Menu.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Menu.java
@@ -1190,7 +1190,7 @@ public void setEnabled (boolean enabled) {
 public void setLocation (int x, int y) {
 	checkWidget ();
 	int zoom = getZoom();
-	setLocationInPixels(DPIUtil.autoScaleUp(x, zoom), DPIUtil.autoScaleUp(y, zoom));
+	setLocationInPixels(DPIUtil.scaleUp(x, zoom), DPIUtil.scaleUp(y, zoom));
 }
 
 void setLocationInPixels (int x, int y) {
@@ -1227,7 +1227,7 @@ void setLocationInPixels (int x, int y) {
 public void setLocation (Point location) {
 	checkWidget ();
 	if (location == null) error (SWT.ERROR_NULL_ARGUMENT);
-	location = DPIUtil.autoScaleUp(location, getZoom());
+	location = DPIUtil.scaleUp(location, getZoom());
 	setLocationInPixels(location.x, location.y);
 }
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Sash.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Sash.java
@@ -292,7 +292,7 @@ LRESULT WM_LBUTTONDOWN (long wParam, long lParam) {
 	if (isDisposed ()) return LRESULT.ZERO;
 
 	/* Draw the banding rectangle */
-	Rectangle boundsInPixels = DPIUtil.autoScaleUp(event.getBounds(), getZoom());
+	Rectangle boundsInPixels = DPIUtil.scaleUp(event.getBounds(), getZoom());
 	if (event.doit) {
 		dragging = true;
 		lastX = boundsInPixels.x;
@@ -377,8 +377,8 @@ LRESULT WM_MOUSEMOVE (long wParam, long lParam) {
 	if (isDisposed ()) return LRESULT.ZERO;
 	if (event.doit) {
 		Rectangle bounds = event.getBounds();
-		lastX = DPIUtil.autoScaleUp(bounds.x, zoom);
-		lastY = DPIUtil.autoScaleUp(bounds.y, zoom);
+		lastX = DPIUtil.scaleUp(bounds.x, zoom);
+		lastY = DPIUtil.scaleUp(bounds.y, zoom);
 	}
 	int flags = OS.RDW_UPDATENOW | OS.RDW_ALLCHILDREN;
 	OS.RedrawWindow (hwndTrack, null, 0, flags);

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Scrollable.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Scrollable.java
@@ -121,10 +121,10 @@ long callWindowProc (long hwnd, int msg, long wParam, long lParam) {
 public Rectangle computeTrim (int x, int y, int width, int height) {
 	checkWidget ();
 	int zoom = getZoom();
-	x = DPIUtil.autoScaleUp(x, zoom);
-	y = DPIUtil.autoScaleUp(y, zoom);
-	width = DPIUtil.autoScaleUp(width, zoom);
-	height = DPIUtil.autoScaleUp(height, zoom);
+	x = DPIUtil.scaleUp(x, zoom);
+	y = DPIUtil.scaleUp(y, zoom);
+	width = DPIUtil.scaleUp(width, zoom);
+	height = DPIUtil.scaleUp(height, zoom);
 	return DPIUtil.scaleDown(computeTrimInPixels(x, y, width, height), zoom);
 }
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Shell.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Shell.java
@@ -1739,7 +1739,7 @@ public void setImeInputMode (int mode) {
 public void setMaximumSize (int width, int height) {
 	checkWidget ();
 	int zoom = getZoom();
-	setMaximumSizeInPixels(DPIUtil.autoScaleUp(width, zoom), DPIUtil.autoScaleUp(height, zoom));
+	setMaximumSizeInPixels(DPIUtil.scaleUp(width, zoom), DPIUtil.scaleUp(height, zoom));
 }
 
 /**
@@ -1767,7 +1767,7 @@ public void setMaximumSize (int width, int height) {
 public void setMaximumSize (Point size) {
 	checkWidget ();
 	if (size == null) error (SWT.ERROR_NULL_ARGUMENT);
-	size = DPIUtil.autoScaleUp(size, getZoom());
+	size = DPIUtil.scaleUp(size, getZoom());
 	setMaximumSizeInPixels(size.x, size.y);
 }
 
@@ -1814,7 +1814,7 @@ void setMaximumSizeInPixels (int width, int height) {
 public void setMinimumSize (int width, int height) {
 	checkWidget ();
 	int zoom = getZoom();
-	setMinimumSizeInPixels(DPIUtil.autoScaleUp(width, zoom), DPIUtil.autoScaleUp(height, zoom));
+	setMinimumSizeInPixels(DPIUtil.scaleUp(width, zoom), DPIUtil.scaleUp(height, zoom));
 }
 
 void setMinimumSizeInPixels (int width, int height) {
@@ -1862,7 +1862,7 @@ void setMinimumSizeInPixels (int width, int height) {
 public void setMinimumSize (Point size) {
 	checkWidget ();
 	if (size == null) error (SWT.ERROR_NULL_ARGUMENT);
-	size = DPIUtil.autoScaleUp(size, getZoom());
+	size = DPIUtil.scaleUp(size, getZoom());
 	setMinimumSizeInPixels(size.x, size.y);
 }
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TabFolder.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TabFolder.java
@@ -455,7 +455,7 @@ int imageIndex (Image image) {
 	 */
 	if (image == null) return -1;
 	if (imageList == null) {
-		Rectangle bounds = DPIUtil.autoScaleBounds(image.getBounds(), this.getZoom(), 100);
+		Rectangle bounds = DPIUtil.scaleBounds(image.getBounds(), this.getZoom(), 100);
 		imageList = display.getImageList (style & SWT.RIGHT_TO_LEFT, bounds.width, bounds.height, this.getZoom());
 		int index = imageList.add (image);
 		long hImageList = imageList.getHandle ();
@@ -510,7 +510,7 @@ Point minimumSize (int wHint, int hHint, boolean flushCache) {
 		}
 		int zoom = getZoom();
 		if (index == count) {
-			Rectangle rect = DPIUtil.autoScaleUp(child.getBounds (), zoom);
+			Rectangle rect = DPIUtil.scaleUp(child.getBounds (), zoom);
 			width = Math.max (width, rect.x + rect.width);
 			height = Math.max (height, rect.y + rect.height);
 		} else {
@@ -518,7 +518,7 @@ Point minimumSize (int wHint, int hHint, boolean flushCache) {
 			 * Since computeSize can be overridden by subclasses, we cannot
 			 * call computeSizeInPixels directly.
 			 */
-			Point size = DPIUtil.autoScaleUp(child.computeSize (DPIUtil.scaleDown(wHint, zoom), DPIUtil.scaleDown(hHint, zoom), flushCache), zoom);
+			Point size = DPIUtil.scaleUp(child.computeSize (DPIUtil.scaleDown(wHint, zoom), DPIUtil.scaleDown(hHint, zoom), flushCache), zoom);
 			width = Math.max (width, size.x);
 			height = Math.max (height, size.y);
 		}

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Table.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Table.java
@@ -2476,7 +2476,7 @@ public TableItem getItem (int index) {
 public TableItem getItem (Point point) {
 	checkWidget ();
 	if (point == null) error (SWT.ERROR_NULL_ARGUMENT);
-	return getItemInPixels (DPIUtil.autoScaleUp(point, getZoom()));
+	return getItemInPixels (DPIUtil.scaleUp(point, getZoom()));
 }
 
 TableItem getItemInPixels (Point point) {
@@ -2832,7 +2832,7 @@ boolean hitTestSelection (int index, int x, int y) {
 		long hFont = item.fontHandle (0);
 		if (hFont != -1) hFont = OS.SelectObject (hDC, hFont);
 		Event event = sendMeasureItemEvent (item, index, 0, hDC);
-		if (DPIUtil.autoScaleUp(event.getBounds(), getZoom()).contains (x, y)) result = true;
+		if (DPIUtil.scaleUp(event.getBounds(), getZoom()).contains (x, y)) result = true;
 		if (hFont != -1) hFont = OS.SelectObject (hDC, hFont);
 		if (newFont != 0) OS.SelectObject (hDC, oldFont);
 		OS.ReleaseDC (handle, hDC);
@@ -2849,7 +2849,7 @@ int imageIndex (Image image, int column) {
 		setSubImagesVisible (true);
 	}
 	if (imageList == null) {
-		Rectangle bounds = DPIUtil.autoScaleBounds(image.getBounds(), this.getZoom(), 100);
+		Rectangle bounds = DPIUtil.scaleBounds(image.getBounds(), this.getZoom(), 100);
 		imageList = display.getImageList (style & SWT.RIGHT_TO_LEFT, bounds.width, bounds.height, getZoom());
 		int index = imageList.indexOf (image);
 		if (index == -1) index = imageList.add (image);
@@ -2889,7 +2889,7 @@ int imageIndex (Image image, int column) {
 int imageIndexHeader (Image image) {
 	if (image == null) return OS.I_IMAGENONE;
 	if (headerImageList == null) {
-		Rectangle bounds = DPIUtil.autoScaleBounds(image.getBounds(), this.getZoom(), 100);
+		Rectangle bounds = DPIUtil.scaleBounds(image.getBounds(), this.getZoom(), 100);
 		headerImageList = display.getImageList (style & SWT.RIGHT_TO_LEFT, bounds.width, bounds.height, getZoom());
 		int index = headerImageList.indexOf (image);
 		if (index == -1) index = headerImageList.add (image);
@@ -3530,7 +3530,7 @@ void sendEraseItemEvent (TableItem item, NMLVCUSTOMDRAW nmcd, long lParam, Event
 		RECT textRect = item.getBounds ((int)nmcd.dwItemSpec, nmcd.iSubItem, true, false, fullText, false, hDC);
 		if ((style & SWT.FULL_SELECTION) == 0) {
 			if (measureEvent != null) {
-				Rectangle boundsInPixels = DPIUtil.autoScaleUp(measureEvent.getBounds(), getZoom());
+				Rectangle boundsInPixels = DPIUtil.scaleUp(measureEvent.getBounds(), getZoom());
 				textRect.right = Math.min (cellRect.right, boundsInPixels.x + boundsInPixels.width);
 			}
 			if (!ignoreDrawFocus) {
@@ -3649,7 +3649,7 @@ Event sendMeasureItemEvent (TableItem item, int row, int column, long hDC) {
 	gc.dispose ();
 	OS.RestoreDC (hDC, nSavedDC);
 	if (!isDisposed () && !item.isDisposed ()) {
-		Rectangle boundsInPixels = DPIUtil.autoScaleUp(event.getBounds(), getZoom());
+		Rectangle boundsInPixels = DPIUtil.scaleUp(event.getBounds(), getZoom());
 		if (columnCount == 0) {
 			int width = (int)OS.SendMessage (handle, OS.LVM_GETCOLUMNWIDTH, 0, 0);
 			if (boundsInPixels.x + boundsInPixels.width > width) setScrollWidth (boundsInPixels.x + boundsInPixels.width);
@@ -7186,7 +7186,7 @@ LRESULT wmNotifyToolTip (NMHDR hdr, long wParam, long lParam) {
 					Event event = sendMeasureItemEvent (item, pinfo.iItem, pinfo.iSubItem, hDC);
 					if (!isDisposed () && !item.isDisposed ()) {
 						RECT itemRect = new RECT ();
-						Rectangle boundsInPixels = DPIUtil.autoScaleUp(event.getBounds(), getZoom());
+						Rectangle boundsInPixels = DPIUtil.scaleUp(event.getBounds(), getZoom());
 						OS.SetRect (itemRect, boundsInPixels.x, boundsInPixels.y, boundsInPixels.x + boundsInPixels.width, boundsInPixels.y + boundsInPixels.height);
 						if (hdr.code == OS.TTN_SHOW) {
 							RECT toolRect = toolTipRect (itemRect);

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TableColumn.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TableColumn.java
@@ -440,7 +440,7 @@ public void pack () {
 				if (hFont != -1) hFont = OS.SelectObject (hDC, hFont);
 				if (isDisposed () || parent.isDisposed ()) break;
 				Rectangle bounds = event.getBounds();
-				columnWidth = Math.max (columnWidth, DPIUtil.autoScaleUp(bounds.x + bounds.width, getZoom()) - headerRect.left);
+				columnWidth = Math.max (columnWidth, DPIUtil.scaleUp(bounds.x + bounds.width, getZoom()) - headerRect.left);
 			}
 		}
 		if (newFont != 0) OS.SelectObject (hDC, oldFont);
@@ -854,7 +854,7 @@ public void setToolTipText (String string) {
  */
 public void setWidth (int width) {
 	checkWidget ();
-	setWidthInPixels(DPIUtil.autoScaleUp(width, getZoom()));
+	setWidthInPixels(DPIUtil.scaleUp(width, getZoom()));
 }
 
 void setWidthInPixels (int width) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ToolBar.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ToolBar.java
@@ -568,7 +568,7 @@ public ToolItem getItem (int index) {
 public ToolItem getItem (Point point) {
 	checkWidget ();
 	if (point == null) error (SWT.ERROR_NULL_ARGUMENT);
-	return getItemInPixels(DPIUtil.autoScaleUp(point, getZoom()));
+	return getItemInPixels(DPIUtil.scaleUp(point, getZoom()));
 }
 
 ToolItem getItemInPixels (Point point) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ToolItem.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ToolItem.java
@@ -1080,7 +1080,7 @@ public void setToolTipText (String string) {
  */
 public void setWidth (int width) {
 	checkWidget();
-	setWidthInPixels(DPIUtil.autoScaleUp(width, getZoom()));
+	setWidthInPixels(DPIUtil.scaleUp(width, getZoom()));
 }
 
 void setWidthInPixels (int width) {
@@ -1107,7 +1107,7 @@ void updateImages (boolean enabled) {
 	ImageList hotImageList = parent.getHotImageList ();
 	ImageList disabledImageList = parent.getDisabledImageList();
 	if (info.iImage == OS.I_IMAGENONE) {
-		Rectangle bounds = DPIUtil.autoScaleBounds(image.getBounds(), getParent().getZoom(), 100);
+		Rectangle bounds = DPIUtil.scaleBounds(image.getBounds(), getParent().getZoom(), 100);
 		int listStyle = parent.style & SWT.RIGHT_TO_LEFT;
 		if (imageList == null) {
 			imageList = display.getImageListToolBar (listStyle, bounds.width, bounds.height, getZoom());
@@ -1229,7 +1229,7 @@ private static void handleDPIChange(Widget widget, int newZoom, float scalingFac
 		Display display = item.getDisplay();
 		int listStyle = parent.style & SWT.RIGHT_TO_LEFT;
 
-		Rectangle bounds = DPIUtil.autoScaleBounds(image.getBounds(), newZoom, 100);
+		Rectangle bounds = DPIUtil.scaleBounds(image.getBounds(), newZoom, 100);
 		if (parent.getImageList() == null) {
 			parent.setImageList (display.getImageListToolBar (listStyle, bounds.width, bounds.height, item.getZoom()));
 		}

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ToolTip.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ToolTip.java
@@ -358,7 +358,7 @@ public void setAutoHide (boolean autoHide) {
 public void setLocation (int x, int y) {
 	checkWidget ();
 	int zoom = getZoom();
-	setLocationInPixels(DPIUtil.autoScaleUp(x, zoom), DPIUtil.autoScaleUp(y, zoom));
+	setLocationInPixels(DPIUtil.scaleUp(x, zoom), DPIUtil.scaleUp(y, zoom));
 }
 
 void setLocationInPixels (int x, int y) {
@@ -393,7 +393,7 @@ void setLocationInPixels (int x, int y) {
 public void setLocation (Point location) {
 	checkWidget ();
 	if (location == null) error (SWT.ERROR_NULL_ARGUMENT);
-	location = DPIUtil.autoScaleUp(location, getZoom());
+	location = DPIUtil.scaleUp(location, getZoom());
 	setLocationInPixels(location.x, location.y);
 }
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Tracker.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Tracker.java
@@ -846,7 +846,7 @@ public void setRectangles (Rectangle [] rectangles) {
 	if (rectangles == null) error (SWT.ERROR_NULL_ARGUMENT);
 	Rectangle [] rectanglesInPixels = new Rectangle [rectangles.length];
 	for (int i = 0; i < rectangles.length; i++) {
-		rectanglesInPixels [i] = DPIUtil.autoScaleUp (rectangles [i], getZoom());
+		rectanglesInPixels [i] = DPIUtil.scaleUp (rectangles [i], getZoom());
 	}
 	setRectanglesInPixels (rectanglesInPixels);
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Tree.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Tree.java
@@ -765,7 +765,7 @@ LRESULT CDDS_ITEMPOSTPAINT (NMTVCUSTOMDRAW nmcd, long wParam, long lParam) {
 						if (size == null) size = DPIUtil.scaleDown (getImageSize (), zoom); // To Points
 						if (!ignoreDrawForeground) {
 							//int y1 = rect.top + (index == 0 ? (getItemHeight () - size.y) / 2 : 0);
-							int y1 = rect.top + DPIUtil.autoScaleUp((getItemHeight () - size.y) / 2, zoom);
+							int y1 = rect.top + DPIUtil.scaleUp((getItemHeight () - size.y) / 2, zoom);
 							int x1 = Math.max (rect.left, rect.left - inset + 1);
 							GCData data = new GCData();
 							data.device = display;
@@ -775,7 +775,7 @@ LRESULT CDDS_ITEMPOSTPAINT (NMTVCUSTOMDRAW nmcd, long wParam, long lParam) {
 							OS.SelectClipRgn (hDC, 0);
 							gc.dispose ();
 						}
-						OS.SetRect (rect, rect.left + DPIUtil.autoScaleUp(size.x, zoom) + offset, rect.top, rect.right - inset, rect.bottom);
+						OS.SetRect (rect, rect.left + DPIUtil.scaleUp(size.x, zoom) + offset, rect.top, rect.right - inset, rect.bottom);
 					} else {
 						if (i == 0) {
 							if (OS.SendMessage (handle, OS.TVM_GETIMAGELIST, OS.TVSIL_NORMAL, 0) != 0) {
@@ -1031,7 +1031,7 @@ LRESULT CDDS_ITEMPREPAINT (NMTVCUSTOMDRAW nmcd, long wParam, long lParam) {
 		Rectangle boundsInPixels = null;
 		if (hooks (SWT.MeasureItem)) {
 			measureEvent = sendMeasureItemEvent (item, index, hDC, selected ? SWT.SELECTED : 0);
-			boundsInPixels = DPIUtil.autoScaleUp(measureEvent.getBounds(), getZoom());
+			boundsInPixels = DPIUtil.scaleUp(measureEvent.getBounds(), getZoom());
 			if (isDisposed () || item.isDisposed ()) return null;
 		}
 		selectionForeground = -1;
@@ -2804,7 +2804,7 @@ boolean findCell (int x, int y, TreeItem [] item, int [] index, RECT [] cellRect
 						int detail = (state & OS.TVIS_SELECTED) != 0 ? SWT.SELECTED : 0;
 						Event event = sendMeasureItemEvent (item [0], order [index [0]], hDC, detail);
 						if (isDisposed () || item [0].isDisposed ()) break;
-						Rectangle boundsInPixels = DPIUtil.autoScaleUp(event.getBounds(), getZoom());
+						Rectangle boundsInPixels = DPIUtil.scaleUp(event.getBounds(), getZoom());
 						itemRect [0] = new RECT ();
 						itemRect [0].left = boundsInPixels.x;
 						itemRect [0].right = boundsInPixels.x + boundsInPixels.width;
@@ -3287,7 +3287,7 @@ TreeItem getItem (NMTVCUSTOMDRAW nmcd) {
 public TreeItem getItem (Point point) {
 	checkWidget ();
 	if (point == null) error (SWT.ERROR_NULL_ARGUMENT);
-	return getItemInPixels(DPIUtil.autoScaleUp(point, getZoom()));
+	return getItemInPixels(DPIUtil.scaleUp(point, getZoom()));
 }
 
 TreeItem getItemInPixels (Point point) {
@@ -3730,7 +3730,7 @@ boolean hitTestSelection (long hItem, int x, int y) {
 	int state = (int)OS.SendMessage (handle, OS.TVM_GETITEMSTATE, hItem, OS.TVIS_SELECTED);
 	int detail = (state & OS.TVIS_SELECTED) != 0 ? SWT.SELECTED : 0;
 	Event event = sendMeasureItemEvent (item, order [index [0]], hDC, detail);
-	if (DPIUtil.autoScaleUp(event.getBounds(), getZoom()).contains (x, y)) result = true;
+	if (DPIUtil.scaleUp(event.getBounds(), getZoom()).contains (x, y)) result = true;
 	if (newFont != 0) OS.SelectObject (hDC, oldFont);
 	OS.ReleaseDC (handle, hDC);
 //	if (isDisposed () || item.isDisposed ()) return false;
@@ -3740,7 +3740,7 @@ boolean hitTestSelection (long hItem, int x, int y) {
 int imageIndex (Image image, int index) {
 	if (image == null) return OS.I_IMAGENONE;
 	if (imageList == null) {
-		Rectangle bounds = DPIUtil.autoScaleBounds(image.getBounds(), this.getZoom(), 100);
+		Rectangle bounds = DPIUtil.scaleBounds(image.getBounds(), this.getZoom(), 100);
 		imageList = display.getImageList (style & SWT.RIGHT_TO_LEFT, bounds.width, bounds.height, getZoom());
 	}
 	int imageIndex = imageList.indexOf (image);
@@ -3764,7 +3764,7 @@ int imageIndex (Image image, int index) {
 int imageIndexHeader (Image image) {
 	if (image == null) return OS.I_IMAGENONE;
 	if (headerImageList == null) {
-		Rectangle bounds = DPIUtil.autoScaleBounds(image.getBounds(), this.getZoom(), 100);
+		Rectangle bounds = DPIUtil.scaleBounds(image.getBounds(), this.getZoom(), 100);
 		headerImageList = display.getImageList (style & SWT.RIGHT_TO_LEFT, bounds.width, bounds.height, getZoom());
 		int index = headerImageList.indexOf (image);
 		if (index == -1) index = headerImageList.add (image);
@@ -4558,7 +4558,7 @@ Event sendMeasureItemEvent (TreeItem item, int index, long hDC, int detail) {
 	gc.dispose ();
 	OS.RestoreDC (hDC, nSavedDC);
 	if (isDisposed () || item.isDisposed ()) return null;
-	Rectangle rect = DPIUtil.autoScaleUp(event.getBounds(), getZoom());
+	Rectangle rect = DPIUtil.scaleUp(event.getBounds(), getZoom());
 	if (hwndHeader != 0) {
 		if (columnCount == 0) {
 			if (rect.x + rect.width > scrollWidth) {
@@ -7929,7 +7929,7 @@ LRESULT wmNotifyHeader (NMHDR hdr, long wParam, long lParam) {
 							data.device = display;
 							GC gc = createNewGC(nmcd.hdc, data);
 							int zoom = getZoom();
-							Rectangle imageBounds = DPIUtil.autoScaleBounds(columns[i].image.getBounds(), zoom, 100);
+							Rectangle imageBounds = DPIUtil.scaleBounds(columns[i].image.getBounds(), zoom, 100);
 							int y = Math.max (0, (nmcd.bottom - imageBounds.height) / 2);
 							gc.drawImage (columns[i].image, DPIUtil.scaleDown(x, zoom), DPIUtil.scaleDown(y, zoom));
 							x += imageBounds.width + 12;

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TreeColumn.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TreeColumn.java
@@ -359,7 +359,7 @@ public void pack () {
 				Event event = parent.sendMeasureItemEvent (item, index, hDC, detail);
 				if (isDisposed () || parent.isDisposed ()) break;
 				Rectangle bounds = event.getBounds();
-				itemRight = DPIUtil.autoScaleUp(bounds.x + bounds.width, getZoom());
+				itemRight = DPIUtil.scaleUp(bounds.x + bounds.width, getZoom());
 			} else {
 				long hFont = item.fontHandle (index);
 				if (hFont != -1) hFont = OS.SelectObject (hDC, hFont);
@@ -717,7 +717,7 @@ public void setToolTipText (String string) {
  */
 public void setWidth (int width) {
 	checkWidget ();
-	setWidthInPixels(DPIUtil.autoScaleUp(width, getZoom()));
+	setWidthInPixels(DPIUtil.scaleUp(width, getZoom()));
 }
 
 void setWidthInPixels (int width) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Widget.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Widget.java
@@ -1664,7 +1664,7 @@ boolean showMenu (int x, int y, int detail) {
 	if (!event.doit) return true;
 	Menu menu = getMenu ();
 	if (menu != null && !menu.isDisposed ()) {
-		Point locInPixels = DPIUtil.autoScaleUp(event.getLocation(), zoom); // In Pixels
+		Point locInPixels = DPIUtil.scaleUp(event.getLocation(), zoom); // In Pixels
 		if (x != locInPixels.x || y != locInPixels.y) {
 			menu.setLocation (event.getLocation());
 		}

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/DPIUtilTests.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/DPIUtilTests.java
@@ -202,17 +202,17 @@ public class DPIUtilTests {
 		assertArrayEquals(String.format("Scaling up int array to device zoom (%d) to 100 with device failed",
 				DPIUtil.getDeviceZoom()), valueAt200, scaledValue);
 
-		scaledValue = DPIUtil.autoScaleUp(valueAt100, 200);
+		scaledValue = DPIUtil.scaleUp(valueAt100, 200);
 		assertArrayEquals("Scaling up int array to 200 failed", valueAt200, scaledValue);
-		scaledValue = DPIUtil.autoScaleUp((Device) null, valueAt100, 200);
+		scaledValue = DPIUtil.scaleUp((Device) null, valueAt100, 200);
 		assertArrayEquals("Scaling up int array to 200 with device failed", valueAt200, scaledValue);
-		scaledValue = DPIUtil.autoScaleUp(valueAt100, 150);
+		scaledValue = DPIUtil.scaleUp(valueAt100, 150);
 		assertArrayEquals("Scaling up int array to 150 failed", valueAt150, scaledValue);
-		scaledValue = DPIUtil.autoScaleUp((Device) null, valueAt100, 150);
+		scaledValue = DPIUtil.scaleUp((Device) null, valueAt100, 150);
 		assertArrayEquals("Scaling up int array to 150 with device failed", valueAt150, scaledValue);
-		scaledValue = DPIUtil.autoScaleUp(valueAt100, 100);
+		scaledValue = DPIUtil.scaleUp(valueAt100, 100);
 		assertSame("Scaling up int array without zoom change failed", valueAt100, scaledValue);
-		scaledValue = DPIUtil.autoScaleUp((Device) null, valueAt100, 100);
+		scaledValue = DPIUtil.scaleUp((Device) null, valueAt100, 100);
 		assertSame("Scaling up int array without zoom change with device failed", valueAt100, scaledValue);
 	}
 
@@ -229,17 +229,17 @@ public class DPIUtilTests {
 		assertEquals(String.format("Scaling up integer to device zoom (%d) to 100 with device failed",
 				DPIUtil.getDeviceZoom()), valueAt200, scaledValue);
 
-		scaledValue = DPIUtil.autoScaleUp(valueAt100, 200);
+		scaledValue = DPIUtil.scaleUp(valueAt100, 200);
 		assertEquals("Scaling up integer to 200 failed", valueAt200, scaledValue);
-		scaledValue = DPIUtil.autoScaleUp((Device) null, valueAt100, 200);
+		scaledValue = DPIUtil.scaleUp((Device) null, valueAt100, 200);
 		assertEquals("Scaling up integer to 200 with device failed", valueAt200, scaledValue);
-		scaledValue = DPIUtil.autoScaleUp(valueAt100, 150);
+		scaledValue = DPIUtil.scaleUp(valueAt100, 150);
 		assertEquals("Scaling up integer to 150 failed", valueAt150, scaledValue);
-		scaledValue = DPIUtil.autoScaleUp((Device) null, valueAt100, 150);
+		scaledValue = DPIUtil.scaleUp((Device) null, valueAt100, 150);
 		assertEquals("Scaling up integer to 150 with device failed", valueAt150, scaledValue);
-		scaledValue = DPIUtil.autoScaleUp(valueAt100, 100);
+		scaledValue = DPIUtil.scaleUp(valueAt100, 100);
 		assertSame("Scaling up integer without zoom change failed", valueAt100, scaledValue);
-		scaledValue = DPIUtil.autoScaleUp((Device) null, valueAt100, 100);
+		scaledValue = DPIUtil.scaleUp((Device) null, valueAt100, 100);
 		assertSame("Scaling up integer without zoom change with device failed", valueAt100, scaledValue);
 	}
 
@@ -256,17 +256,17 @@ public class DPIUtilTests {
 		assertEquals(String.format("Scaling up integer to device zoom (%d) to 100 with device failed",
 				DPIUtil.getDeviceZoom()), valueAt200, scaledValue, 0.001f);
 
-		scaledValue = DPIUtil.autoScaleUp(valueAt100, 200);
+		scaledValue = DPIUtil.scaleUp(valueAt100, 200);
 		assertEquals("Scaling up integer to 200 failed", valueAt200, scaledValue, 0.001f);
-		scaledValue = DPIUtil.autoScaleUp((Device) null, valueAt100, 200);
+		scaledValue = DPIUtil.scaleUp((Device) null, valueAt100, 200);
 		assertEquals("Scaling up integer to 200 with device failed", valueAt200, scaledValue, 0.001f);
-		scaledValue = DPIUtil.autoScaleUp(valueAt100, 150);
+		scaledValue = DPIUtil.scaleUp(valueAt100, 150);
 		assertEquals("Scaling up integer to 150 failed", valueAt150, scaledValue, 0.001f);
-		scaledValue = DPIUtil.autoScaleUp((Device) null, valueAt100, 150);
+		scaledValue = DPIUtil.scaleUp((Device) null, valueAt100, 150);
 		assertEquals("Scaling up integer to 150 with device failed", valueAt150, scaledValue, 0.001f);
-		scaledValue = DPIUtil.autoScaleUp(valueAt100, 100);
+		scaledValue = DPIUtil.scaleUp(valueAt100, 100);
 		assertEquals("Scaling up integer without zoom change failed", valueAt100, scaledValue, 0.001f);
-		scaledValue = DPIUtil.autoScaleUp((Device) null, valueAt100, 100);
+		scaledValue = DPIUtil.scaleUp((Device) null, valueAt100, 100);
 		assertEquals("Scaling up integer without zoom change with device failed", valueAt100, scaledValue, 0.001f);
 	}
 
@@ -283,17 +283,17 @@ public class DPIUtilTests {
 		assertEquals(String.format("Scaling up Point to device zoom (%d) to 100 with device failed",
 				DPIUtil.getDeviceZoom()), valueAt200, scaledValue);
 
-		scaledValue = DPIUtil.autoScaleUp(valueAt100, 200);
+		scaledValue = DPIUtil.scaleUp(valueAt100, 200);
 		assertEquals("Scaling up Point to 200 failed", valueAt200, scaledValue);
-		scaledValue = DPIUtil.autoScaleUp((Device) null, valueAt100, 200);
+		scaledValue = DPIUtil.scaleUp((Device) null, valueAt100, 200);
 		assertEquals("Scaling up Point to 200 with device failed", valueAt200, scaledValue);
-		scaledValue = DPIUtil.autoScaleUp(valueAt100, 150);
+		scaledValue = DPIUtil.scaleUp(valueAt100, 150);
 		assertEquals("Scaling up Point to 150 failed", valueAt150, scaledValue);
-		scaledValue = DPIUtil.autoScaleUp((Device) null, valueAt100, 150);
+		scaledValue = DPIUtil.scaleUp((Device) null, valueAt100, 150);
 		assertEquals("Scaling up Point to 150 with device failed", valueAt150, scaledValue);
-		scaledValue = DPIUtil.autoScaleUp(valueAt100, 100);
+		scaledValue = DPIUtil.scaleUp(valueAt100, 100);
 		assertSame("Scaling up Point without zoom change failed", valueAt100, scaledValue);
-		scaledValue = DPIUtil.autoScaleUp((Device) null, valueAt100, 100);
+		scaledValue = DPIUtil.scaleUp((Device) null, valueAt100, 100);
 		assertSame("Scaling up Point without zoom change with device failed", valueAt100, scaledValue);
 	}
 
@@ -311,17 +311,17 @@ public class DPIUtilTests {
 		assertEquals(String.format("Scaling up Rectangle to device zoom (%d) to 100 with device failed",
 				DPIUtil.getDeviceZoom()), valueAt200, scaledValue);
 
-		scaledValue = DPIUtil.autoScaleUp(valueAt100, 200);
+		scaledValue = DPIUtil.scaleUp(valueAt100, 200);
 		assertEquals("Scaling up Rectangle to 200 failed", valueAt200, scaledValue);
-		scaledValue = DPIUtil.autoScaleUp((Device) null, valueAt100, 200);
+		scaledValue = DPIUtil.scaleUp((Device) null, valueAt100, 200);
 		assertEquals("Scaling up Rectangle to 200 with device failed", valueAt200, scaledValue);
-		scaledValue = DPIUtil.autoScaleUp(valueAt100, 150);
+		scaledValue = DPIUtil.scaleUp(valueAt100, 150);
 		assertEquals("Scaling up Rectangle to 150 failed", valueAt150, scaledValue);
-		scaledValue = DPIUtil.autoScaleUp((Device) null, valueAt100, 150);
+		scaledValue = DPIUtil.scaleUp((Device) null, valueAt100, 150);
 		assertEquals("Scaling up Rectangle to 150 with device failed", valueAt150, scaledValue);
-		scaledValue = DPIUtil.autoScaleUp(valueAt100, 100);
+		scaledValue = DPIUtil.scaleUp(valueAt100, 100);
 		assertSame("Scaling up Rectangle without zoom change failed", valueAt100, scaledValue);
-		scaledValue = DPIUtil.autoScaleUp((Device) null, valueAt100, 100);
+		scaledValue = DPIUtil.scaleUp((Device) null, valueAt100, 100);
 		assertSame("Scaling up Rectangle without zoom change with device failed", valueAt100, scaledValue);
 	}
 }


### PR DESCRIPTION
This PR contributes to the renaming of methods DPIUtil.autoScaleUp containing int zoom as an argument to DPIUtil.scaleUp, since the scaling is not done automatically but based on the zoom level which is provided.

Contributes to #62 and #127