### PR TITLE
[win32] Forward ZoomChanged to all child widgets

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/graphics/GCWin32Tests.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/graphics/GCWin32Tests.java
@@ -20,7 +20,6 @@ import java.util.concurrent.atomic.*;
 
 import org.eclipse.swt.*;
 import org.eclipse.swt.internal.*;
-import org.eclipse.swt.widgets.*;
 import org.junit.jupiter.api.*;
 
 class GCWin32Tests extends Win32AutoscaleTestBase {
@@ -43,11 +42,7 @@ class GCWin32Tests extends Win32AutoscaleTestBase {
 		assertEquals("GCData must have a zoom level equal to the actual zoom level of the widget/shell", DPIUtil.getNativeDeviceZoom(), (int) gcNativeZoom.join());
 
 		int newSWTZoom = zoom * 2;
-		Event swtEvent = new Event();
-		swtEvent.type = SWT.ZoomChanged;
-		swtEvent.widget = shell;
-		swtEvent.detail = newSWTZoom;
-		shell.notifyListeners(SWT.ZoomChanged, swtEvent);
+		changeDPIZoom(newSWTZoom);
 		isScaled.set(true);
 		shell.setVisible(false);
 		shell.setVisible(true);

--- a/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/internal/Win32AutoscaleTestBase.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/internal/Win32AutoscaleTestBase.java
@@ -13,7 +13,6 @@
  *******************************************************************************/
 package org.eclipse.swt.internal;
 
-import org.eclipse.swt.*;
 import org.eclipse.swt.widgets.*;
 import org.junit.jupiter.api.*;
 
@@ -42,11 +41,7 @@ public abstract class Win32AutoscaleTestBase {
 	}
 
 	protected void changeDPIZoom (int nativeZoom) {
-		Event event = new Event();
-		event.type = SWT.ZoomChanged;
-		event.widget = shell;
-		event.detail = nativeZoom;
-		event.doit = true;
-		shell.notifyListeners(SWT.ZoomChanged, event);
+		float scalingFactor = 1f * DPIUtil.getZoomForAutoscaleProperty(nativeZoom) / DPIUtil.getZoomForAutoscaleProperty(shell.nativeZoom);
+		DPIZoomChangeRegistry.applyChange(shell, nativeZoom, scalingFactor);
 	}
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/DPIZoomChangeRegistry.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/DPIZoomChangeRegistry.java
@@ -16,6 +16,7 @@ package org.eclipse.swt.internal;
 import java.util.*;
 import java.util.Map.*;
 
+import org.eclipse.swt.*;
 import org.eclipse.swt.widgets.*;
 
 public class DPIZoomChangeRegistry {
@@ -54,6 +55,12 @@ public class DPIZoomChangeRegistry {
 				handler.handleDPIChange(widget, newZoom, scalingFactor);
 			}
 		}
+		Event event = new Event();
+		event.type = SWT.ZoomChanged;
+		event.widget = widget;
+		event.detail = newZoom;
+		event.doit = true;
+		widget.notifyListeners(SWT.ZoomChanged, event);
 	}
 
 	public static void registerHandler(DPIZoomChangeHandler zoomChangeVisitor, Class<? extends Widget> clazzToRegisterFor) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Shell.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Shell.java
@@ -311,11 +311,6 @@ Shell (Display display, Shell parent, int style, long handle, boolean embedded) 
 
 	reskinWidget();
 	createWidget ();
-
-
-	if (getDisplay().isRescalingAtRuntime()) {
-		addListener(SWT.ZoomChanged, this::handleZoomEvent);
-	}
 }
 
 /**
@@ -2645,12 +2640,6 @@ LRESULT WM_WINDOWPOSCHANGING (long wParam, long lParam) {
 		OS.MoveMemory (lParam, lpwp, WINDOWPOS.sizeof);
 	}
 	return result;
-}
-
-private void handleZoomEvent(Event event) {
-	int newNativeZoom = event.detail;
-	float scalingFactor = 1f * DPIUtil.getZoomForAutoscaleProperty(newNativeZoom) / getZoom();
-	DPIZoomChangeRegistry.applyChange(this, newNativeZoom, scalingFactor);
 }
 
 private static void handleDPIChange(Widget widget, int newZoom, float scalingFactor) {


### PR DESCRIPTION
This PR adapt how the DPI change is propagated into the DPI update mechanism. In comes down to the following:

## Automatic rescaling is not active
It is exactly as in the beginning -> A ZoomChanged event is send for the affected control, wenn the zoom is changed

## Automatic rescaling is active
The update is no longer propagation via a ZoomChanged event that was used by a listener in a Shell to propagate this change into the DPIZoomChangeRegistry, but it is directly propagated into DPIZoomChangeRegistry in the WM_DPICHANGED callback.
Additionally, for each widget, that is handled in DPIZoomChangeRegistry for a dpi change a ZoomChanged event is created and sent to the widget. That enables creators of custom widget to hook into the update and refresh the state of the affected widget, e.g. refresh a widget, when it is rendering its content without a layout manager. 

Contributes to #62 and #131