### PR TITLE
For Menu.wmTimer use Menu.indexOf instead of MenuItem.index

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Menu.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Menu.java
@@ -1349,7 +1349,7 @@ LRESULT wmTimer (long wParam, long lParam) {
 		OS.GetCursorPos (pt);
 		if (selectedMenuItem != null && selectedMenuItem.parent != null) {
 			RECT rect = new RECT ();
-			boolean success = OS.GetMenuItemRect (0, selectedMenuItem.parent.handle, selectedMenuItem.index, rect);
+			boolean success = OS.GetMenuItemRect (0, selectedMenuItem.parent.handle, indexOf(selectedMenuItem), rect);
 			if (!success) return null;
 			if (OS.PtInRect (rect, pt)) {
 				// Mouse cursor is within the bounds of menu item

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/MenuItem.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/MenuItem.java
@@ -42,7 +42,7 @@ import org.eclipse.swt.internal.win32.*;
 public class MenuItem extends Item {
 	Menu parent, menu;
 	long hBitmap;
-	int id, accelerator, userId, index;
+	int id, accelerator, userId;
 	ToolTip itemToolTip;
 	/* Image margin. */
 	final static int MARGIN_WIDTH = 1;
@@ -94,7 +94,7 @@ public class MenuItem extends Item {
 public MenuItem (Menu parent, int style) {
 	super (parent, checkStyle (style));
 	this.parent = parent;
-	parent.createItem (this, (index = parent.getItemCount ()));
+	parent.createItem (this, parent.getItemCount ());
 }
 
 /**
@@ -136,16 +136,7 @@ public MenuItem (Menu parent, int style) {
 public MenuItem (Menu parent, int style, int index) {
 	super (parent, checkStyle (style));
 	this.parent = parent;
-	parent.createItem (this, (this.index = index));
-}
-
-MenuItem (Menu parent, Menu menu, int style, int index) {
-	super (parent, checkStyle (style));
-	this.parent = parent;
-	this.menu = menu;
-	this.index = index;
-	if (menu != null) menu.cascade = this;
-	display.addMenuItem (this);
+	parent.createItem (this, index);
 }
 
 /**


### PR DESCRIPTION
- Remove MenuItem.index which is now unused.
- Remove unused MenuItem.MenuItem(Menu, Menu, int, int)

https://github.com/eclipse-platform/eclipse.platform.ui/issues/2483