### PR TITLE
Bump riscv64 version

### DIFF
--- a/binaries/org.eclipse.swt.gtk.linux.riscv64/META-INF/MANIFEST.MF
+++ b/binaries/org.eclipse.swt.gtk.linux.riscv64/META-INF/MANIFEST.MF
@@ -1,9 +1,9 @@
 Manifest-Version: 1.0
-Fragment-Host: org.eclipse.swt;bundle-version="[3.127.0,4.0.0)"
+Fragment-Host: org.eclipse.swt;bundle-version="[3.128.0,4.0.0)"
 Bundle-Name: %fragmentName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.swt.gtk.linux.riscv64; singleton:=true
-Bundle-Version: 3.127.100.qualifier
+Bundle-Version: 3.128.0.qualifier
 Bundle-ManifestVersion: 2
 Bundle-Localization: fragment
 Export-Package: 


### PR DESCRIPTION
This PR upgrades riscv64 version from `3.127.100` to `3.128.0`