### PR TITLE
Widget.getData: fix NPE

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Widget.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Widget.java
@@ -593,8 +593,7 @@ public Object getData () {
 public Object getData (String key) {
 	checkWidget();
 	if (key == null) error (SWT.ERROR_NULL_ARGUMENT);
-	if ((state & KEYED_DATA) != 0) {
-		Object [] table = (Object []) data;
+	if ((state & KEYED_DATA) != 0 && data instanceof Object [] table) {
 		for (int i=1; i<table.length; i+=2) {
 			if (key.equals (table [i])) return table [i+1];
 		}


### PR DESCRIPTION
fix java.lang.NullPointerException: Cannot read the array length because "table" is null

As Widget.setData(Object) can be called with null argument even if KEYED_DATA is set.