### PR TITLE
Handle local resource references in Edge#setText()

### DIFF
--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_browser_Browser.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_browser_Browser.java
@@ -527,7 +527,6 @@ public void test_isLocationForCustomText_setUrlAfterDisposedThrowsSwtException()
 
 @Test
 public void test_isLocationForCustomText_isSetUrlNotCustomTextUrlAfterSetText() {
-	assumeFalse("behavior is not (yet) supported by Edge browser", isEdge);	// Edge doesn't fire a changed event if the URL is the same as the previous location.
 	String url = getValidUrl();
 	AtomicBoolean locationChanged = new AtomicBoolean(false);
 	browser.addLocationListener(changedAdapter(event -> {
@@ -544,7 +543,6 @@ public void test_isLocationForCustomText_isSetUrlNotCustomTextUrlAfterSetText() 
 
 @Test
 public void test_isLocationForCustomText_isFirstSetTextURLStillCustomTextUrlAfterSetUrl() {
-	assumeFalse("behavior is not (yet) supported by Edge browser", isEdge);	// Edge doesn't fire a changed event if the URL is the same as the previous location.
 	AtomicBoolean locationChanged = new AtomicBoolean(false);
 	browser.addLocationListener(changedAdapter(event -> locationChanged.set(true)));
 	String url = getValidUrl();
@@ -582,7 +580,6 @@ public void test_isLocationForCustomText_isSetUrlNotCustomTextUrl() {
 
 @Test
 public void test_isLocationForCustomText() {
-	assumeFalse("behavior is not (yet) supported by Edge browser", isEdge);	// Edge doesn't fire a changed event if the URL is the same as the previous location.
 	AtomicBoolean locationChanged = new AtomicBoolean(false);
 	browser.addLocationListener(changedAdapter(e -> locationChanged.set(true)));
 	browser.setText("Hello world");
@@ -601,7 +598,6 @@ public void test_LocationListener_changing() {
 }
 @Test
 public void test_LocationListener_changed() {
-	assumeFalse("behavior is not (yet) supported by Edge browser", isEdge);
 
 	AtomicBoolean changedFired = new AtomicBoolean(false);
 	browser.addLocationListener(changedAdapter(e ->	changedFired.set(true)));
@@ -612,8 +608,6 @@ public void test_LocationListener_changed() {
 }
 @Test
 public void test_LocationListener_changingAndOnlyThenChanged() {
-	assumeFalse("behavior is not (yet) supported by Edge browser", isEdge);
-
 	// Test proper order of events.
 	// Check that 'changed' is only fired after 'changing' has fired at least once.
 	AtomicBoolean changingFired = new AtomicBoolean(false);
@@ -657,8 +651,6 @@ public void test_LocationListener_changingAndOnlyThenChanged() {
 
 @Test
 public void test_LocationListener_then_ProgressListener() {
-	assumeFalse("behavior is not (yet) supported by Edge browser", isEdge);
-
 	AtomicBoolean locationChanged = new AtomicBoolean(false);
 	AtomicBoolean progressChanged = new AtomicBoolean(false);
 	AtomicBoolean progressChangedAfterLocationChanged = new AtomicBoolean(false);
@@ -752,8 +744,6 @@ public void test_LocationListener_ProgressListener_cancledLoad () {
 @Test
 /** Ensue that only one changed and one completed event are fired for url changes */
 public void test_LocationListener_ProgressListener_noExtraEvents() {
-	assumeFalse("behavior is not (yet) supported by Edge browser", isEdge);
-
 	AtomicInteger changedCount = new AtomicInteger(0);
 	AtomicInteger completedCount = new AtomicInteger(0);
 
@@ -860,7 +850,6 @@ public void test_OpenWindowListener_open_ChildPopup() {
 /** Validate event order : Child's visibility should come before progress completed event */
 @Test
 public void test_OpenWindow_Progress_Listener_ValidateEventOrder() {
-	assumeFalse("behavior is not (yet) supported by Edge browser", isEdge);
 
 	AtomicBoolean windowOpenFired = new AtomicBoolean(false);
 	AtomicBoolean childCompleted = new AtomicBoolean(false);
@@ -1105,7 +1094,6 @@ public void test_TitleListener_event() {
 	assertTrue(errMsg, passed);
 }
 
-
 @Test
 public void test_setText() {
 	String expectedTitle = "Website Title";
@@ -1199,16 +1187,16 @@ private void validateTitleChanged(String expectedTitle, Runnable browserSetFunc)
 	browserSetFunc.run();
 	shell.open();
 
-	boolean hasFinished = waitForPassCondition(() -> actualTitle.get().length() != 0
-			&& !actualTitle.get().contains("about:blank")); // Windows sometimes does 2 loads, one "about:blank", and one actual load.
-	boolean passed = hasFinished && actualTitle.get().equals(expectedTitle);
+	boolean passed = waitForPassCondition(() -> actualTitle.get().equals(expectedTitle));
 	String errMsg = "";
-	if (!hasFinished)
-		errMsg = "Test timed out. TitleListener not fired";
-	else if (!actualTitle.get().equals(expectedTitle)) {
-		errMsg = "\nExpected title and actual title do not match."
-				+ "\nExpected: " + expectedTitle
-				+ "\nActual: " + actualTitle;
+	if (!passed) {
+		if (actualTitle.get().length() == 0) {
+			errMsg = "Test timed out. TitleListener not fired";
+		} else {
+			errMsg = "\nExpected title and actual title do not match."
+					+ "\nExpected: " + expectedTitle
+					+ "\nActual: " + actualTitle;
+		}
 	}
 	assertTrue(errMsg + testLog.toString(), passed);
 }
@@ -1328,8 +1316,6 @@ public void test_VisibilityWindowListener_multiple_shells() {
  */
 @Test
 public void test_VisibilityWindowListener_eventSize() {
-	assumeFalse("behavior is not (yet) supported by Edge browser", isEdge);
-
 	shell.setSize(200,300);
 	AtomicBoolean childCompleted = new AtomicBoolean(false);
 	AtomicReference<Point> result = new AtomicReference<>(new Point(0,0));


### PR DESCRIPTION
This contribution fixes Edge browser for win32 to allow serving webpages using setText method where the source code may refer to local resources.

The problem with setText in the modern browser is that webView2 navigates to a page "about:blank" (which is not the part of the intranet) [[reference](https://learn.microsoft.com/en-us/dotnet/api/microsoft.web.webview2.winforms.webview2.navigatetostring?view=webview2-dotnet-1.0.2535.41#remarks)] and sets the html to the DOM. In case the html contains reference to local resource, the browsers throws error "can't load local resource" because of security reasons. This contribution fixes it by navigating edge to a temporary file created in the temporary folder of the OS and hence allowing it to load the local resources, and then sets the html to the DOM directly.

**Note: We only need the file to get a concrete local address instead of "about:local" for setText method. We don't perform any I/O to the file itself.**

To test the implementation, you need to set the default browser to Edge. To do it in the source code, change org.eclipse.swt.browser.BrowserFactory.createWebBrowser with the following source code: 
`return new Edge();`

**Scope not covered:** 
* This standalone implementation makes the javadoc tooltip open in an edge browser. (Would be covered in a follow up PR, part of eclipse.jdt.ui)
* The caching of intro page (Welcome page) is also not covered by this PR. (Would be covered in a follow up PR, part of eclipse.platform)

contributes to #213