### PR TITLE
Build GTK 4 binaries

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,7 +19,7 @@ def runOnNativeBuildAgent(String platform, Closure body) {
 	def final nativeBuildStageName = 'Build SWT-native binaries'
 	if (platform == 'gtk.linux.x86_64') {
 		podTemplate(inheritFrom: 'ubuntu-latest' /* inhert general configuration */, containers: [
-			containerTemplate(name: 'swtbuild', image: 'eclipse/platformreleng-centos-swt-build:8',
+			containerTemplate(name: 'swtbuild', image: 'eclipse/platformreleng-debian-swtnativebuild:12',
 				resourceRequestCpu:'1000m', resourceRequestMemory:'512Mi',
 				resourceLimitCpu:'2000m', resourceLimitMemory:'4096Mi',
 				alwaysPullImage: true, command: 'cat', ttyEnabled: true)
@@ -228,7 +228,15 @@ pipeline {
 										if (isUnix()){
 											sh '''
 												mkdir libs
-												sh build.sh install
+												if [ "${PLATFORM}" = "gtk.linux.aarch64" ]; then
+													sh build.sh -gtk3 install
+												elif [ "${PLATFORM}" = "gtk.linux.ppc64le" ]; then
+													sh build.sh -gtk3 install
+												elif [ "${PLATFORM}" = "gtk.linux.riscv64" ]; then
+													sh build.sh -gtk3 install
+												else
+													sh build.sh install 
+												fi
 												ls -1R libs
 											'''
 										} else {

--- a/binaries/pom.xml
+++ b/binaries/pom.xml
@@ -135,12 +135,10 @@
 														</exec>
 													</then>
 													<else>
-														<property name="gtk_version" value="3.0" />
 														<exec dir="${build_dir}" executable="sh" failonerror="true">
 															<arg line="build.sh"/>
 															<env key="SWT_JAVA_HOME" value="${SWT_JAVA_HOME}"/>
 															<env key="OUTPUT_DIR" value="${project.basedir}"/>
-															<env key="GTK_VERSION" value="${gtk_version}"/>
 															<env key="MODEL" value="${arch}"/>
 															<arg line="install clean"/>
 														</exec>

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/build.sh
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/build.sh
@@ -280,14 +280,7 @@ func_build_gtk3 () {
 	fi
 }
 
-if [ "$1" = "-gtk-all" ]; then
-	shift
-	func_echo_plus "Note: When building multiple GTK versions, a cleanup is required (and automatically performed) between them."
-	func_clean_up
-	func_build_gtk4 "$@"
-	func_clean_up
-	func_build_gtk3 "$@"
-elif [ "$1" = "-gtk4" ]; then
+if [ "$1" = "-gtk4" ]; then
 	shift
 	func_build_gtk4 "$@"
 elif [ "$1" = "-gtk3" ]; then
@@ -295,7 +288,17 @@ elif [ "$1" = "-gtk3" ]; then
 	func_build_gtk3 "$@"
 elif [ "${GTK_VERSION}" = "4.0" ]; then
 	func_build_gtk4 "$@"
-elif [ "${GTK_VERSION}" = "3.0" -o "${GTK_VERSION}" = "" ]; then
-	export GTK_VERSION="3.0"
+elif [ "${GTK_VERSION}" = "3.0" ]; then
+	func_build_gtk3 "$@"
+else
+	if [ "$1" = "-gtk-all" ]; then
+		shift
+	fi
+	func_echo_plus "==== Building GTK3 + GTK 4 ===="
+	func_echo_plus "Note: When building multiple GTK versions, a cleanup is required (and automatically performed) between them."
+	func_clean_up
+	func_build_gtk4 "$@"
+	func_echo_plus "Note: When building multiple GTK versions, a cleanup is required (and automatically performed) between them."
+	func_clean_up
 	func_build_gtk3 "$@"
 fi


### PR DESCRIPTION
Currently the GTK4 binaries are not build as part of the build, this has several drawbacks:

1) If anything is adjusted for GTK4 part it might break without notice 2) We have no GTK4 binaries by default

This enables *compilation* of the gtk4 parts to see at least everything can be compiled.

The following has to be checked:

- [x] do we have everything to compile for Jenkins Pod
- [x] do we have everything to compile for Github
- [ ] ...