### PR TITLE
Positioning shells correctly for multi zoom level

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Control.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Control.java
@@ -3969,8 +3969,9 @@ void subclass () {
  */
 public Point toControl (int x, int y) {
 	checkWidget ();
-	int zoom = getZoom();
-	return DPIUtil.scaleDown(toControlInPixels(DPIUtil.scaleUp(x, zoom), DPIUtil.scaleUp(y, zoom)), zoom);
+	Point displayPointInPixels = getDisplay().translateLocationInPixelsInDisplayCoordinateSystem(x, y);
+	final Point controlPointInPixels = toControlInPixels(displayPointInPixels.x, displayPointInPixels.y);
+	return DPIUtil.scaleDown(controlPointInPixels, getZoom());
 }
 
 Point toControlInPixels (int x, int y) {
@@ -4003,9 +4004,7 @@ Point toControlInPixels (int x, int y) {
 public Point toControl (Point point) {
 	checkWidget ();
 	if (point == null) error (SWT.ERROR_NULL_ARGUMENT);
-	int zoom = getZoom();
-	point = DPIUtil.scaleUp(point, zoom);
-	return DPIUtil.scaleDown(toControlInPixels(point.x, point.y), zoom);
+	return toControl(point.x, point.y);
 }
 
 /**
@@ -4031,7 +4030,8 @@ public Point toControl (Point point) {
 public Point toDisplay (int x, int y) {
 	checkWidget ();
 	int zoom = getZoom();
-	return DPIUtil.scaleDown(toDisplayInPixels(DPIUtil.scaleUp(x, zoom), DPIUtil.scaleUp(y, zoom)), zoom);
+	Point displayPointInPixels = toDisplayInPixels(DPIUtil.scaleUp(x, zoom), DPIUtil.scaleUp(y, zoom));
+	return getDisplay().translateLocationInPointInDisplayCoordinateSystem(displayPointInPixels.x, displayPointInPixels.y);
 }
 
 Point toDisplayInPixels (int x, int y) {
@@ -4064,9 +4064,7 @@ Point toDisplayInPixels (int x, int y) {
 public Point toDisplay (Point point) {
 	checkWidget ();
 	if (point == null) error (SWT.ERROR_NULL_ARGUMENT);
-	int zoom = getZoom();
-	point = DPIUtil.scaleUp(point, zoom);
-	return DPIUtil.scaleDown(toDisplayInPixels(point.x, point.y), zoom);
+	return toDisplay(point.x, point.y);
 }
 
 long topHandle () {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Shell.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Shell.java
@@ -1567,6 +1567,42 @@ public void setAlpha (int alpha) {
 }
 
 @Override
+public Rectangle getBounds() {
+	Rectangle boundsInPixels = getBoundsInPixels();
+	return display.translateRectangleInPointsInDisplayCoordinateSystemByContainment(boundsInPixels.x, boundsInPixels.y, boundsInPixels.width, boundsInPixels.height);
+}
+
+@Override
+public Point getLocation() {
+	Point locationInPixels = getLocationInPixels();
+	return display.translateLocationInPointInDisplayCoordinateSystem(locationInPixels.x, locationInPixels.y);
+}
+
+@Override
+public void setLocation(Point location) {
+	if (location == null) error (SWT.ERROR_NULL_ARGUMENT);
+	setLocation(location.x, location.y);
+}
+
+@Override
+public void setLocation(int x, int y) {
+	Point location = display.translateLocationInPixelsInDisplayCoordinateSystem(x, y);
+	setLocationInPixels(location.x, location.y);
+}
+
+@Override
+public void setBounds(Rectangle rect) {
+	if (rect == null) error (SWT.ERROR_NULL_ARGUMENT);
+	setBounds(rect.x, rect.y, rect.width, rect.height);
+}
+
+@Override
+public void setBounds(int x, int y, int width, int height) {
+	Rectangle boundsInPixels = display.translateRectangleInPixelsInDisplayCoordinateSystemByContainment(x, y, width, height);
+	setBoundsInPixels(boundsInPixels.x, boundsInPixels.y, boundsInPixels.width, boundsInPixels.height);
+}
+
+@Override
 void setBoundsInPixels (int x, int y, int width, int height, int flags, boolean defer) {
 	if (fullScreen) setFullScreen (false);
 	/*


### PR DESCRIPTION
This contribution enforces displays to store x,y coordinates in point as the absolute pixels in the display coordinate system. while scaling the width and height to the points, following this the map methods are reimplemented to do the right conversion between the new display coordinate system and the coordinates within a control.

The top left coordinates of monitors (x, y) are stored in the absolurte pixels coordinate of the display to avoid any overlap of any monitor bounds on scaling down as per their zoom level, i.e., to locate the monitor for a point, we can easily skim and find which monitor it belongs to, hence confirming the zoom needed for scaling.

e.g.  Monitor A: 100 x 100 (zoom: 100%, x-coordinates: 0 - 100) - On scaling down: 0 - 100
        Monitor B: 100 x 100 (zoom: 100%, x-coordinates: 100 - 200) - On scaling down: 50 - 100
        Here, the x-coordinates of A and B overlap, hence for a point at a location between (50, 100), there is ambiguity.

With the new system the scaledDown coordinates will be:
Monitor A: 0 - 100
Monitor B: 100 - 150
and scaling up: 0 - 100, 100 - 200, respectively

contributes to #62 and #127