### PR TITLE
Add field isLocationForCustomText in LocationEvent

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Browser/common/org/eclipse/swt/browser/LocationEvent.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Browser/common/org/eclipse/swt/browser/LocationEvent.java
@@ -42,6 +42,12 @@ public class LocationEvent extends TypedEvent {
 	public boolean top;
 
 	/**
+	 * A flag indicating if the location is for the custom text.
+	 * @since 3.128
+	 */
+	public boolean isLocationForCustomText;
+
+	/**
 	 * A flag indicating whether the location loading should be allowed.
 	 * Setting this field to <code>false</code> will cancel the operation.
 	 */

--- a/bundles/org.eclipse.swt/Eclipse SWT Browser/win32/org/eclipse/swt/browser/Edge.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Browser/win32/org/eclipse/swt/browser/Edge.java
@@ -624,6 +624,7 @@ int handleNavigationStarting(long pView, long pArgs, boolean top) {
 	event.display = browser.getDisplay();
 	event.widget = browser;
 	event.location = url;
+	event.isLocationForCustomText = browser.isLocationForCustomText(url);
 	event.top = top;
 	event.doit = true;
 	for (LocationListener listener : locationListeners) {
@@ -665,6 +666,7 @@ int handleSourceChanged(long pView, long pArgs) {
 		event.display = browser.getDisplay();
 		event.widget = browser;
 		event.location = url;
+		event.isLocationForCustomText = browser.isLocationForCustomText(url);
 		event.top = true;
 		for (LocationListener listener : locationListeners) {
 			listener.changed(event);

--- a/bundles/org.eclipse.swt/Eclipse SWT Browser/win32/org/eclipse/swt/browser/IE.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Browser/win32/org/eclipse/swt/browser/IE.java
@@ -520,6 +520,7 @@ public void create(Composite parent, int style) {
 					newEvent1.display = browser.getDisplay();
 					newEvent1.widget = browser;
 					newEvent1.location = url1;
+					newEvent1.isLocationForCustomText = browser.isLocationForCustomText(url1);
 					newEvent1.doit = true;
 					for (LocationListener locationListener : locationListeners) {
 						locationListener.changing(newEvent1);
@@ -608,6 +609,7 @@ public void create(Composite parent, int style) {
 						locationEvent.display = browser.getDisplay();
 						locationEvent.widget = browser;
 						locationEvent.location = url2;
+						locationEvent.isLocationForCustomText = browser.isLocationForCustomText(url2);
 						locationEvent.top = top2.getAddress() == dispatch2.getAddress();
 						for (LocationListener locationListener : locationListeners) {
 							locationListener.changed(locationEvent);

--- a/bundles/org.eclipse.swt/Eclipse SWT WebKit/cocoa/org/eclipse/swt/browser/WebKit.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT WebKit/cocoa/org/eclipse/swt/browser/WebKit.java
@@ -660,6 +660,7 @@ void webView_didChangeLocationWithinPageForFrame(long sender, long frameID) {
 	location.display = display;
 	location.widget = browser;
 	location.location = url2;
+	location.isLocationForCustomText = browser.isLocationForCustomText(url2);
 	location.top = top;
 	for (int i = 0; i < locationListeners.length; i++) {
 		locationListeners[i].changed(location);
@@ -965,6 +966,7 @@ void webView_didCommitLoadForFrame(long sender, long frameID) {
 	location.display = display;
 	location.widget = browser;
 	location.location = url2;
+	location.isLocationForCustomText = browser.isLocationForCustomText(url2);
 	location.top = top;
 	for (int i = 0; i < locationListeners.length; i++) {
 		locationListeners[i].changed(location);
@@ -1492,6 +1494,7 @@ void webView_decidePolicyForNavigationAction_request_frame_decisionListener(long
 	newEvent.display = browser.getDisplay();
 	newEvent.widget = browser;
 	newEvent.location = url2;
+	newEvent.isLocationForCustomText = browser.isLocationForCustomText(url2);
 	newEvent.doit = true;
 	if (locationListeners != null) {
 		for (int i = 0; i < locationListeners.length; i++) {

--- a/bundles/org.eclipse.swt/Eclipse SWT WebKit/gtk/org/eclipse/swt/browser/WebKit.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT WebKit/gtk/org/eclipse/swt/browser/WebKit.java
@@ -1735,6 +1735,7 @@ long handleLoadCommitted (long uri, boolean top) {
 	event.display = browser.getDisplay ();
 	event.widget = browser;
 	event.location = url;
+	event.isLocationForCustomText = browser.isLocationForCustomText(url);
 	event.top = top;
 	Runnable fireLocationChanged = () ->  {
 		if (browser.isDisposed ()) return;
@@ -2291,6 +2292,7 @@ long webkit_decide_policy (long web_view, long decision, int decision_type, long
 		newEvent.display = browser.getDisplay ();
 		newEvent.widget = browser;
 		newEvent.location = url;
+		newEvent.isLocationForCustomText = browser.isLocationForCustomText(url);
 		newEvent.doit = true;
 
 		try {


### PR DESCRIPTION
This contribution adds a new field isLocationForCustomText in LcoationEvent. This field can be used to check whether the location of the event is the custom text location of the browser, making it easy for the clients to check such conditions without accessing the browser.

contributes to #213