### PR TITLE
[win] De-register resources with zoom support from device

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Device.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Device.java
@@ -959,6 +959,10 @@ void registerResourceWithZoomSupport(Resource resource) {
 	resourcesWithZoomSupport.add(resource);
 }
 
+void deregisterResourceWithZoomSupport(Resource resource) {
+	resourcesWithZoomSupport.remove(resource);
+}
+
 /**
  * Destroys the handles of all the resources in the resource tracker by
  * identifying the zoom levels which is not valid for any monitor

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Image.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Image.java
@@ -1187,6 +1187,7 @@ long [] createGdipImage(Integer zoom) {
 
 @Override
 void destroy () {
+	device.deregisterResourceWithZoomSupport(this);
 	if (memGC != null) memGC.dispose();
 	destroyHandle();
 	memGC = null;

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Path.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Path.java
@@ -437,6 +437,7 @@ void cubicToInPixels(float cx1, float cy1, float cx2, float cy2, float x, float 
 
 @Override
 void destroy() {
+	device.deregisterResourceWithZoomSupport(this);
 	zoomLevelToHandle.values().forEach(Gdip::GraphicsPath_delete);
 	zoomLevelToHandle.clear();
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Pattern.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Pattern.java
@@ -261,6 +261,7 @@ void setImageHandle(Image image, int zoom) {
 
 @Override
 void destroy() {
+	device.deregisterResourceWithZoomSupport(this);
 	for (long handle: zoomLevelToHandle.values()) {
 		destroyHandle(handle);
 	}

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Region.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Region.java
@@ -223,6 +223,7 @@ public boolean contains (Point pt) {
 
 @Override
 void destroy () {
+	device.deregisterResourceWithZoomSupport(this);
 	zoomToHandle.values().forEach(handle -> OS.DeleteObject(handle));
 	zoomToHandle.clear();
 	operations.clear();

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Transform.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Transform.java
@@ -156,6 +156,7 @@ static float[] checkTransform(float[] elements) {
 
 @Override
 void destroy() {
+	device.deregisterResourceWithZoomSupport(this);
 	zoomLevelToHandle.values().forEach(Gdip::Matrix_delete);
 	zoomLevelToHandle.clear();
 }


### PR DESCRIPTION
Resources with zoom support are registered at their device so that handles for zoom levels that are not necessary anymore can be disposed. When these resources are destroyed, they are currently not de-registered form their device, potentially leading to resource leaks. This change makes the resources de-register themselves form their device when being destroyed.

Fixes regression from:
- #1477

Fixes https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/1752

![{73E6A5F0-38EC-48D0-AF43-F821B5B4FD56}](https://github.com/user-attachments/assets/c7993f7a-b90e-4d3c-aacf-4c4f5f0ec64d)
