### PR TITLE
#414: slow StyledTextRenderer for unicode and unprintable control characters

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/TextLayout.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/TextLayout.java
@@ -2854,6 +2854,13 @@ public boolean isDisposed () {
 	return device == null;
 }
 
+private char replaceBelowSpaceCharacters(char chr) {
+	return chr >= ' '
+		? chr
+		//: (char)(0x2400 + chr);
+		: ' ';
+}
+
 /*
  *  Itemize the receiver text
  */
@@ -2895,8 +2902,11 @@ StyleItem[] itemize () {
 		 */
 		for (int i = 0, latestNeutralIndex = -2, latestUnicodeIndex = -2; i < length; i++) {
 			char c = chars[i];
+			if (c < ' ') {
+				c = replaceBelowSpaceCharacters(c);
+			}
 
-			if (c >= ' ' && c <= '~' && !Character.isAlphabetic(c)) {
+			if (c <= '~' && !Character.isAlphabetic(c)) {
 				latestNeutralIndex = i;
 			} else if (c > 255) {
 				latestUnicodeIndex = i;
@@ -3740,6 +3750,9 @@ void shape (GC  gc, final long hdc, final StyleItem run) {
 	final int[] buffer = new int[1];
 	final char[] chars = new char[run.length];
 	segmentsText.getChars(run.start, run.start + run.length, chars, 0);
+	for (int i = 0; i < chars.length; i++) {
+		chars[i] = replaceBelowSpaceCharacters(chars[i]);
+	}
 
 	final int maxGlyphs = (chars.length * 3 / 2) + 16;
 	long hHeap = OS.GetProcessHeap();


### PR DESCRIPTION
This test replaces the characters 0x00-0x1F with some alternative character (by default ' ') for rendering. This improves the performance significantly.