### PR TITLE
Replace DPIUtil.get(Native)DeviceZoom for win32

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/win32/org/eclipse/swt/dnd/TableDragSourceEffect.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/win32/org/eclipse/swt/dnd/TableDragSourceEffect.java
@@ -147,7 +147,7 @@ public class TableDragSourceEffect extends DragSourceEffect {
 					data.transparentPixel = shdi.crColorKey << 8;
 				}
 				Display display = control.getDisplay();
-				dragSourceImage = new Image(display, new AutoScaleImageDataProvider(display, data, DPIUtil.getDeviceZoom()));
+				dragSourceImage = new Image(display, new AutoScaleImageDataProvider(display, data, DPIUtil.getZoomForAutoscaleProperty(control.nativeZoom)));
 				OS.SelectObject (memHdc, oldMemBitmap);
 				OS.DeleteDC (memHdc);
 				OS.DeleteObject (memDib);

--- a/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/win32/org/eclipse/swt/dnd/TreeDragSourceEffect.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/win32/org/eclipse/swt/dnd/TreeDragSourceEffect.java
@@ -146,7 +146,7 @@ public class TreeDragSourceEffect extends DragSourceEffect {
 					data.transparentPixel = shdi.crColorKey << 8;
 				}
 				Display display = control.getDisplay ();
-				dragSourceImage = new Image (display, new AutoScaleImageDataProvider(display, data, DPIUtil.getDeviceZoom()));
+				dragSourceImage = new Image (display, new AutoScaleImageDataProvider(display, data, DPIUtil.getZoomForAutoscaleProperty(control.nativeZoom)));
 				OS.SelectObject (memHdc, oldMemBitmap);
 				OS.DeleteDC (memHdc);
 				OS.DeleteObject (memDib);

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Image.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Image.java
@@ -2229,7 +2229,7 @@ public long internal_new_GC (GCData data) {
 		data.device = device;
 		data.nativeZoom = initialNativeZoom;
 		data.image = this;
-		data.font = SWTFontProvider.getSystemFont(device, DPIUtil.getNativeDeviceZoom());
+		data.font = SWTFontProvider.getSystemFont(device, initialNativeZoom);
 	}
 	return imageDC;
 }


### PR DESCRIPTION
Now that we have the zoom level information avaialble for the element, we can use the right zoom information instead of DPIUtil.get(Native)DeviceZoom method calls since this information might not always be right.