### PR TITLE
[GTK4] SIGSEGV in OS.gdk_display_get_default() during splash screen

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/org/eclipse/swt/internal/gtk/OS.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/org/eclipse/swt/internal/gtk/OS.java
@@ -687,10 +687,6 @@ public class OS extends C {
 
 		System.setProperty("org.eclipse.swt.internal.gtk.version",
 				(GTK.GTK_VERSION >>> 16) + "." + (GTK.GTK_VERSION >>> 8 & 0xFF) + "." + (GTK.GTK_VERSION & 0xFF));
-		// set GDK backend if we are on X11
-		if (isX11()) {
-			System.setProperty("org.eclipse.swt.internal.gdk.backend", "x11");
-		}
 	}
 
 protected static byte [] ascii (String name) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Display.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Display.java
@@ -1204,6 +1204,8 @@ void createDisplay (DeviceData data) {
 	themeDark = checkAndSetThemeDetails(themeName);
 	if (OS.isX11()) {
 		xDisplay = GTK.GTK4 ? 0 : GDK.gdk_x11_get_default_xdisplay();
+		// set GDK backend if we are on X11
+		System.setProperty("org.eclipse.swt.internal.gdk.backend", "x11");
 	}
 	if (OS.SWT_DEBUG) Device.DEBUG = true;
 	long ptr = GTK.gtk_check_version (GTK3_MAJOR, GTK3_MINOR, GTK3_MICRO);


### PR DESCRIPTION
The static initializer in OS is calling "gdk_display_get_default()" via "isX11()" and therefore violates the requirement that "gtk_init()"/"gtk_init_check()" must be invoked before any other GTK+ function. While doing so works in GTK3, it is by no means a documented behavior, but rather something that works by pure chance [1].

With this change, the system property is moved from the initializer to the Display constructor, where the init function is explicity called. The change itself was made in an error being thrown while executing the JUnit tests on Wayland [2]. But because the display is created before those are executed, it shouldn't matter where this property is set.

[1] https://bugs.eclipse.org/bugs/show_bug.cgi?id=465863
[2] https://bugs.eclipse.org/bugs/show_bug.cgi?id=528968