### PR TITLE
Build gtk.linux.riscv64 native SWT fragment

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -46,6 +46,17 @@ def getNativeJdkUrl(String os, String arch){ // To update the used JDK version u
 			"""
 		}
 		return "file://${WORKSPACE}/repackage-win32.aarch64-jdk/jdk.tar.gz"
+	} else if ('linux'.equals(os) && 'riscv64'.equals(arch)) {
+		// Downloading jdk and renew it for riscv64 architecture on Linux
+		dir("${WORKSPACE}/repackage-linux.riscv64-jdk") {
+				sh """
+				curl -L 'https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.12%2B7/OpenJDK17U-jdk_riscv64_linux_hotspot_17.0.12_7.tar.gz' > jdk.tar.gz
+				tar -xzf jdk.tar.gz jdk-17.0.12+7/include/ jdk-17.0.12+7/lib/
+				cd jdk-17.0.12+7
+				tar -czf ../jdk.tar.gz include/ lib/
+				"""
+		}
+		return "file://${WORKSPACE}/repackage-linux.riscv64-jdk/jdk.tar.gz"
 	}
 	return "https://download.eclipse.org/justj/jres/17/downloads/20230428_1804/org.eclipse.justj.openjdk.hotspot.jre.minimal.stripped-17.0.7-${os}-${arch}.tar.gz"
 }
@@ -186,6 +197,7 @@ pipeline {
 						'cocoa.macosx.x86_64',\
 						'gtk.linux.aarch64',\
 						'gtk.linux.ppc64le',\
+						'gtk.linux.riscv64',\
 						'gtk.linux.x86_64',\
 						'win32.win32.aarch64',\
 						'win32.win32.x86_64'

--- a/binaries/org.eclipse.swt.gtk.linux.riscv64/META-INF/MANIFEST.MF
+++ b/binaries/org.eclipse.swt.gtk.linux.riscv64/META-INF/MANIFEST.MF
@@ -1,9 +1,9 @@
 Manifest-Version: 1.0
-Fragment-Host: org.eclipse.swt;bundle-version="[3.127.0,4.0.0)"
+Fragment-Host: org.eclipse.swt;bundle-version="[3.128.0,4.0.0)"
 Bundle-Name: %fragmentName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.swt.gtk.linux.riscv64; singleton:=true
-Bundle-Version: 3.127.100.qualifier
+Bundle-Version: 3.128.0.qualifier
 Bundle-ManifestVersion: 2
 Bundle-Localization: fragment
 Export-Package: 

--- a/binaries/pom.xml
+++ b/binaries/pom.xml
@@ -37,6 +37,7 @@
 		<module>org.eclipse.swt.cocoa.macosx.aarch64</module>
 		<module>org.eclipse.swt.gtk.linux.aarch64</module>
 		<module>org.eclipse.swt.gtk.linux.ppc64le</module>
+		<module>org.eclipse.swt.gtk.linux.riscv64</module>
 		<module>org.eclipse.swt.gtk.linux.x86_64</module>
 		<module>org.eclipse.swt.win32.win32.aarch64</module>
 		<module>org.eclipse.swt.win32.win32.x86_64</module>


### PR DESCRIPTION
With command

```shell
mvn verify -DskipTests=true -Dnative=gtk.linux.riscv64
```

riscv64 artifact can be generated at `binaries/org.eclipse.swt.gtk.linux.riscv64/target/`