### PR TITLE
Guard monitor.zoom with isRescalingAtRuntime flag

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Display.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Display.java
@@ -3157,7 +3157,7 @@ private Rectangle translateRectangleInPixelsInDisplayCoordinateSystem(int x, int
 
 private Rectangle translateRectangleInPixelsInDisplayCoordinateSystem(int x, int y, int width, int height, Monitor monitorOfLocation, Monitor monitorOfArea) {
 	Point topLeft = getPixelsFromPoint(monitorOfLocation, x, y);
-	int zoom = DPIUtil.getZoomForAutoscaleProperty(monitorOfArea.zoom);
+	int zoom = getApplicableMonitorZoom(monitorOfArea);
 	int widthInPixels = DPIUtil.scaleUp(width, zoom);
 	int heightInPixels = DPIUtil.scaleUp(height, zoom);
 	return new Rectangle(topLeft.x, topLeft.y, widthInPixels, heightInPixels);
@@ -3176,10 +3176,14 @@ private Rectangle translateRectangleInPointsInDisplayCoordinateSystem(int x, int
 
 private Rectangle translateRectangleInPointsInDisplayCoordinateSystem(int x, int y, int widthInPixels, int heightInPixels, Monitor monitorOfLocation, Monitor monitorOfArea) {
 	Point topLeft = getPointFromPixels(monitorOfLocation, x, y);
-	int zoom = DPIUtil.getZoomForAutoscaleProperty(monitorOfArea.zoom);
+	int zoom = getApplicableMonitorZoom(monitorOfArea);
 	int width = DPIUtil.scaleDown(widthInPixels, zoom);
 	int height = DPIUtil.scaleDown(heightInPixels, zoom);
 	return new Rectangle(topLeft.x, topLeft.y, width, height);
+}
+
+private int getApplicableMonitorZoom(Monitor monitor) {
+	return DPIUtil.getZoomForAutoscaleProperty(isRescalingAtRuntime() ? monitor.zoom : getDeviceZoom());
 }
 
 long messageProc (long hwnd, long msg, long wParam, long lParam) {
@@ -5480,21 +5484,21 @@ private Monitor getContainingMonitorInPixelsCoordinate(int xInPixels, int yInPix
 }
 
 private Rectangle getMonitorClientAreaInPixels(Monitor monitor) {
-	int zoom = DPIUtil.getZoomForAutoscaleProperty(monitor.zoom);
+	int zoom = getApplicableMonitorZoom(monitor);
 	int widthInPixels = DPIUtil.scaleUp(monitor.clientWidth, zoom);
 	int heightInPixels = DPIUtil.scaleUp(monitor.clientHeight, zoom);
 	return new Rectangle(monitor.clientX, monitor.clientY, widthInPixels, heightInPixels);
 }
 
 private Point getPixelsFromPoint(Monitor monitor, int x, int y) {
-	int zoom = DPIUtil.getZoomForAutoscaleProperty(monitor.zoom);
+	int zoom = getApplicableMonitorZoom(monitor);
 	int mappedX = DPIUtil.scaleUp(x - monitor.clientX, zoom) + monitor.clientX;
 	int mappedY = DPIUtil.scaleUp(y - monitor.clientY, zoom) + monitor.clientY;
 	return new Point(mappedX, mappedY);
 }
 
 private Point getPointFromPixels(Monitor monitor, int x, int y) {
-	int zoom = DPIUtil.getZoomForAutoscaleProperty(monitor.zoom);
+	int zoom = getApplicableMonitorZoom(monitor);
 	int mappedX = DPIUtil.scaleDown(x - monitor.clientX, zoom) + monitor.clientX;
 	int mappedY = DPIUtil.scaleDown(y - monitor.clientY, zoom) + monitor.clientY;
 	return new Point(mappedX, mappedY);


### PR DESCRIPTION
This contribution protects the unintended usage of different zoom levels of different monitors in trasnlating the points and rectangles from control to display coordinate system when the isRescalingAtRuntime flag is disabled.

contributes to #62 and #127

### How To Test
* Set your monitor setup like this: 

> Left Monitor: 200% Zoom, Right Monitor : 100% Zoom (Primary Monitor)

* Create this Snippet:
```java
public class TestSnippet {

	public static void main(String[] args) {
		Display display = new Display();
		Shell shell = new Shell(display);
		shell.setText("Snippet Lol");
		Text text = new Text(shell, SWT.BORDER);
		text.setBounds(20, 20, 500, 30);
		Button button = new Button(shell, SWT.PUSH);
		button.setBounds(100, 80, 100, 30);
		button.setText("Relocate");
		button.addSelectionListener(new SelectionAdapter() {
			@Override
			public void widgetSelected(SelectionEvent e) {
				Point location = shell.getLocation();
				location.x = Integer.parseInt(text.getText());
				shell.setLocation(location);
			}
		});
		shell.open();
		while (!shell.isDisposed()) {
			if (!display.readAndDispatch())
				display.sleep();
		}
		display.dispose();
	}
}
```
* Checkout the master branch
* Disable rescaling
* Let's say your 200% monitor has pixels from -2000 to 0. Enter the value of x more than the half, i.e. > -1000 and < 0. 
* You will see the shell placed in the other monitor (100% monitor in the right) and not in the one expected, because 200 is used as the scaling factor and not the primary monitor zoom.
* Now Enable rescaling.
* Try it again, you'll see the placement to be in the 200% monitor.
* Now, switch to the branch _guard_monitor_zoom_usage_ and try the whole scenario with rescaling disabled. It should use the primary monitor zoom (100%) and the shell should be positioned in the 200% monitor when you set the x >-1000 and < 0.
* If you enable the flag, the behavior should be identical to the behavior on master.

Note: The placement of the shell for x > -1000 is done wrt to the zoom of primary monitor in case it is outside the scaled down bounds. However, when the bounds of the monitor are set in setClientArea method, they are not scaled down according to their zoom level when autoScaleOnRuntime is disabled hence, the code considers -2000 to 0 to be under 200% monitor in th scaled down variant and scales it up by 200% when asked to translate the point. We cannot store the zoom differently to comply with the usage of monitor in other places since it is the part of common widgets. hence, we need to make sure we don't use the monitor zoom while mapping the coordinates when the flag is disabled but rather use the default zoom.