### PR TITLE
Edge: Dark mode support: Use LIGHT instead of AUTO

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Browser/win32/org/eclipse/swt/browser/Edge.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Browser/win32/org/eclipse/swt/browser/Edge.java
@@ -581,7 +581,7 @@ void setupBrowser(int hr, long pv) {
 		if (Boolean.TRUE.equals(browser.getDisplay().getData(EDGE_USE_DARK_PREFERED_COLOR_SCHEME))) {
 			profile.put_PreferredColorScheme(/* COREWEBVIEW2_PREFERRED_COLOR_SCHEME_DARK */ 2);
 		} else {
-			profile.put_PreferredColorScheme(/* COREWEBVIEW2_PREFERRED_COLOR_SCHEME_AUTO */ 0);
+			profile.put_PreferredColorScheme(/* COREWEBVIEW2_PREFERRED_COLOR_SCHEME_LIGHT */ 1);
 		}
 	}
 


### PR DESCRIPTION
In the scenario
- System: Dark
- Eclipse: Light

we need to explicitly set
- Edge: Light

as well, as with the previous
- Edge: Auto

it would inherit 'Dark' from the system, which is not desired.

Follow-up on 4d61d1dfcc879911bcb361e1af25b08ef19ed88e / #1530.