### PR TITLE
Switch to temurin JVM

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -92,7 +92,7 @@ pipeline {
 		label 'centos-latest'
 	}
 	tools {
-		jdk 'openjdk-jdk17-latest'
+		jdk 'temurin-jdk17-latest'
 		maven 'apache-maven-latest'
 	}
 	environment {


### PR DESCRIPTION
Openjdk one is stuck at 17.0.2 while temurin one is updated to newer builds.