### PR TITLE
Command+Q on Snippet99

### DIFF
--- a/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet99.java
+++ b/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet99.java
@@ -30,13 +30,26 @@ public static void main (String [] args) {
 	Display display = new Display ();
 	final Shell shell = new Shell (display);
 	shell.setText("Snippet 99");
-	shell.addListener (SWT.Close, event -> {
-		MessageBox messageBox = new MessageBox(shell, SWT.ICON_QUESTION | SWT.YES | SWT.NO);
-		messageBox.setText("Information");
-		messageBox.setMessage("Close the shell?");
-		messageBox.setButtonLabels(Map.of(SWT.YES, "Close"));
-		event.doit = messageBox.open () == SWT.YES;
-	});
+	// Listener for when the shell close button is clicked
+    shell.addListener (SWT.Close, event -> {
+        if (!shell.isDisposed()) {
+            MessageBox messageBox = new MessageBox(shell, SWT.ICON_QUESTION | SWT.YES | SWT.NO);
+            messageBox.setText("Information");
+            messageBox.setMessage("Close the shell?");
+            messageBox.setButtonLabels(Map.of(SWT.YES, "Close"));
+            event.doit = messageBox.open () == SWT.YES;
+        }
+    });
+    // Dispose listener to implement Cmd+Q (on macOS)
+    display.addListener(SWT.Dispose, event -> {
+        if (!shell.isDisposed()) {
+            MessageBox messageBox = new MessageBox(shell, SWT.ICON_QUESTION | SWT.YES | SWT.NO);
+            messageBox.setText("Information");
+            messageBox.setMessage("Close the application?");
+            messageBox.setButtonLabels(Map.of(SWT.YES, "Close"));
+            event.doit = messageBox.open() == SWT.YES;
+        }
+    });
 	shell.pack ();
 	shell.open();
 	while (!shell.isDisposed ()) {


### PR DESCRIPTION
Fixes: https://github.com/eclipse-platform/eclipse.platform.swt/issues/1205

Snippet99 requires modification as Command+Q is not implemented on that. Currently, the snippet demonstrates a message box pop-up when attempting to close the dialog window, but pressing Command+Q closes the window without triggering this behaviour. The snippet has been updated to implement Command+Q functionality and to add an SWT dispose listener to the display object.