### PR TITLE
Correct faulty reference to listener constants for Widget

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Widget.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Widget.java
@@ -446,7 +446,7 @@ boolean resignFirstResponder (long id, long sel) {
  * be notified when an event of the given type occurs. When the
  * event does occur in the widget, the listener is notified by
  * sending it the <code>handleEvent()</code> message. The event
- * type is one of the event constants defined in class {@link SWTError}.
+ * type is one of the event constants defined in class {@link SWT}.
  *
  * @param eventType the type of event to listen for
  * @param listener the listener which should be notified when the event occurs

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Widget.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Widget.java
@@ -307,7 +307,7 @@ void _addListener (int eventType, Listener listener) {
  * be notified when an event of the given type occurs. When the
  * event does occur in the widget, the listener is notified by
  * sending it the <code>handleEvent()</code> message. The event
- * type is one of the event constants defined in class {@link SWTError}.
+ * type is one of the event constants defined in class {@link SWT}.
  *
  * @param eventType the type of event to listen for
  * @param listener the listener which should be notified when the event occurs

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Widget.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Widget.java
@@ -202,7 +202,7 @@ void _removeListener (int eventType, Listener listener) {
  * be notified when an event of the given type occurs. When the
  * event does occur in the widget, the listener is notified by
  * sending it the <code>handleEvent()</code> message. The event
- * type is one of the event constants defined in class {@link SWTError}.
+ * type is one of the event constants defined in class {@link SWT}.
  *
  * @param eventType the type of event to listen for
  * @param listener the listener which should be notified when the event occurs


### PR DESCRIPTION
Widget#addListener(int, Listener) currently states that event constants are defined in the SWTError class, but these constants are defined in the SWT class. This change fixes the faulty reference.

The faulty reference was introduced with:
- #1112

@HannesWell, I guess this was just by accident and not intended, right?