### PR TITLE
[win32] Prevent event on tree column resize

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Tree.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Tree.java
@@ -90,7 +90,7 @@ public class Tree extends Composite {
 	int sortDirection;
 	boolean dragStarted, gestureCompleted, insertAfter, shrink, ignoreShrink;
 	boolean ignoreSelect, ignoreExpand, ignoreDeselect, ignoreResize;
-	boolean lockSelection, oldSelected, newSelected, ignoreColumnMove;
+	boolean lockSelection, oldSelected, newSelected, ignoreColumnMove, ignoreColumnResize;
 	boolean linesVisible, customDraw, painted, ignoreItemHeight;
 	boolean ignoreCustomDraw, ignoreDrawForeground, ignoreDrawBackground, ignoreDrawFocus;
 	boolean ignoreDrawSelection, ignoreDrawHot, ignoreFullSelection, explorerTheme;
@@ -8090,22 +8090,24 @@ LRESULT wmNotifyHeader (NMHDR hdr, long wParam, long lParam) {
 						int flags = OS.RDW_UPDATENOW | OS.RDW_ALLCHILDREN;
 						OS.RedrawWindow (handle, null, 0, flags);
 					}
-					TreeColumn column = columns [phdn.iItem];
-					if (column != null) {
-						column.updateToolTip (phdn.iItem);
-						column.sendEvent (SWT.Resize);
-						if (isDisposed ()) return LRESULT.ZERO;
-						TreeColumn [] newColumns = new TreeColumn [columnCount];
-						System.arraycopy (columns, 0, newColumns, 0, columnCount);
-						int [] order = getColumnOrder();
-						boolean moved = false;
-						for (int i=0; i<columnCount; i++) {
-							TreeColumn nextColumn = newColumns [order [i]];
-							if (moved && !nextColumn.isDisposed ()) {
-								nextColumn.updateToolTip (order [i]);
-								nextColumn.sendEvent (SWT.Move);
+					if (!ignoreColumnResize) {
+						TreeColumn column = columns [phdn.iItem];
+						if (column != null) {
+							column.updateToolTip (phdn.iItem);
+							column.sendEvent (SWT.Resize);
+							if (isDisposed ()) return LRESULT.ZERO;
+							TreeColumn [] newColumns = new TreeColumn [columnCount];
+							System.arraycopy (columns, 0, newColumns, 0, columnCount);
+							int [] order = getColumnOrder();
+							boolean moved = false;
+							for (int i=0; i<columnCount; i++) {
+								TreeColumn nextColumn = newColumns [order [i]];
+								if (moved && !nextColumn.isDisposed ()) {
+									nextColumn.updateToolTip (order [i]);
+									nextColumn.sendEvent (SWT.Move);
+								}
+								if (nextColumn == column) moved = true;
 							}
-							if (nextColumn == column) moved = true;
 						}
 					}
 				}

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TreeColumn.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TreeColumn.java
@@ -764,10 +764,16 @@ private static void handleDPIChange(Widget widget, int newZoom, float scalingFac
 	if (!(widget instanceof TreeColumn treeColumn)) {
 		return;
 	}
-	treeColumn.setWidth(Math.round(treeColumn.getWidth() * scalingFactor));
+	Tree tree = treeColumn.getParent();
+	boolean ignoreColumnResize = tree.ignoreColumnResize;
+	tree.ignoreColumnResize = true;
+	final int newColumnWidth = Math.round(treeColumn.getWidthInPixels() * scalingFactor);
+	treeColumn.setWidthInPixels(newColumnWidth);
+	tree.ignoreColumnResize = ignoreColumnResize;
+
 	Image image = treeColumn.image;
 	if (image != null) {
-		treeColumn.setImage (image);
+		treeColumn.setImage(image);
 	}
 }
 }


### PR DESCRIPTION
This PR prevents the creation of a SWT.Resize event when tree columns are resized after a zoom change. Therefore, the ignoreColumnResize attribute is added to Tree to copy the behavior of Table in the same scenario. This attribute is used during the resizing because of the zoom change to disable the creation of the resize event.

This will prevent JFace TreeColumnLayouts to break when using ColumnWeighData to configure column sizes. They would be invalidated when a SWT.Resize occurs.

As the resizing of the column after a zoom change is not really a resizing but just an adjusting to the new environment, preventing a SWT.Resize event seems like the way to go.

You can test the different behaviour of the PR with Snippet027TreeLayout
