### PR TITLE
Replace Inforamtion control on mouse click in Edge

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Browser/win32/org/eclipse/swt/browser/Edge.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Browser/win32/org/eclipse/swt/browser/Edge.java
@@ -994,6 +994,15 @@ int handleGotFocus(long pView, long pArg) {
 	ignoreFocus = true;
 	OS.SendMessage (browser.handle, OS.WM_SETFOCUS, 0, 0);
 	ignoreFocus = false;
+
+	Event newEvent = new Event();
+	newEvent.widget = browser;
+	Point position = browser.getDisplay().getCursorLocation(); // To Points
+	position = browser.getDisplay().map(null, browser, position);
+	newEvent.x = position.x; newEvent.y = position.y;
+	newEvent.type = SWT.MouseEnter;
+	browser.notifyListeners(newEvent.type, newEvent);
+
 	return COM.S_OK;
 }
 


### PR DESCRIPTION
This PR contributes to the triggering of the event on mouseclick to replace an information control of the javadoc tooltip while using Edge Browser.

contributes to #212