### PR TITLE
Edge: Inherit dark theme from Eclipse

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT PI/win32/org/eclipse/swt/internal/ole/win32/COM.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/win32/org/eclipse/swt/internal/ole/win32/COM.java
@@ -88,6 +88,7 @@ public class COM extends OS {
 	public static final GUID IID_ICoreWebView2_2 = IIDFromString("{9E8F0CF8-E670-4B5E-B2BC-73E061E3184C}"); //$NON-NLS-1$
 	public static final GUID IID_ICoreWebView2_11 = IIDFromString("{0BE78E56-C193-4051-B943-23B460C08BDB}"); //$NON-NLS-1$
 	public static final GUID IID_ICoreWebView2_12 = IIDFromString("{35D69927-BCFA-4566-9349-6B3E0D154CAC}"); //$NON-NLS-1$
+	public static final GUID IID_ICoreWebView2_13 = IIDFromString("{F75F09A8-667E-4983-88D6-C8773F315E84}"); //$NON-NLS-1$
 
 	// IA2 related GUIDS
 	public static final GUID IIDIAccessible2 = IIDFromString("{E89F726E-C4F4-4c19-BB19-B647D7FA8478}"); //$NON-NLS-1$

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/win32/org/eclipse/swt/internal/ole/win32/ICoreWebView2Profile.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/win32/org/eclipse/swt/internal/ole/win32/ICoreWebView2Profile.java
@@ -1,0 +1,50 @@
+/*******************************************************************************
+ * Copyright (c) 2024 SAP SE and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     SAP SE - initial implementation
+ *******************************************************************************/
+package org.eclipse.swt.internal.ole.win32;
+
+public class ICoreWebView2Profile extends IUnknown {
+
+public ICoreWebView2Profile(long address) {
+	super(address);
+}
+
+public int get_ProfileName(long[] value) {
+	return COM.VtblCall(3, address, value);
+}
+
+public int get_IsInPrivateModeEnabled(long[] value) {
+	return COM.VtblCall(4, address, value);
+}
+
+public int get_ProfilePath(long[] value) {
+	return COM.VtblCall(5, address, value);
+}
+
+public int get_DefaultDownloadFolderPath(long[] value) {
+	return COM.VtblCall(6, address, value);
+}
+
+public int put_DefaultDownloadFolderPath(long[] value) {
+	return COM.VtblCall(7, address, value);
+}
+
+public int get_PreferredColorScheme(long[] value) {
+	return COM.VtblCall(8, address, value);
+}
+
+public int put_PreferredColorScheme(long value) {
+	return COM.VtblCall(9, address, value);
+}
+
+}

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/win32/org/eclipse/swt/internal/ole/win32/ICoreWebView2_13.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/win32/org/eclipse/swt/internal/ole/win32/ICoreWebView2_13.java
@@ -1,0 +1,26 @@
+/*******************************************************************************
+ * Copyright (c) 2024 SAP SE and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     SAP SE - initial implementation
+ *******************************************************************************/
+package org.eclipse.swt.internal.ole.win32;
+
+public class ICoreWebView2_13 extends ICoreWebView2_12 {
+
+public ICoreWebView2_13(long address) {
+	super(address);
+}
+
+public int get_Profile(long[] value) {
+	return COM.VtblCall(105, address, value);
+}
+
+}

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/win32/org/eclipse/swt/internal/win32/OS.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/win32/org/eclipse/swt/internal/win32/OS.java
@@ -2285,6 +2285,7 @@ public static final void setTheme(boolean isDarkTheme) {
 	display.setData("org.eclipse.swt.internal.win32.Combo.useDarkTheme",       isDarkTheme);
 	display.setData("org.eclipse.swt.internal.win32.ProgressBar.useColors",    isDarkTheme);
 	display.setData("org.eclipse.swt.internal.win32.Text.useDarkThemeIcons",   isDarkTheme);
+	display.setData("org.eclipse.swt.internal.win32.Edge.useDarkPreferedColorScheme", isDarkTheme);
 }
 
 public static final boolean SetWindowText (long hWnd, TCHAR lpString) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Display.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Display.java
@@ -270,6 +270,17 @@ public class Display extends Device implements Executor {
 	 */
 	static final String USE_DARKTHEME_TEXT_ICONS = "org.eclipse.swt.internal.win32.Text.useDarkThemeIcons"; //$NON-NLS-1$
 	boolean textUseDarkthemeIcons = false;
+	/**
+	 * Use dark prefered color scheme in Edge browser.
+	 * Note:<br>
+	 * <ul>
+	 *   <li>When setting this property on the display, it is first AND'ed with !disableCustomThemeTweaks.
+	 *   <li>The data is then read from withing Edge.
+	 *   <li>This is to avoid adding public methods/members.
+	 * </ul>
+	 * Expects a <code>boolean</code> value.
+	 */
+	static final String EDGE_USE_DARK_PREFERED_COLOR_SCHEME = "org.eclipse.swt.internal.win32.Edge.useDarkPreferedColorScheme"; //$NON-NLS-1$
 
 	/* Custom icons */
 	private HashMap<Integer, Long> sizeToSearchIconHandle = new HashMap<>();
@@ -4574,6 +4585,9 @@ public void setData (String key, Object value) {
 			break;
 		case USE_DARKTHEME_TEXT_ICONS:
 			textUseDarkthemeIcons = !disableCustomThemeTweaks && _toBoolean(value);
+			break;
+		case EDGE_USE_DARK_PREFERED_COLOR_SCHEME:
+			value = !disableCustomThemeTweaks && _toBoolean(value);
 			break;
 	}
 


### PR DESCRIPTION
Set ICoreWebView2Profile#put_PreferredColorScheme() based on the Eclipse theme, if this is dark.

The same way it is done in

  Display.setData(USE_DARKMODE_EXPLORER_THEME_KEY, ...)

via

  OS.SetPreferredAppMode(PreferredAppMode_...);

Fixes #1529