### PR TITLE
[win32] Refactor toolbar dpi callback

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/win32/org/eclipse/swt/dnd/DragSource.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/win32/org/eclipse/swt/dnd/DragSource.java
@@ -491,7 +491,8 @@ private void drag(Event dragEvent) {
 	hwndDrag = 0;
 	topControl = null;
 	if (image != null) {
-		imagelist = new ImageList(SWT.NONE, DPIUtil.getZoomForAutoscaleProperty(nativeZoom));
+		int zoom = DPIUtil.getZoomForAutoscaleProperty(nativeZoom);
+		imagelist = new ImageList(SWT.NONE, zoom);
 		imagelist.add(image);
 		topControl = control.getShell();
 		/*
@@ -519,7 +520,7 @@ private void drag(Event dragEvent) {
 				null);
 			OS.ShowWindow (hwndDrag, OS.SW_SHOW);
 		}
-		OS.ImageList_BeginDrag(imagelist.getHandle(), 0, offsetX, event.offsetY);
+		OS.ImageList_BeginDrag(imagelist.getHandle(zoom), 0, offsetX, event.offsetY);
 		/*
 		* Feature in Windows. When ImageList_DragEnter() is called,
 		* it takes a snapshot of the screen  If a drag is started
@@ -530,7 +531,6 @@ private void drag(Event dragEvent) {
 		*/
 		int flags = OS.RDW_UPDATENOW | OS.RDW_ALLCHILDREN;
 		OS.RedrawWindow (topControl.handle, null, 0, flags);
-		int zoom = DPIUtil.getZoomForAutoscaleProperty(nativeZoom);
 		POINT pt = new POINT ();
 		pt.x = DPIUtil.scaleUp(dragEvent.x, zoom);// To Pixels
 		pt.y = DPIUtil.scaleUp(dragEvent.y, zoom);// To Pixels

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/win32/org/eclipse/swt/internal/win32/OS.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/win32/org/eclipse/swt/internal/win32/OS.java
@@ -1362,6 +1362,7 @@ public class OS extends C {
 	public static final int TBS_DOWNISLEFT = 0x0400;
 	public static final int TBS_HORZ = 0x0;
 	public static final int TBS_VERT = 0x2;
+	public static final int TB_ADDBUTTONS = 0x444;
 	public static final int TB_ADDSTRING = 0x44d;
 	public static final int TB_AUTOSIZE = 0x421;
 	public static final int TB_BUTTONCOUNT = 0x418;

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/ImageList.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/ImageList.java
@@ -25,8 +25,8 @@ public class ImageList {
 	int style, refCount;
 	Image [] images;
 	private final int zoom;
-	private int width, height;
-	private int flags;
+	private final int width, height;
+	private final int flags;
 
 	private HashMap<Integer, Long> zoomToHandle = new HashMap<>();
 
@@ -36,8 +36,9 @@ public ImageList (int style, int zoom) {
 
 public ImageList (int style, int width, int height, int zoom) {
 	this.style = style;
-	this.flags = OS.ILC_MASK | OS.ILC_COLOR32;
-	if ((style & SWT.RIGHT_TO_LEFT) != 0) this.flags |= OS.ILC_MIRROR;
+	int listFlags = OS.ILC_MASK | OS.ILC_COLOR32;
+	if ((style & SWT.RIGHT_TO_LEFT) != 0) listFlags |= OS.ILC_MIRROR;
+	this.flags = listFlags;
 	this.height = height;
 	this.width = width;
 	handle = OS.ImageList_Create (width, height, this.flags, 16, 16);

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Button.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Button.java
@@ -148,7 +148,7 @@ void _setImage (Image image) {
 			imageList.add (disabledImage);
 		}
 		BUTTON_IMAGELIST buttonImageList = new BUTTON_IMAGELIST ();
-		buttonImageList.himl = imageList.getHandle ();
+		buttonImageList.himl = imageList.getHandle(getZoom());
 		int oldBits = OS.GetWindowLong (handle, OS.GWL_STYLE), newBits = oldBits;
 		newBits &= ~(OS.BS_LEFT | OS.BS_CENTER | OS.BS_RIGHT);
 		if ((style & SWT.LEFT) != 0) newBits |= OS.BS_LEFT;
@@ -189,7 +189,7 @@ void _setText (String text) {
 	if ((style & SWT.RIGHT) != 0) newBits |= OS.BS_RIGHT;
 	if (imageList != null) {
 		BUTTON_IMAGELIST buttonImageList = new BUTTON_IMAGELIST ();
-		buttonImageList.himl = imageList.getHandle ();
+		buttonImageList.himl = imageList.getHandle(getZoom());
 		if (text.length () == 0) {
 			if ((style & SWT.LEFT) != 0) buttonImageList.uAlign = OS.BUTTON_IMAGELIST_ALIGN_LEFT;
 			if ((style & SWT.CENTER) != 0) buttonImageList.uAlign = OS.BUTTON_IMAGELIST_ALIGN_CENTER;
@@ -779,7 +779,7 @@ public void setAlignment (int alignment) {
 	if ((style & SWT.RIGHT) != 0) newBits |= OS.BS_RIGHT;
 	if (imageList != null) {
 		BUTTON_IMAGELIST buttonImageList = new BUTTON_IMAGELIST ();
-		buttonImageList.himl = imageList.getHandle ();
+		buttonImageList.himl = imageList.getHandle(getZoom());
 		if (text.length () == 0) {
 			if ((style & SWT.LEFT) != 0) buttonImageList.uAlign = OS.BUTTON_IMAGELIST_ALIGN_LEFT;
 			if ((style & SWT.CENTER) != 0) buttonImageList.uAlign = OS.BUTTON_IMAGELIST_ALIGN_CENTER;
@@ -1042,7 +1042,7 @@ void updateImageList () {
 			disabledImage = new Image (display, image, SWT.IMAGE_DISABLE);
 			imageList.add (disabledImage);
 		}
-		buttonImageList.himl = imageList.getHandle ();
+		buttonImageList.himl = imageList.getHandle(getZoom());
 		OS.SendMessage (handle, OS.BCM_SETIMAGELIST, 0, buttonImageList);
 		/*
 		* Bug in Windows.  Under certain cirumstances yet to be

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TabFolder.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TabFolder.java
@@ -458,7 +458,7 @@ int imageIndex (Image image) {
 		Rectangle bounds = DPIUtil.scaleBounds(image.getBounds(), this.getZoom(), 100);
 		imageList = display.getImageList (style & SWT.RIGHT_TO_LEFT, bounds.width, bounds.height, this.getZoom());
 		int index = imageList.add (image);
-		long hImageList = imageList.getHandle ();
+		long hImageList = imageList.getHandle(getZoom());
 		OS.SendMessage (handle, OS.TCM_SETIMAGELIST, 0, hImageList);
 		return index;
 	}
@@ -840,7 +840,7 @@ void updateOrientation () {
 		Point size = imageList.getImageSize ();
 		display.releaseImageList (imageList);
 		imageList = display.getImageList (style & SWT.RIGHT_TO_LEFT, size.x, size.y, this.getZoom());
-		long hImageList = imageList.getHandle ();
+		long hImageList = imageList.getHandle(getZoom());
 		OS.SendMessage (handle, OS.TCM_SETIMAGELIST, 0, hImageList);
 		TCITEM tcItem = new TCITEM ();
 		tcItem.mask = OS.TCIF_IMAGE;

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Table.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Table.java
@@ -2853,7 +2853,7 @@ int imageIndex (Image image, int column) {
 		imageList = display.getImageList (style & SWT.RIGHT_TO_LEFT, bounds.width, bounds.height, getZoom());
 		int index = imageList.indexOf (image);
 		if (index == -1) index = imageList.add (image);
-		long hImageList = imageList.getHandle ();
+		long hImageList = imageList.getHandle(getZoom());
 		/*
 		* Bug in Windows.  Making any change to an item that
 		* changes the item height of a table while the table
@@ -2870,7 +2870,7 @@ int imageIndex (Image image, int column) {
 		}
 		OS.SendMessage (handle, OS.LVM_SETIMAGELIST, OS.LVSIL_SMALL, hImageList);
 		if (headerImageList != null) {
-			long hHeaderImageList = headerImageList.getHandle ();
+			long hHeaderImageList = headerImageList.getHandle(getZoom());
 			OS.SendMessage (hwndHeader, OS.HDM_SETIMAGELIST, 0, hHeaderImageList);
 		}
 		fixCheckboxImageList (false);
@@ -2893,7 +2893,7 @@ int imageIndexHeader (Image image) {
 		headerImageList = display.getImageList (style & SWT.RIGHT_TO_LEFT, bounds.width, bounds.height, getZoom());
 		int index = headerImageList.indexOf (image);
 		if (index == -1) index = headerImageList.add (image);
-		long hImageList = headerImageList.getHandle ();
+		long hImageList = headerImageList.getHandle(getZoom());
 		OS.SendMessage (hwndHeader, OS.HDM_SETIMAGELIST, 0, hImageList);
 		return index;
 	}
@@ -5126,7 +5126,7 @@ void setTableEmpty () {
 		OS.SendMessage (handle, OS.LVM_SETIMAGELIST, OS.LVSIL_SMALL, hImageList);
 		OS.SendMessage (handle, OS.LVM_SETIMAGELIST, OS.LVSIL_SMALL, 0);
 		if (headerImageList != null) {
-			long hHeaderImageList = headerImageList.getHandle ();
+			long hHeaderImageList = headerImageList.getHandle(getZoom());
 			long hwndHeader = OS.SendMessage (handle, OS.LVM_GETHEADER, 0, 0);
 			OS.SendMessage (hwndHeader, OS.HDM_SETIMAGELIST, 0, hHeaderImageList);
 		}
@@ -5590,7 +5590,7 @@ void updateOrientation () {
 				}
 			}
 		}
-		long hImageList = imageList.getHandle ();
+		long hImageList = imageList.getHandle(getZoom());
 		OS.SendMessage (handle, OS.LVM_SETIMAGELIST, OS.LVSIL_SMALL, hImageList);
 	}
 	if (hwndHeader != 0) {
@@ -5618,7 +5618,7 @@ void updateOrientation () {
 					}
 				}
 			}
-			long hHeaderImageList = headerImageList.getHandle ();
+			long hHeaderImageList = headerImageList.getHandle(getZoom());
 			OS.SendMessage (hwndHeader, OS.HDM_SETIMAGELIST, 0, hHeaderImageList);
 		}
 	}

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ToolBar.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ToolBar.java
@@ -1046,10 +1046,11 @@ void setDropDownItems (boolean set) {
 }
 
 void setDisabledImageList (ImageList imageList) {
-	if (disabledImageList == imageList) return;
-	long hImageList = 0;
+	long hImageList = OS.SendMessage (handle, OS.TB_GETDISABLEDIMAGELIST, 0, 0);
 	if ((disabledImageList = imageList) != null) {
-		hImageList = disabledImageList.getHandle ();
+		long newImageList = disabledImageList.getHandle(getZoom());
+		if(hImageList == newImageList) return;
+		hImageList = newImageList;
 	}
 	setDropDownItems (false);
 	OS.SendMessage (handle, OS.TB_SETDISABLEDIMAGELIST, 0, hImageList);
@@ -1083,10 +1084,11 @@ public void setFont (Font font) {
 }
 
 void setHotImageList (ImageList imageList) {
-	if (hotImageList == imageList) return;
-	long hImageList = 0;
+	long hImageList = OS.SendMessage (handle, OS.TB_GETHOTIMAGELIST, 0, 0);
 	if ((hotImageList = imageList) != null) {
-		hImageList = hotImageList.getHandle ();
+		long newImageList = hotImageList.getHandle(getZoom());
+		if(hImageList == newImageList) return;
+		hImageList = newImageList;
 	}
 	setDropDownItems (false);
 	OS.SendMessage (handle, OS.TB_SETHOTIMAGELIST, 0, hImageList);
@@ -1094,10 +1096,11 @@ void setHotImageList (ImageList imageList) {
 }
 
 void setImageList (ImageList imageList) {
-	if (this.imageList == imageList) return;
-	long hImageList = 0;
+	long hImageList = OS.SendMessage (handle, OS.TB_GETIMAGELIST, 0, 0);
 	if ((this.imageList = imageList) != null) {
-		hImageList = imageList.getHandle ();
+		long newImageList = imageList.getHandle(getZoom());
+		if (hImageList == newImageList) return;
+		hImageList = newImageList;
 	}
 	setDropDownItems (false);
 	OS.SendMessage (handle, OS.TB_SETIMAGELIST, 0, hImageList);
@@ -1293,9 +1296,9 @@ void updateOrientation () {
 		display.releaseToolImageList (imageList);
 		display.releaseToolHotImageList (hotImageList);
 		display.releaseToolDisabledImageList (disabledImageList);
-		OS.SendMessage (handle, OS.TB_SETIMAGELIST, 0, newImageList.getHandle ());
-		OS.SendMessage (handle, OS.TB_SETHOTIMAGELIST, 0, newHotImageList.getHandle ());
-		OS.SendMessage (handle, OS.TB_SETDISABLEDIMAGELIST, 0, newDisabledImageList.getHandle ());
+		OS.SendMessage (handle, OS.TB_SETIMAGELIST, 0, newImageList.getHandle(getZoom()));
+		OS.SendMessage (handle, OS.TB_SETHOTIMAGELIST, 0, newHotImageList.getHandle(getZoom()));
+		OS.SendMessage (handle, OS.TB_SETDISABLEDIMAGELIST, 0, newDisabledImageList.getHandle(getZoom()));
 		imageList = newImageList;
 		hotImageList = newHotImageList;
 		disabledImageList = newDisabledImageList;
@@ -1759,7 +1762,7 @@ private static void handleDPIChange(Widget widget, int newZoom, float scalingFac
 
 	}
 	for (ToolItem item : toolItems) {
-		toolBar.destroyItem(item);
+//		toolBar.destroyItem(item);
 		// Resize after, as zoom update changes references to imageLists
 		DPIZoomChangeRegistry.applyChange(item, newZoom, scalingFactor);
 	}
@@ -1767,7 +1770,7 @@ private static void handleDPIChange(Widget widget, int newZoom, float scalingFac
 	for (int i = 0; i < toolItems.length; i++) {
 		ToolItem toolItem = toolItems[i];
 
-		toolBar.createItem(toolItem, i);
+//		toolBar.createItem(toolItem, i);
 		String currentText =  toolItem.getText();
 		toolItem.setText(" ");
 		toolItem.setText(currentText);

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ToolItem.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ToolItem.java
@@ -50,10 +50,6 @@ public class ToolItem extends Item {
 	short cx;
 	int foreground = -1, background = -1;
 
-	static {
-		DPIZoomChangeRegistry.registerHandler(ToolItem::handleDPIChange, ToolItem.class);
-	}
-
 /**
  * Constructs a new instance of this class given its parent
  * (which must be a <code>ToolBar</code>) and a style value
@@ -1217,29 +1213,5 @@ LRESULT wmCommandChild (long wParam, long lParam) {
 	}
 	sendSelectionEvent (SWT.Selection);
 	return null;
-}
-
-private static void handleDPIChange(Widget widget, int newZoom, float scalingFactor) {
-	if (!(widget instanceof ToolItem item)) {
-		return;
-	}
-	Image image = item.getImage();
-	if (image != null) {
-		ToolBar parent = item.getParent();
-		Display display = item.getDisplay();
-		int listStyle = parent.style & SWT.RIGHT_TO_LEFT;
-
-		Rectangle bounds = DPIUtil.scaleBounds(image.getBounds(), newZoom, 100);
-		if (parent.getImageList() == null) {
-			parent.setImageList (display.getImageListToolBar (listStyle, bounds.width, bounds.height, item.getZoom()));
-		}
-		if (parent.getDisabledImageList() == null) {
-			parent.setDisabledImageList (display.getImageListToolBarDisabled (listStyle, bounds.width, bounds.height, item.getZoom()));
-		}
-		if (parent.getHotImageList() == null) {
-			parent.setHotImageList (display.getImageListToolBarHot (listStyle, bounds.width, bounds.height, item.getZoom()));
-		}
-	}
-	item.setWidthInPixels(0);
 }
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Tree.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Tree.java
@@ -3751,7 +3751,7 @@ int imageIndex (Image image, int index) {
 		* times, Windows does work making this operation slow.  The fix
 		* is to test for the same image list before setting the new one.
 		*/
-		long hImageList = imageList.getHandle ();
+		long hImageList = imageList.getHandle(getZoom());
 		long hOldImageList = OS.SendMessage (handle, OS.TVM_GETIMAGELIST, OS.TVSIL_NORMAL, 0);
 		if (hOldImageList != hImageList) {
 			OS.SendMessage (handle, OS.TVM_SETIMAGELIST, OS.TVSIL_NORMAL, hImageList);
@@ -3768,7 +3768,7 @@ int imageIndexHeader (Image image) {
 		headerImageList = display.getImageList (style & SWT.RIGHT_TO_LEFT, bounds.width, bounds.height, getZoom());
 		int index = headerImageList.indexOf (image);
 		if (index == -1) index = headerImageList.add (image);
-		long hImageList = headerImageList.getHandle ();
+		long hImageList = headerImageList.getHandle(getZoom());
 		if (hwndHeader != 0) {
 			OS.SendMessage (hwndHeader, OS.HDM_SETIMAGELIST, 0, hImageList);
 		}
@@ -5729,7 +5729,7 @@ void updateImageList () {
 	* times, Windows does work making this operation slow.  The fix
 	* is to test for the same image list before setting the new one.
 	*/
-	long hImageList = i == items.length ? 0 : imageList.getHandle ();
+	long hImageList = i == items.length ? 0 : imageList.getHandle(getZoom());
 	long hOldImageList = OS.SendMessage (handle, OS.TVM_GETIMAGELIST, OS.TVSIL_NORMAL, 0);
 	if (hImageList != hOldImageList) {
 		OS.SendMessage (handle, OS.TVM_SETIMAGELIST, OS.TVSIL_NORMAL, hImageList);
@@ -5803,7 +5803,7 @@ void updateOrientation () {
 				}
 			}
 		}
-		long hImageList = imageList.getHandle ();
+		long hImageList = imageList.getHandle(getZoom());
 		OS.SendMessage (handle, OS.TVM_SETIMAGELIST, OS.TVSIL_NORMAL, hImageList);
 	}
 	if (hwndHeader != 0) {
@@ -5831,7 +5831,7 @@ void updateOrientation () {
 					}
 				}
 			}
-			long hImageListHeader = headerImageList.getHandle ();
+			long hImageListHeader = headerImageList.getHandle(getZoom());
 			OS.SendMessage (hwndHeader, OS.HDM_SETIMAGELIST, 0, hImageListHeader);
 		}
 	}


### PR DESCRIPTION
This PR mainly is targeted on refactoring the existing callback for ToolBar and ToolItem after a DPI change in the win32 implementation. 
To achieve that a method to scale an ImageList was added. Scaled variants of an image list are saved and reused similar to the other Resources.
The refactoring uses the scalable ImageLists to reuse the existing toolbar items and only resets the ImageList with a correctly scaled one. Due to the limitations of the win32 implementation all items must be removed and re-added via the win32-API to make shrinking of toolbars possible. Additionally, the commit removes the now unused callback in ToolItem.

All calls to the ImageList handle are replaced to use the added method.