### PR TITLE
[win32] Always use native zoom for OS theme calls

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Button.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Button.java
@@ -1311,7 +1311,7 @@ private int getCheckboxTextOffset(long hdc) {
 	SIZE size = new SIZE();
 
 	if (OS.IsAppThemed ()) {
-		OS.GetThemePartSize(display.hButtonTheme(getZoom()), hdc, OS.BP_CHECKBOX, OS.CBS_UNCHECKEDNORMAL, null, OS.TS_TRUE, size);
+		OS.GetThemePartSize(display.hButtonTheme(nativeZoom), hdc, OS.BP_CHECKBOX, OS.CBS_UNCHECKEDNORMAL, null, OS.TS_TRUE, size);
 		result += size.cx;
 	} else {
 		result += DPIUtil.scaleUp(13, nativeZoom);
@@ -1543,7 +1543,7 @@ LRESULT wmDrawChild (long wParam, long lParam) {
 		boolean pressed = ((struct.itemState & OS.ODS_SELECTED) != 0);
 		boolean enabled = getEnabled ();
 		int iStateId = getThemeStateId(style, pressed, enabled);
-		OS.DrawThemeBackground (display.hScrollBarThemeAuto (getZoom()), struct.hDC, OS.SBP_ARROWBTN, iStateId, rect, null);
+		OS.DrawThemeBackground (display.hScrollBarThemeAuto(nativeZoom), struct.hDC, OS.SBP_ARROWBTN, iStateId, rect, null);
 	} else {
 		int uState = OS.DFCS_SCROLLLEFT;
 		switch (style & (SWT.UP | SWT.DOWN | SWT.LEFT | SWT.RIGHT)) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Composite.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Composite.java
@@ -1856,7 +1856,7 @@ LRESULT wmNCPaint (long hwnd, long wParam, long lParam) {
 				rect.left = rect.top = 0;
 				int border = getSystemMetrics (OS.SM_CXEDGE);
 				OS.ExcludeClipRect (hDC, border, border, rect.right - border, rect.bottom - border);
-				OS.DrawThemeBackground (display.hEditTheme (getZoom()), hDC, OS.EP_EDITTEXT, OS.ETS_NORMAL, rect, null);
+				OS.DrawThemeBackground(display.hEditTheme(nativeZoom), hDC, OS.EP_EDITTEXT, OS.ETS_NORMAL, rect, null);
 				OS.ReleaseDC (hwnd, hDC);
 				return new LRESULT (code);
 			}

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ExpandBar.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ExpandBar.java
@@ -137,7 +137,7 @@ static int checkStyle (int style) {
 			long hDC = OS.GetDC (handle);
 			long hTheme = 0;
 			if (isAppThemed ()) {
-				hTheme = display.hExplorerBarTheme (getZoom());
+				hTheme = display.hExplorerBarTheme(nativeZoom);
 			}
 			long hCurrentFont = 0, oldFont = 0;
 			if (hTheme == 0) {
@@ -247,13 +247,13 @@ void drawThemeBackground (long hDC, long hwnd, RECT rect) {
 	RECT rect2 = new RECT ();
 	OS.GetClientRect (handle, rect2);
 	OS.MapWindowPoints (handle, hwnd, rect2, 2);
-	OS.DrawThemeBackground (display.hExplorerBarTheme (getZoom()), hDC, OS.EBP_NORMALGROUPBACKGROUND, 0, rect2, null);
+	OS.DrawThemeBackground (display.hExplorerBarTheme(nativeZoom), hDC, OS.EBP_NORMALGROUPBACKGROUND, 0, rect2, null);
 }
 
 void drawWidget (GC gc, RECT clipRect) {
 	long hTheme = 0;
 	if (isAppThemed ()) {
-		hTheme = display.hExplorerBarTheme (getZoom());
+		hTheme = display.hExplorerBarTheme(nativeZoom);
 	}
 	if (hTheme != 0) {
 		RECT rect = new RECT ();

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TabFolder.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TabFolder.java
@@ -298,7 +298,7 @@ void drawThemeBackground (long hDC, long hwnd, RECT rect) {
 	OS.GetClientRect (handle, rect2);
 	OS.MapWindowPoints (handle, hwnd, rect2, 2);
 	if (OS.IntersectRect (new RECT (), rect2, rect)) {
-		OS.DrawThemeBackground (display.hTabTheme (getZoom()), hDC, OS.TABP_BODY, 0, rect2, null);
+		OS.DrawThemeBackground (display.hTabTheme(nativeZoom), hDC, OS.TABP_BODY, 0, rect2, null);
 	}
 }
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Table.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Table.java
@@ -4263,14 +4263,14 @@ void setCheckboxImageList (int width, int height, boolean fixScroll) {
 		 * artifacts, limit the rectangle to actual checkbox bitmap size.
 		 */
 		SIZE size = new SIZE();
-		OS.GetThemePartSize(display.hButtonTheme(getZoom()), memDC, OS.BP_CHECKBOX, 0, null, OS.TS_TRUE, size);
+		OS.GetThemePartSize(display.hButtonTheme(nativeZoom), memDC, OS.BP_CHECKBOX, 0, null, OS.TS_TRUE, size);
 		itemWidth = Math.min (size.cx, itemWidth);
 		itemHeight = Math.min (size.cy, itemHeight);
 	}
 	int left = (width - itemWidth) / 2, top = (height - itemHeight) / 2;
 	OS.SetRect (rect, left, top, left + itemWidth, top + itemHeight);
 	if (OS.IsAppThemed ()) {
-		long hTheme = display.hButtonTheme(getZoom());
+		long hTheme = display.hButtonTheme(nativeZoom);
 		OS.DrawThemeBackground (hTheme, memDC, OS.BP_CHECKBOX, OS.CBS_UNCHECKEDNORMAL, rect, null);
 		rect.left += width;  rect.right += width;
 		OS.DrawThemeBackground (hTheme, memDC, OS.BP_CHECKBOX, OS.CBS_CHECKEDNORMAL, rect, null);

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Text.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Text.java
@@ -2751,7 +2751,7 @@ LRESULT WM_DRAWITEM (long wParam, long lParam) {
 	drawBackground (struct.hDC, rect, -1, pt.x, pt.y);
 	if (struct.CtlID == SWT.ICON_CANCEL && struct.hwndItem == hwndActiveIcon && OS.IsAppThemed()) {
 		int state = OS.GetKeyState (OS.VK_LBUTTON) < 0 ? OS.PBS_PRESSED : OS.PBS_HOT;
-		OS.DrawThemeBackground (display.hButtonThemeAuto (getZoom()), struct.hDC, OS.BP_PUSHBUTTON, state, rect, null);
+		OS.DrawThemeBackground(display.hButtonThemeAuto(nativeZoom), struct.hDC, OS.BP_PUSHBUTTON, state, rect, null);
 	}
 	int width = rect.right - rect.left;
 	int height = rect.bottom - rect.top;

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Tree.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Tree.java
@@ -4781,14 +4781,14 @@ void setCheckboxImageList () {
 		 * artifacts, limit the rectangle to actual checkbox bitmap size.
 		 */
 		SIZE size = new SIZE();
-		OS.GetThemePartSize(display.hButtonTheme(getZoom()), memDC, OS.BP_CHECKBOX, 0, null, OS.TS_TRUE, size);
+		OS.GetThemePartSize(display.hButtonTheme(nativeZoom), memDC, OS.BP_CHECKBOX, 0, null, OS.TS_TRUE, size);
 		itemWidth = Math.min (size.cx, itemWidth);
 		itemHeight = Math.min (size.cy, itemHeight);
 	}
 	int left = (width - itemWidth) / 2, top = (height - itemHeight) / 2 + 1;
 	OS.SetRect (rect, left + width, top, left + width + itemWidth, top + itemHeight);
 	if (OS.IsAppThemed ()) {
-		long hTheme = display.hButtonTheme(getZoom());
+		long hTheme = display.hButtonTheme(nativeZoom);
 		OS.DrawThemeBackground (hTheme, memDC, OS.BP_CHECKBOX, OS.CBS_UNCHECKEDNORMAL, rect, null);
 		rect.left += width;  rect.right += width;
 		OS.DrawThemeBackground (hTheme, memDC, OS.BP_CHECKBOX, OS.CBS_CHECKEDNORMAL, rect, null);

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Widget.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Widget.java
@@ -2349,7 +2349,7 @@ LRESULT wmPrint (long hwnd, long wParam, long lParam) {
 				rect.left = rect.top = 0;
 				int border = getSystemMetrics (OS.SM_CXEDGE);
 				OS.ExcludeClipRect (wParam, border, border, rect.right - border, rect.bottom - border);
-				OS.DrawThemeBackground (display.hEditTheme (getZoom()), wParam, OS.EP_EDITTEXT, OS.ETS_NORMAL, rect, null);
+				OS.DrawThemeBackground(display.hEditTheme(nativeZoom), wParam, OS.EP_EDITTEXT, OS.ETS_NORMAL, rect, null);
 				return new LRESULT (code);
 			}
 		}


### PR DESCRIPTION
This commit changes all DPI dependent OS theme calls to use the native zoom instead of using the zoom adjusted by the swt.autoScale setting. This is neccessary, because theme dependent elements like the checkbox for a button will be drawn by the OS and must be calculated with the native zoom.

Fixes #1573