### PR TITLE
Revert "Extend Browser API to check for custom text location"

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Browser/common/org/eclipse/swt/browser/Browser.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Browser/common/org/eclipse/swt/browser/Browser.java
@@ -13,9 +13,6 @@
  *******************************************************************************/
 package org.eclipse.swt.browser;
 
-import java.net.*;
-import java.util.*;
-
 import org.eclipse.swt.*;
 import org.eclipse.swt.widgets.*;
 
@@ -1188,21 +1185,6 @@ public boolean setUrl (String url, String postData, String[] headers) {
 	checkWidget();
 	if (url == null) SWT.error (SWT.ERROR_NULL_ARGUMENT);
 	return webBrowser.setUrl (url, postData, headers);
-}
-
-/**
- * Checks if the location supplied is the location for setting custom text in the browser.
- * This means, when passing the browser URL to this method after a custom text has been set
- * via {@link #setText(String)} will yield true as long as no further navigation
- * to some other location is performed.
- *
- * @param location the URL to be checked, must not be null
- *
- * @since 3.128
- */
-public boolean isLocationForCustomText(String location) {
-	checkWidget();
-	return URI.create(Objects.requireNonNull(location)).equals(webBrowser.getUriForCustomText());
 }
 
 /**

--- a/bundles/org.eclipse.swt/Eclipse SWT Browser/common/org/eclipse/swt/browser/WebBrowser.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Browser/common/org/eclipse/swt/browser/WebBrowser.java
@@ -13,7 +13,6 @@
  *******************************************************************************/
 package org.eclipse.swt.browser;
 
-import java.net.*;
 import java.util.*;
 import java.util.List;
 
