### PR TITLE
Remove getZoomForAutoscaleProperty calls for win32

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT AWT/win32/org/eclipse/swt/awt/SWT_AWT.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT AWT/win32/org/eclipse/swt/awt/SWT_AWT.java
@@ -250,7 +250,7 @@ public static Frame new_Frame (final Composite parent) {
 
 	parent.getDisplay().asyncExec(() -> {
 		if (parent.isDisposed()) return;
-		final Rectangle clientArea = DPIUtil.scaleUp(parent.getClientArea(), DPIUtil.getZoomForAutoscaleProperty(parent.nativeZoom)); // To Pixels
+		final Rectangle clientArea = DPIUtil.scaleUp(parent.getClientArea(), parent.nativeZoom); // To Pixels
 		EventQueue.invokeLater(() -> {
 			frame.setSize (clientArea.width, clientArea.height);
 			frame.validate ();

--- a/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CTabFolder.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CTabFolder.java
@@ -2519,6 +2519,7 @@ void updateButtons() {
 	if (showMax) {
 		if (minMaxTb == null) {
 			minMaxTb = new ToolBar(this, SWT.FLAT);
+			minMaxTb.setBackground(getDisplay().getSystemColor(SWT.COLOR_DARK_MAGENTA));
 			initAccessibleMinMaxTb();
 			addTabControl(minMaxTb, SWT.TRAIL, 0, false);
 		}
@@ -2542,6 +2543,7 @@ void updateButtons() {
 	if (showMin) {
 		if (minMaxTb == null) {
 			minMaxTb = new ToolBar(this, SWT.FLAT);
+			minMaxTb.setBackground(getDisplay().getSystemColor(SWT.COLOR_DARK_MAGENTA));
 			initAccessibleMinMaxTb();
 			addTabControl(minMaxTb, SWT.TRAIL, 0, false);
 		}

--- a/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/win32/org/eclipse/swt/dnd/DragSource.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/win32/org/eclipse/swt/dnd/DragSource.java
@@ -491,7 +491,7 @@ private void drag(Event dragEvent) {
 	hwndDrag = 0;
 	topControl = null;
 	if (image != null) {
-		int zoom = DPIUtil.getZoomForAutoscaleProperty(nativeZoom);
+		int zoom = nativeZoom;
 		imagelist = new ImageList(SWT.NONE, zoom);
 		imagelist.add(image);
 		topControl = control.getShell();

--- a/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/win32/org/eclipse/swt/dnd/DragSource.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/win32/org/eclipse/swt/dnd/DragSource.java
@@ -491,8 +491,7 @@ private void drag(Event dragEvent) {
 	hwndDrag = 0;
 	topControl = null;
 	if (image != null) {
-		int zoom = nativeZoom;
-		imagelist = new ImageList(SWT.NONE, zoom);
+		imagelist = new ImageList(SWT.NONE, nativeZoom);
 		imagelist.add(image);
 		topControl = control.getShell();
 		/*
@@ -520,7 +519,7 @@ private void drag(Event dragEvent) {
 				null);
 			OS.ShowWindow (hwndDrag, OS.SW_SHOW);
 		}
-		OS.ImageList_BeginDrag(imagelist.getHandle(zoom), 0, offsetX, event.offsetY);
+		OS.ImageList_BeginDrag(imagelist.getHandle(nativeZoom), 0, offsetX, event.offsetY);
 		/*
 		* Feature in Windows. When ImageList_DragEnter() is called,
 		* it takes a snapshot of the screen  If a drag is started
@@ -532,8 +531,8 @@ private void drag(Event dragEvent) {
 		int flags = OS.RDW_UPDATENOW | OS.RDW_ALLCHILDREN;
 		OS.RedrawWindow (topControl.handle, null, 0, flags);
 		POINT pt = new POINT ();
-		pt.x = DPIUtil.scaleUp(dragEvent.x, zoom);// To Pixels
-		pt.y = DPIUtil.scaleUp(dragEvent.y, zoom);// To Pixels
+		pt.x = DPIUtil.scaleUp(dragEvent.x, nativeZoom);// To Pixels
+		pt.y = DPIUtil.scaleUp(dragEvent.y, nativeZoom);// To Pixels
 		OS.MapWindowPoints (control.handle, 0, pt, 1);
 		RECT rect = new RECT ();
 		OS.GetWindowRect (hwndDrag, rect);

--- a/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/win32/org/eclipse/swt/dnd/DropTarget.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/win32/org/eclipse/swt/dnd/DropTarget.java
@@ -281,9 +281,8 @@ int DragEnter_64(long pDataObject, int grfKeyState, long pt, long pdwEffect) {
 }
 
 int DragEnter(long pDataObject, int grfKeyState, int pt_x, int pt_y, long pdwEffect) {
-	int zoom = nativeZoom;
-	pt_x = DPIUtil.scaleDown(pt_x, zoom);// To Points
-	pt_y = DPIUtil.scaleDown(pt_y, zoom);// To Points
+	pt_x = DPIUtil.scaleDown(pt_x, nativeZoom);// To Points
+	pt_y = DPIUtil.scaleDown(pt_y, nativeZoom);// To Points
 	selectedDataType = null;
 	selectedOperation = DND.DROP_NONE;
 	if (iDataObject != null) iDataObject.Release();
@@ -349,9 +348,8 @@ int DragOver_64(int grfKeyState, long pt, long pdwEffect) {
 }
 
 int DragOver(int grfKeyState, int pt_x, int pt_y, long pdwEffect) {
-	int zoom = nativeZoom;
-	pt_x = DPIUtil.scaleDown(pt_x, zoom);// To Points
-	pt_y = DPIUtil.scaleDown(pt_y, zoom);// To Points
+	pt_x = DPIUtil.scaleDown(pt_x, nativeZoom);// To Points
+	pt_y = DPIUtil.scaleDown(pt_y, nativeZoom);// To Points
 	if (iDataObject == null) return COM.S_FALSE;
 	int oldKeyOperation = keyOperation;
 
@@ -405,9 +403,8 @@ int Drop_64(long pDataObject, int grfKeyState, long pt, long pdwEffect) {
 
 int Drop(long pDataObject, int grfKeyState, int pt_x, int pt_y, long pdwEffect) {
 	try {
-		int zoom = nativeZoom;
-		pt_x = DPIUtil.scaleDown(pt_x, zoom);// To Points
-		pt_y = DPIUtil.scaleDown(pt_y, zoom);// To Points
+		pt_x = DPIUtil.scaleDown(pt_x, nativeZoom);// To Points
+		pt_y = DPIUtil.scaleDown(pt_y, nativeZoom);// To Points
 		DNDEvent event = new DNDEvent();
 		event.widget = this;
 		event.time = OS.GetMessageTime();

--- a/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/win32/org/eclipse/swt/dnd/DropTarget.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/win32/org/eclipse/swt/dnd/DropTarget.java
@@ -281,7 +281,7 @@ int DragEnter_64(long pDataObject, int grfKeyState, long pt, long pdwEffect) {
 }
 
 int DragEnter(long pDataObject, int grfKeyState, int pt_x, int pt_y, long pdwEffect) {
-	int zoom = DPIUtil.getZoomForAutoscaleProperty(nativeZoom);
+	int zoom = nativeZoom;
 	pt_x = DPIUtil.scaleDown(pt_x, zoom);// To Points
 	pt_y = DPIUtil.scaleDown(pt_y, zoom);// To Points
 	selectedDataType = null;
@@ -349,7 +349,7 @@ int DragOver_64(int grfKeyState, long pt, long pdwEffect) {
 }
 
 int DragOver(int grfKeyState, int pt_x, int pt_y, long pdwEffect) {
-	int zoom = DPIUtil.getZoomForAutoscaleProperty(nativeZoom);
+	int zoom = nativeZoom;
 	pt_x = DPIUtil.scaleDown(pt_x, zoom);// To Points
 	pt_y = DPIUtil.scaleDown(pt_y, zoom);// To Points
 	if (iDataObject == null) return COM.S_FALSE;
@@ -405,7 +405,7 @@ int Drop_64(long pDataObject, int grfKeyState, long pt, long pdwEffect) {
 
 int Drop(long pDataObject, int grfKeyState, int pt_x, int pt_y, long pdwEffect) {
 	try {
-		int zoom = DPIUtil.getZoomForAutoscaleProperty(nativeZoom);
+		int zoom = nativeZoom;
 		pt_x = DPIUtil.scaleDown(pt_x, zoom);// To Points
 		pt_y = DPIUtil.scaleDown(pt_y, zoom);// To Points
 		DNDEvent event = new DNDEvent();

--- a/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/win32/org/eclipse/swt/dnd/TableDragSourceEffect.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/win32/org/eclipse/swt/dnd/TableDragSourceEffect.java
@@ -15,7 +15,6 @@ package org.eclipse.swt.dnd;
 
 import org.eclipse.swt.*;
 import org.eclipse.swt.graphics.*;
-import org.eclipse.swt.internal.*;
 import org.eclipse.swt.internal.DPIUtil.*;
 import org.eclipse.swt.internal.win32.*;
 import org.eclipse.swt.widgets.*;
@@ -147,7 +146,7 @@ public class TableDragSourceEffect extends DragSourceEffect {
 					data.transparentPixel = shdi.crColorKey << 8;
 				}
 				Display display = control.getDisplay();
-				dragSourceImage = new Image(display, new AutoScaleImageDataProvider(display, data, DPIUtil.getZoomForAutoscaleProperty(control.nativeZoom)));
+				dragSourceImage = new Image(display, new AutoScaleImageDataProvider(display, data, control.nativeZoom));
 				OS.SelectObject (memHdc, oldMemBitmap);
 				OS.DeleteDC (memHdc);
 				OS.DeleteObject (memDib);

--- a/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/win32/org/eclipse/swt/dnd/TableDropTargetEffect.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/win32/org/eclipse/swt/dnd/TableDropTargetEffect.java
@@ -151,7 +151,7 @@ public class TableDropTargetEffect extends DropTargetEffect {
 		int effect = checkEffect(event.feedback);
 		long handle = table.handle;
 		Point coordinates = new Point(event.x, event.y);
-		coordinates = DPIUtil.scaleUp(table.toControl(coordinates), DPIUtil.getZoomForAutoscaleProperty(table.nativeZoom)); // To Pixels
+		coordinates = DPIUtil.scaleUp(table.toControl(coordinates), table.nativeZoom); // To Pixels
 		LVHITTESTINFO pinfo = new LVHITTESTINFO();
 		pinfo.x = coordinates.x;
 		pinfo.y = coordinates.y;

--- a/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/win32/org/eclipse/swt/dnd/TreeDragSourceEffect.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/win32/org/eclipse/swt/dnd/TreeDragSourceEffect.java
@@ -15,7 +15,6 @@ package org.eclipse.swt.dnd;
 
 import org.eclipse.swt.*;
 import org.eclipse.swt.graphics.*;
-import org.eclipse.swt.internal.*;
 import org.eclipse.swt.internal.DPIUtil.*;
 import org.eclipse.swt.internal.win32.*;
 import org.eclipse.swt.widgets.*;
@@ -146,7 +145,7 @@ public class TreeDragSourceEffect extends DragSourceEffect {
 					data.transparentPixel = shdi.crColorKey << 8;
 				}
 				Display display = control.getDisplay ();
-				dragSourceImage = new Image (display, new AutoScaleImageDataProvider(display, data, DPIUtil.getZoomForAutoscaleProperty(control.nativeZoom)));
+				dragSourceImage = new Image (display, new AutoScaleImageDataProvider(display, data, control.nativeZoom));
 				OS.SelectObject (memHdc, oldMemBitmap);
 				OS.DeleteDC (memHdc);
 				OS.DeleteObject (memDib);

--- a/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/win32/org/eclipse/swt/dnd/TreeDropTargetEffect.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/win32/org/eclipse/swt/dnd/TreeDropTargetEffect.java
@@ -165,7 +165,7 @@ public class TreeDropTargetEffect extends DropTargetEffect {
 		int effect = checkEffect(event.feedback);
 		long handle = tree.handle;
 		Point coordinates = new Point(event.x, event.y);
-		coordinates = DPIUtil.scaleUp(tree.toControl(coordinates), DPIUtil.getZoomForAutoscaleProperty(tree.nativeZoom)); // To Pixels
+		coordinates = DPIUtil.scaleUp(tree.toControl(coordinates), tree.nativeZoom); // To Pixels
 		TVHITTESTINFO lpht = new TVHITTESTINFO ();
 		lpht.x = coordinates.x;
 		lpht.y = coordinates.y;

--- a/bundles/org.eclipse.swt/Eclipse SWT OLE Win32/win32/org/eclipse/swt/ole/win32/OleClientSite.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT OLE Win32/win32/org/eclipse/swt/ole/win32/OleClientSite.java
@@ -810,7 +810,7 @@ protected int GetWindow(long phwnd) {
 	return COM.S_OK;
 }
 RECT getRect() {
-	Rectangle area = DPIUtil.scaleUp(getClientArea(), DPIUtil.getZoomForAutoscaleProperty(nativeZoom)); // To Pixels
+	Rectangle area = DPIUtil.scaleUp(getClientArea(), nativeZoom); // To Pixels
 	RECT rect = new RECT();
 	rect.left   = area.x;
 	rect.top    = area.y;
@@ -987,14 +987,14 @@ private int OnInPlaceDeactivate() {
 	return COM.S_OK;
 }
 private int OnPosRectChange(long lprcPosRect) {
-	Point size = DPIUtil.scaleUp(getSize(), DPIUtil.getZoomForAutoscaleProperty(nativeZoom)); // To Pixels
+	Point size = DPIUtil.scaleUp(getSize(), nativeZoom); // To Pixels
 	setExtent(size.x, size.y);
 	return COM.S_OK;
 }
 private void onPaint(Event e) {
 	if (state == STATE_RUNNING || state == STATE_INPLACEACTIVE) {
 		SIZE size = getExtent();
-		Rectangle area = DPIUtil.scaleUp(getClientArea(), DPIUtil.getZoomForAutoscaleProperty(nativeZoom)); // To Pixels
+		Rectangle area = DPIUtil.scaleUp(getClientArea(), nativeZoom); // To Pixels
 		RECT rect = new RECT();
 		if (getProgramID().startsWith("Excel.Sheet")) { //$NON-NLS-1$
 			rect.left = area.x; rect.right = area.x + (area.height * size.cx / size.cy);
@@ -1369,7 +1369,7 @@ void setBorderSpace(RECT newBorderwidth) {
 	setBounds();
 }
 void setBounds() {
-	int zoom = DPIUtil.getZoomForAutoscaleProperty(nativeZoom);
+	int zoom = nativeZoom;
 	Rectangle area = DPIUtil.scaleDown(frame.getClientArea(), zoom); // To Pixels
 	setBounds(DPIUtil.scaleDown(borderWidths.left, zoom),
 			  DPIUtil.scaleDown(borderWidths.top, zoom),

--- a/bundles/org.eclipse.swt/Eclipse SWT OLE Win32/win32/org/eclipse/swt/ole/win32/OleClientSite.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT OLE Win32/win32/org/eclipse/swt/ole/win32/OleClientSite.java
@@ -1369,12 +1369,11 @@ void setBorderSpace(RECT newBorderwidth) {
 	setBounds();
 }
 void setBounds() {
-	int zoom = nativeZoom;
-	Rectangle area = DPIUtil.scaleDown(frame.getClientArea(), zoom); // To Pixels
-	setBounds(DPIUtil.scaleDown(borderWidths.left, zoom),
-			  DPIUtil.scaleDown(borderWidths.top, zoom),
-			  DPIUtil.scaleDown(area.width - borderWidths.left - borderWidths.right, zoom),
-			  DPIUtil.scaleDown(area.height - borderWidths.top - borderWidths.bottom, zoom));
+	Rectangle area = DPIUtil.scaleDown(frame.getClientArea(), nativeZoom); // To Pixels
+	setBounds(DPIUtil.scaleDown(borderWidths.left, nativeZoom),
+			  DPIUtil.scaleDown(borderWidths.top, nativeZoom),
+			  DPIUtil.scaleDown(area.width - borderWidths.left - borderWidths.right, nativeZoom),
+			  DPIUtil.scaleDown(area.height - borderWidths.top - borderWidths.bottom, nativeZoom));
 	setObjectRects();
 }
 private void setExtent(int width, int height){

--- a/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/internal/Win32AutoscaleTestBase.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/internal/Win32AutoscaleTestBase.java
@@ -42,7 +42,7 @@ public abstract class Win32AutoscaleTestBase {
 
 	protected void changeDPIZoom (int nativeZoom) {
 		DPIUtil.setDeviceZoom(nativeZoom);
-		float scalingFactor = 1f * DPIUtil.getZoomForAutoscaleProperty(nativeZoom) / DPIUtil.getZoomForAutoscaleProperty(shell.nativeZoom);
+		float scalingFactor = 1f * nativeZoom / shell.nativeZoom;
 		DPIZoomChangeRegistry.applyChange(shell, nativeZoom, scalingFactor);
 	}
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/DPIUtil.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/DPIUtil.java
@@ -604,7 +604,7 @@ public static int getDeviceZoom() {
 
 public static void setDeviceZoom (int nativeDeviceZoom) {
 	DPIUtil.nativeDeviceZoom = nativeDeviceZoom;
-	int deviceZoom = getZoomForAutoscaleProperty (nativeDeviceZoom);
+	int deviceZoom = nativeDeviceZoom;
 
 	DPIUtil.deviceZoom = deviceZoom;
 	System.setProperty("org.eclipse.swt.internal.deviceZoom", Integer.toString(deviceZoom));

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/FontMetrics.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/FontMetrics.java
@@ -175,7 +175,7 @@ public int getLeading() {
 }
 
 private int getZoom() {
-	return DPIUtil.getZoomForAutoscaleProperty(nativeZoom);
+	return nativeZoom;
 }
 
 /**

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/GC.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/GC.java
@@ -3932,7 +3932,7 @@ void init(Drawable drawable, GCData data, long hDC) {
 	}
 	Image image = data.image;
 	if (image != null) {
-		data.hNullBitmap = OS.SelectObject(hDC, Image.win32_getHandle(image, DPIUtil.getZoomForAutoscaleProperty(data.nativeZoom)));
+		data.hNullBitmap = OS.SelectObject(hDC, Image.win32_getHandle(image, data.nativeZoom));
 		image.memGC = this;
 	}
 	int layout = data.layout;
@@ -5160,7 +5160,7 @@ private static int sin(int angle, int length) {
 }
 
 private int getZoom() {
-	return DPIUtil.getZoomForAutoscaleProperty(data.nativeZoom);
+	return data.nativeZoom;
 }
 
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/GC.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/GC.java
@@ -976,9 +976,12 @@ public void drawImage (Image image, int srcX, int srcY, int srcWidth, int srcHei
 	if (image == null) SWT.error (SWT.ERROR_NULL_ARGUMENT);
 	if (image.isDisposed()) SWT.error(SWT.ERROR_INVALID_ARGUMENT);
 
-	int deviceZoom = getZoom();
+	int deviceZoom = image.useDeviceZoom ? DPIUtil.getZoomForAutoscaleProperty(getZoom()) : getZoom();
 	Rectangle src = DPIUtil.scaleUp(drawable, new Rectangle(srcX, srcY, srcWidth, srcHeight), deviceZoom);
-	Rectangle dest = DPIUtil.scaleUp(drawable, new Rectangle(destX, destY, destWidth, destHeight), deviceZoom);
+	destX = DPIUtil.scaleUp(destX, getZoom());
+	destY = DPIUtil.scaleUp(destY, getZoom());
+	destWidth = DPIUtil.scaleUp(destWidth, deviceZoom);
+	destHeight = DPIUtil.scaleUp(destHeight, deviceZoom);
 	if (deviceZoom != 100) {
 		/*
 		 * This is a HACK! Due to rounding errors at fractional scale factors,
@@ -996,13 +999,13 @@ public void drawImage (Image image, int srcX, int srcY, int srcWidth, int srcHei
 			}
 		}
 	}
-	drawImage(image, src.x, src.y, src.width, src.height, dest.x, dest.y, dest.width, dest.height, false);
+	drawImage(image, src.x, src.y, src.width, src.height, destX, destY, destWidth, destHeight, false);
 }
 
 void drawImage(Image srcImage, int srcX, int srcY, int srcWidth, int srcHeight, int destX, int destY, int destWidth, int destHeight, boolean simple) {
 	if (data.gdipGraphics != 0) {
 		//TODO - cache bitmap
-		long [] gdipImage = srcImage.createGdipImage(getZoom());
+		long [] gdipImage = srcImage.createGdipImage(DPIUtil.getZoomForAutoscaleProperty(getZoom()));
 		long img = gdipImage[0];
 		int imgWidth = Gdip.Image_GetWidth(img);
 		int imgHeight = Gdip.Image_GetHeight(img);

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Image.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Image.java
@@ -2333,7 +2333,7 @@ public void setBackground(Color color) {
 }
 
 private int getZoom() {
-	return DPIUtil.getZoomForAutoscaleProperty(initialNativeZoom);
+	return initialNativeZoom;
 }
 /**
  * Returns a string containing a concise, human-readable

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/TextLayout.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/TextLayout.java
@@ -379,10 +379,10 @@ void computeRuns (GC gc) {
 	}
 	SCRIPT_LOGATTR logAttr = new SCRIPT_LOGATTR();
 	SCRIPT_PROPERTIES properties = new SCRIPT_PROPERTIES();
-	int wrapIndentInPixels = DPIUtil.scaleUp(wrapIndent, getZoom(gc));
-	int indentInPixels = DPIUtil.scaleUp(indent, getZoom(gc));
-	int wrapWidthInPixels = DPIUtil.scaleUp(wrapWidth, getZoom(gc));
-	int[] tabsInPixels = DPIUtil.scaleUp(tabs, getZoom(gc));
+	int wrapIndentInPixels = DPIUtil.scaleUp(wrapIndent, getNativeZoom(gc));
+	int indentInPixels = DPIUtil.scaleUp(indent, getNativeZoom(gc));
+	int wrapWidthInPixels = DPIUtil.scaleUp(wrapWidth, getNativeZoom(gc));
+	int[] tabsInPixels = DPIUtil.scaleUp(tabs, getNativeZoom(gc));
 	int lineWidth = indentInPixels, lineStart = 0, lineCount = 1;
 	for (int i=0; i<allRuns.length - 1; i++) {
 		StyleItem run = allRuns[i];
@@ -549,8 +549,8 @@ void computeRuns (GC gc) {
 				TEXTMETRIC lptm = new TEXTMETRIC();
 				OS.SelectObject(srcHdc, getItemFont(run, gc));
 				metricsAdapter.GetTextMetrics(srcHdc, lptm);
-				run.ascentInPoints = DPIUtil.scaleDown(getDevice(), lptm.tmAscent, getZoom(gc));
-				run.descentInPoints = DPIUtil.scaleDown(getDevice(), lptm.tmDescent, getZoom(gc));
+				run.ascentInPoints = DPIUtil.scaleDown(getDevice(), lptm.tmAscent, getNativeZoom(gc));
+				run.descentInPoints = DPIUtil.scaleDown(getDevice(), lptm.tmDescent, getNativeZoom(gc));
 				ascentInPoints = Math.max(ascentInPoints, run.ascentInPoints);
 				descentInPoints = Math.max(descentInPoints, run.descentInPoints);
 			}
@@ -705,7 +705,7 @@ long createGdipBrush(Color color, int alpha) {
  */
 public void draw (GC gc, int x, int y) {
 	checkLayout();
-	drawInPixels(gc, DPIUtil.scaleUp(getDevice(), x, getZoom(gc)), DPIUtil.scaleUp(getDevice(), y, getZoom(gc)));
+	drawInPixels(gc, DPIUtil.scaleUp(getDevice(), x, getNativeZoom(gc)), DPIUtil.scaleUp(getDevice(), y, getNativeZoom(gc)));
 }
 
 /**
@@ -729,7 +729,7 @@ public void draw (GC gc, int x, int y) {
  */
 public void draw (GC gc, int x, int y, int selectionStart, int selectionEnd, Color selectionForeground, Color selectionBackground) {
 	checkLayout();
-	drawInPixels(gc, DPIUtil.scaleUp(getDevice(), x, getZoom(gc)), DPIUtil.scaleUp(getDevice(), y, getZoom(gc)), selectionStart, selectionEnd, selectionForeground, selectionBackground);
+	drawInPixels(gc, DPIUtil.scaleUp(getDevice(), x, getNativeZoom(gc)), DPIUtil.scaleUp(getDevice(), y, getNativeZoom(gc)), selectionStart, selectionEnd, selectionForeground, selectionBackground);
 }
 
 void drawInPixels (GC gc, int x, int y, int selectionStart, int selectionEnd, Color selectionForeground, Color selectionBackground) {
@@ -765,21 +765,13 @@ void drawInPixels (GC gc, int x, int y, int selectionStart, int selectionEnd, Co
  */
 public void draw (GC gc, int x, int y, int selectionStart, int selectionEnd, Color selectionForeground, Color selectionBackground, int flags) {
 	checkLayout();
-	drawInPixels(gc, DPIUtil.scaleUp(getDevice(), x, getZoom(gc)), DPIUtil.scaleUp(getDevice(), y, getZoom(gc)), selectionStart, selectionEnd, selectionForeground, selectionBackground, flags);
+	drawInPixels(gc, DPIUtil.scaleUp(getDevice(), x, getNativeZoom(gc)), DPIUtil.scaleUp(getDevice(), y, getNativeZoom(gc)), selectionStart, selectionEnd, selectionForeground, selectionBackground, flags);
 }
 
 private int getNativeZoom(GC gc) {
 	if (gc != null) {
 		return gc.data.nativeZoom;
 	}
-	return nativeZoom;
-}
-
-private int getZoom(GC gc){
-	return getNativeZoom(gc);
-}
-
-private int getZoom() {
 	return nativeZoom;
 }
 
@@ -839,9 +831,9 @@ void drawInPixels (GC gc, int x, int y, int selectionStart, int selectionEnd, Co
 	OS.SetBkMode(hdc, OS.TRANSPARENT);
 	for (int line=0; line<runs.length; line++) {
 		int drawX = x + getLineIndentInPixel(line);
-		int drawY = y + DPIUtil.scaleUp(getDevice(), lineY[line], getZoom(gc));
+		int drawY = y + DPIUtil.scaleUp(getDevice(), lineY[line], getNativeZoom(gc));
 		StyleItem[] lineRuns = runs[line];
-		int lineHeight = DPIUtil.scaleUp(getDevice(), lineY[line+1] - lineY[line] - lineSpacingInPoints, getZoom(gc));
+		int lineHeight = DPIUtil.scaleUp(getDevice(), lineY[line+1] - lineY[line] - lineSpacingInPoints, getNativeZoom(gc));
 
 		//Draw last line selection
 		if ((flags & (SWT.FULL_SELECTION | SWT.DELIMITER_SELECTION)) != 0 && (hasSelection || (flags & SWT.LAST_LINE_SELECTION) != 0)) {
@@ -896,10 +888,10 @@ void drawInPixels (GC gc, int x, int y, int selectionStart, int selectionEnd, Co
 		}
 
 		//Draw the text, underline, strikeout, and border of the runs in the line
-		int baselineInPixels = Math.max(0, DPIUtil.scaleUp(getDevice(), ascent, getZoom(gc)));
+		int baselineInPixels = Math.max(0, DPIUtil.scaleUp(getDevice(), ascent, getNativeZoom(gc)));
 		int lineUnderlinePos = 0;
 		for (StyleItem run : lineRuns) {
-			baselineInPixels = Math.max(baselineInPixels, DPIUtil.scaleUp(getDevice(), run.ascentInPoints, getZoom(gc)));
+			baselineInPixels = Math.max(baselineInPixels, DPIUtil.scaleUp(getDevice(), run.ascentInPoints, getNativeZoom(gc)));
 			lineUnderlinePos = Math.min(lineUnderlinePos, run.underlinePos);
 		}
 		RECT borderClip = null, underlineClip = null, strikeoutClip = null, pRect = null;
@@ -1179,7 +1171,7 @@ RECT drawRunText(GC gc, long hdc, StyleItem run, RECT rect, int baselineInPixels
 	boolean partialSelection = hasSelection && !fullSelection && !(selectionStart > end || run.start > selectionEnd);
 	int offset = (orientation & SWT.RIGHT_TO_LEFT) != 0 ? -1 : 0;
 	int x = rect.left + offset;
-	int y = rect.top + (baselineInPixels - DPIUtil.scaleUp(getDevice(), run.ascentInPoints, getZoom(gc)));
+	int y = rect.top + (baselineInPixels - DPIUtil.scaleUp(getDevice(), run.ascentInPoints, getNativeZoom(gc)));
 	long hFont = getItemFont(run, gc);
 	OS.SelectObject(hdc, hFont);
 	if (fullSelection) {
@@ -1210,7 +1202,7 @@ RECT drawRunTextGDIP(GC gc, long graphics, StyleItem run, RECT rect, long gdipFo
 	// rendering (such as ScriptTextOut()) which put top of the character
 	// at requested position.
 	int drawY = rect.top + baselineInPixels;
-	if (run.style != null && run.style.rise != 0) drawY -= DPIUtil.scaleUp(getDevice(), run.style.rise, getZoom(gc));
+	if (run.style != null && run.style.rise != 0) drawY -= DPIUtil.scaleUp(getDevice(), run.style.rise, getNativeZoom(gc));
 
 	int drawX = rect.left;
 	long brush = color;
@@ -1362,7 +1354,7 @@ RECT drawStrikeout(GC gc, long hdc, int x, int baselineInPixels, StyleItem[] lin
 			}
 		}
 		RECT rect = new RECT();
-		int riseInPixels = DPIUtil.scaleUp(getDevice(), style.rise, getZoom(gc));
+		int riseInPixels = DPIUtil.scaleUp(getDevice(), style.rise, getNativeZoom(gc));
 		OS.SetRect(rect, x + left, baselineInPixels - run.strikeoutPos - riseInPixels, x + run.x + run.width, baselineInPixels - run.strikeoutPos + run.strikeoutThickness - riseInPixels);
 		long brush = OS.CreateSolidBrush(color);
 		OS.FillRect(hdc, rect, brush);
@@ -1412,7 +1404,7 @@ RECT drawStrikeoutGDIP(GC gc, long graphics, int x, int baselineInPixels, StyleI
 				}
 			}
 		}
-		int riseInPixels = DPIUtil.scaleUp(getDevice(), style.rise, getZoom(gc));
+		int riseInPixels = DPIUtil.scaleUp(getDevice(), style.rise, getNativeZoom(gc));
 		if (clipRect != null) {
 			int gstate = Gdip.Graphics_Save(graphics);
 			if (clipRect.left == -1) clipRect.left = 0;
@@ -1470,7 +1462,7 @@ RECT drawUnderline(GC gc, long hdc, int x, int baselineInPixels, int lineUnderli
 			}
 		}
 		RECT rect = new RECT();
-		int riseInPixels = DPIUtil.scaleUp(getDevice(), style.rise, getZoom(gc));
+		int riseInPixels = DPIUtil.scaleUp(getDevice(), style.rise, getNativeZoom(gc));
 		OS.SetRect(rect, x + left, baselineInPixels - lineUnderlinePos - riseInPixels, x + run.x + run.width, baselineInPixels - lineUnderlinePos + run.underlineThickness - riseInPixels);
 		if (clipRect != null) {
 			if (clipRect.left == -1) clipRect.left = 0;
@@ -1546,7 +1538,7 @@ RECT drawUnderline(GC gc, long hdc, int x, int baselineInPixels, int lineUnderli
 				int penStyle = style.underlineStyle == UNDERLINE_IME_DASH ? OS.PS_DASH : OS.PS_DOT;
 				long pen = OS.CreatePen(penStyle, 1, color);
 				long oldPen = OS.SelectObject(hdc, pen);
-				int descentInPixels = DPIUtil.scaleUp(getDevice(), run.descentInPoints, getZoom(gc));
+				int descentInPixels = DPIUtil.scaleUp(getDevice(), run.descentInPoints, getNativeZoom(gc));
 				OS.SetRect(rect, rect.left, baselineInPixels + descentInPixels, rect.right, baselineInPixels + descentInPixels + run.underlineThickness);
 				OS.MoveToEx(hdc, rect.left, rect.top, 0);
 				OS.LineTo(hdc, rect.right, rect.top);
@@ -1602,7 +1594,7 @@ RECT drawUnderlineGDIP (GC gc, long graphics, int x, int baselineInPixels, int l
 			}
 		}
 		RECT rect = new RECT();
-		int riseInPixels = DPIUtil.scaleUp(getDevice(), style.rise, getZoom(gc));
+		int riseInPixels = DPIUtil.scaleUp(getDevice(), style.rise, getNativeZoom(gc));
 		OS.SetRect(rect, x + left, baselineInPixels - lineUnderlinePos - riseInPixels, x + run.x + run.width, baselineInPixels - lineUnderlinePos + run.underlineThickness - riseInPixels);
 		Rect gdipRect = null;
 		if (clipRect != null) {
@@ -1698,7 +1690,7 @@ RECT drawUnderlineGDIP (GC gc, long graphics, int x, int baselineInPixels, int l
 					gstate = Gdip.Graphics_Save(graphics);
 					Gdip.Graphics_SetClip(graphics, gdipRect, Gdip.CombineModeExclude);
 				}
-				int descentInPixels = DPIUtil.scaleUp(getDevice(), run.descentInPoints, getZoom(gc));
+				int descentInPixels = DPIUtil.scaleUp(getDevice(), run.descentInPoints, getNativeZoom(gc));
 				Gdip.Graphics_DrawLine(graphics, pen, rect.left, baselineInPixels + descentInPixels, run.width - run.length, baselineInPixels + descentInPixels);
 				if (gdipRect != null) {
 					Gdip.Graphics_Restore(graphics, gstate);
@@ -1789,7 +1781,7 @@ public Rectangle getBounds () {
 		width = wrapWidth;
 	} else {
 		for (int line=0; line<runs.length; line++) {
-			width = Math.max(width, DPIUtil.scaleDown(lineWidthInPixels[line], getZoom()) + getLineIndent(line));
+			width = Math.max(width, DPIUtil.scaleDown(lineWidthInPixels[line], getNativeZoom(null)) + getLineIndent(line));
 		}
 	}
 	return new Rectangle (0, 0, width, lineY[lineY.length - 1] + getVerticalIndent());
@@ -1811,7 +1803,7 @@ public Rectangle getBounds () {
  */
 public Rectangle getBounds (int start, int end) {
 	checkLayout();
-	return DPIUtil.scaleDown(getDevice(), getBoundsInPixels(start, end), getZoom(null));
+	return DPIUtil.scaleDown(getDevice(), getBoundsInPixels(start, end), getNativeZoom(null));
 }
 
 Rectangle getBoundsInPixels (int start, int end) {
@@ -1889,8 +1881,8 @@ Rectangle getBoundsInPixels (int start, int end) {
 		}
 		left = Math.min(left, runLead);
 		right = Math.max(right, runTrail);
-		top = Math.min(top, DPIUtil.scaleUp(lineY[lineIndex], getZoom(null)));
-		bottom = Math.max(bottom, DPIUtil.scaleUp(lineY[lineIndex + 1] - lineSpacingInPoints, getZoom(null)));
+		top = Math.min(top, DPIUtil.scaleUp(lineY[lineIndex], getNativeZoom(null)));
+		bottom = Math.max(bottom, DPIUtil.scaleUp(lineY[lineIndex + 1] - lineSpacingInPoints, getNativeZoom(null)));
 	}
 	return new Rectangle(left, top, right - left, bottom - top + getScaledVerticalIndent());
 }
@@ -2016,16 +2008,16 @@ public int getLevel (int offset) {
  */
 public Rectangle getLineBounds (int lineIndex) {
 	checkLayout();
-	return DPIUtil.scaleDown(getDevice(), getLineBoundsInPixels(lineIndex), getZoom());
+	return DPIUtil.scaleDown(getDevice(), getLineBoundsInPixels(lineIndex), getNativeZoom(null));
 }
 
 Rectangle getLineBoundsInPixels(int lineIndex) {
 	computeRuns(null);
 	if (!(0 <= lineIndex && lineIndex < runs.length)) SWT.error(SWT.ERROR_INVALID_RANGE);
 	int x = getLineIndentInPixel(lineIndex);
-	int y = DPIUtil.scaleUp(getDevice(), lineY[lineIndex], getZoom());
+	int y = DPIUtil.scaleUp(getDevice(), lineY[lineIndex], getNativeZoom(null));
 	int width = lineWidthInPixels[lineIndex];
-	int height = DPIUtil.scaleUp(getDevice(), lineY[lineIndex + 1] - lineY[lineIndex] - lineSpacingInPoints, getZoom());
+	int height = DPIUtil.scaleUp(getDevice(), lineY[lineIndex + 1] - lineY[lineIndex] - lineSpacingInPoints, getNativeZoom(null));
 	return new Rectangle (x, y, width, height);
 }
 
@@ -2046,18 +2038,18 @@ public int getLineCount () {
 }
 
 int getLineIndent(int lineIndex) {
-	return DPIUtil.scaleDown(getLineIndentInPixel(lineIndex), getZoom());
+	return DPIUtil.scaleDown(getLineIndentInPixel(lineIndex), getNativeZoom(null));
 }
 
 int getLineIndentInPixel (int lineIndex) {
-	int lineIndent = DPIUtil.scaleUp(wrapIndent, getZoom());
+	int lineIndent = DPIUtil.scaleUp(wrapIndent, getNativeZoom(null));
 	if (lineIndex == 0) {
-		lineIndent = DPIUtil.scaleUp(indent, getZoom());
+		lineIndent = DPIUtil.scaleUp(indent, getNativeZoom(null));
 	} else {
 		StyleItem[] previousLine = runs[lineIndex - 1];
 		StyleItem previousRun = previousLine[previousLine.length - 1];
 		if (previousRun.lineBreak && !previousRun.softBreak) {
-			lineIndent = DPIUtil.scaleUp(indent, getZoom());
+			lineIndent = DPIUtil.scaleUp(indent, getNativeZoom(null));
 		}
 	}
 	if (wrapWidth != -1) {
@@ -2071,8 +2063,8 @@ int getLineIndentInPixel (int lineIndex) {
 		if (partialLine) {
 			int lineWidth = this.lineWidthInPixels[lineIndex] + lineIndent;
 			switch (alignment) {
-				case SWT.CENTER: lineIndent += (DPIUtil.scaleUp(wrapWidth, getZoom()) - lineWidth) / 2; break;
-				case SWT.RIGHT: lineIndent += DPIUtil.scaleUp(wrapWidth, getZoom()) - lineWidth; break;
+				case SWT.CENTER: lineIndent += (DPIUtil.scaleUp(wrapWidth, getNativeZoom(null)) - lineWidth) / 2; break;
+				case SWT.RIGHT: lineIndent += DPIUtil.scaleUp(wrapWidth, getNativeZoom(null)) - lineWidth; break;
 			}
 		}
 	}
@@ -2145,10 +2137,10 @@ public FontMetrics getLineMetrics (int lineIndex) {
 			descentInPoints = Math.max(descentInPoints, run.descentInPoints);
 		}
 	}
-	lptm.tmAscent = DPIUtil.scaleUp(getDevice(), ascentInPoints, getZoom());
-	lptm.tmDescent = DPIUtil.scaleUp(getDevice(), descentInPoints, getZoom());
-	lptm.tmHeight = DPIUtil.scaleUp(getDevice(), ascentInPoints + descentInPoints, getZoom());
-	lptm.tmInternalLeading = DPIUtil.scaleUp(getDevice(), leadingInPoints, getZoom());
+	lptm.tmAscent = DPIUtil.scaleUp(getDevice(), ascentInPoints, getNativeZoom(null));
+	lptm.tmDescent = DPIUtil.scaleUp(getDevice(), descentInPoints, getNativeZoom(null));
+	lptm.tmHeight = DPIUtil.scaleUp(getDevice(), ascentInPoints + descentInPoints, getNativeZoom(null));
+	lptm.tmInternalLeading = DPIUtil.scaleUp(getDevice(), leadingInPoints, getNativeZoom(null));
 	lptm.tmAveCharWidth = 0;
 	return FontMetrics.win32_new(lptm, nativeZoom);
 }
@@ -2192,7 +2184,7 @@ public int[] getLineOffsets () {
  */
 public Point getLocation (int offset, boolean trailing) {
 	checkLayout();
-	return DPIUtil.scaleDown(getDevice(), getLocationInPixels(offset, trailing), getZoom());
+	return DPIUtil.scaleDown(getDevice(), getLocationInPixels(offset, trailing), getNativeZoom(null));
 }
 
 Point getLocationInPixels (int offset, boolean trailing) {
@@ -2207,7 +2199,7 @@ Point getLocationInPixels (int offset, boolean trailing) {
 	}
 	line = Math.min(line, runs.length - 1);
 	if (offset == length) {
-		return new Point(getLineIndentInPixel(line) + lineWidthInPixels[line], DPIUtil.scaleUp(getDevice(), lineY[line], getZoom()));
+		return new Point(getLineIndentInPixel(line) + lineWidthInPixels[line], DPIUtil.scaleUp(getDevice(), lineY[line], getNativeZoom(null)));
 	}
 	/* For trailing use the low surrogate and for lead use the high surrogate */
 	char ch = segmentsText.charAt(offset);
@@ -2251,7 +2243,7 @@ Point getLocationInPixels (int offset, boolean trailing) {
 				final int iX = ScriptCPtoX(runOffset, trailing, run);
 				width = (orientation & SWT.RIGHT_TO_LEFT) != 0 ? run.width - iX : iX;
 			}
-			return new Point(run.x + width, DPIUtil.scaleUp(getDevice(), lineY[line], getZoom()) + getScaledVerticalIndent());
+			return new Point(run.x + width, DPIUtil.scaleUp(getDevice(), lineY[line], getNativeZoom(null)) + getScaledVerticalIndent());
 		}
 	}
 	return new Point(0, 0);
@@ -2402,7 +2394,7 @@ int _getOffset(int offset, int movement, boolean forward) {
  */
 public int getOffset (Point point, int[] trailing) {
 	checkLayout();
-	if (point == null) SWT.error (SWT.ERROR_NULL_ARGUMENT);	return getOffsetInPixels(DPIUtil.scaleUp(getDevice(), point, getZoom()), trailing);
+	if (point == null) SWT.error (SWT.ERROR_NULL_ARGUMENT);	return getOffsetInPixels(DPIUtil.scaleUp(getDevice(), point, getNativeZoom(null)), trailing);
 }
 
 int getOffsetInPixels (Point point, int[] trailing) {
@@ -2434,7 +2426,7 @@ int getOffsetInPixels (Point point, int[] trailing) {
  */
 public int getOffset (int x, int y, int[] trailing) {
 	checkLayout();
-	return getOffsetInPixels(DPIUtil.scaleUp(getDevice(), x, getZoom()), DPIUtil.scaleUp(getDevice(), y, getZoom()), trailing);
+	return getOffsetInPixels(DPIUtil.scaleUp(getDevice(), x, getNativeZoom(null)), DPIUtil.scaleUp(getDevice(), y, getNativeZoom(null)), trailing);
 }
 
 int getOffsetInPixels (int x, int y, int[] trailing) {
@@ -2443,7 +2435,7 @@ int getOffsetInPixels (int x, int y, int[] trailing) {
 	int line;
 	int lineCount = runs.length;
 	for (line=0; line<lineCount; line++) {
-		if (DPIUtil.scaleUp(getDevice(), lineY[line + 1], getZoom()) > y) break;
+		if (DPIUtil.scaleUp(getDevice(), lineY[line + 1], getNativeZoom(null)) > y) break;
 	}
 	line = Math.min(line, runs.length - 1);
 	StyleItem[] lineRuns = runs[line];
@@ -2702,7 +2694,7 @@ private int getScaledVerticalIndent() {
 	if (verticalIndentInPoints == 0) {
 		return verticalIndentInPoints;
 	}
-	return DPIUtil.scaleUp(getDevice(), verticalIndentInPoints, getZoom());
+	return DPIUtil.scaleUp(getDevice(), verticalIndentInPoints, getNativeZoom(null));
 }
 
 /**
@@ -3923,9 +3915,9 @@ void shape (GC  gc, final long hdc, final StyleItem run) {
 				lptm = new TEXTMETRIC();
 				metricsAdapter.GetTextMetrics(hdc, lptm);
 			}
-			run.ascentInPoints = DPIUtil.scaleDown(getDevice(), lptm.tmAscent, getZoom(gc));
-			run.descentInPoints = DPIUtil.scaleDown(getDevice(), lptm.tmDescent, getZoom(gc));
-			run.leadingInPoints = DPIUtil.scaleDown(getDevice(), lptm.tmInternalLeading, getZoom(gc));
+			run.ascentInPoints = DPIUtil.scaleDown(getDevice(), lptm.tmAscent, getNativeZoom(gc));
+			run.descentInPoints = DPIUtil.scaleDown(getDevice(), lptm.tmDescent, getNativeZoom(gc));
+			run.leadingInPoints = DPIUtil.scaleDown(getDevice(), lptm.tmInternalLeading, getNativeZoom(gc));
 		}
 		if (lotm != null) {
 			run.underlinePos = lotm.otmsUnderscorePosition;
@@ -3935,7 +3927,7 @@ void shape (GC  gc, final long hdc, final StyleItem run) {
 		} else {
 			run.underlinePos = 1;
 			run.underlineThickness = 1;
-			run.strikeoutPos = DPIUtil.scaleUp(getDevice(), run.ascentInPoints, getZoom(gc)) / 2;
+			run.strikeoutPos = DPIUtil.scaleUp(getDevice(), run.ascentInPoints, getNativeZoom(gc)) / 2;
 			run.strikeoutThickness = 1;
 		}
 		run.ascentInPoints += style.rise;
@@ -3943,9 +3935,9 @@ void shape (GC  gc, final long hdc, final StyleItem run) {
 	} else {
 		TEXTMETRIC lptm = new TEXTMETRIC();
 		metricsAdapter.GetTextMetrics(hdc, lptm);
-		run.ascentInPoints = DPIUtil.scaleDown(getDevice(), lptm.tmAscent, getZoom(gc));
-		run.descentInPoints = DPIUtil.scaleDown(getDevice(), lptm.tmDescent, getZoom(gc));
-		run.leadingInPoints = DPIUtil.scaleDown(getDevice(), lptm.tmInternalLeading, getZoom(gc));
+		run.ascentInPoints = DPIUtil.scaleDown(getDevice(), lptm.tmAscent, getNativeZoom(gc));
+		run.descentInPoints = DPIUtil.scaleDown(getDevice(), lptm.tmDescent, getNativeZoom(gc));
+		run.leadingInPoints = DPIUtil.scaleDown(getDevice(), lptm.tmInternalLeading, getNativeZoom(gc));
 	}
 }
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/TextLayout.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/TextLayout.java
@@ -776,11 +776,11 @@ private int getNativeZoom(GC gc) {
 }
 
 private int getZoom(GC gc){
-	return DPIUtil.getZoomForAutoscaleProperty(getNativeZoom(gc));
+	return getNativeZoom(gc);
 }
 
 private int getZoom() {
-	return DPIUtil.getZoomForAutoscaleProperty(nativeZoom);
+	return nativeZoom;
 }
 
 void drawInPixels (GC gc, int x, int y) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/ImageList.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/ImageList.java
@@ -44,7 +44,7 @@ public ImageList (int style, int width, int height, int zoom) {
 	handle = OS.ImageList_Create (width, height, this.flags, 16, 16);
 	zoomToHandle.put(zoom, handle);
 	images = new Image [4];
-	this.zoom = zoom;
+	this.zoom = DPIUtil.getZoomForAutoscaleProperty(zoom);
 }
 
 public int add (Image image) {
@@ -331,6 +331,7 @@ public int getStyle () {
 }
 
 public long getHandle(int targetZoom) {
+	targetZoom = DPIUtil.getZoomForAutoscaleProperty(targetZoom);
 	if (!zoomToHandle.containsKey(targetZoom)) {
 		int scaledWidth = DPIUtil.scaleUp(DPIUtil.scaleDown(width, this.zoom), targetZoom);
 		int scaledHeight = DPIUtil.scaleUp(DPIUtil.scaleDown(height, this.zoom), targetZoom);

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Control.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Control.java
@@ -4905,7 +4905,7 @@ LRESULT WM_DPICHANGED (long wParam, long lParam) {
 		if (newNativeZoom != oldNativeZoom) {
 			DPIUtil.setDeviceZoom (newNativeZoom);
 
-			float scalingFactor = 1f * DPIUtil.getZoomForAutoscaleProperty(newNativeZoom) / DPIUtil.getZoomForAutoscaleProperty(oldNativeZoom);
+			float scalingFactor = 1f * newNativeZoom / oldNativeZoom;
 			DPIZoomChangeRegistry.applyChange(this, newNativeZoom, scalingFactor);
 
 			RECT rect = new RECT ();
@@ -4914,14 +4914,14 @@ LRESULT WM_DPICHANGED (long wParam, long lParam) {
 			return LRESULT.ZERO;
 		}
 	} else {
-		int newZoom = DPIUtil.getZoomForAutoscaleProperty (newNativeZoom);
-		int oldZoom = DPIUtil.getZoomForAutoscaleProperty (nativeZoom);
+		int newZoom = newNativeZoom;
+		int oldZoom = nativeZoom;
 		if (newZoom != oldZoom) {
 			// Throw the DPI change event if zoom value changes
 			Event event = new Event();
 			event.type = SWT.ZoomChanged;
 			event.widget = this;
-			event.detail = DPIUtil.getZoomForAutoscaleProperty(newNativeZoom);
+			event.detail = newNativeZoom;
 			event.doit = true;
 			notifyListeners(SWT.ZoomChanged, event);
 			return LRESULT.ZERO;

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ToolItem.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ToolItem.java
@@ -1103,7 +1103,7 @@ void updateImages (boolean enabled) {
 	ImageList hotImageList = parent.getHotImageList ();
 	ImageList disabledImageList = parent.getDisabledImageList();
 	if (info.iImage == OS.I_IMAGENONE) {
-		Rectangle bounds = DPIUtil.scaleBounds(image.getBounds(), getParent().getZoom(), 100);
+		Rectangle bounds = DPIUtil.scaleBounds(image.getBounds(), getParent().getDeviceZoom(), 100);
 		int listStyle = parent.style & SWT.RIGHT_TO_LEFT;
 		if (imageList == null) {
 			imageList = display.getImageListToolBar (listStyle, bounds.width, bounds.height, getZoom());
@@ -1213,5 +1213,10 @@ LRESULT wmCommandChild (long wParam, long lParam) {
 	}
 	sendSelectionEvent (SWT.Selection);
 	return null;
+}
+
+@Override
+int getZoom() {
+	return DPIUtil.getZoomForAutoscaleProperty(nativeZoom);
 }
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Widget.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Widget.java
@@ -2657,7 +2657,7 @@ GC createNewGC(long hDC, GCData data) {
 }
 
 int getZoom() {
-	return DPIUtil.getZoomForAutoscaleProperty(nativeZoom);
+	return nativeZoom;
 }
 
 private static void handleDPIChange(Widget widget, int newZoom, float scalingFactor) {


### PR DESCRIPTION
This PR contributes to the removal of getZoomForAutoscaleProperty  calls for win32 which is used to have the right zoom level for the widgets based on what the native zoom of the monitor is. However, this method is only needed for images and the rest can be taken care of by the Layout Manager while using native zoom.

contributes #62 and #127