### PR TITLE
Fix Edge Browser Deadlock issue for instantiation during a WebView Callback

### DIFF
--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_browser_Browser.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_browser_Browser.java
@@ -753,6 +753,18 @@ public void test_LocationListener_ProgressListener_cancledLoad () {
 	 */
 }
 
+@Test
+public void test_LocationListener_LocationListener_ordered_changing () {
+	List<String> locations = new ArrayList<>();
+	browser.addLocationListener(changingAdapter(event -> locations.add(event.location)));
+	shell.open();
+	browser.setText("You should not see this message.");
+	String url = getValidUrl();
+	browser.setUrl(url);
+	waitForPassCondition(() -> locations.size() == 2);
+	assertTrue("Change of locations do not fire in order.", browser.isLocationForCustomText(locations.get(0)) && locations.get(1).contains("testWebsiteWithTitle.html"));
+}
+
 
 @Test
 /** Ensue that only one changed and one completed event are fired for url changes */
@@ -1238,18 +1250,9 @@ private void validateTitleChanged(String expectedTitle, Runnable browserSetFunc)
 	browserSetFunc.run();
 	shell.open();
 
-	boolean passed = waitForPassCondition(() -> actualTitle.get().equals(expectedTitle));
-	String errMsg = "";
-	if (!passed) {
-		if (actualTitle.get().length() == 0) {
-			errMsg = "Test timed out. TitleListener not fired";
-		} else {
-			errMsg = "\nExpected title and actual title do not match."
-					+ "\nExpected: " + expectedTitle
-					+ "\nActual: " + actualTitle;
-		}
-	}
-	assertTrue(errMsg + testLog.toString(), passed);
+	waitForPassCondition(() -> actualTitle.get().equals(expectedTitle));
+	assertTrue("Test timed out. TitleListener not fired", actualTitle.get().length() != 0);
+	assertEquals(testLog.toString(), expectedTitle, actualTitle.get());
 }
 
 @Test


### PR DESCRIPTION
This contribution fixes Edge browser for win32 to handle the deadlock issue during the instantiation of a new edge browser object amidst a webview callback.

The problem with webview is that it can't execute tasks simultaneously and all the requests are serialized. Hence, a new request to the webview inside its callback leads to a deadlock since, both the tasks wait for each other to execute. The solution is to schedule the Webview calls during the callback asynchronously and let the control in the callback move on.

contributes to #669 

## Scope not covered
* This implementation doesn't fix the evaluate calls during the webview callback and would be addressed in a separate issue.

## Pre-requisites
- #1395 

## Testing
- Change the method `org.eclipse.swt.browser.BrowserFactory.createWebBrowser` to: 

```java
WebBrowser createWebBrowser (int style) {
	return new Edge ();
}
```