### PR TITLE
Create CTabFolder images with ImageDataProvider

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CTabFolder.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CTabFolder.java
@@ -17,8 +17,6 @@ import org.eclipse.swt.*;
 import org.eclipse.swt.accessibility.*;
 import org.eclipse.swt.events.*;
 import org.eclipse.swt.graphics.*;
-import org.eclipse.swt.internal.*;
-import org.eclipse.swt.internal.DPIUtil.*;
 import org.eclipse.swt.widgets.*;
 
 /**
@@ -720,24 +718,25 @@ public Rectangle computeTrim (int x, int y, int width, int height) {
 	return trim;
 }
 Image createButtonImage(Display display, int button) {
-	GC tempGC = new GC (this);
-	Point size = renderer.computeSize(button, SWT.NONE, tempGC, SWT.DEFAULT, SWT.DEFAULT);
-	tempGC.dispose();
+	return new Image(display, (ImageDataProvider) zoom -> {
+		GC tempGC = new GC (CTabFolder.this);
+		Point size = renderer.computeSize(button, SWT.NONE, tempGC, SWT.DEFAULT, SWT.DEFAULT);
+		tempGC.dispose();
 
-	Rectangle trim = renderer.computeTrim(button, SWT.NONE, 0, 0, 0, 0);
-	Image image = new Image (display, size.x - trim.width, size.y - trim.height);
-	GC gc = new GC (image);
-	Color transColor = renderer.parent.getBackground();
-	gc.setBackground(transColor);
-	gc.fillRectangle(image.getBounds());
-	renderer.draw(button, SWT.NONE, new Rectangle(trim.x, trim.y, size.x, size.y), gc);
-	gc.dispose ();
+		Rectangle trim = renderer.computeTrim(button, SWT.NONE, 0, 0, 0, 0);
+		Image image = new Image (display, size.x - trim.width, size.y - trim.height);
+		GC gc = new GC (image);
+		Color transColor = renderer.parent.getBackground();
+		gc.setBackground(transColor);
+		gc.fillRectangle(image.getBounds());
+		renderer.draw(button, SWT.NONE, new Rectangle(trim.x, trim.y, size.x, size.y), gc);
+		gc.dispose ();
 
-	final ImageData imageData = image.getImageData (DPIUtil.getDeviceZoom ());
-	imageData.transparentPixel = imageData.palette.getPixel(transColor.getRGB());
-	image.dispose();
-	image = new Image(display, new AutoScaleImageDataProvider(display, imageData, DPIUtil.getDeviceZoom()));
-	return image;
+		final ImageData imageData = image.getImageData (zoom);
+		imageData.transparentPixel = imageData.palette.getPixel(transColor.getRGB());
+		image.dispose();
+		return imageData;
+	});
 }
 
 private void notifyItemCountChange() {


### PR DESCRIPTION
This commit changes the createButtonImage method in CTabFolder. Until now the requested image data were created once and are scaled to other zoom settings with an AutoScaleImageDataProvider, which is a destructive operation when scaling it to a smaller zoom. With this change the whole logic is moved into an ImageDataProvider, so each time ImageData for a specific zoom value is requested, it will be created from scratch for this zoom value.

If you have the rescaling enabled in win32 switching from 200% to 100% would shrink the image to something like
![image](https://github.com/user-attachments/assets/036cb032-61df-4f1d-8e1e-057c640090f0)

With the change it looks like 
![image](https://github.com/user-attachments/assets/64757c76-2202-4dd1-8dcb-8a77a821c746)

This is affected a common widget, so it must be tested on all OS. As I currently don't have a working Linux or MacOS available, I cannot do it myself.