### PR TITLE
Need to print the exception message to give more information

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/org/eclipse/swt/internal/gtk/OS.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/org/eclipse/swt/internal/gtk/OS.java
@@ -87,14 +87,24 @@ public class OS extends C {
 				Library.loadLibrary("swt-pi4");
 			} catch (Throwable e) {
 				System.err.println("SWT OS.java Error: Failed to load swt-pi4, loading swt-pi3 as fallback.");
-				Library.loadLibrary("swt-pi3");
+				try {
+					Library.loadLibrary("swt-pi3");
+				} catch (Throwable fallback) {
+					e.addSuppressed(fallback);
+					throw e;
+				}
 			}
 		} else {
 			try {
 				Library.loadLibrary("swt-pi3");
 			} catch (Throwable e) {
 				System.err.println("SWT OS.java Error: Failed to load swt-pi3, loading swt-pi4 as fallback.");
-				Library.loadLibrary("swt-pi4");
+				try {
+					Library.loadLibrary("swt-pi4");
+				} catch (Throwable fallback) {
+					e.addSuppressed(fallback);
+					throw e;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
If running on a system that does not have the required glibc version then important information is lost to tell the user what is wrong. For example:

version 'GLIBC_2.34' not found (required by .../libswt-pi3-gtk-4966r6.so)