### PR TITLE
Switch back GitHub Actions workflow to use current Tycho version

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -71,7 +71,6 @@ jobs:
         --fail-at-end
         -DskipNativeTests=false
         -DfailIfNoTests=false
-        '-Dtycho.version=4.0.8'
         clean install
     - name: Performance tests
       if: contains(github.event.pull_request.labels.*.name, 'performance')

--- a/binaries/org.eclipse.swt.cocoa.macosx.aarch64/.settings/.api_filters
+++ b/binaries/org.eclipse.swt.cocoa.macosx.aarch64/.settings/.api_filters
@@ -248,105 +248,11 @@
             </message_arguments>
         </filter>
     </resource>
-    <resource path="Eclipse SWT/cocoa/org/eclipse/swt/graphics/GCData.java" type="org.eclipse.swt.graphics.GCData">
-        <filter id="338940029">
-            <message_arguments>
-                <message_argument value="org.eclipse.swt.graphics.GCData"/>
-                <message_argument value="bg"/>
-            </message_arguments>
-        </filter>
-        <filter id="338940029">
-            <message_arguments>
-                <message_argument value="org.eclipse.swt.graphics.GCData"/>
-                <message_argument value="clipPath"/>
-            </message_arguments>
-        </filter>
-        <filter id="338940029">
-            <message_arguments>
-                <message_argument value="org.eclipse.swt.graphics.GCData"/>
-                <message_argument value="fg"/>
-            </message_arguments>
-        </filter>
-        <filter id="338940029">
-            <message_arguments>
-                <message_argument value="org.eclipse.swt.graphics.GCData"/>
-                <message_argument value="flippedContext"/>
-            </message_arguments>
-        </filter>
-        <filter id="338940029">
-            <message_arguments>
-                <message_argument value="org.eclipse.swt.graphics.GCData"/>
-                <message_argument value="inverseTransform"/>
-            </message_arguments>
-        </filter>
-        <filter id="338940029">
-            <message_arguments>
-                <message_argument value="org.eclipse.swt.graphics.GCData"/>
-                <message_argument value="layoutManager"/>
-            </message_arguments>
-        </filter>
-        <filter id="338940029">
-            <message_arguments>
-                <message_argument value="org.eclipse.swt.graphics.GCData"/>
-                <message_argument value="paintRect"/>
-            </message_arguments>
-        </filter>
-        <filter id="338940029">
-            <message_arguments>
-                <message_argument value="org.eclipse.swt.graphics.GCData"/>
-                <message_argument value="path"/>
-            </message_arguments>
-        </filter>
-        <filter id="338940029">
-            <message_arguments>
-                <message_argument value="org.eclipse.swt.graphics.GCData"/>
-                <message_argument value="size"/>
-            </message_arguments>
-        </filter>
-        <filter id="338940029">
-            <message_arguments>
-                <message_argument value="org.eclipse.swt.graphics.GCData"/>
-                <message_argument value="textContainer"/>
-            </message_arguments>
-        </filter>
-        <filter id="338940029">
-            <message_arguments>
-                <message_argument value="org.eclipse.swt.graphics.GCData"/>
-                <message_argument value="textStorage"/>
-            </message_arguments>
-        </filter>
-        <filter id="338940029">
-            <message_arguments>
-                <message_argument value="org.eclipse.swt.graphics.GCData"/>
-                <message_argument value="transform"/>
-            </message_arguments>
-        </filter>
-        <filter id="338940029">
-            <message_arguments>
-                <message_argument value="org.eclipse.swt.graphics.GCData"/>
-                <message_argument value="view"/>
-            </message_arguments>
-        </filter>
-        <filter id="338940029">
-            <message_arguments>
-                <message_argument value="org.eclipse.swt.graphics.GCData"/>
-                <message_argument value="visiblePath"/>
-            </message_arguments>
-        </filter>
-    </resource>
     <resource path="Eclipse SWT/cocoa/org/eclipse/swt/widgets/Composite.java" type="org.eclipse.swt.widgets.Composite">
         <filter id="576778288">
             <message_arguments>
                 <message_argument value="Scrollable"/>
                 <message_argument value="Composite"/>
-            </message_arguments>
-        </filter>
-    </resource>
-    <resource path="Eclipse SWT/cocoa/org/eclipse/swt/widgets/Display.java" type="org.eclipse.swt.widgets.Display">
-        <filter id="336744520">
-            <message_arguments>
-                <message_argument value="@noextend"/>
-                <message_argument value="org.eclipse.swt.widgets.Display"/>
             </message_arguments>
         </filter>
     </resource>

--- a/binaries/org.eclipse.swt.cocoa.macosx.x86_64/.settings/.api_filters
+++ b/binaries/org.eclipse.swt.cocoa.macosx.x86_64/.settings/.api_filters
@@ -248,105 +248,11 @@
             </message_arguments>
         </filter>
     </resource>
