### PR TITLE
Add snippets project to Tycho build #1390

### DIFF
--- a/examples/org.eclipse.swt.snippets/META-INF/MANIFEST.MF
+++ b/examples/org.eclipse.swt.snippets/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.swt.snippets
-Bundle-Version: 3.4.100
+Bundle-Version: 3.4.100.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.swt

--- a/examples/org.eclipse.swt.snippets/pom.xml
+++ b/examples/org.eclipse.swt.snippets/pom.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright (c) 2024 Eclipse Foundation and others.
+  All rights reserved. This program and the accompanying materials
+  are made available under the terms of the Eclipse Distribution License v1.0
+  which accompanies this distribution, and is available at
+  http://www.eclipse.org/org/documents/edl-v10.php
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <artifactId>eclipse.platform.swt.localbuild</artifactId>
+    <groupId>eclipse.platform.swt</groupId>
+    <version>4.33.0-SNAPSHOT</version>
+    <relativePath>../../local-build/local-build-parent</relativePath>
+  </parent>
+  <groupId>org.eclipse.swt</groupId>
+  <artifactId>org.eclipse.swt.snippets</artifactId>
+  <version>3.4.100-SNAPSHOT</version>
+  <packaging>eclipse-plugin</packaging>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>com.coderplus.maven.plugins</groupId>
+        <artifactId>copy-rename-maven-plugin</artifactId>
+        <version>1.0</version>
+        <executions>
+          <execution>
+            <id>copy-classpath-for-os</id>
+            <phase>generate-sources</phase>
+            <goals>
+              <goal>copy</goal>
+            </goals>
+            <configuration>
+              <sourceFile>.classpath_${tycho.env.osgi.ws}</sourceFile>
+              <destinationFile>.classpath</destinationFile>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -230,6 +230,7 @@
     <module>examples/org.eclipse.swt.examples.browser.demos</module>
     <module>examples/org.eclipse.swt.examples.launcher</module>
     <module>examples/org.eclipse.swt.examples.ole.win32</module>
+    <module>examples/org.eclipse.swt.snippets</module>
     <module>examples/org.eclipse.swt.examples.views</module>
     <module>tests/org.eclipse.swt.tests</module>
     <module>features/org.eclipse.swt.tools.feature</module>


### PR DESCRIPTION
The snippets project org.eclipse.swt.snippets is currently not part of the Tycho build. This change adds it to the build using a Maven plugin to copy the OS-specific classpath file according to the current environment.

⚠️ This is only for sharing the state of work, as this will require Tycho support for classpath exclusion to work properly:
- https://github.com/eclipse-tycho/tycho/issues/253

Contributes to https://github.com/eclipse-platform/eclipse.platform.swt/issues/1390