### PR TITLE
Only consider rescaling at runtime enabled when DPI awareness mode fits

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT PI/win32/org/eclipse/swt/internal/win32/OS.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/win32/org/eclipse/swt/internal/win32/OS.java
@@ -369,8 +369,8 @@ public class OS extends C {
 	public static final short DMDUP_SIMPLEX = 1;
 	public static final short DMDUP_VERTICAL = 2;
 	public static final short DMDUP_HORIZONTAL = 3;
-	public static final int DPI_AWARENESS_CONTEXT_UNAWARE = 16;
-	public static final int DPI_AWARENESS_CONTEXT_SYSTEM_AWARE = 17;
+	public static final int DPI_AWARENESS_CONTEXT_UNAWARE = 24592;
+	public static final int DPI_AWARENESS_CONTEXT_SYSTEM_AWARE = 24593;
 	public static final int DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE = 18;
 	public static final int DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2 = 34;
 	public static final int DSTINVERT = 0x550009;

--- a/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/widgets/DisplayWin32Test.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/widgets/DisplayWin32Test.java
@@ -1,0 +1,55 @@
+package org.eclipse.swt.widgets;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.eclipse.swt.internal.*;
+import org.eclipse.swt.internal.win32.*;
+import org.junit.jupiter.api.*;
+
+public class DisplayWin32Test {
+
+	private Display display;
+
+	@BeforeAll
+	public static void assumeIsFittingPlatform() {
+		PlatformSpecificExecution.assumeIsFittingPlatform();
+	}
+
+	@BeforeEach
+	public void createDisplay() {
+		display = new Display();
+	}
+
+	@AfterEach
+	public void destroyDisplay() {
+		display.dispose();
+	}
+
+	@Test
+	public void setRescaleAtRuntime_activate() {
+		display.setRescalingAtRuntime(true);
+		assertTrue(display.isRescalingAtRuntime());
+		assertEquals(OS.DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2, OS.GetThreadDpiAwarenessContext());
+	}
+
+	@Test
+	public void setRescaleAtRuntime_deactivate() {
+		display.setRescalingAtRuntime(false);
+		assertFalse(display.isRescalingAtRuntime());
+		assertEquals(OS.DPI_AWARENESS_CONTEXT_SYSTEM_AWARE, OS.GetThreadDpiAwarenessContext());
+	}
+
+	@Test
+	public void setRescaleAtRuntime_toggling() {
+		display.setRescalingAtRuntime(false);
+		assertFalse(display.isRescalingAtRuntime());
+		assertEquals(OS.DPI_AWARENESS_CONTEXT_SYSTEM_AWARE, OS.GetThreadDpiAwarenessContext());
+		display.setRescalingAtRuntime(true);
+		assertTrue(display.isRescalingAtRuntime());
+		assertEquals(OS.DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2, OS.GetThreadDpiAwarenessContext());
+		display.setRescalingAtRuntime(false);
+		assertFalse(display.isRescalingAtRuntime());
+		assertEquals(OS.DPI_AWARENESS_CONTEXT_SYSTEM_AWARE, OS.GetThreadDpiAwarenessContext());
+	}
+
+}

--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Display.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Display.java
@@ -6856,9 +6856,11 @@ public boolean isRescalingAtRuntime() {
  * method on other operating system will have no effect.
  *
  * @param activate whether rescaling shall be activated or deactivated
+ * @return whether activating or deactivating the rescaling was successful
  * @since 3.127
  */
-public void setRescalingAtRuntime(boolean activate) {
+public boolean setRescalingAtRuntime(boolean activate) {
 	// not implemented for Cocoa
+	return false;
 }
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Display.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Display.java
@@ -6290,10 +6290,12 @@ public boolean isRescalingAtRuntime() {
  * method on other operating system will have no effect.
  *
  * @param activate whether rescaling shall be activated or deactivated
+ * @return whether activating or deactivating the rescaling was successful
  * @since 3.127
  */
-public void setRescalingAtRuntime(boolean activate) {
+public boolean setRescalingAtRuntime(boolean activate) {
 	// not implemented for GTK
+	return false;
 }
 
 }


### PR DESCRIPTION
Activating rescaling at runtime requires a proper DPI awareness mode to be set. Currently, if setting the DPI awareness mode fails, rescaling may still be activated if the user requested to. With this change, setting the rescaling mode of a Display ensures that the correct DPI awareness for the UI thread is set and, in case an error occurs, the rescaling mode is not changed. It also adapts some faulty constants and provides according test cases for setting the rescaling behavior.