### PR TITLE
[win32] Fix TextLayout::getBounds vertical indent

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/graphics/TextLayoutWin32Tests.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/graphics/TextLayoutWin32Tests.java
@@ -13,7 +13,8 @@
  *******************************************************************************/
 package org.eclipse.swt.graphics;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 import org.eclipse.swt.internal.*;
 import org.junit.jupiter.api.*;
@@ -38,7 +39,26 @@ class TextLayoutWin32Tests extends Win32AutoscaleTestBase {
 		layout.draw(scaledGc, 10, 10);
 		Rectangle scaledBounds = layout.getBounds();
 
-		assertEquals("The public API for getBounds should give the same result for any zoom level", scaledBounds, unscaledBounds);
+		assertEquals(unscaledBounds, scaledBounds, "The public API for getBounds should give the same result for any zoom level");
+	}
+
+	@Test
+	public void testCalculateGetBoundsWithVerticalIndent() {
+		TextLayout layout = new TextLayout(display);
+		layout.setVerticalIndent(16);
+		layout.setText(text);
+		Rectangle unscaledBounds = layout.getBounds();
+
+		int scalingFactor = 2;
+		int newZoom = DPIUtil.getNativeDeviceZoom() * scalingFactor;
+		changeDPIZoom(newZoom);
+		TextLayout scaledLayout = new TextLayout(display);
+		scaledLayout.setVerticalIndent(16);
+		scaledLayout.setText(text);
+		Rectangle scaledBounds = scaledLayout.getBounds();
+
+		assertNotEquals(layout.nativeZoom, scaledLayout.nativeZoom, "The native zoom for the TextLayouts must differ");
+		assertEquals(unscaledBounds.height, scaledBounds.height, 1, "The public API for getBounds with vertical indent > 0 should give a similar result for any zoom level");
 	}
 
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/internal/Win32AutoscaleTestBase.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/internal/Win32AutoscaleTestBase.java
@@ -41,6 +41,7 @@ public abstract class Win32AutoscaleTestBase {
 	}
 
 	protected void changeDPIZoom (int nativeZoom) {
+		DPIUtil.setDeviceZoom(nativeZoom);
 		float scalingFactor = 1f * DPIUtil.getZoomForAutoscaleProperty(nativeZoom) / DPIUtil.getZoomForAutoscaleProperty(shell.nativeZoom);
 		DPIZoomChangeRegistry.applyChange(shell, nativeZoom, scalingFactor);
 	}

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/TextLayout.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/TextLayout.java
@@ -1792,7 +1792,7 @@ public Rectangle getBounds () {
 			width = Math.max(width, DPIUtil.scaleDown(lineWidthInPixels[line], getZoom()) + getLineIndent(line));
 		}
 	}
-	return new Rectangle (0, 0, width, lineY[lineY.length - 1] + getScaledVerticalIndent());
+	return new Rectangle (0, 0, width, lineY[lineY.length - 1] + getVerticalIndent());
 }
 
 /**


### PR DESCRIPTION
This commit fixes too high lines when vertical indent was set for one TextLayout. There was a usage of vertical indent in pixels where vertical indent in points should have been used.

With PR
![image](https://github.com/user-attachments/assets/21457850-b2e8-4ec7-9f91-58cdb94a1462)

Without PR
 ![image](https://github.com/user-attachments/assets/6438a00c-bf6c-4988-87c6-d575ecd1f5a2)
