### PR TITLE
Rename auto scale image data

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/graphics/Image.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/graphics/Image.java
@@ -1329,7 +1329,7 @@ public ImageData getImageData(int zoom) {
 	} finally {
 		if (pool != null) pool.release();
 	}
-	return DPIUtil.autoScaleImageData (device, getImageData(100), zoom, 100);
+	return DPIUtil.scaleImageData (device, getImageData(100), zoom, 100);
 }
 
 /** Returns the best available representation. May be 100% or 200% iff there is an image provider. */

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/DPIUtil.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/DPIUtil.java
@@ -282,15 +282,15 @@ public static Rectangle scaleDown(Drawable drawable, Rectangle rect, int zoom) {
 /**
  * Auto-scale image with ImageData
  */
-public static ImageData autoScaleImageData (Device device, final ImageData imageData, int targetZoom, int currentZoom) {
+public static ImageData scaleImageData (Device device, final ImageData imageData, int targetZoom, int currentZoom) {
 	if (imageData == null || targetZoom == currentZoom || (device != null && !device.isAutoScalable())) return imageData;
 	float scaleFactor = (float) targetZoom / (float) currentZoom;
 	return autoScaleImageData(device, imageData, scaleFactor);
 }
 
 
-public static ImageData autoScaleImageData (Device device, final ElementAtZoom<ImageData> elementAtZoom, int targetZoom) {
-	return autoScaleImageData(device, elementAtZoom.element(), targetZoom, elementAtZoom.zoom());
+public static ImageData scaleImageData (Device device, final ElementAtZoom<ImageData> elementAtZoom, int targetZoom) {
+	return scaleImageData(device, elementAtZoom.element(), targetZoom, elementAtZoom.zoom());
 }
 
 private static ImageData autoScaleImageData (Device device, final ImageData imageData, float scaleFactor) {
@@ -687,7 +687,7 @@ public static final class AutoScaleImageDataProvider implements ImageDataProvide
 	}
 	@Override
 	public ImageData getImageData(int zoom) {
-		return DPIUtil.autoScaleImageData(device, imageData, zoom, currentZoom);
+		return DPIUtil.scaleImageData(device, imageData, zoom, currentZoom);
 	}
 }
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/graphics/Image.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/graphics/Image.java
@@ -728,7 +728,7 @@ boolean refreshImageForZoom () {
 			if (deviceZoomLevel != currentDeviceZoom) {
 				ImageData data = getImageDataAtCurrentZoom();
 				destroy ();
-				ImageData resizedData = DPIUtil.autoScaleImageData(device, data, deviceZoomLevel, currentDeviceZoom);
+				ImageData resizedData = DPIUtil.scaleImageData(device, data, deviceZoomLevel, currentDeviceZoom);
 				init(resizedData);
 				init();
 				refreshed = true;
@@ -1106,12 +1106,12 @@ public ImageData getImageData (int zoom) {
 		return getImageDataAtCurrentZoom();
 	} else if (imageDataProvider != null) {
 		ElementAtZoom<ImageData> data = DPIUtil.validateAndGetImageDataAtZoom (imageDataProvider, zoom);
-		return DPIUtil.autoScaleImageData (device, data.element(), zoom, data.zoom());
+		return DPIUtil.scaleImageData (device, data.element(), zoom, data.zoom());
 	} else if (imageFileNameProvider != null) {
 		ElementAtZoom<String> fileName = DPIUtil.validateAndGetImagePathAtZoom (imageFileNameProvider, zoom);
-		return DPIUtil.autoScaleImageData (device, new ImageData (fileName.element()), zoom, fileName.zoom());
+		return DPIUtil.scaleImageData (device, new ImageData (fileName.element()), zoom, fileName.zoom());
 	} else {
-		return DPIUtil.autoScaleImageData (device, getImageDataAtCurrentZoom (), zoom, currentDeviceZoom);
+		return DPIUtil.scaleImageData (device, getImageDataAtCurrentZoom (), zoom, currentDeviceZoom);
 	}
 }
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Image.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Image.java
@@ -732,7 +732,7 @@ public Image(Device device, ImageDataProvider imageDataProvider) {
 	this.imageDataProvider = imageDataProvider;
 	initialNativeZoom = DPIUtil.getNativeDeviceZoom();
 	ElementAtZoom<ImageData> data =  DPIUtil.validateAndGetImageDataAtZoom(imageDataProvider, getZoom());
-	ImageData resizedData = DPIUtil.autoScaleImageData(device, data.element(), getZoom(), data.zoom());
+	ImageData resizedData = DPIUtil.scaleImageData(device, data.element(), getZoom(), data.zoom());
 	init (resizedData, getZoom());
 	init();
 }
@@ -769,13 +769,13 @@ public static Long win32_getHandle (Image image, int zoom) {
 			if (handle == 0) image.init(new ImageData (imageCandidate.element()), zoom);
 			image.init();
 		} else {
-			ImageData resizedData = DPIUtil.autoScaleImageData (image.device, new ImageData (imageCandidate.element()), zoom, imageCandidate.zoom());
+			ImageData resizedData = DPIUtil.scaleImageData (image.device, new ImageData (imageCandidate.element()), zoom, imageCandidate.zoom());
 			image.init(resizedData, zoom);
 			image.init ();
 		}
 	} else if (image.imageDataProvider != null) {
 		ElementAtZoom<ImageData> imageCandidate = DPIUtil.validateAndGetImageDataAtZoom (image.imageDataProvider, zoom);
-		ImageData resizedData = DPIUtil.autoScaleImageData (image.device, imageCandidate.element(), zoom, imageCandidate.zoom());
+		ImageData resizedData = DPIUtil.scaleImageData (image.device, imageCandidate.element(), zoom, imageCandidate.zoom());
 		image.init(resizedData, zoom);
 		image.init();
 	} else {
@@ -1378,10 +1378,10 @@ public ImageData getImageData (int zoom) {
 		return getImageDataAtCurrentZoom();
 	} else if (imageDataProvider != null) {
 		ElementAtZoom<ImageData> data = DPIUtil.validateAndGetImageDataAtZoom (imageDataProvider, zoom);
-		return DPIUtil.autoScaleImageData (device, data.element(), zoom, data.zoom());
+		return DPIUtil.scaleImageData (device, data.element(), zoom, data.zoom());
 	} else if (imageFileNameProvider != null) {
 		ElementAtZoom<String> fileName = DPIUtil.validateAndGetImagePathAtZoom (imageFileNameProvider, zoom);
-		return DPIUtil.autoScaleImageData (device, new ImageData (fileName.element()), zoom, fileName.zoom());
+		return DPIUtil.scaleImageData (device, new ImageData (fileName.element()), zoom, fileName.zoom());
 	}
 
 	// if a GC is initialized with an Image (memGC != null), the image data must not be resized, because it would
@@ -1394,9 +1394,9 @@ public ImageData getImageData (int zoom) {
 		this.dataAtBaseZoom = new ElementAtZoom<>(getImageData(currentZoom), currentZoom);
 	}
 	if (this.dataAtBaseZoom != null) {
-		return DPIUtil.autoScaleImageData(device, this.dataAtBaseZoom, zoom);
+		return DPIUtil.scaleImageData(device, this.dataAtBaseZoom, zoom);
 	} else {
-		return DPIUtil.autoScaleImageData (device, getImageDataAtCurrentZoom (), zoom, currentZoom);
+		return DPIUtil.scaleImageData (device, getImageDataAtCurrentZoom (), zoom, currentZoom);
 	}
 }
 


### PR DESCRIPTION
This PR renames the method autoScaleImageData to scaleImageData in DPIUtil for the variants of the method which accept a target zoom since it sounds more relevant to the action.

Contributes to #62 and #127