### PR TITLE
Make Edge browser available in ControlExample

### DIFF
--- a/examples/org.eclipse.swt.examples/src/org/eclipse/swt/examples/controlexample/BrowserTab.java
+++ b/examples/org.eclipse.swt.examples/src/org/eclipse/swt/examples/controlexample/BrowserTab.java
@@ -48,6 +48,7 @@ class BrowserTab extends Tab {
 
 	/* Style widgets added to the "Style" group */
 	Button webKitButton;
+	Button edgeButton;
 
 	String errorMessage, lastText, lastUrl;
 
@@ -92,6 +93,7 @@ class BrowserTab extends Tab {
 		int style = getDefaultStyle();
 		if (borderButton.getSelection ()) style |= SWT.BORDER;
 		if (webKitButton.getSelection ()) style |= SWT.WEBKIT;
+		if (edgeButton.getSelection ()) style |= SWT.EDGE;
 
 		/* Create the example widgets */
 		try {
@@ -162,8 +164,10 @@ class BrowserTab extends Tab {
 		super.createStyleGroup ();
 
 		/* Create the extra widgets */
-		webKitButton = new Button (styleGroup, SWT.CHECK);
+		webKitButton = new Button (styleGroup, SWT.RADIO);
 		webKitButton.setText ("SWT.WEBKIT");
+		edgeButton = new Button (styleGroup, SWT.RADIO);
+		edgeButton.setText ("SWT.EDGE");
 		borderButton = new Button (styleGroup, SWT.CHECK);
 		borderButton.setText ("SWT.BORDER");
 	}
@@ -340,6 +344,7 @@ class BrowserTab extends Tab {
 	void setExampleWidgetState () {
 		super.setExampleWidgetState ();
 		webKitButton.setSelection (browser == null ? false : (browser.getStyle () & SWT.WEBKIT) != 0);
+		edgeButton.setSelection (browser == null ? false : (browser.getStyle () & SWT.EDGE) != 0);
 		borderButton.setSelection (browser == null ? false : (browser.getStyle () & SWT.BORDER) != 0);
 	}
 }


### PR DESCRIPTION
The SWT ControlExample does currently not provide a configuration option to use Edge browser on Windows (i.e., to activate the SWT.EDGE flag, like is provided for SWT.WEBKIT) already.
This change adds an according configuration option.

![image](https://github.com/user-attachments/assets/8ebb7f17-9497-4a74-a397-4cd490bac3bd)
