### PR TITLE
[win32] Fix initialization of thread dpi awareness

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Display.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Display.java
@@ -583,9 +583,6 @@ public Display () {
  */
 public Display (DeviceData data) {
 	super (data);
-	if (DPIUtil.isAutoScaleOnRuntimeActive()) {
-		setRescalingAtRuntime(true);
-	}
 }
 
 Control _getFocusControl () {
@@ -939,6 +936,9 @@ public void close () {
 protected void create (DeviceData data) {
 	checkSubclass ();
 	checkDisplay (thread = Thread.currentThread (), true);
+	if (DPIUtil.isAutoScaleOnRuntimeActive()) {
+		setRescalingAtRuntime(true);
+	}
 	createDisplay (data);
 	register (this);
 	if (Default == null) Default = this;


### PR DESCRIPTION
This commit moves the initialization of the thread DPI awareness into the creation method. It was done too late before which resulted in all calls do Display::messageProc being executed with the wrong DPI awarness if the thread dpi awareness differs from the process DPI awareness.

##How to test

1. Configure your execution javaw.exe to be started with system DPI awareness (https://www.eclipse.org/swt/faq.php#winexternalmanifestfile) :
<dpi1:dpiAware>true</dpi1:dpiAware>
<dpi2:dpiAwareness>system</dpi2:dpiAwareness>
3. Prepare a two monitor setup, e.g primary 100% and secondary 200%
4. Start the ControlExample with
-Dswt.autoScale=quarter
-Dswt.autoScale.updateOnRuntime=true
5. Move the example to the **secondary** monitor
6. Change the zoom of the **primary** monitor
The shell will be layouted strange in some places,e.g. the right part in the ButtonTaB
![image](https://github.com/user-attachments/assets/f91e76a9-fa1c-4ae8-9cb7-e98e9b58fa5a)


