### PR TITLE
Drawing custom menu items for Menu Bar **Dark Theme Only**

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT PI/win32/org/eclipse/swt/internal/win32/OS.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/win32/org/eclipse/swt/internal/win32/OS.java
@@ -897,6 +897,7 @@ public class OS extends C {
 	public static final int MFS_CHECKED = 0x8;
 	public static final int MFS_DISABLED = 0x3;
 	public static final int MFS_GRAYED = 0x3;
+	public static final int MFT_OWNERDRAW = 0x100;
 	public static final int MFT_RADIOCHECK = 0x200;
 	public static final int MFT_RIGHTJUSTIFY = 0x4000;
 	public static final int MFT_RIGHTORDER = 0x2000;
@@ -1019,6 +1020,8 @@ public class OS extends C {
 	public static final int OBJ_PEN = 0x1;
 	public static final int OBM_CHECKBOXES = 0x7ff7;
 	public static final int ODS_SELECTED = 0x1;
+	public static final int ODS_NOACCEL = 0x0100;
+	public static final int ODS_INACTIVE = 0x80;
 	public static final int ODT_MENU = 0x1;
 	public static final int OIC_BANG = 0x7F03;
 	public static final int OIC_HAND = 0x7F01;

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Menu.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Menu.java
@@ -358,7 +358,7 @@ void createItem (MenuItem item, int index) {
 	info.fMask = OS.MIIM_ID | OS.MIIM_TYPE | OS.MIIM_DATA;
 	info.wID = item.id;
 	info.dwItemData = item.id;
-	info.fType = item.widgetStyle ();
+	info.fType = (style & SWT.BAR) != 0 && needsMenuCallback() ? OS.MFT_OWNERDRAW :  item.widgetStyle ();
 	info.dwTypeData = pszText;
 	boolean success = OS.InsertMenuItem (handle, index, true, info);
 	if (pszText != 0) OS.HeapFree (hHeap, 0, pszText);


### PR DESCRIPTION
Using gc to draw menu item, moving the responsibility from OS due to wrong scaling of menu bar horizontally in **Dark** Theme. Snippet 373 can be used to test menuItems with images. 

Additional points covered in this PR: 

- Changing the text color from a grayish tone to white.
- When ALT key is pressed mnemonics are underlined and work as a toggle, the behavior which was missing from dark theme previously.

Screenshot of the fix: 

![image](https://github.com/user-attachments/assets/4002ccef-65fa-4a22-9665-394296531e82)

## HOW TO TEST

- Run the `RunTimeWorkspace` with the following **VM Arguments**
```
-Dswt.autoScale=quarter
-Dswt.autoScale.updateOnRuntime=true
```
- Go to "Windows" -> "Preferences" -> "General" -> "Appearance" 
- Change theme to "Dark" 
- Click "Apply and Close" 
- Move the window from 100 -> 175 (or anything 100+) zoom level
- See if menu bar is properly aligned.

## SCENARIOS TESTED

autoscale.updateOnRuntime = false && autoscale=int200 (Prevent regressions)
100% (Primary), 175% (Second)
150% (Primary), 200% (Second)
175% (Primary), 125% (Second)
200% (Primary), 100% (Second)
200% (Primary), 150% (Second)
autoscale.updateOnRuntime = false && autoscale=quarter (Prevent regressions)
150% (Primary), 200% (Second)
175% (Primary), 125% (Second)
autoscale.updateOnRuntime = true && autoscale=int200
100% (Primary), 175% (Second)
150% (Primary), 200% (Second)
175% (Primary), 125% (Second)
200% (Primary), 100% (Second)
autoscale.updateOnRuntime = true && autoscale=quarter
150% (Primary), 200% (Second) 
175% (Primary), 125% (Second)

## EXPECTED BEHAVIOUR

The menu bar should be scaled properly.

contributes to https://github.com/eclipse-platform/eclipse.platform.swt/issues/62 and https://github.com/eclipse-platform/eclipse.platform.swt/issues/127
