### PR TITLE
Add early return to ToolBar::handleDPIChange in case it has no items

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ToolBar.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ToolBar.java
@@ -1754,6 +1754,10 @@ private static void handleDPIChange(Widget widget, int newZoom, float scalingFac
 	var seperatorWidth = new int[toolItems.length];
 	int itemCount = toolItems.length;
 
+	if (itemCount == 0) {
+		return;
+	}
+
 	record ToolItemData(ToolItem toolItem, TBBUTTON button) {
 	}
 


### PR DESCRIPTION
If the toolbar has no items then the method still executes and sends 2 unnecessary `OS` calls:
* `OS.SendMessage(toolBar.handle, OS.TB_BUTTONSTRUCTSIZE, TBBUTTON.sizeof, 0);`
* `OS.SendMessage(toolBar.handle, OS.TB_AUTOSIZE, 0, 0);`

## How to test
* Modify the `Snippet18` and remove all items in the toolbar
* Run the modified `Snippet18` with the vm arguments: `-Dswt.autoScale.updateOnRuntime=true`

### Expected results
* Same visual result as the code in `master`
* The OS calls should not happen.