### PR TITLE
[Oomph-Setup] Fix link to SWT setup badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Thanks for your interest in this project.
 For information about contributing to Eclipse Platform in general, see the general [CONTRIBUTING](https://github.com/eclipse-platform/.github/blob/main/CONTRIBUTING.md) page.
 
 
-[![Create Eclipse Development Environment for Eclipse SWT](https://download.eclipse.org/oomph/www/setups/svg/Eclipse_SWT.svg)](
+[![Create Eclipse Development Environment for Eclipse SWT](https://download.eclipse.org/oomph/www/setups/svg/SWT.svg)](
 https://www.eclipse.org/setups/installer/?url=https://raw.githubusercontent.com/eclipse-platform/eclipse.platform.swt/master/bundles/org.eclipse.swt.tools/Oomph/PlatformSWTConfiguration.setup&show=true
 "Click to open Eclipse-Installer Auto Launch or drag into your running installer")
 


### PR DESCRIPTION
Follow-up on https://github.com/eclipse-platform/eclipse.platform.swt/pull/1509, where the link was anticipated incorrectly.