### PR TITLE
Missing scrollbars in compare editor

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Widget.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Widget.java
@@ -2669,7 +2669,7 @@ int getSystemMetrics(int nIndex) {
 	 * DPI dependent metrics were introduced after 2016 version of windows 10
 	 */
 	if (OS.WIN32_BUILD >= OS.WIN32_BUILD_WIN10_1607) {
-		return OS.GetSystemMetricsForDpi(nIndex, DPIUtil.mapZoomToDPI(getZoom()));
+		return OS.GetSystemMetricsForDpi(nIndex, DPIUtil.mapZoomToDPI(nativeZoom));
 	}
 	return OS.GetSystemMetrics(nIndex);
 }


### PR DESCRIPTION
Scrollbars are missing on non default screen scaling [Blocker for 4.33 M3 build]. Regression occurred due to https://github.com/eclipse-platform/eclipse.platform.swt/pull/1209

Contributes to: https://github.com/eclipse-platform/eclipse.platform/issues/1489