### PR TITLE
Replacing the usage of getBoundsInPixels with getBounds

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/GC.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/GC.java
@@ -466,7 +466,7 @@ void copyAreaInPixels(Image image, int x, int y) {
 	if (image == null) SWT.error(SWT.ERROR_NULL_ARGUMENT);
 	if (image.type != SWT.BITMAP || image.isDisposed()) SWT.error(SWT.ERROR_INVALID_ARGUMENT);
 	/* Copy the bitmap area */
-	Rectangle rect = image.getBoundsInPixels();
+	Rectangle rect = image.getBounds(data.nativeZoom);
 	long memHdc = OS.CreateCompatibleDC(handle);
 	long hOldBitmap = OS.SelectObject(memHdc, Image.win32_getHandle(image, getZoom()));
 	OS.BitBlt(memHdc, 0, 0, rect.width, rect.height, handle, x, y, OS.SRCCOPY);

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Image.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Image.java
@@ -252,13 +252,13 @@ public Image(Device device, Image srcImage, int flag) {
 	device = this.device;
 	if (srcImage == null) SWT.error(SWT.ERROR_NULL_ARGUMENT);
 	if (srcImage.isDisposed()) SWT.error(SWT.ERROR_INVALID_ARGUMENT);
-	Rectangle rect = srcImage.getBoundsInPixels();
 	this.type = srcImage.type;
 	this.imageDataProvider = srcImage.imageDataProvider;
 	this.imageFileNameProvider = srcImage.imageFileNameProvider;
 	this.styleFlag = srcImage.styleFlag | flag;
 	initialNativeZoom = srcImage.initialNativeZoom;
 	this.dataAtBaseZoom = srcImage.dataAtBaseZoom;
+	Rectangle rect = srcImage.getBounds(initialNativeZoom);
 	switch (flag) {
 		case SWT.IMAGE_COPY: {
 			switch (type) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Table.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Table.java
@@ -7293,7 +7293,7 @@ LRESULT wmNotifyToolTip (NMTTCUSTOMDRAW nmcd, long lParam) {
 					if (pinfo.iSubItem != 0) x -= gridWidth;
 					Image image = item.getImage (pinfo.iSubItem);
 					if (image != null) {
-						Rectangle rect = image.getBoundsInPixels ();
+						Rectangle rect = image.getBoundsInPixels();
 						RECT imageRect = item.getBounds (pinfo.iItem, pinfo.iSubItem, false, true, false, false, hDC);
 						Point size = imageList == null ? new Point (rect.width, rect.height) : imageList.getImageSize ();
 						int y = imageRect.top + Math.max (0, (imageRect.bottom - imageRect.top - size.y) / 2);


### PR DESCRIPTION
Initial native image must be the one that will be used by a widget, thats why using getBounds with initialNativeZoom. This PR just remove the usage of deprecated method getBoundsInPixels wherever possible. This doesn't fix anything broken. 