### PR TITLE
Destroy unused handles

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/Resource.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/Resource.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.swt.graphics;
 
+import java.util.*;
 import java.util.function.*;
 
 import org.eclipse.swt.*;
@@ -121,6 +122,17 @@ Resource(Device device) {
 }
 
 void destroy() {
+}
+
+/**
+ * Destroy all handles of the resource which are not necessary for the given
+ * zoom levels. This method is supposed to be overridden by sub-classes that
+ * retain handles for different zoom levels.
+ *
+ * @param zoomLevels The zoom levels for which the handles are supposed to be
+ *                   retained.
+ */
+void destroyHandlesExcept(Set<Integer> zoomLevels) {
 }
 
 /**

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Path.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Path.java
@@ -86,6 +86,7 @@ private Path(Device device, int zoom) {
 	if (handle == 0) SWT.error(SWT.ERROR_NO_HANDLES);
 	zoomLevelToHandle.put(initialZoom, handle);
 	init();
+	this.device.registerResourceWithZoomSupport(this);
 }
 
 /**
@@ -133,6 +134,7 @@ public Path (Device device, Path path, float flatness) {
 	initialZoom = path.initialZoom;
 	zoomLevelToHandle.put(initialZoom, handle);
 	init();
+	this.device.registerResourceWithZoomSupport(this);
 }
 
 /**
@@ -172,6 +174,7 @@ private Path(Device device, PathData data, int zoom) {
 	this(device, zoom);
 	if (data == null) SWT.error(SWT.ERROR_NULL_ARGUMENT);
 	init(data);
+	this.device.registerResourceWithZoomSupport(this);
 }
 
 /**
@@ -436,6 +439,18 @@ void cubicToInPixels(float cx1, float cy1, float cx2, float cy2, float x, float 
 void destroy() {
 	zoomLevelToHandle.values().forEach(Gdip::GraphicsPath_delete);
 	zoomLevelToHandle.clear();
+}
+
+@Override
+void destroyHandlesExcept(Set<Integer> zoomLevels) {
+	zoomLevelToHandle.entrySet().removeIf(entry -> {
+		final Integer zoom = entry.getKey();
+		if (!zoomLevels.contains(zoom) && zoom != initialZoom) {
+			Gdip.GraphicsPath_delete(entry.getValue());
+			return true;
+		}
+		return false;
+	});
 }
 
 /**

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Region.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Region.java
@@ -84,6 +84,7 @@ public Region (Device device) {
 	zoomToHandle.put(initialZoom, handle);
 	if (handle == 0) SWT.error(SWT.ERROR_NO_HANDLES);
 	init();
+	this.device.registerResourceWithZoomSupport(this);
 }
 
 /**
@@ -225,6 +226,18 @@ void destroy () {
 	zoomToHandle.values().forEach(handle -> OS.DeleteObject(handle));
 	zoomToHandle.clear();
 	operations.clear();
+}
+
+@Override
+void destroyHandlesExcept(Set<Integer> zoomLevels) {
+	zoomToHandle.entrySet().removeIf(entry -> {
+		final Integer zoom = entry.getKey();
+		if (!zoomLevels.contains(zoom) && zoom != initialZoom) {
+			OS.DeleteObject(entry.getValue());
+			return true;
+		}
+		return false;
+	});
 }
 
 /**

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Transform.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Transform.java
@@ -145,6 +145,7 @@ public Transform (Device device, float m11, float m12, float m21, float m22, flo
 	if (handle == 0) SWT.error(SWT.ERROR_NO_HANDLES);
 	zoomLevelToHandle.put(initialZoom, handle);
 	init();
+	this.device.registerResourceWithZoomSupport(this);
 }
 
 static float[] checkTransform(float[] elements) {
@@ -157,6 +158,18 @@ static float[] checkTransform(float[] elements) {
 void destroy() {
 	zoomLevelToHandle.values().forEach(Gdip::Matrix_delete);
 	zoomLevelToHandle.clear();
+}
+
+@Override
+void destroyHandlesExcept(Set<Integer> zoomLevels) {
+	zoomLevelToHandle.entrySet().removeIf(entry -> {
+		final Integer zoom = entry.getKey();
+		if (!zoomLevels.contains(zoom) && zoom != initialZoom) {
+			Gdip.Matrix_delete(entry.getValue());
+			return true;
+		}
+		return false;
+	});
 }
 
 /**

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Control.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Control.java
@@ -4899,6 +4899,7 @@ LRESULT WM_DPICHANGED (long wParam, long lParam) {
 	// Map DPI to Zoom and compare
 	int newNativeZoom = DPIUtil.mapDPIToZoom (OS.HIWORD (wParam));
 	if (getDisplay().isRescalingAtRuntime()) {
+		Device.win32_destroyUnusedHandles(getDisplay());
 		int oldNativeZoom = nativeZoom;
 		if (newNativeZoom != oldNativeZoom) {
 			DPIUtil.setDeviceZoom (newNativeZoom);


### PR DESCRIPTION
This PR contributes to the cleanup of those handles of Resources which were created for the zoom levels which are not applicable for the existing zoom levels of all the monitor. i.e., if there were 2 monitors with 100% and 200% zoom levels and the seconds monitor is switched to 100% as well. On the DPI_CHANGED event, we trigger a cleanup of handles of the resources using the resource tracker to remove the handles which were created for 200% zoom level since there doesn't exist any monitor with a zoom level of 100% anymore.

With this PR, we also refactor the resource tracker to allow it to track all the resources for win32 all the time but rather using the tracking flag to report errors, since that is the only use case of the tracking flag as of now. By allowing the Resource Tracker to track the resources, we can trigger the cleanup of all the relevant handles from a single point.

Contributes to #62 and #127