### PR TITLE
Parameterize browser tests to allow executing them for Edge browser #671

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Browser/win32/org/eclipse/swt/browser/Edge.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Browser/win32/org/eclipse/swt/browser/Edge.java
@@ -425,7 +425,7 @@ class WebViewProvider {
  * is required for processing the OS events during browser initialization, since
  * Edge browser initialization happens asynchronously.
  * <p>
- * {@link Display#readAndDisplay()} also processes events scheduled for
+ * {@link Display#readAndDispatch()} also processes events scheduled for
  * asynchronous execution via {@link Display#asyncExec(Runnable)}. This may
  * include events such as the disposal of the browser's parent composite, which
  * leads to a failure in browser initialization if processed in between the OS


### PR DESCRIPTION
Browser tests were only executed for the default configuration of a system's browser using the SWT.NONE flag. Other configurations, such as using the Edge browser in Windows, were not tested.

This change parameterizes the browser tests to also allow executing them for Edge browser on Windows. Due to current issues with the tests in the CI, this change only adds the parameterization but does not add Edge as a parameter yet.

This prepares for finally activating automated tests for Edge browser and thus contributes to https://github.com/eclipse-platform/eclipse.platform.swt/issues/671

This is extracted from:
- #672