### PR TITLE
[win32] Revert and adapt fix for coordinate system for rescaling scenario

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Control.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Control.java
@@ -3970,6 +3970,11 @@ void subclass () {
 public Point toControl (int x, int y) {
 	checkWidget ();
 	int zoom = getZoom();
+	if (getDisplay().isRescalingAtRuntime()) {
+		Point displayPointInPixels = getDisplay().translateLocationInPixelsInDisplayCoordinateSystem(x, y);
+		final Point controlPointInPixels = toControlInPixels(displayPointInPixels.x, displayPointInPixels.y);
+		return DPIUtil.scaleDown(controlPointInPixels, zoom);
+	}
 	return DPIUtil.scaleDown(toControlInPixels(DPIUtil.scaleUp(x, zoom), DPIUtil.scaleUp(y, zoom)), zoom);
 }
 
@@ -4003,9 +4008,7 @@ Point toControlInPixels (int x, int y) {
 public Point toControl (Point point) {
 	checkWidget ();
 	if (point == null) error (SWT.ERROR_NULL_ARGUMENT);
-	int zoom = getZoom();
-	point = DPIUtil.scaleUp(point, zoom);
-	return DPIUtil.scaleDown(toControlInPixels(point.x, point.y), zoom);
+	return toControl(point.x, point.y);
 }
 
 /**
@@ -4031,6 +4034,10 @@ public Point toControl (Point point) {
 public Point toDisplay (int x, int y) {
 	checkWidget ();
 	int zoom = getZoom();
+	if (getDisplay().isRescalingAtRuntime()) {
+		Point displayPointInPixels = toDisplayInPixels(DPIUtil.scaleUp(x, zoom), DPIUtil.scaleUp(y, zoom));
+		return getDisplay().translateLocationInPointInDisplayCoordinateSystem(displayPointInPixels.x, displayPointInPixels.y);
+	}
 	return DPIUtil.scaleDown(toDisplayInPixels(DPIUtil.scaleUp(x, zoom), DPIUtil.scaleUp(y, zoom)), zoom);
 }
 
@@ -4064,9 +4071,7 @@ Point toDisplayInPixels (int x, int y) {
 public Point toDisplay (Point point) {
 	checkWidget ();
 	if (point == null) error (SWT.ERROR_NULL_ARGUMENT);
-	int zoom = getZoom();
-	point = DPIUtil.scaleUp(point, zoom);
-	return DPIUtil.scaleDown(toDisplayInPixels(point.x, point.y), zoom);
+	return toDisplay(point.x, point.y);
 }
 
 long topHandle () {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Control.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Control.java
@@ -3969,9 +3969,8 @@ void subclass () {
  */
 public Point toControl (int x, int y) {
 	checkWidget ();
-	Point displayPointInPixels = getDisplay().translateLocationInPixelsInDisplayCoordinateSystem(x, y);
-	final Point controlPointInPixels = toControlInPixels(displayPointInPixels.x, displayPointInPixels.y);
-	return DPIUtil.scaleDown(controlPointInPixels, getZoom());
+	int zoom = getZoom();
+	return DPIUtil.scaleDown(toControlInPixels(DPIUtil.scaleUp(x, zoom), DPIUtil.scaleUp(y, zoom)), zoom);
 }
 
 Point toControlInPixels (int x, int y) {
@@ -4004,7 +4003,9 @@ Point toControlInPixels (int x, int y) {
 public Point toControl (Point point) {
 	checkWidget ();
 	if (point == null) error (SWT.ERROR_NULL_ARGUMENT);
-	return toControl(point.x, point.y);
+	int zoom = getZoom();
+	point = DPIUtil.scaleUp(point, zoom);
+	return DPIUtil.scaleDown(toControlInPixels(point.x, point.y), zoom);
 }
 
 /**
@@ -4030,8 +4031,7 @@ public Point toControl (Point point) {
 public Point toDisplay (int x, int y) {
 	checkWidget ();
 	int zoom = getZoom();
-	Point displayPointInPixels = toDisplayInPixels(DPIUtil.scaleUp(x, zoom), DPIUtil.scaleUp(y, zoom));
-	return getDisplay().translateLocationInPointInDisplayCoordinateSystem(displayPointInPixels.x, displayPointInPixels.y);
+	return DPIUtil.scaleDown(toDisplayInPixels(DPIUtil.scaleUp(x, zoom), DPIUtil.scaleUp(y, zoom)), zoom);
 }
 
 Point toDisplayInPixels (int x, int y) {
@@ -4064,7 +4064,9 @@ Point toDisplayInPixels (int x, int y) {
 public Point toDisplay (Point point) {
 	checkWidget ();
 	if (point == null) error (SWT.ERROR_NULL_ARGUMENT);
-	return toDisplay(point.x, point.y);
+	int zoom = getZoom();
+	point = DPIUtil.scaleUp(point, zoom);
+	return DPIUtil.scaleDown(toDisplayInPixels(point.x, point.y), zoom);
 }
 
 long topHandle () {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Display.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Display.java
@@ -1704,7 +1704,11 @@ public Control getCursorControl () {
  */
 public Point getCursorLocation () {
 	checkDevice ();
-	return DPIUtil.autoScaleDown(getCursorLocationInPixels());
+	Point cursorLocationInPixels = getCursorLocationInPixels();
+	if (isRescalingAtRuntime()) {
+		return translateLocationInPointInDisplayCoordinateSystem(cursorLocationInPixels.x, cursorLocationInPixels.y);
+	}
+	return DPIUtil.autoScaleDown(cursorLocationInPixels);
 }
 
 Point getCursorLocationInPixels () {
@@ -2183,14 +2187,21 @@ Monitor getMonitor (long hmonitor) {
 	OS.GetMonitorInfo (hmonitor, lpmi);
 	Monitor monitor = new Monitor ();
 	monitor.handle = hmonitor;
-	Rectangle boundsInPixels = new Rectangle (lpmi.rcMonitor_left, lpmi.rcMonitor_top, lpmi.rcMonitor_right - lpmi.rcMonitor_left,lpmi.rcMonitor_bottom - lpmi.rcMonitor_top);
-	monitor.setBounds (DPIUtil.autoScaleDown (boundsInPixels));
-	Rectangle clientAreaInPixels = new Rectangle (lpmi.rcWork_left, lpmi.rcWork_top, lpmi.rcWork_right - lpmi.rcWork_left, lpmi.rcWork_bottom - lpmi.rcWork_top);
-	monitor.setClientArea (DPIUtil.autoScaleDown (clientAreaInPixels));
+	Rectangle boundsInPixels = new Rectangle(lpmi.rcMonitor_left, lpmi.rcMonitor_top, lpmi.rcMonitor_right - lpmi.rcMonitor_left,lpmi.rcMonitor_bottom - lpmi.rcMonitor_top);
+	Rectangle clientAreaInPixels = new Rectangle(lpmi.rcWork_left, lpmi.rcWork_top, lpmi.rcWork_right - lpmi.rcWork_left, lpmi.rcWork_bottom - lpmi.rcWork_top);
 	int [] dpiX = new int[1];
 	int [] dpiY = new int[1];
 	int result = OS.GetDpiForMonitor (monitor.handle, OS.MDT_EFFECTIVE_DPI, dpiX, dpiY);
 	result = (result == OS.S_OK) ? DPIUtil.mapDPIToZoom (dpiX[0]) : 100;
+
+	if (DPIUtil.isAutoScaleOnRuntimeActive()) {
+		int autoscaleZoom = DPIUtil.getZoomForAutoscaleProperty(result);
+		monitor.setBounds(getMonitorBoundsInPointsInDisplayCoordinateSystem(boundsInPixels, autoscaleZoom));
+		monitor.setClientArea(getMonitorBoundsInPointsInDisplayCoordinateSystem(clientAreaInPixels, autoscaleZoom));
+	} else {
+		monitor.setBounds(DPIUtil.autoScaleDown(boundsInPixels));
+		monitor.setClientArea(DPIUtil.autoScaleDown(clientAreaInPixels));
+	}
 	if (result == 0) {
 		System.err.println("***WARNING: GetDpiForMonitor: SWT could not get valid monitor scaling factor.");
 		result = 100;
@@ -2201,6 +2212,13 @@ Monitor getMonitor (long hmonitor) {
 	 */
 	monitor.zoom = result;
 	return monitor;
+}
+
+private Rectangle getMonitorBoundsInPointsInDisplayCoordinateSystem(Rectangle boundsInPixels, int zoom) {
+	Rectangle bounds = DPIUtil.scaleDown(boundsInPixels, zoom);
+	bounds.x = boundsInPixels.x;
+	bounds.y = boundsInPixels.y;
+	return bounds;
 }
 
 /**
@@ -2944,6 +2962,9 @@ boolean isValidThread () {
 public Point map (Control from, Control to, Point point) {
 	checkDevice ();
 	if (point == null) error (SWT.ERROR_NULL_ARGUMENT);
+	if (isRescalingAtRuntime()) {
+		return map(from, to, point.x, point.y);
+	}
 	int zoom = getZoomLevelForMapping(from, to);
 	point = DPIUtil.scaleUp(point, zoom);
 	return DPIUtil.scaleDown(mapInPixels(from, to, point), zoom);
@@ -2991,6 +3012,20 @@ Point mapInPixels (Control from, Control to, Point point) {
  */
 public Point map (Control from, Control to, int x, int y) {
 	checkDevice ();
+	if (isRescalingAtRuntime()) {
+		Point mappedPointInPoints;
+		if (from == null) {
+			Point mappedPointInpixels = mapInPixels(from, to, getPixelsFromPoint(to.getShell().getMonitor(), x, y));
+			mappedPointInPoints = DPIUtil.scaleDown(mappedPointInpixels, to.getZoom());
+		} else if (to == null) {
+			Point mappedPointInpixels = mapInPixels(from, to, DPIUtil.scaleUp(new Point(x, y), from.getZoom()));
+			mappedPointInPoints = getPointFromPixels(from.getShell().getMonitor(), mappedPointInpixels.x, mappedPointInpixels.y);
+		} else {
+			Point mappedPointInpixels = mapInPixels(from, to, DPIUtil.scaleUp(new Point(x, y), from.getZoom()));
+			mappedPointInPoints = DPIUtil.scaleDown(mappedPointInpixels, to.getZoom());
+		}
+		return mappedPointInPoints;
+	}
 	int zoom = getZoomLevelForMapping(from, to);
 	x = DPIUtil.scaleUp(x, zoom);
 	y = DPIUtil.scaleUp(y, zoom);
@@ -3058,6 +3093,9 @@ private int getZoomLevelForMapping(Control from, Control to) {
 public Rectangle map (Control from, Control to, Rectangle rectangle) {
 	checkDevice ();
 	if (rectangle == null) error (SWT.ERROR_NULL_ARGUMENT);
+	if (isRescalingAtRuntime()) {
+		return map(from, to, rectangle.x, rectangle.y, rectangle.width, rectangle.height);
+	}
 	int zoom = getZoomLevelForMapping(from, to);
 	rectangle = DPIUtil.scaleUp(rectangle, zoom);
 	return DPIUtil.scaleDown(mapInPixels(from, to, rectangle), zoom);
@@ -3107,6 +3145,20 @@ Rectangle mapInPixels (Control from, Control to, Rectangle rectangle) {
  */
 public Rectangle map (Control from, Control to, int x, int y, int width, int height) {
 	checkDevice ();
+	if (isRescalingAtRuntime()) {
+		Rectangle mappedRectangleInPoints;
+		if (from == null) {
+			Rectangle mappedRectangleInPixels = mapInPixels(from, to, translateRectangleInPixelsInDisplayCoordinateSystem(x, y, width, height, to.getShell().getMonitor()));
+			mappedRectangleInPoints = DPIUtil.scaleDown(mappedRectangleInPixels, to.getZoom());
+		} else if (to == null) {
+			Rectangle mappedRectangleInPixels = mapInPixels(from, to, DPIUtil.scaleUp(new Rectangle(x, y, width, height), from.getZoom()));
+			mappedRectangleInPoints = translateRectangleInPointsInDisplayCoordinateSystem(mappedRectangleInPixels.x, mappedRectangleInPixels.y, mappedRectangleInPixels.width, mappedRectangleInPixels.height, from.getShell().getMonitor());
+		} else {
+			Rectangle mappedRectangleInPixels = mapInPixels(from, to, DPIUtil.scaleUp(new Rectangle(x, y, width, height), from.getZoom()));
+			mappedRectangleInPoints = DPIUtil.scaleDown(mappedRectangleInPixels, to.getZoom());
+		}
+		return mappedRectangleInPoints;
+	}
 	int zoom = getZoomLevelForMapping(from, to);
 	x = DPIUtil.scaleUp(x, zoom);
 	y = DPIUtil.scaleUp(y, zoom);
@@ -3128,6 +3180,57 @@ Rectangle mapInPixels (Control from, Control to, int x, int y, int width, int he
 	rect.bottom = y + height;
 	OS.MapWindowPoints (hwndFrom, hwndTo, rect, 2);
 	return new Rectangle (rect.left, rect.top, rect.right - rect.left, rect.bottom - rect.top);
+}
+
+Point translateLocationInPixelsInDisplayCoordinateSystem(int x, int y) {
+	Monitor monitor = getContainingMonitor(x, y);
+	return getPixelsFromPoint(monitor, x, y);
+}
+
+Point translateLocationInPointInDisplayCoordinateSystem(int x, int y) {
+	Monitor monitor = getContainingMonitorInPixelsCoordinate(x, y);
+	return getPointFromPixels(monitor, x, y);
+}
+
+Rectangle translateRectangleInPixelsInDisplayCoordinateSystemByContainment(int x, int y, int width, int height) {
+	Monitor monitorByLocation = getContainingMonitor(x, y);
+	Monitor monitorByContainment = getContainingMonitor(x, y, width, height);
+	return translateRectangleInPixelsInDisplayCoordinateSystem(x, y, width, height, monitorByLocation, monitorByContainment);
+}
+
+private Rectangle translateRectangleInPixelsInDisplayCoordinateSystem(int x, int y, int width, int height, Monitor monitor) {
+	return translateRectangleInPixelsInDisplayCoordinateSystem(x, y, width, height, monitor, monitor);
+}
+
+private Rectangle translateRectangleInPixelsInDisplayCoordinateSystem(int x, int y, int width, int height, Monitor monitorOfLocation, Monitor monitorOfArea) {
+	Point topLeft = getPixelsFromPoint(monitorOfLocation, x, y);
+	int zoom = getApplicableMonitorZoom(monitorOfArea);
+	int widthInPixels = DPIUtil.scaleUp(width, zoom);
+	int heightInPixels = DPIUtil.scaleUp(height, zoom);
+	return new Rectangle(topLeft.x, topLeft.y, widthInPixels, heightInPixels);
+}
+
+Rectangle translateRectangleInPointsInDisplayCoordinateSystemByContainment(int x, int y, int widthInPixels, int heightInPixels) {
+	Monitor monitorByLocation = getContainingMonitor(x, y);
+	Monitor monitorByContainment = getContainingMonitor(x, y, widthInPixels, heightInPixels);
+	return translateRectangleInPointsInDisplayCoordinateSystem(x, y, widthInPixels, heightInPixels, monitorByLocation, monitorByContainment);
+}
+
+private Rectangle translateRectangleInPointsInDisplayCoordinateSystem(int x, int y, int widthInPixels, int heightInPixels, Monitor monitor) {
+	return translateRectangleInPointsInDisplayCoordinateSystem(x, y, widthInPixels, heightInPixels, monitor, monitor);
+}
+
+
+private Rectangle translateRectangleInPointsInDisplayCoordinateSystem(int x, int y, int widthInPixels, int heightInPixels, Monitor monitorOfLocation, Monitor monitorOfArea) {
+	Point topLeft = getPointFromPixels(monitorOfLocation, x, y);
+	int zoom = getApplicableMonitorZoom(monitorOfArea);
+	int width = DPIUtil.scaleDown(widthInPixels, zoom);
+	int height = DPIUtil.scaleDown(heightInPixels, zoom);
+	return new Rectangle(topLeft.x, topLeft.y, width, height);
+}
+
+private int getApplicableMonitorZoom(Monitor monitor) {
+	return DPIUtil.getZoomForAutoscaleProperty(isRescalingAtRuntime() ? monitor.zoom : getDeviceZoom());
 }
 
 long messageProc (long hwnd, long msg, long wParam, long lParam) {
@@ -4355,7 +4458,12 @@ public void sendPostExternalEventDispatchEvent () {
  */
 public void setCursorLocation (int x, int y) {
 	checkDevice ();
-	setCursorLocationInPixels (DPIUtil.autoScaleUp (x), DPIUtil.autoScaleUp (y));
+	if (isRescalingAtRuntime()) {
+		Point cursorLocationInPixels = translateLocationInPixelsInDisplayCoordinateSystem(x, y);
+		setCursorLocationInPixels (cursorLocationInPixels.x, cursorLocationInPixels.y);
+	} else {
+		setCursorLocationInPixels (DPIUtil.autoScaleUp (x), DPIUtil.autoScaleUp (y));
+	}
 }
 
 void setCursorLocationInPixels (int x, int y) {
@@ -5390,4 +5498,63 @@ private boolean setDPIAwareness(int desiredDpiAwareness) {
 	return true;
 }
 
+private Monitor getContainingMonitor(int x, int y) {
+	Monitor[] monitors = getMonitors();
+	for (Monitor currentMonitor : monitors) {
+		Rectangle clientArea = currentMonitor.getClientArea();
+		if (clientArea.contains(x, y)) {
+			return currentMonitor;
+		}
+	}
+	return getPrimaryMonitor();
+}
+
+private Monitor getContainingMonitor(int x, int y, int width, int height) {
+	Rectangle rectangle = new Rectangle(x, y, width, height);
+	Monitor[] monitors = getMonitors();
+	Monitor selectedMonitor = getPrimaryMonitor();
+	int highestArea = 0;
+	for (Monitor currentMonitor : monitors) {
+		Rectangle clientArea = currentMonitor.getClientArea();
+		Rectangle intersection = clientArea.intersection(rectangle);
+		int area = intersection.width * intersection.height;
+		if (area > highestArea) {
+			selectedMonitor = currentMonitor;
+			highestArea = area;
+		}
+	}
+	return selectedMonitor;
+}
+
+private Monitor getContainingMonitorInPixelsCoordinate(int xInPixels, int yInPixels) {
+	Monitor[] monitors = getMonitors();
+	for (Monitor current : monitors) {
+		Rectangle clientArea = getMonitorClientAreaInPixels(current);
+		if (clientArea.contains(xInPixels, yInPixels)) {
+			return current;
+		}
+	}
+	return getPrimaryMonitor();
+}
+
+private Rectangle getMonitorClientAreaInPixels(Monitor monitor) {
+	int zoom = getApplicableMonitorZoom(monitor);
+	int widthInPixels = DPIUtil.scaleUp(monitor.clientWidth, zoom);
+	int heightInPixels = DPIUtil.scaleUp(monitor.clientHeight, zoom);
+	return new Rectangle(monitor.clientX, monitor.clientY, widthInPixels, heightInPixels);
+}
+
+private Point getPixelsFromPoint(Monitor monitor, int x, int y) {
+	int zoom = getApplicableMonitorZoom(monitor);
+	int mappedX = DPIUtil.scaleUp(x - monitor.clientX, zoom) + monitor.clientX;
+	int mappedY = DPIUtil.scaleUp(y - monitor.clientY, zoom) + monitor.clientY;
+	return new Point(mappedX, mappedY);
+}
+
+private Point getPointFromPixels(Monitor monitor, int x, int y) {
+	int zoom = getApplicableMonitorZoom(monitor);
+	int mappedX = DPIUtil.scaleDown(x - monitor.clientX, zoom) + monitor.clientX;
+	int mappedY = DPIUtil.scaleDown(y - monitor.clientY, zoom) + monitor.clientY;
+	return new Point(mappedX, mappedY);
+}
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Display.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Display.java
@@ -1704,8 +1704,7 @@ public Control getCursorControl () {
  */
 public Point getCursorLocation () {
 	checkDevice ();
-	Point cursorLocationInPixels = getCursorLocationInPixels();
-	return translateLocationInPointInDisplayCoordinateSystem(cursorLocationInPixels.x, cursorLocationInPixels.y);
+	return DPIUtil.autoScaleDown(getCursorLocationInPixels());
 }
 
 Point getCursorLocationInPixels () {
@@ -2184,38 +2183,24 @@ Monitor getMonitor (long hmonitor) {
 	OS.GetMonitorInfo (hmonitor, lpmi);
 	Monitor monitor = new Monitor ();
 	monitor.handle = hmonitor;
-	Rectangle boundsInPixels = new Rectangle(lpmi.rcMonitor_left, lpmi.rcMonitor_top, lpmi.rcMonitor_right - lpmi.rcMonitor_left,lpmi.rcMonitor_bottom - lpmi.rcMonitor_top);
-	Rectangle clientAreaInPixels = new Rectangle(lpmi.rcWork_left, lpmi.rcWork_top, lpmi.rcWork_right - lpmi.rcWork_left, lpmi.rcWork_bottom - lpmi.rcWork_top);
+	Rectangle boundsInPixels = new Rectangle (lpmi.rcMonitor_left, lpmi.rcMonitor_top, lpmi.rcMonitor_right - lpmi.rcMonitor_left,lpmi.rcMonitor_bottom - lpmi.rcMonitor_top);
+	monitor.setBounds (DPIUtil.autoScaleDown (boundsInPixels));
+	Rectangle clientAreaInPixels = new Rectangle (lpmi.rcWork_left, lpmi.rcWork_top, lpmi.rcWork_right - lpmi.rcWork_left, lpmi.rcWork_bottom - lpmi.rcWork_top);
+	monitor.setClientArea (DPIUtil.autoScaleDown (clientAreaInPixels));
 	int [] dpiX = new int[1];
 	int [] dpiY = new int[1];
 	int result = OS.GetDpiForMonitor (monitor.handle, OS.MDT_EFFECTIVE_DPI, dpiX, dpiY);
 	result = (result == OS.S_OK) ? DPIUtil.mapDPIToZoom (dpiX[0]) : 100;
-
-	int autoscaleZoom;
-	if (DPIUtil.isAutoScaleOnRuntimeActive()) {
-		autoscaleZoom = DPIUtil.getZoomForAutoscaleProperty(result);
-	} else {
-		autoscaleZoom = DPIUtil.getDeviceZoom();
-	}
 	if (result == 0) {
 		System.err.println("***WARNING: GetDpiForMonitor: SWT could not get valid monitor scaling factor.");
 		result = 100;
 	}
-	monitor.setBounds(getMonitorBoundsInPointsInDisplayCoordinateSystem(boundsInPixels, autoscaleZoom));
-	monitor.setClientArea(getMonitorBoundsInPointsInDisplayCoordinateSystem(clientAreaInPixels, autoscaleZoom));
 	/*
 	 * Always return true monitor zoom value as fetched from native, else will lead
 	 * to scaling issue on OS Win8.1 and above, for more details refer bug 537614.
 	 */
 	monitor.zoom = result;
 	return monitor;
-}
-
-private Rectangle getMonitorBoundsInPointsInDisplayCoordinateSystem(Rectangle boundsInPixels, int zoom) {
-	Rectangle bounds = DPIUtil.scaleDown(boundsInPixels, zoom);
-	bounds.x = boundsInPixels.x;
-	bounds.y = boundsInPixels.y;
-	return bounds;
 }
 
 /**
@@ -2959,7 +2944,9 @@ boolean isValidThread () {
 public Point map (Control from, Control to, Point point) {
 	checkDevice ();
 	if (point == null) error (SWT.ERROR_NULL_ARGUMENT);
-	return map(from, to, point.x, point.y);
+	int zoom = getZoomLevelForMapping(from, to);
+	point = DPIUtil.scaleUp(point, zoom);
+	return DPIUtil.scaleDown(mapInPixels(from, to, point), zoom);
 }
 
 Point mapInPixels (Control from, Control to, Point point) {
@@ -3004,18 +2991,10 @@ Point mapInPixels (Control from, Control to, Point point) {
  */
 public Point map (Control from, Control to, int x, int y) {
 	checkDevice ();
-	Point mappedPointInPoints;
-	if (from == null) {
-		Point mappedPointInpixels = mapInPixels(from, to, getPixelsFromPoint(to.getShell().getMonitor(), x, y));
-		mappedPointInPoints = DPIUtil.scaleDown(mappedPointInpixels, to.getZoom());
-	} else if (to == null) {
-		Point mappedPointInpixels = mapInPixels(from, to, DPIUtil.scaleUp(new Point(x, y), from.getZoom()));
-		mappedPointInPoints = getPointFromPixels(from.getShell().getMonitor(), mappedPointInpixels.x, mappedPointInpixels.y);
-	} else {
-		Point mappedPointInpixels = mapInPixels(from, to, DPIUtil.scaleUp(new Point(x, y), from.getZoom()));
-		mappedPointInPoints = DPIUtil.scaleDown(mappedPointInpixels, to.getZoom());
-	}
-	return mappedPointInPoints;
+	int zoom = getZoomLevelForMapping(from, to);
+	x = DPIUtil.scaleUp(x, zoom);
+	y = DPIUtil.scaleUp(y, zoom);
+	return DPIUtil.scaleDown(mapInPixels(from, to, x, y), zoom);
 }
 
 Point mapInPixels (Control from, Control to, int x, int y) {
@@ -3029,6 +3008,15 @@ Point mapInPixels (Control from, Control to, int x, int y) {
 	point.y = y;
 	OS.MapWindowPoints (hwndFrom, hwndTo, point, 1);
 	return new Point (point.x, point.y);
+}
+
+private int getZoomLevelForMapping(Control from, Control to) {
+	if (from != null && from.isDisposed()) error (SWT.ERROR_INVALID_ARGUMENT);
+	if (to != null && to.isDisposed()) error (SWT.ERROR_INVALID_ARGUMENT);
+	if (to != null) {
+		return to.getZoom();
+	}
+	return from.getZoom();
 }
 
 /**
@@ -3070,7 +3058,9 @@ Point mapInPixels (Control from, Control to, int x, int y) {
 public Rectangle map (Control from, Control to, Rectangle rectangle) {
 	checkDevice ();
 	if (rectangle == null) error (SWT.ERROR_NULL_ARGUMENT);
-	return map(from, to, rectangle.x, rectangle.y, rectangle.width, rectangle.height);
+	int zoom = getZoomLevelForMapping(from, to);
+	rectangle = DPIUtil.scaleUp(rectangle, zoom);
+	return DPIUtil.scaleDown(mapInPixels(from, to, rectangle), zoom);
 }
 
 Rectangle mapInPixels (Control from, Control to, Rectangle rectangle) {
@@ -3117,18 +3107,12 @@ Rectangle mapInPixels (Control from, Control to, Rectangle rectangle) {
  */
 public Rectangle map (Control from, Control to, int x, int y, int width, int height) {
 	checkDevice ();
-	Rectangle mappedRectangleInPoints;
-	if (from == null) {
-		Rectangle mappedRectangleInPixels = mapInPixels(from, to, translateRectangleInPixelsInDisplayCoordinateSystem(x, y, width, height, to.getShell().getMonitor()));
-		mappedRectangleInPoints = DPIUtil.scaleDown(mappedRectangleInPixels, to.getZoom());
-	} else if (to == null) {
-		Rectangle mappedRectangleInPixels = mapInPixels(from, to, DPIUtil.scaleUp(new Rectangle(x, y, width, height), from.getZoom()));
-		mappedRectangleInPoints = translateRectangleInPointsInDisplayCoordinateSystem(mappedRectangleInPixels.x, mappedRectangleInPixels.y, mappedRectangleInPixels.width, mappedRectangleInPixels.height, from.getShell().getMonitor());
-	} else {
-		Rectangle mappedRectangleInPixels = mapInPixels(from, to, DPIUtil.scaleUp(new Rectangle(x, y, width, height), from.getZoom()));
-		mappedRectangleInPoints = DPIUtil.scaleDown(mappedRectangleInPixels, to.getZoom());
-	}
-	return mappedRectangleInPoints;
+	int zoom = getZoomLevelForMapping(from, to);
+	x = DPIUtil.scaleUp(x, zoom);
+	y = DPIUtil.scaleUp(y, zoom);
+	width = DPIUtil.scaleUp(width, zoom);
+	height = DPIUtil.scaleUp(height, zoom);
+	return DPIUtil.scaleDown(mapInPixels(from, to, x, y, width, height), zoom);
 }
 
 Rectangle mapInPixels (Control from, Control to, int x, int y, int width, int height) {
@@ -3144,57 +3128,6 @@ Rectangle mapInPixels (Control from, Control to, int x, int y, int width, int he
 	rect.bottom = y + height;
 	OS.MapWindowPoints (hwndFrom, hwndTo, rect, 2);
 	return new Rectangle (rect.left, rect.top, rect.right - rect.left, rect.bottom - rect.top);
-}
-
-Point translateLocationInPixelsInDisplayCoordinateSystem(int x, int y) {
-	Monitor monitor = getContainingMonitor(x, y);
-	return getPixelsFromPoint(monitor, x, y);
-}
-
-Point translateLocationInPointInDisplayCoordinateSystem(int x, int y) {
-	Monitor monitor = getContainingMonitorInPixelsCoordinate(x, y);
-	return getPointFromPixels(monitor, x, y);
-}
-
-Rectangle translateRectangleInPixelsInDisplayCoordinateSystemByContainment(int x, int y, int width, int height) {
-	Monitor monitorByLocation = getContainingMonitor(x, y);
-	Monitor monitorByContainment = getContainingMonitor(x, y, width, height);
-	return translateRectangleInPixelsInDisplayCoordinateSystem(x, y, width, height, monitorByLocation, monitorByContainment);
-}
-
-private Rectangle translateRectangleInPixelsInDisplayCoordinateSystem(int x, int y, int width, int height, Monitor monitor) {
-	return translateRectangleInPixelsInDisplayCoordinateSystem(x, y, width, height, monitor, monitor);
-}
-
-private Rectangle translateRectangleInPixelsInDisplayCoordinateSystem(int x, int y, int width, int height, Monitor monitorOfLocation, Monitor monitorOfArea) {
-	Point topLeft = getPixelsFromPoint(monitorOfLocation, x, y);
-	int zoom = getApplicableMonitorZoom(monitorOfArea);
-	int widthInPixels = DPIUtil.scaleUp(width, zoom);
-	int heightInPixels = DPIUtil.scaleUp(height, zoom);
-	return new Rectangle(topLeft.x, topLeft.y, widthInPixels, heightInPixels);
-}
-
-Rectangle translateRectangleInPointsInDisplayCoordinateSystemByContainment(int x, int y, int widthInPixels, int heightInPixels) {
-	Monitor monitorByLocation = getContainingMonitor(x, y);
-	Monitor monitorByContainment = getContainingMonitor(x, y, widthInPixels, heightInPixels);
-	return translateRectangleInPointsInDisplayCoordinateSystem(x, y, widthInPixels, heightInPixels, monitorByLocation, monitorByContainment);
-}
-
-private Rectangle translateRectangleInPointsInDisplayCoordinateSystem(int x, int y, int widthInPixels, int heightInPixels, Monitor monitor) {
-	return translateRectangleInPointsInDisplayCoordinateSystem(x, y, widthInPixels, heightInPixels, monitor, monitor);
-}
-
-
-private Rectangle translateRectangleInPointsInDisplayCoordinateSystem(int x, int y, int widthInPixels, int heightInPixels, Monitor monitorOfLocation, Monitor monitorOfArea) {
-	Point topLeft = getPointFromPixels(monitorOfLocation, x, y);
-	int zoom = getApplicableMonitorZoom(monitorOfArea);
-	int width = DPIUtil.scaleDown(widthInPixels, zoom);
-	int height = DPIUtil.scaleDown(heightInPixels, zoom);
-	return new Rectangle(topLeft.x, topLeft.y, width, height);
-}
-
-private int getApplicableMonitorZoom(Monitor monitor) {
-	return DPIUtil.getZoomForAutoscaleProperty(isRescalingAtRuntime() ? monitor.zoom : getDeviceZoom());
 }
 
 long messageProc (long hwnd, long msg, long wParam, long lParam) {
@@ -4422,8 +4355,7 @@ public void sendPostExternalEventDispatchEvent () {
  */
 public void setCursorLocation (int x, int y) {
 	checkDevice ();
-	Point cursorLocationInPixels = translateLocationInPixelsInDisplayCoordinateSystem(x, y);
-	setCursorLocationInPixels (cursorLocationInPixels.x, cursorLocationInPixels.y);
+	setCursorLocationInPixels (DPIUtil.autoScaleUp (x), DPIUtil.autoScaleUp (y));
 }
 
 void setCursorLocationInPixels (int x, int y) {
@@ -5458,63 +5390,4 @@ private boolean setDPIAwareness(int desiredDpiAwareness) {
 	return true;
 }
 
-private Monitor getContainingMonitor(int x, int y) {
-	Monitor[] monitors = getMonitors();
-	for (Monitor currentMonitor : monitors) {
-		Rectangle clientArea = currentMonitor.getClientArea();
-		if (clientArea.contains(x, y)) {
-			return currentMonitor;
-		}
-	}
-	return getPrimaryMonitor();
-}
-
-private Monitor getContainingMonitor(int x, int y, int width, int height) {
-	Rectangle rectangle = new Rectangle(x, y, width, height);
-	Monitor[] monitors = getMonitors();
-	Monitor selectedMonitor = getPrimaryMonitor();
-	int highestArea = 0;
-	for (Monitor currentMonitor : monitors) {
-		Rectangle clientArea = currentMonitor.getClientArea();
-		Rectangle intersection = clientArea.intersection(rectangle);
-		int area = intersection.width * intersection.height;
-		if (area > highestArea) {
-			selectedMonitor = currentMonitor;
-			highestArea = area;
-		}
-	}
-	return selectedMonitor;
-}
-
-private Monitor getContainingMonitorInPixelsCoordinate(int xInPixels, int yInPixels) {
-	Monitor[] monitors = getMonitors();
-	for (Monitor current : monitors) {
-		Rectangle clientArea = getMonitorClientAreaInPixels(current);
-		if (clientArea.contains(xInPixels, yInPixels)) {
-			return current;
-		}
-	}
-	return getPrimaryMonitor();
-}
-
-private Rectangle getMonitorClientAreaInPixels(Monitor monitor) {
-	int zoom = getApplicableMonitorZoom(monitor);
-	int widthInPixels = DPIUtil.scaleUp(monitor.clientWidth, zoom);
-	int heightInPixels = DPIUtil.scaleUp(monitor.clientHeight, zoom);
-	return new Rectangle(monitor.clientX, monitor.clientY, widthInPixels, heightInPixels);
-}
-
-private Point getPixelsFromPoint(Monitor monitor, int x, int y) {
-	int zoom = getApplicableMonitorZoom(monitor);
-	int mappedX = DPIUtil.scaleUp(x - monitor.clientX, zoom) + monitor.clientX;
-	int mappedY = DPIUtil.scaleUp(y - monitor.clientY, zoom) + monitor.clientY;
-	return new Point(mappedX, mappedY);
-}
-
-private Point getPointFromPixels(Monitor monitor, int x, int y) {
-	int zoom = getApplicableMonitorZoom(monitor);
-	int mappedX = DPIUtil.scaleDown(x - monitor.clientX, zoom) + monitor.clientX;
-	int mappedY = DPIUtil.scaleDown(y - monitor.clientY, zoom) + monitor.clientY;
-	return new Point(mappedX, mappedY);
-}
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Shell.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Shell.java
@@ -1567,6 +1567,56 @@ public void setAlpha (int alpha) {
 }
 
 @Override
+public Rectangle getBounds() {
+	if (getDisplay().isRescalingAtRuntime()) {
+		Rectangle boundsInPixels = getBoundsInPixels();
+		return display.translateRectangleInPointsInDisplayCoordinateSystemByContainment(boundsInPixels.x, boundsInPixels.y, boundsInPixels.width, boundsInPixels.height);
+	}
+	return super.getBounds();
+}
+
+@Override
+public Point getLocation() {
+	if (getDisplay().isRescalingAtRuntime()) {
+		Point locationInPixels = getLocationInPixels();
+		return display.translateLocationInPointInDisplayCoordinateSystem(locationInPixels.x, locationInPixels.y);
+	}
+	return super.getLocation();
+}
+
+@Override
+public void setLocation(Point location) {
+	if (location == null) error (SWT.ERROR_NULL_ARGUMENT);
+	setLocation(location.x, location.y);
+}
+
+@Override
+public void setLocation(int x, int y) {
+	if (getDisplay().isRescalingAtRuntime()) {
+		Point location = display.translateLocationInPixelsInDisplayCoordinateSystem(x, y);
+		setLocationInPixels(location.x, location.y);
+	} else {
+		super.setLocation(x, y);
+	}
+}
+
+@Override
+public void setBounds(Rectangle rect) {
+	if (rect == null) error (SWT.ERROR_NULL_ARGUMENT);
+	setBounds(rect.x, rect.y, rect.width, rect.height);
+}
+
+@Override
+public void setBounds(int x, int y, int width, int height) {
+	if (getDisplay().isRescalingAtRuntime()) {
+		Rectangle boundsInPixels = display.translateRectangleInPixelsInDisplayCoordinateSystemByContainment(x, y, width, height);
+		setBoundsInPixels(boundsInPixels.x, boundsInPixels.y, boundsInPixels.width, boundsInPixels.height);
+	} else {
+		super.setBounds(x, y, width, height);
+	}
+}
+
+@Override
 void setBoundsInPixels (int x, int y, int width, int height, int flags, boolean defer) {
 	if (fullScreen) setFullScreen (false);
 	/*

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Shell.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Shell.java
@@ -1567,42 +1567,6 @@ public void setAlpha (int alpha) {
 }
 
 @Override
-public Rectangle getBounds() {
-	Rectangle boundsInPixels = getBoundsInPixels();
-	return display.translateRectangleInPointsInDisplayCoordinateSystemByContainment(boundsInPixels.x, boundsInPixels.y, boundsInPixels.width, boundsInPixels.height);
-}
-
-@Override
-public Point getLocation() {
-	Point locationInPixels = getLocationInPixels();
-	return display.translateLocationInPointInDisplayCoordinateSystem(locationInPixels.x, locationInPixels.y);
-}
-
-@Override
-public void setLocation(Point location) {
-	if (location == null) error (SWT.ERROR_NULL_ARGUMENT);
-	setLocation(location.x, location.y);
-}
-
-@Override
-public void setLocation(int x, int y) {
-	Point location = display.translateLocationInPixelsInDisplayCoordinateSystem(x, y);
-	setLocationInPixels(location.x, location.y);
-}
-
-@Override
-public void setBounds(Rectangle rect) {
-	if (rect == null) error (SWT.ERROR_NULL_ARGUMENT);
-	setBounds(rect.x, rect.y, rect.width, rect.height);
-}
-
-@Override
-public void setBounds(int x, int y, int width, int height) {
-	Rectangle boundsInPixels = display.translateRectangleInPixelsInDisplayCoordinateSystemByContainment(x, y, width, height);
-	setBoundsInPixels(boundsInPixels.x, boundsInPixels.y, boundsInPixels.width, boundsInPixels.height);
-}
-
-@Override
 void setBoundsInPixels (int x, int y, int width, int height, int flags, boolean defer) {
 	if (fullScreen) setFullScreen (false);
 	/*


### PR DESCRIPTION
While testing we noticed some **regressions**, that were introduced with the commits https://github.com/eclipse-platform/eclipse.platform.swt/commit/4f60cb68dbf10c060b323c360a939d7ecf879440 and https://github.com/eclipse-platform/eclipse.platform.swt/commit/7a04f7a6cf7eccda8681f6c59d8f5d4064004e24. These commits were focused on providing a proper point coordinate system when multiple zoom values are involved and _rescaling at runtime_ is active, **but** they also introduced behavioral changes when the _rescaling at runtime_ is **not** active.

There are mainly three possible approaches to handle this regression:

1. Properly rework the coordinate system to support multi zoom environments. This is not doable for the upcoming release, but should be done for the next release
2. Only revert https://github.com/eclipse-platform/eclipse.platform.swt/commit/4f60cb68dbf10c060b323c360a939d7ecf879440 and https://github.com/eclipse-platform/eclipse.platform.swt/commit/7a04f7a6cf7eccda8681f6c59d8f5d4064004e24. This would solve the regression, but re-introduce some issues in the multi-zoom environment,  when rescaling at runtime. As we will  introduce the rescaling feature with the upcoming release via the experimental flag, this would negatively affect it.
3. Retain the adaptions added https://github.com/eclipse-platform/eclipse.platform.swt/commit/4f60cb68dbf10c060b323c360a939d7ecf879440 and https://github.com/eclipse-platform/eclipse.platform.swt/commit/7a04f7a6cf7eccda8681f6c59d8f5d4064004e24, but properly guard them to differentiate between the scenarios with rescaling at runtime active and inactive.

This PR uses the 3rd approach. The first commit is a squashed commit to revert https://github.com/eclipse-platform/eclipse.platform.swt/commit/4f60cb68dbf10c060b323c360a939d7ecf879440 and https://github.com/eclipse-platform/eclipse.platform.swt/commit/7a04f7a6cf7eccda8681f6c59d8f5d4064004e24. The second commit reintroduces the changes with guards.

### One scenario to test
Primary Monitor: 125% (Left)
Secondary Monitor: 175% (Right)

When moving the workbench to the secondary monitor and opening the search window,  the window appears on the primary (fallback) monitor instead of the secondary monitor.