### PR TITLE
Initialize Win32 Display thread with correct OS DPI awareness 

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Display.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Display.java
@@ -582,6 +582,29 @@ public Display () {
  */
 public Display (DeviceData data) {
 	super (data);
+	initializeProperDPIAwareness();
+}
+
+private void initializeProperDPIAwareness() {
+	if (!DPIUtil.isAutoScaleOnRuntimeActive()) {
+		return;
+	}
+	// Auto scaling on runtime requires DPI awareness mode "Per Monitor V2"
+	boolean perMonitorV2Available = OS.WIN32_BUILD > OS.WIN32_BUILD_WIN10_1809;
+	if (!perMonitorV2Available) {
+		System.err.println(
+				"***WARNING: rescaling at runtime is activated but the OS version does not support required DPI awareness mode PerMonitorV2.");
+		return;
+	}
+
+	boolean alreadyUsesPerMonitorV2 = OS.GetThreadDpiAwarenessContext() == OS.DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2;
+	if (alreadyUsesPerMonitorV2) {
+		return;
+	}
+	long setDpiAwarenessResult = OS.SetThreadDpiAwarenessContext(OS.DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2);
+	if (setDpiAwarenessResult == 0L) {
+		System.err.println("***WARNING: setting DPI awareness to PerMonitorV2 failed.");
+	}
 }
 
 Control _getFocusControl () {


### PR DESCRIPTION
The runtime auto-scaling for multi-monitor HiDPI support on Windows requires the system's DPI awareness to be set to PerMonitorV2. This change makes the Display class initialize its UI thread with the according DPI awareness.

Contributes to https://github.com/eclipse-platform/eclipse.platform.swt/issues/62

Contributes to https://github.com/eclipse-platform/eclipse.platform.swt/issues/131

<s>⚠️  Depends on and has to be merged after #1355</s>

### How to test

You need to start an application with a different DPI awareness mode than "Per Monitor V2", e.g., by changing the JVMs manifest, with the runtime autoscaling activated (VM argument `-Dswt.autoScale.updateOnRuntime=true`).
I have added a manifest with DPI awareness set to "System" to my JVM and started SWT Snippet 106 on a 100% monitor and moved to a 150% monitor. Here is how it looks like.

Without this change:
![image](https://github.com/user-attachments/assets/b776717d-8c3d-4a22-9ae9-6e3c4022ebbe)

With this change:
![image](https://github.com/user-attachments/assets/dede6b57-d199-4a18-a683-dc504084feca)

To avoid confusion, the shrunken size is because of the default scaling method `integer200` which "corrects" the widgets sizes to 100% scaling. This is existing SWT behavior. With scaling mode set to `quarter`, it looks like this:
![image](https://github.com/user-attachments/assets/ca70fc7d-c2c1-4ccd-a6b5-8be795d88740)
