### PR TITLE
#414: slow StyledTextRenderer for unicode and unprintable control cha…

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/TextLayout.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/TextLayout.java
@@ -2857,6 +2857,14 @@ public boolean isDisposed () {
 	return device == null;
 }
 
+private static char replaceBelowSpaceCharacters(char chr) {
+	if (chr >= 0x20 || chr == '\t' || chr == '\r' || chr == '\n') {
+		return chr;
+	}
+
+	return '?'; // (char)(0x2400 + chr);
+}
+
 /*
  *  Itemize the receiver text
  */
@@ -2884,6 +2892,9 @@ StyleItem[] itemize () {
 	int[] pcItems = new int[1];
 	char[] chars = new char[length];
 	segmentsText.getChars(0, length, chars, 0);
+	for (int i = 0; i < length; i++) {
+		chars[i] = replaceBelowSpaceCharacters(chars[i]);
+	}
 	// enable font ligatures
 	scriptControl.fMergeNeutralItems = true;
 	/*
@@ -3743,6 +3754,9 @@ void shape (GC  gc, final long hdc, final StyleItem run) {
 	final int[] buffer = new int[1];
 	final char[] chars = new char[run.length];
 	segmentsText.getChars(run.start, run.start + run.length, chars, 0);
+	for (int i = 0; i < chars.length; i++) {
+		chars[i] = replaceBelowSpaceCharacters(chars[i]);
+	}
 
 	final int maxGlyphs = (chars.length * 3 / 2) + 16;
 	long hHeap = OS.GetProcessHeap();


### PR DESCRIPTION
…racters

This test replaces the characters 0x00-0x1F with some alternative character (by default '?') for rendering. This improves the performance significantly.

The previous pull request (https://github.com/eclipse-platform/eclipse.platform.swt/pull/1425) did not work.

Note, that when changing `replaceBelowSpaceCharacters` to return the commented unicode characters, the snippet will fail with a "No more handles" exception. I reckon, we best should stick to a US-ASCII character from the range 0x20<=..<0x7F.