### PR TITLE
fix NPE in CTabFolder.onPaint #1515

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CTabFolder.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CTabFolder.java
@@ -2062,6 +2062,9 @@ void onPaint(Event event) {
 	}
 
 	GC gc = event.gc;
+	if (gc == null) {
+		return;
+	}
 	Font gcFont = gc.getFont();
 	Color gcBackground = gc.getBackground();
 	Color gcForeground = gc.getForeground();


### PR DESCRIPTION
was reproduceable with
StackRendererTest.testOnboardingIsHiddenWhenEditorOpened()

https://github.com/eclipse-platform/eclipse.platform.swt/issues/1515