### PR TITLE
Remove erroneous assertion from browser test #1455

### DIFF
--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_browser_Browser.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_browser_Browser.java
@@ -540,7 +540,6 @@ public void test_isLocationForCustomText_isSetUrlNotCustomTextUrlAfterSetText() 
 	locationChanged.set(false);
 	browser.setUrl(url.toASCIIString());
 	assertTrue("Time Out: The Browser didn't navigate to the URL", waitForPassCondition(locationChanged::get));
-	assertEquals("Url is wrongly considered Custom Text Url", URI.create(browser.getUrl()), url);
 	assertFalse("The navigated URL is falsly indicated to be the custom text URL", browser.isLocationForCustomText(browser.getUrl()));
 }
 


### PR DESCRIPTION
The browser test case test_isLocationForCustomText_isSetUrlNotCustomTextUrlAfterSetText validates that after setting a browser URL this same URL is then returned by Browser#getURL(). However, the Browser API does not guarantee this behavior and the assertion is even unnecessary for the scenario to be tested, which is already covered by other assertions at the proper level of abstraction.

This change removes the unnecessary assertion.

Contributes to https://github.com/eclipse-platform/eclipse.platform.swt/issues/1455