### PR TITLE
Remove CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,0 @@
-**/gtk @sravanlakkimsetti
-**/win32  @niraj-modi
-**/cocoa @lshanmug


### PR DESCRIPTION
None of the people listed is actively reviewing things thus this gives false expectation as it makes contributors believe that the assigned reviewer will do something.