### PR TITLE
Win32: Fix compatibility with Windows Server 2012, Windows Server 2016, and Windows 8.1

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT PI/win32/library/os.c
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/win32/library/os.c
@@ -3276,7 +3276,15 @@ JNIEXPORT jint JNICALL OS_NATIVE(GetSystemMetricsForDpi)
 {
 	jint rc = 0;
 	OS_NATIVE_ENTER(env, that, GetSystemMetricsForDpi_FUNC);
+/*
 	rc = (jint)GetSystemMetricsForDpi(arg0, arg1);
+*/
+	{
+		OS_LOAD_FUNCTION(fp, GetSystemMetricsForDpi)
+		if (fp) {
+			rc = (jint)((jint (CALLING_CONVENTION*)(jint, jint))fp)(arg0, arg1);
+		}
+	}
 	OS_NATIVE_EXIT(env, that, GetSystemMetricsForDpi_FUNC);
 	return rc;
 }
@@ -3374,7 +3382,15 @@ JNIEXPORT jlong JNICALL OS_NATIVE(GetThreadDpiAwarenessContext)
 {
 	jlong rc = 0;
 	OS_NATIVE_ENTER(env, that, GetThreadDpiAwarenessContext_FUNC);
+/*
 	rc = (jlong)GetThreadDpiAwarenessContext();
+*/
+	{
+		OS_LOAD_FUNCTION(fp, GetThreadDpiAwarenessContext)
+		if (fp) {
+			rc = (jlong)((jlong (CALLING_CONVENTION*)())fp)();
+		}
+	}
 	OS_NATIVE_EXIT(env, that, GetThreadDpiAwarenessContext_FUNC);
 	return rc;
 }
@@ -6616,7 +6632,15 @@ JNIEXPORT jlong JNICALL OS_NATIVE(OpenThemeDataForDpi)
 	jlong rc = 0;
 	OS_NATIVE_ENTER(env, that, OpenThemeDataForDpi_FUNC);
 	if (arg1) if ((lparg1 = (*env)->GetCharArrayElements(env, arg1, NULL)) == NULL) goto fail;
+/*
 	rc = (jlong)OpenThemeDataForDpi((HWND)arg0, (LPCWSTR)lparg1, arg2);
+*/
+	{
+		OS_LOAD_FUNCTION(fp, OpenThemeDataForDpi)
+		if (fp) {
+			rc = (jlong)((jlong (CALLING_CONVENTION*)(HWND, LPCWSTR, jint))fp)((HWND)arg0, (LPCWSTR)lparg1, arg2);
+		}
+	}
 fail:
 	if (arg1 && lparg1) (*env)->ReleaseCharArrayElements(env, arg1, lparg1, JNI_ABORT);
 	OS_NATIVE_EXIT(env, that, OpenThemeDataForDpi_FUNC);
@@ -8865,7 +8889,15 @@ JNIEXPORT jlong JNICALL OS_NATIVE(SetThreadDpiAwarenessContext)
 {
 	jlong rc = 0;
 	OS_NATIVE_ENTER(env, that, SetThreadDpiAwarenessContext_FUNC);
+/*
 	rc = (jlong)SetThreadDpiAwarenessContext((DPI_AWARENESS_CONTEXT)arg0);
+*/
+	{
+		OS_LOAD_FUNCTION(fp, SetThreadDpiAwarenessContext)
+		if (fp) {
+			rc = (jlong)((jlong (CALLING_CONVENTION*)(DPI_AWARENESS_CONTEXT))fp)((DPI_AWARENESS_CONTEXT)arg0);
+		}
+	}
 	OS_NATIVE_EXIT(env, that, SetThreadDpiAwarenessContext_FUNC);
 	return rc;
 }
@@ -9215,7 +9247,15 @@ JNIEXPORT jboolean JNICALL OS_NATIVE(SystemParametersInfoForDpi)
 	jboolean rc = 0;
 	OS_NATIVE_ENTER(env, that, SystemParametersInfoForDpi_FUNC);
 	if (arg2) if ((lparg2 = getNONCLIENTMETRICSFields(env, arg2, &_arg2)) == NULL) goto fail;
