### PR TITLE
Temporarily revert to Tycho 4.0.8 for GitHub Actions builds

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -73,6 +73,7 @@ jobs:
         --fail-at-end
         -DskipNativeTests=false
         -DfailIfNoTests=false
+        -Dtycho.version=4.0.8
         clean install
     - name: Performance tests
       if: contains(github.event.pull_request.labels.*.name, 'performance')


### PR DESCRIPTION
GitHub actions builds are currently failing because of invalid fragments in the classpath when compiling the SWT fragments after updating to Tycho 4.0.8. This change temporarily reverts the used Tycho verison in the GitHub Actions workflow to 4.0.8.

### Why?
We are approaching M1 and several PRs that are intended to be merged for M1 are blocked by failing builds (see discussion in https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/2360). In order to unblock them, I would like to apply this temporary revert. I will provide a follow-up PR rolling back this temporary revert and also propose to merge that soon to move back to the current Tycho version and try to properly address the issue.
