### PR TITLE
set Location of menu wrt Display coordinate system

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Menu.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Menu.java
@@ -1188,9 +1188,7 @@ public void setEnabled (boolean enabled) {
  * </ul>
  */
 public void setLocation (int x, int y) {
-	checkWidget ();
-	int zoom = getZoom();
-	setLocationInPixels(DPIUtil.scaleUp(x, zoom), DPIUtil.scaleUp(y, zoom));
+	setLocation(new Point(x, y));
 }
 
 void setLocationInPixels (int x, int y) {
@@ -1227,7 +1225,7 @@ void setLocationInPixels (int x, int y) {
 public void setLocation (Point location) {
 	checkWidget ();
 	if (location == null) error (SWT.ERROR_NULL_ARGUMENT);
-	location = DPIUtil.scaleUp(location, getZoom());
+	location = getDisplay().translateLocationInPixelsInDisplayCoordinateSystem(location.x, location.y);
 	setLocationInPixels(location.x, location.y);
 }
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Widget.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Widget.java
@@ -1651,8 +1651,8 @@ boolean showMenu (int x, int y) {
 
 boolean showMenu (int x, int y, int detail) {
 	Event event = new Event ();
-	int zoom = getZoom();
-	event.setLocation(DPIUtil.scaleDown(x, zoom), DPIUtil.scaleDown(y, zoom));
+	Point mappedLocation = getDisplay().translateLocationInPointInDisplayCoordinateSystem(x, y);
+	event.setLocation(mappedLocation.x, mappedLocation.y);
 	event.detail = detail;
 	if (event.detail == SWT.MENU_KEYBOARD) {
 		updateMenuLocation (event);
@@ -1663,7 +1663,7 @@ boolean showMenu (int x, int y, int detail) {
 	if (!event.doit) return true;
 	Menu menu = getMenu ();
 	if (menu != null && !menu.isDisposed ()) {
-		Point locInPixels = DPIUtil.scaleUp(event.getLocation(), zoom); // In Pixels
+		Point locInPixels = DPIUtil.scaleUp(event.getLocation(), getZoom()); // In Pixels
 		if (x != locInPixels.x || y != locInPixels.y) {
 			menu.setLocation (event.getLocation());
 		}


### PR DESCRIPTION
This PR contributes to the following regression:

In a multi zoom setup (mine was left (primary 200%), right (secondary 175%) there is a regression (both with and without update on autoscale) in menus.
We need to treat Menus similar to Shells -> they are always positioned with an absolute value. Currently they are set with two different ways:

1. Old zoomed down location, e.g. in Widget::showMenu -> this still works
2. New zoomed location, e.g. Push menus like the Run configurations -> this will result in

![image](https://github.com/user-attachments/assets/5c02753a-1fee-4401-a360-84b655a85f11)


however, the locations supplied to these methods are in display coordinate system and hence must be scaled with the right methods as reflected in the PR.