### PR TITLE
Remove unused enableAutoScaling property of Device on Windows

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Device.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Device.java
@@ -56,9 +56,6 @@ public abstract class Device implements Drawable {
 
 	volatile boolean disposed;
 
-	/* Auto-Scaling*/
-	boolean enableAutoScaling = true;
-
 	/*
 	* TEMPORARY CODE. When a graphics object is
 	* created and the device parameter is null,
@@ -937,14 +934,6 @@ protected void release () {
  */
 public void setWarnings (boolean warnings) {
 	checkDevice ();
-}
-
-boolean getEnableAutoScaling() {
-	return enableAutoScaling;
-}
-
-void setEnableAutoScaling(boolean value) {
-	enableAutoScaling = value;
 }
 
 /**


### PR DESCRIPTION
The property "enableAutoScaling" has been introduced the Device class in the Windows implementation for HiDPI support year ago, but it has never been used. This removes the unused property.