### PR TITLE
[win32] Prevent event on table column resize

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TableColumn.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TableColumn.java
@@ -891,8 +891,13 @@ private static void handleDPIChange(Widget widget, int newZoom, float scalingFac
 	if (!(widget instanceof TableColumn tableColumn)) {
 		return;
 	}
+	Table table = tableColumn.getParent();
+	boolean ignoreColumnResize = table.ignoreColumnResize;
+	table.ignoreColumnResize = true;
 	final int newColumnWidth = Math.round(tableColumn.getWidthInPixels() * scalingFactor);
 	tableColumn.setWidthInPixels(newColumnWidth);
+	table.ignoreColumnResize = ignoreColumnResize;
+
 	Image image = tableColumn.getImage();
 	if (image != null) {
 		tableColumn.setImage(image);


### PR DESCRIPTION
This PR prevents the creation of a SWT.Resize event when table columns are resized after a zoom change. Therefore, the ignoreColumnResize attribute is utilized during the resizing to disable the creation of the resize event.

This will prevent JFace TableColumnLayouts to break when using ColumnWeighData to configure column sizes. They would be invalidated when a SWT.Resize occurs.

As the resizing of the column after a zoom change is not really a resizing but just an adjusting to the new environment, preventing a SWT.Resize event seems like the way to go.

You can test the different behaviour of the PR with Snippet016TableLayout