+/*
 	rc = (jboolean)SystemParametersInfoForDpi(arg0, arg1, lparg2, arg3, arg4);
+*/
+	{
+		OS_LOAD_FUNCTION(fp, SystemParametersInfoForDpi)
+		if (fp) {
+			rc = (jboolean)((jboolean (CALLING_CONVENTION*)(jint, jint, NONCLIENTMETRICS *, jint, jint))fp)(arg0, arg1, lparg2, arg3, arg4);
+		}
+	}
 fail:
 	if (arg2 && lparg2) setNONCLIENTMETRICSFields(env, arg2, lparg2);
 	OS_NATIVE_EXIT(env, that, SystemParametersInfoForDpi_FUNC);

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/win32/library/os_custom.h
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/win32/library/os_custom.h
@@ -20,3 +20,8 @@
 /* Libraries for dynamic loaded functions */
 #define GetDpiForMonitor_LIB "shcore.dll"
 #define RtlGetVersion_LIB "ntdll.dll"
+#define OpenThemeDataForDpi_LIB "uxtheme.dll"
+#define GetSystemMetricsForDpi_LIB "user32.dll"
+#define GetThreadDpiAwarenessContext_LIB "user32.dll"
+#define SetThreadDpiAwarenessContext_LIB "user32.dll"
+#define SystemParametersInfoForDpi_LIB "user32.dll"

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/win32/org/eclipse/swt/internal/win32/OS.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/win32/org/eclipse/swt/internal/win32/OS.java
@@ -2990,6 +2990,7 @@ public static final native long GetSysColorBrush (int nIndex);
 /** @param hWnd cast=(HWND) */
 public static final native long GetSystemMenu (long hWnd, boolean bRevert);
 public static final native int GetSystemMetrics (int nIndex);
+/** @method flags=dynamic */
 public static final native int GetSystemMetricsForDpi (int nIndex, int dpi);
 /** @param hDC cast=(HDC) */
 public static final native int GetTextColor (long hDC);
@@ -3784,6 +3785,7 @@ public static final native boolean OpenClipboard (long hWndNewOwner);
  */
 public static final native long OpenThemeData (long hwnd, char[] pszClassList);
 /**
+ * @method flags=dynamic
  * @param hwnd cast=(HWND)
  * @param pszClassList cast=(LPCWSTR),flags=no_out
  */
@@ -4354,8 +4356,12 @@ public static final native int SetPixel (long hdc, int X, int Y, int crColor);
 /** @param hdc cast=(HDC) */
 public static final native int SetPolyFillMode (long hdc, int iPolyFillMode);
 public static final native boolean SetProcessDPIAware ();
-/** @param dpiContext cast=(DPI_AWARENESS_CONTEXT) */
+/**
+ * @method flags=dynamic
+ * @param dpiContext cast=(DPI_AWARENESS_CONTEXT)
+ */
 public static final native long SetThreadDpiAwarenessContext (long dpiContext);
+/** @method flags=dynamic */
 public static final native long GetThreadDpiAwarenessContext ();
 /** @method flags=no_gen */
 public static final native int SetPreferredAppMode(int mode);
@@ -4462,6 +4468,7 @@ public static final native boolean SystemParametersInfo (int uiAction, int uiPar
 public static final native boolean SystemParametersInfo (int uiAction, int uiParam, RECT pvParam, int fWinIni);
 public static final native boolean SystemParametersInfo (int uiAction, int uiParam, NONCLIENTMETRICS pvParam, int fWinIni);
 public static final native boolean SystemParametersInfo (int uiAction, int uiParam, int [] pvParam, int fWinIni);
+/** @method flags=dynamic */
 public static final native boolean SystemParametersInfoForDpi (int uiAction, int uiParam, NONCLIENTMETRICS pvParam, int fWinIni, int dpi);
 /**
  * @param lpKeyState cast=(PBYTE)


### PR DESCRIPTION
This PR marks the following Win32 functions as _dynamic_:
- `OpenThemeDataForDpi`<sup>1</sup>
- `GetSystemMetricsForDpi`
- `GetThreadDpiAwarenessContext`
- `SetThreadDpiAwarenessContext`
- `SystemParametersInfoForDpi`

It's enough to make SWT run on Windows Server 2016, Windows Server 2012, and Windows 8.1.

The Java code that uses these functions **already checks** if the OS version is above the minimum required, so no actions should be taken there.

<sup>1</sup>Although the `OpenThemeDataForDpi` is [documented](https://learn.microsoft.com/en-us/windows/win32/api/uxtheme/nf-uxtheme-openthemedatafordpi) to be available since Windows Server 2016, it's not available there, or at least not in the LTS version.

Addresses and fixes #1252 and possibly many other issues related to running SWT apps on older versions of Windows.