### PR TITLE
Expand Bar is not scaled during DPI change

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ExpandBar.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ExpandBar.java
@@ -878,6 +878,7 @@ private static void handleDPIChange(Widget widget, int newZoom, float scalingFac
 	for (ExpandItem item : expandBar.getItems()) {
 		DPIZoomChangeRegistry.applyChange(item, newZoom, scalingFactor);
 	}
+	expandBar.layoutItems(0, true);
 	expandBar.redraw();
 }
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ExpandItem.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ExpandItem.java
@@ -539,7 +539,7 @@ private static void handleDPIChange(Widget widget, int newZoom, float scalingFac
 	if (item.height != 0 || item.width != 0) {
 		int newWidth = Math.round(item.width * scalingFactor);
 		int newHeight = Math.round(item.height * scalingFactor);
-		item.setBoundsInPixels(item.x, item.y, newWidth, newHeight, false, true);
+		item.setBoundsInPixels(item.x, item.y, newWidth, newHeight, true, true);
 	}
 }
 }


### PR DESCRIPTION
When moving from one zoom level monitor to another zoom level (no matter what %), The expanded items and texts are not drawn at correct coordinates.

## HOW TO TEST
- Run the `ControlExample` with the following **VM Arguments**
```
-Dswt.autoScale=quarter
-Dswt.autoScale.updateOnRuntime=true
```
- Switch to the tab "Expand Items"
- Move the window from 200 to 100 zoom level monitor (Producible in any combination of zoom levels)
- See if the "expanded" items are aligned to correct coordinates

## SCREENSHOTS

**Before Fix:**
![image](https://github.com/user-attachments/assets/be8c82d0-e263-460e-ab96-8929ae9ac95b)

**After Fix:**
![image](https://github.com/user-attachments/assets/0112b9d7-6d4c-4191-921e-084c710ea292)

## Requires
* [x] https://github.com/eclipse-platform/eclipse.platform.swt/pull/1527


Contributes to https://github.com/eclipse-platform/eclipse.platform.swt/issues/62 and https://github.com/eclipse-platform/eclipse.platform.swt/issues/127
