### PR TITLE
Use centos-9 to build the swt natives

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,7 +24,7 @@ kind: Pod
 spec:
   containers:
   - name: "swtbuild"
-    image: "eclipse/platformreleng-centos-swt-build:8"
+    image: "eclipse/platformreleng-centos-swt-build:9"
     imagePullPolicy: "Always"
     resources:
       limits:


### PR DESCRIPTION
Centos-8 is out of service and [the container even does not build anymore](https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2263) therefore we can't get any updates.

This changes the build to use Centos 9 for building instead.

FYI @akurtakov @fredg02 @sravanlakkimsetti 

I'll cancel the first build and trigger one with forced binary compilation so we can see everything works fine, this should then be merged as soon as the master is open for next release so we can get enough time to test. This will also be a prerequisite for GTK4+ support.