### PR TITLE
GlyphMetrics.width not properly scaled up

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/TextLayout.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/TextLayout.java
@@ -1861,7 +1861,7 @@ Rectangle getBoundsInPixels (int start, int end) {
 			int cx = 0;
 			if (run.style != null && run.style.metrics != null) {
 				GlyphMetrics metrics = run.style.metrics;
-				cx = DPIUtil.scaleUp(getDevice(), metrics.width, nativeZoom) * (start - run.start);
+				cx = DPIUtil.scaleUp(getDevice(), metrics.width, getZoom()) * (start - run.start);
 			} else if (!run.tab) {
 				int iX = ScriptCPtoX(start - run.start, false, run);
 				cx = isRTL ? run.width - iX : iX;
@@ -1876,7 +1876,7 @@ Rectangle getBoundsInPixels (int start, int end) {
 			int cx = run.width;
 			if (run.style != null && run.style.metrics != null) {
 				GlyphMetrics metrics = run.style.metrics;
-				cx = DPIUtil.scaleUp(getDevice(), metrics.width, nativeZoom) * (end - run.start + 1);
+				cx = DPIUtil.scaleUp(getDevice(), metrics.width, getZoom()) * (end - run.start + 1);
 			} else if (!run.tab) {
 				int iX = ScriptCPtoX(end - run.start, true, run);
 				cx = isRTL ? run.width - iX : iX;
@@ -2247,7 +2247,7 @@ Point getLocationInPixels (int offset, boolean trailing) {
 			int width;
 			if (run.style != null && run.style.metrics != null) {
 				GlyphMetrics metrics = run.style.metrics;
-				width = DPIUtil.scaleUp(getDevice(), metrics.width, nativeZoom) * (offset - run.start + (trailing ? 1 : 0));
+				width = DPIUtil.scaleUp(getDevice(), metrics.width, getZoom()) * (offset - run.start + (trailing ? 1 : 0));
 			} else if (run.tab) {
 				width = (trailing || (offset == length)) ? run.width : 0;
 			} else {
@@ -2469,7 +2469,7 @@ int getOffsetInPixels (int x, int y, int[] trailing) {
 			if (run.style != null && run.style.metrics != null) {
 				GlyphMetrics metrics = run.style.metrics;
 				if (metrics.width > 0) {
-					final int metricsWidthInPixels = DPIUtil.scaleUp(getDevice(), metrics.width, nativeZoom);
+					final int metricsWidthInPixels = DPIUtil.scaleUp(getDevice(), metrics.width, getZoom());
 					if (trailing != null) {
 						trailing[0] = (xRun % metricsWidthInPixels < metricsWidthInPixels / 2) ? 0 : 1;
 					}
@@ -3915,7 +3915,7 @@ void shape (GC  gc, final long hdc, final StyleItem run) {
 			 *  equals zero for FFFC (possibly other unicode code points), the fix
 			 *  is to make sure the glyph is at least one pixel wide.
 			 */
-			run.width = DPIUtil.scaleUp(getDevice(), metrics.width, nativeZoom) * Math.max (1, run.glyphCount);
+			run.width = DPIUtil.scaleUp(getDevice(), metrics.width, getZoom()) * Math.max (1, run.glyphCount);
 			run.ascentInPoints = metrics.ascent;
 			run.descentInPoints = metrics.descent;
 			run.leadingInPoints = 0;


### PR DESCRIPTION
LineContentCodeMinings are not properly rendered on windows with odd text scale factors like 125%, 150%, 250%, ... 

Here a screenshot of the CodeMiningDemo application located in eclipse.platform.ui\examples\org.eclipse.jface.text.examples.
<img width="391" alt="codemining_zoom_150" src="https://github.com/user-attachments/assets/fe89648b-6633-4ab0-ba5a-86b7f0d670cc">
The gap after the echoed code mining "echo" does not appear for text scale factor 100% and 200%.

The gap disappears by applying the changes in this pull request as shown in the next screenshot:
<img width="385" alt="codemining_zoom_150_fixed" src="https://github.com/user-attachments/assets/86da9fd6-6070-42b2-87ec-b00a9edbb17d">


All `DPIUtil.scaleUp()` calls in class `org.eclipse.swt.graphics.TextLayout` use the result of `getZoom` as zoom level; but not the ones for `GlyphMetrics.width` which use the value `nativeZoom`. Is this intended? This pull request now uses also `getZoom` for `GlyphMetrics.width`.

