### PR TITLE
Install libgtk-4-dev

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -44,7 +44,7 @@ jobs:
       if: ${{ matrix.config.native == 'gtk.linux.x86_64'}}
       run: |
         sudo apt-get update -qq 
-        sudo apt-get install -qq -y libgtk-3-dev freeglut3-dev webkit2gtk-driver
+        sudo apt-get install -qq -y libgtk-3-dev libgtk-4-dev freeglut3-dev webkit2gtk-driver
     - name: Pull large static Windows binaries
       if: ${{ matrix.config.native == 'win32.win32.x86_64'}}
       run: |


### PR DESCRIPTION
As all build-maschines are now have libgtk-4-dev we should do the same for the github verification.