### PR TITLE
Fix riscv64 MANIFEST.MF header field

### DIFF
--- a/binaries/org.eclipse.swt.gtk.linux.riscv64/META-INF/MANIFEST.MF
+++ b/binaries/org.eclipse.swt.gtk.linux.riscv64/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-SymbolicName: org.eclipse.swt.gtk.linux.riscv64; singleton:=true
 Bundle-Version: 3.127.100.qualifier
 Bundle-ManifestVersion: 2
 Bundle-Localization: fragment
-Export-Package:
+Export-Package: 
  org.eclipse.swt,
  org.eclipse.swt.accessibility,
  org.eclipse.swt.awt,


### PR DESCRIPTION
A blank after a header field is essential.

Fixes https://github.com/eclipse-platform/eclipse.platform.swt/pull/1445