-    <resource path="Eclipse SWT/cocoa/org/eclipse/swt/graphics/GCData.java" type="org.eclipse.swt.graphics.GCData">
-        <filter id="338940029">
-            <message_arguments>
-                <message_argument value="org.eclipse.swt.graphics.GCData"/>
-                <message_argument value="bg"/>
-            </message_arguments>
-        </filter>
-        <filter id="338940029">
-            <message_arguments>
-                <message_argument value="org.eclipse.swt.graphics.GCData"/>
-                <message_argument value="clipPath"/>
-            </message_arguments>
-        </filter>
-        <filter id="338940029">
-            <message_arguments>
-                <message_argument value="org.eclipse.swt.graphics.GCData"/>
-                <message_argument value="fg"/>
-            </message_arguments>
-        </filter>
-        <filter id="338940029">
-            <message_arguments>
-                <message_argument value="org.eclipse.swt.graphics.GCData"/>
-                <message_argument value="flippedContext"/>
-            </message_arguments>
-        </filter>
-        <filter id="338940029">
-            <message_arguments>
-                <message_argument value="org.eclipse.swt.graphics.GCData"/>
-                <message_argument value="inverseTransform"/>
-            </message_arguments>
-        </filter>
-        <filter id="338940029">
-            <message_arguments>
-                <message_argument value="org.eclipse.swt.graphics.GCData"/>
-                <message_argument value="layoutManager"/>
-            </message_arguments>
-        </filter>
-        <filter id="338940029">
-            <message_arguments>
-                <message_argument value="org.eclipse.swt.graphics.GCData"/>
-                <message_argument value="paintRect"/>
-            </message_arguments>
-        </filter>
-        <filter id="338940029">
-            <message_arguments>
-                <message_argument value="org.eclipse.swt.graphics.GCData"/>
-                <message_argument value="path"/>
-            </message_arguments>
-        </filter>
-        <filter id="338940029">
-            <message_arguments>
-                <message_argument value="org.eclipse.swt.graphics.GCData"/>
-                <message_argument value="size"/>
-            </message_arguments>
-        </filter>
-        <filter id="338940029">
-            <message_arguments>
-                <message_argument value="org.eclipse.swt.graphics.GCData"/>
-                <message_argument value="textContainer"/>
-            </message_arguments>
-        </filter>
-        <filter id="338940029">
-            <message_arguments>
-                <message_argument value="org.eclipse.swt.graphics.GCData"/>
-                <message_argument value="textStorage"/>
-            </message_arguments>
-        </filter>
-        <filter id="338940029">
-            <message_arguments>
-                <message_argument value="org.eclipse.swt.graphics.GCData"/>
-                <message_argument value="transform"/>
-            </message_arguments>
-        </filter>
-        <filter id="338940029">
-            <message_arguments>
-                <message_argument value="org.eclipse.swt.graphics.GCData"/>
-                <message_argument value="view"/>
-            </message_arguments>
-        </filter>
-        <filter id="338940029">
-            <message_arguments>
-                <message_argument value="org.eclipse.swt.graphics.GCData"/>
-                <message_argument value="visiblePath"/>
-            </message_arguments>
-        </filter>
-    </resource>
     <resource path="Eclipse SWT/cocoa/org/eclipse/swt/widgets/Composite.java" type="org.eclipse.swt.widgets.Composite">
         <filter id="576778288">
             <message_arguments>
                 <message_argument value="Scrollable"/>
                 <message_argument value="Composite"/>
-            </message_arguments>
-        </filter>
-    </resource>
-    <resource path="Eclipse SWT/cocoa/org/eclipse/swt/widgets/Display.java" type="org.eclipse.swt.widgets.Display">
-        <filter id="336744520">
-            <message_arguments>
-                <message_argument value="@noextend"/>
-                <message_argument value="org.eclipse.swt.widgets.Display"/>
             </message_arguments>
         </filter>
     </resource>


### PR DESCRIPTION
The Tycho version used in GitHub Actions workflow has been temporarily reverted to 4.0.8. This change switched back the Tycho version defined in the Tycho build itself.

Since recent PDE and Tycho changes that apply with this change of the Tycho version, the API filters for GCData and Display on MacOS are not necessary anymore and produce warnings due to being obsolete. Thus, this change also removes the according filters. The commit has been taken from as it semantically belongs to the Tycho version change (and is required to make the CI builds run successfully):
- #1478

<s>⚠️ This PR is supposed to be merged once the issue discussed in https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/2360 and reproduced via https://github.com/eclipse-tycho/tycho/pull/4293 has been resolved or once we want to have SWT use latest Tycho again to further investigate the failures.</s>

Supercedes and thus closes #1478