### PR TITLE
[win32] Fix for refreshing the background image

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Control.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Control.java
@@ -5810,7 +5810,7 @@ private static void handleDPIChange(Widget widget, int newZoom, float scalingFac
 	}
 	resizeFont(control, control.getShell().nativeZoom);
 
-	Image image = control.getBackgroundImage();
+	Image image = control.backgroundImage;
 	if (image != null) {
 		if (image.isDisposed()) {
 			control.setBackgroundImage(null);


### PR DESCRIPTION
This PR adapts the refreshing of a background image of a control on a DPI change. This must only be done, if the image was set directly on the control.