@@ -37,7 +36,6 @@ abstract class WebBrowser {
 
 	static final String ERROR_ID = "org.eclipse.swt.browser.error"; // $NON-NLS-1$
 	static final String EXECUTE_ID = "SWTExecuteTemporaryFunction"; // $NON-NLS-1$
-	private static final URI URI_FOR_CUSTOM_TEXT_PAGE = URI.create("about:blank");
 
 	static List<String[]> NativePendingCookies = new ArrayList<> ();
 	static String CookieName, CookieValue, CookieUrl;
@@ -724,10 +722,6 @@ boolean sendKeyEvent (Event event) {
 
 public void setBrowser (Browser browser) {
 	this.browser = browser;
-}
-
-URI getUriForCustomText() {
-	return URI_FOR_CUSTOM_TEXT_PAGE;
 }
 
 public abstract boolean setText (String html, boolean trusted);

--- a/examples/org.eclipse.swt.examples/src/org/eclipse/swt/examples/controlexample/BrowserTab.java
+++ b/examples/org.eclipse.swt.examples/src/org/eclipse/swt/examples/controlexample/BrowserTab.java
@@ -213,7 +213,7 @@ class BrowserTab extends Tab {
 		/* store the state of the Browser if applicable */
 		if (browser != null) {
 			String url = browser.getUrl();
-			if (url.length() > 0 && !browser.isLocationForCustomText(url)) { //$NON-NLS-1$
+			if (url.length() > 0 && !url.equals("about:blank")) { //$NON-NLS-1$
 				lastUrl = url;
 			} else {
 				String text = browser.getText();

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_browser_Browser.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_browser_Browser.java
@@ -519,75 +519,6 @@ public void test_LocationListener_addAndRemove() {
 }
 
 @Test
-public void test_isLocationForCustomText_setUrlAfterDisposedThrowsSwtException() {
-	Browser testBrowser = createBrowser(shell, SWT.NONE);
-	testBrowser.dispose();
-	assertThrows(SWTException.class, () -> testBrowser.isLocationForCustomText("about:blank"));
-}
-
-@Test
-public void test_isLocationForCustomText_isSetUrlNotCustomTextUrlAfterSetText() {
-	String url = getValidUrl();
-	AtomicBoolean locationChanged = new AtomicBoolean(false);
-	browser.addLocationListener(changedAdapter(event -> {
-			locationChanged.set(true);
-	}));
-
-	browser.setText("Custom text");
-	assertTrue("Time Out: The Browser didn't navigate to the URL", waitForPassCondition(locationChanged::get));
-	locationChanged.set(false);
-	browser.setUrl(url);
-	assertTrue("Time Out: The Browser didn't navigate to the URL", waitForPassCondition(locationChanged::get));
-	assertFalse("The navigated URL is falsly indicated to be the custom text URL", browser.isLocationForCustomText(browser.getUrl()));
-}
-
-@Test
-public void test_isLocationForCustomText_isFirstSetTextURLStillCustomTextUrlAfterSetUrl() {
-	AtomicBoolean locationChanged = new AtomicBoolean(false);
-	browser.addLocationListener(changedAdapter(event -> locationChanged.set(true)));
-	String url = getValidUrl();
-	browser.setText("Custom text");
-	assertTrue(waitForPassCondition(locationChanged::get));
-	String firstUrl = browser.getUrl();
-	locationChanged.set(false);
-	browser.setUrl(url);
-	assertTrue("Time Out: The Browser didn't navigate to the URL", waitForPassCondition(locationChanged::get));
-	assertTrue(browser.isLocationForCustomText(firstUrl));
-	assertFalse(browser.isLocationForCustomText(browser.getUrl()));
-}
-
-private String getValidUrl() {
-	String pluginPath = System.getProperty("PLUGIN_PATH");
-	testLogAppend("PLUGIN_PATH: " + pluginPath);
-	// When test is run via Ant, URL needs to be acquired differently. In that case the PLUGIN_PATH property is set and used.
-	if (pluginPath != null) {
-		return pluginPath + "/data/testWebsiteWithTitle.html";
-	} else {
-		// used when ran from Eclipse gui.
-		return Test_org_eclipse_swt_browser_Browser.class.getClassLoader().getResource("testWebsiteWithTitle.html").toString();
-	}
-}
-
-@Test
-public void test_isLocationForCustomText_isSetUrlNotCustomTextUrl() {
-	AtomicBoolean locationChanged = new AtomicBoolean(false);
-	browser.addLocationListener(changedAdapter(event -> locationChanged.set(true)));
-	String url = getValidUrl();
-	browser.setUrl(url);
-	waitForPassCondition(locationChanged::get);
-	assertFalse("Url is wrongly considered Custom Text Url", browser.isLocationForCustomText(browser.getUrl()));
-}
-
-@Test
-public void test_isLocationForCustomText() {
-	AtomicBoolean locationChanged = new AtomicBoolean(false);
-	browser.addLocationListener(changedAdapter(e -> locationChanged.set(true)));
-	browser.setText("Hello world");
-	assertTrue("Timeout: LocationListener.changing() event was never fired", waitForPassCondition(locationChanged::get));
-	assertTrue("Custom Text URI was not loaded on setText", browser.isLocationForCustomText(browser.getUrl()));
-}
-
-@Test
 public void test_LocationListener_changing() {
 	AtomicBoolean changingFired = new AtomicBoolean(false);
 	browser.addLocationListener(changingAdapter(e -> changingFired.set(true)));
@@ -762,9 +693,20 @@ public void test_LocationListener_LocationListener_ordered_changing () {
 	String url = getValidUrl();
 	browser.setUrl(url);
 	waitForPassCondition(() -> locations.size() == 2);
-	assertTrue("Change of locations do not fire in order.", browser.isLocationForCustomText(locations.get(0)) && locations.get(1).contains("testWebsiteWithTitle.html"));
+	assertTrue("Change of locations do not fire in order.", locations.get(0).equals("about:blank") && locations.get(1).contains("testWebsiteWithTitle.html"));
 }
 
+private String getValidUrl() {
+	String pluginPath = System.getProperty("PLUGIN_PATH");
+	testLogAppend("PLUGIN_PATH: " + pluginPath);
+	// When test is run via Ant, URL needs to be acquired differently. In that case the PLUGIN_PATH property is set and used.
+	if (pluginPath != null) {
+		return pluginPath + "/data/testWebsiteWithTitle.html";
+	} else {
+		// used when ran from Eclipse gui.
+		return Test_org_eclipse_swt_browser_Browser.class.getClassLoader().getResource("testWebsiteWithTitle.html").toString();
+	}
+}
 
 @Test
 /** Ensue that only one changed and one completed event are fired for url changes */


### PR DESCRIPTION
This reverts commit 51b8d8f655c34c9a536a1694c2f8e6273c3c6d76. The API isLocationForCustomText is not needed for Browsers.

contributes to #213