### PR TITLE
Edge: properly handle initialization failures and abortion

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT PI/win32/org/eclipse/swt/internal/ole/win32/COM.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/win32/org/eclipse/swt/internal/ole/win32/COM.java
@@ -183,6 +183,7 @@ public class COM extends OS {
 	public static final int DV_E_STGMEDIUM = -2147221402;
 	public static final int DV_E_TYMED = -2147221399;
 	public static final int DVASPECT_CONTENT = 1;
+	public static final int E_ABORT = 0x80004004;
 	public static final int E_ACCESSDENIED = 0x80070005;
 	public static final int E_FAIL = -2147467259;
 	public static final int E_INVALIDARG = -2147024809;

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/win32/org/eclipse/swt/internal/win32/OS.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/win32/org/eclipse/swt/internal/win32/OS.java
@@ -457,6 +457,7 @@ public class OS extends C {
 	public static final int EN_CHANGE = 0x300;
 	public static final int EP_EDITTEXT = 1;
 	public static final int ERROR_FILE_NOT_FOUND = 0x2;
+	public static final int ERROR_INVALID_STATE = 0x139F;
 	public static final int ERROR_NO_MORE_ITEMS = 0x103;
 	public static final int ERROR_CANCELED = 0x4C7;
 	public static final int ESB_DISABLE_BOTH = 0x3;


### PR DESCRIPTION
There is currently only few handling for failures during initialization of an Edge browser / WebView instance. The Microsoft documentation provides further information on this, in particular:
- ERROR_INVALID_STATE indicates that multiple Edge instances with the same data folder but different environment options exist
- E_ABORT indicates an active abortion of the initialization process
- On any other non-OK return value than the above ones, the app should retry initialization of the instance

This change adds appropriate handling for these scenarios, consisting of uniform rollback logic when the initialization fails or is aborted and retry logic to make repeated creation attempts.

Contributes to https://github.com/eclipse-platform/eclipse.platform.swt/issues/1664