### PR TITLE
Edge: Implement AuthenticationListener handling for BasicAuth

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT PI/win32/org/eclipse/swt/internal/ole/win32/COM.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/win32/org/eclipse/swt/internal/ole/win32/COM.java
@@ -86,6 +86,7 @@ public class COM extends OS {
 	public static final GUID CGID_Explorer = IIDFromString("{000214D0-0000-0000-C000-000000000046}"); //$NON-NLS-1$
 	public static final GUID IID_ICoreWebView2Environment2 = IIDFromString("{41F3632B-5EF4-404F-AD82-2D606C5A9A21}"); //$NON-NLS-1$
 	public static final GUID IID_ICoreWebView2_2 = IIDFromString("{9E8F0CF8-E670-4B5E-B2BC-73E061E3184C}"); //$NON-NLS-1$
+	public static final GUID IID_ICoreWebView2_10 = IIDFromString("{B1690564-6F5A-4983-8E48-31D1143FECDB}"); //$NON-NLS-1$
 	public static final GUID IID_ICoreWebView2_11 = IIDFromString("{0BE78E56-C193-4051-B943-23B460C08BDB}"); //$NON-NLS-1$
 	public static final GUID IID_ICoreWebView2_12 = IIDFromString("{35D69927-BCFA-4566-9349-6B3E0D154CAC}"); //$NON-NLS-1$
 	public static final GUID IID_ICoreWebView2_13 = IIDFromString("{F75F09A8-667E-4983-88D6-C8773F315E84}"); //$NON-NLS-1$

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/win32/org/eclipse/swt/internal/ole/win32/ICoreWebView2BasicAuthenticationRequestedEventArgs.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/win32/org/eclipse/swt/internal/ole/win32/ICoreWebView2BasicAuthenticationRequestedEventArgs.java
@@ -1,0 +1,48 @@
+/*******************************************************************************
+ * Copyright (c) 2024 SAP SE and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ * SAP SE - initial implementation
+ *******************************************************************************/
+package org.eclipse.swt.internal.ole.win32;
+
+public class ICoreWebView2BasicAuthenticationRequestedEventArgs extends IUnknown {
+
+	public ICoreWebView2BasicAuthenticationRequestedEventArgs(long address) {
+		super(address);
+	}
+
+	public int get_Uri(long[] value) {
+		return COM.VtblCall(3, address, value);
+	}
+
+	public int get_Challenge(long[] challenge) {
+		return COM.VtblCall(4, address, challenge);
+	}
+
+	public int get_Response(long[] response) {
+		return COM.VtblCall(5, address, response);
+	}
+
+	public int get_Cancel(int[] cancel) {
+		return COM.VtblCall(6, address, cancel);
+	}
+
+	public int put_Cancel(boolean cancel) {
+		return COM.VtblCall(7, address, cancel ? 1 : 0);
+	}
+
+	/* 8:
+		DECLSPEC_XFGVIRT(ICoreWebView2BasicAuthenticationRequestedEventArgs, GetDeferral)
+		HRESULT ( STDMETHODCALLTYPE *GetDeferral )(
+			ICoreWebView2BasicAuthenticationRequestedEventArgs * This,
+			ICoreWebView2Deferral **deferral);
+	*/
+}

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/win32/org/eclipse/swt/internal/ole/win32/ICoreWebView2BasicAuthenticationResponse.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/win32/org/eclipse/swt/internal/ole/win32/ICoreWebView2BasicAuthenticationResponse.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2024 SAP SE and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ * SAP SE - initial implementation
+ *******************************************************************************/
+package org.eclipse.swt.internal.ole.win32;
+
+public class ICoreWebView2BasicAuthenticationResponse extends IUnknown {
+
+	public ICoreWebView2BasicAuthenticationResponse(long address) {
+		super(address);
+	}
+
+	public int get_UserName(long[] userName) {
+		return COM.VtblCall(3, address, userName);
+	}
+
+	public int put_UserName(char[] userName) {
+		return COM.VtblCall(4, address, userName);
+	}
+
+	public int get_Password(long[] password) {
+		return COM.VtblCall(5, address, password);
+	}
+
+	public int put_Password(char[] password) {
+		return COM.VtblCall(6, address, password);
+	}
+
+}

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/win32/org/eclipse/swt/internal/ole/win32/ICoreWebView2_10.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/win32/org/eclipse/swt/internal/ole/win32/ICoreWebView2_10.java
@@ -13,18 +13,18 @@
  *******************************************************************************/
 package org.eclipse.swt.internal.ole.win32;
 
-public class ICoreWebView2_11 extends ICoreWebView2_10 {
+public class ICoreWebView2_10 extends ICoreWebView2_2 {
 
-public ICoreWebView2_11(long address) {
+public ICoreWebView2_10(long address) {
 	super(address);
 }
 
-public int add_ContextMenuRequested(IUnknown eventHandler, long[] token) {
-	return COM.VtblCall(100, address, eventHandler.getAddress(), token);
+public int add_BasicAuthenticationRequested(IUnknown eventHandler, long[] token) {
+	return COM.VtblCall(97, address, eventHandler.getAddress(), token);
 }
 
-public int remove_ContextMenuRequested(long[] token) {
-	return COM.VtblCall(101, address, token);
+public int remove_BasicAuthenticationRequested(long[] token) {
+	return COM.VtblCall(98, address, token);
 }
 
 }


### PR DESCRIPTION
Differences to IE engine:
- Location attribute:
  - IE does not provide the 'location' for the callback, so this has to be guessed from lastNavigateURL which does not work consistently, e.g. after an immediate Browser.setUrl();
  - Edge does provide the 'location' information consistently
- When returning invalid credentials
  - IE does not call the authentication handler again for further attempts
  - Edge calls the authentication handler again and again. Keeping track of this is out-of-scope for SWT. There is no retryCount field or similar in the event. AuthenticationHandler implementations need to account for unbounded repetitive calls in case the server does not bail out.

Resolves #730.