### PR TITLE
Refactor Image for storing ImageMetadata

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Decorations.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Decorations.java
@@ -914,7 +914,7 @@ void setImages (Image image, Image [] images) {
 	if (smallIcon != null) {
 		switch (smallIcon.type) {
 			case SWT.BITMAP:
-				smallImage = Display.createIcon (smallIcon);
+				smallImage = Display.createIcon (smallIcon, getZoom());
 				hSmallIcon = Image.win32_getHandle(smallImage, getZoom());
 				break;
 			case SWT.ICON:
@@ -926,7 +926,7 @@ void setImages (Image image, Image [] images) {
 	if (largeIcon != null) {
 		switch (largeIcon.type) {
 			case SWT.BITMAP:
-				largeImage = Display.createIcon (largeIcon);
+				largeImage = Display.createIcon (largeIcon, getZoom());
 				hLargeIcon = Image.win32_getHandle(largeImage, getZoom());
 				break;
 			case SWT.ICON:

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Display.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Display.java
@@ -1176,9 +1176,9 @@ static long create32bitDIB (long hBitmap, int alpha, byte [] alphaData, int tran
 	return memDib;
 }
 
-static Image createIcon (Image image) {
+static Image createIcon (Image image, int zoom) {
 	Device device = image.getDevice ();
-	ImageData data = image.getImageDataAtCurrentZoom();
+	ImageData data = image.getImageData(zoom);
 	if (data.alpha == -1 && data.alphaData == null) {
 		ImageData mask = data.getTransparencyMask ();
 		return new Image (device, data, mask);
@@ -1187,7 +1187,7 @@ static Image createIcon (Image image) {
 	long hMask, hBitmap;
 	long hDC = device.internal_new_GC (null);
 	long dstHdc = OS.CreateCompatibleDC (hDC), oldDstBitmap;
-	hBitmap = Display.create32bitDIB (image.handle, data.alpha, data.alphaData, data.transparentPixel);
+	hBitmap = Display.create32bitDIB (Image.win32_getHandle(image, zoom), data.alpha, data.alphaData, data.transparentPixel);
 	hMask = OS.CreateBitmap (width, height, 1, 1, null);
 	oldDstBitmap = OS.SelectObject (dstHdc, hMask);
 	OS.PatBlt (dstHdc, 0, 0, width, height, OS.BLACKNESS);

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TaskBar.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TaskBar.java
@@ -165,13 +165,10 @@ IShellLink createShellLink (MenuItem item) {
 				icon = directory + "\\" + "menu" + item.id + ".ico";
 				ImageData data;
 				if (item.hBitmap != 0) {
-					Image image2 = Image.win32_new (display, SWT.BITMAP, item.hBitmap);
+					long handle = OS.CopyImage(item.hBitmap, SWT.BITMAP, 0, 0, 0);
+					Image image2 = Image.win32_new (display, SWT.BITMAP, handle);
 					data = image2.getImageData (DPIUtil.getDeviceZoom ());
-					/*
-					 * image2 instance doesn't own the handle and shall not be disposed. Make it
-					 * appear disposed to cause leak trackers to ignore it.
-					 */
-					image2.handle = 0;
+					image2.dispose();
 				} else {
 					data = image.getImageData (DPIUtil.getDeviceZoom ());
 				}

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TaskItem.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TaskItem.java
@@ -473,7 +473,7 @@ void updateImage () {
 	long hIcon = 0;
 	switch (overlayImage.type) {
 		case SWT.BITMAP:
-			image2 = Display.createIcon (overlayImage);
+			image2 = Display.createIcon (overlayImage, getZoom());
 			hIcon = Image.win32_getHandle(image2, getZoom());
 			break;
 		case SWT.ICON:

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TrayItem.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TrayItem.java
@@ -457,7 +457,7 @@ public void setImage (Image image) {
 	if (icon != null) {
 		switch (icon.type) {
 			case SWT.BITMAP:
-				image2 = Display.createIcon (image);
+				image2 = Display.createIcon (image, getZoom());
 				hIcon = Image.win32_getHandle(image2, getZoom());
 				break;
 			case SWT.ICON:


### PR DESCRIPTION
This PR contributes to the refactoring of `Image` class for **win32**. 

The goal is to store more than just the `handle` of the image for each zoom level. To do that, a new private class is created (it's called `ImageHandle`) and an image contains one instance of this new class for each zoom level. The class contains the following fields:
- `handle` 
- `height`
- `width`

contributes to #62 and #127 