### PR TITLE
Bump version to match jar signatures

### DIFF
--- a/bundles/org.eclipse.swt.tools.spies/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.swt.tools.spies/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.swt.tools.spies;singleton:=true
-Bundle-Version: 3.109.400.qualifier
+Bundle-Version: 3.109.500.qualifier
 Bundle-ManifestVersion: 2
 Export-Package: org.eclipse.swt.tools.internal,
  org.eclipse.swt.tools.views

--- a/bundles/org.eclipse.swt.tools/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.swt.tools/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.swt.tools; singleton:=true
-Bundle-Version: 3.110.500.qualifier
+Bundle-Version: 3.110.600.qualifier
 Bundle-ManifestVersion: 2
 Export-Package: org.eclipse.swt.tools.internal; x-internal:=true
 Bundle-ActivationPolicy: lazy


### PR DESCRIPTION
- Both need to be bumped because neither is signed by the latest available signing certificate.

https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2335