### PR TITLE
[fix]Use correct DPIUtil call for pixel conversion

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT OLE Win32/win32/org/eclipse/swt/ole/win32/OleClientSite.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT OLE Win32/win32/org/eclipse/swt/ole/win32/OleClientSite.java
@@ -1370,7 +1370,7 @@ void setBorderSpace(RECT newBorderwidth) {
 }
 void setBounds() {
 	int zoom = DPIUtil.getZoomForAutoscaleProperty(nativeZoom);
-	Rectangle area = DPIUtil.scaleDown(frame.getClientArea(), zoom); // To Pixels
+	Rectangle area = DPIUtil.scaleUp(frame.getClientArea(), zoom); // To Pixels
 	setBounds(DPIUtil.scaleDown(borderWidths.left, zoom),
 			  DPIUtil.scaleDown(borderWidths.top, zoom),
 			  DPIUtil.scaleDown(area.width - borderWidths.left - borderWidths.right, zoom),


### PR DESCRIPTION
This commit fixes an issue, where a call to DPIUtil was scaling down from points to pixels instead of scaling down

Fixes #1434