### PR TITLE
Scaling of Color/Font Dialog not working properly after DPI change

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT PI/win32/org/eclipse/swt/internal/win32/OS.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/win32/org/eclipse/swt/internal/win32/OS.java
@@ -370,6 +370,7 @@ public class OS extends C {
 	public static final short DMDUP_VERTICAL = 2;
 	public static final short DMDUP_HORIZONTAL = 3;
 	public static final int DPI_AWARENESS_CONTEXT_UNAWARE = 24592;
+	public static final int DPI_AWARENESS_CONTEXT_UNAWARE_GDISCALED = 1073766416;
 	public static final int DPI_AWARENESS_CONTEXT_SYSTEM_AWARE = 24593;
 	public static final int DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE = 18;
 	public static final int DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2 = 34;

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/FontDialog.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/FontDialog.java
@@ -226,70 +226,85 @@ public FontData open () {
 
 	display.externalEventLoop = true;
 	display.sendPreExternalEventDispatchEvent ();
-	/* Open the dialog */
-	boolean success = OS.ChooseFont (lpcf);
-	display.externalEventLoop = false;
-	display.sendPostExternalEventDispatchEvent ();
-
-	/* Clear the temporary dialog modal parent */
-	if ((style & (SWT.APPLICATION_MODAL | SWT.SYSTEM_MODAL)) != 0) {
-		display.setModalDialog (oldModal);
-	}
-
-	/* Compute the result */
-	if (success) {
-		LOGFONT logFont = new LOGFONT ();
-		OS.MoveMemory (logFont, lpLogFont, LOGFONT.sizeof);
-
+	long currentDpiAwarenessContext = OS.GetThreadDpiAwarenessContext();
+	boolean success = false;
+	try {
 		/*
-		 * This will not work on multiple screens or
-		 * for printing. Should use DC for the proper device.
+		 * Temporarily setting the thread dpi awareness to gdi scaling because window
+		 * dialog has weird resize handling
 		 */
-		long hDC = OS.GetDC(0);
-		int logPixelsY = OS.GetDeviceCaps(hDC, OS.LOGPIXELSY);
-		int pixels = 0;
-		if (logFont.lfHeight > 0) {
+		if (display.isRescalingAtRuntime()) {
+			currentDpiAwarenessContext = OS.SetThreadDpiAwarenessContext(OS.DPI_AWARENESS_CONTEXT_UNAWARE_GDISCALED);
+		}
+
+		/* Open the dialog */
+		success = OS.ChooseFont(lpcf);
+		display.externalEventLoop = false;
+		display.sendPostExternalEventDispatchEvent();
+
+		/* Clear the temporary dialog modal parent */
+		if ((style & (SWT.APPLICATION_MODAL | SWT.SYSTEM_MODAL)) != 0) {
+			display.setModalDialog(oldModal);
+		}
+
+		/* Compute the result */
+		if (success) {
+			LOGFONT logFont = new LOGFONT();
+			OS.MoveMemory(logFont, lpLogFont, LOGFONT.sizeof);
+
 			/*
-			 * Feature in Windows. If the lfHeight of the LOGFONT structure
-			 * is positive, the lfHeight measures the height of the entire
-			 * cell, including internal leading, in logical units. Since the
-			 * height of a font in points does not include the internal leading,
-			 * we must subtract the internal leading, which requires a TEXTMETRIC,
-			 * which in turn requires font creation.
+			 * This will not work on multiple screens or for printing. Should use DC for the
+			 * proper device.
 			 */
-			long hFont = OS.CreateFontIndirect(logFont);
-			long oldFont = OS.SelectObject(hDC, hFont);
-			TEXTMETRIC lptm = new TEXTMETRIC ();
-			OS.GetTextMetrics(hDC, lptm);
-			OS.SelectObject(hDC, oldFont);
-			OS.DeleteObject(hFont);
-			pixels = logFont.lfHeight - lptm.tmInternalLeading;
-		} else {
-			pixels = -logFont.lfHeight;
-		}
-		OS.ReleaseDC(0, hDC);
+			long hDC = OS.GetDC(0);
+			int logPixelsY = OS.GetDeviceCaps(hDC, OS.LOGPIXELSY);
+			int pixels = 0;
+			if (logFont.lfHeight > 0) {
+				/*
+				 * Feature in Windows. If the lfHeight of the LOGFONT structure is positive, the
+				 * lfHeight measures the height of the entire cell, including internal leading,
+				 * in logical units. Since the height of a font in points does not include the
+				 * internal leading, we must subtract the internal leading, which requires a
+				 * TEXTMETRIC, which in turn requires font creation.
+				 */
+				long hFont = OS.CreateFontIndirect(logFont);
+				long oldFont = OS.SelectObject(hDC, hFont);
+				TEXTMETRIC lptm = new TEXTMETRIC();
+				OS.GetTextMetrics(hDC, lptm);
+				OS.SelectObject(hDC, oldFont);
+				OS.DeleteObject(hFont);
+				pixels = logFont.lfHeight - lptm.tmInternalLeading;
+			} else {
+				pixels = -logFont.lfHeight;
+			}
+			OS.ReleaseDC(0, hDC);
 
-		float points = pixels * 72f /logPixelsY;
-		fontData = FontData.win32_new (logFont, points);
-		if (effectsVisible) {
-			int red = lpcf.rgbColors & 0xFF;
-			int green = (lpcf.rgbColors >> 8) & 0xFF;
-			int blue = (lpcf.rgbColors >> 16) & 0xFF;
-			rgb = new RGB (red, green, blue);
+			float points = pixels * 72f / logPixelsY;
+			fontData = FontData.win32_new(logFont, points);
+			if (effectsVisible) {
+				int red = lpcf.rgbColors & 0xFF;
+				int green = (lpcf.rgbColors >> 8) & 0xFF;
+				int blue = (lpcf.rgbColors >> 16) & 0xFF;
+				rgb = new RGB(red, green, blue);
+			}
 		}
+	} finally {
+		/* Reset the dpi awareness context */
+		if (display.isRescalingAtRuntime()) {
+			OS.SetThreadDpiAwarenessContext(currentDpiAwarenessContext);
+		}
+		/* Free the OS memory */
+		if (lpLogFont != 0) OS.HeapFree (hHeap, 0, lpLogFont);
+
+		/* Destroy the BIDI orientation window */
+		if (hwndParent != hwndOwner) {
+			if (enabled) OS.EnableWindow (hwndParent, true);
+			OS.SetActiveWindow (hwndParent);
+			OS.DestroyWindow (hwndOwner);
+		}
+		if (!success) return null;
 	}
 
-	/* Free the OS memory */
-	if (lpLogFont != 0) OS.HeapFree (hHeap, 0, lpLogFont);
-
-	/* Destroy the BIDI orientation window */
-	if (hwndParent != hwndOwner) {
-		if (enabled) OS.EnableWindow (hwndParent, true);
-		OS.SetActiveWindow (hwndParent);
-		OS.DestroyWindow (hwndOwner);
-	}
-
-	if (!success) return null;
 	return fontData;
 }
 


### PR DESCRIPTION
Creating a separate UI thread to set the DPI Awareness context to use UNAWARE GDI scale before opening the either dialogs since windows has issues with dialog scaling in AWARE context

## HOW TO TEST
- Run the `ControlExample` with the following **VM Arguments**
```
-Dswt.autoScale=quarter
-Dswt.autoScale.updateOnRuntime=true
```
- Run the Runtimeworkspace
- Go to Window -> Preferences -> General -> Appearance -> Colors and Fonts
- Collapse **Basic** in the main window
- Double click on any option (to open either color or font dialog) 
- Move the dialog across multiple monitor 
- See if the dialog is scaling correctly on multiple zoom level monitors

## Before Fix

**Case: Primary monitor 200%, Secondary monitor 100%**

100%: 
![image](https://github.com/user-attachments/assets/92ac2f07-63bb-4207-9540-778fde19f8b3)
![image](https://github.com/user-attachments/assets/b7fbc1e9-e88d-485b-9f3d-48f76704503c)


200%:
![image](https://github.com/user-attachments/assets/3ef083e0-5fe1-42ca-9e9c-552d8369ab90)
![image](https://github.com/user-attachments/assets/d2bf7cd5-9744-41a6-96da-7deb4e724ea7)

## After Fix

100%:
![image](https://github.com/user-attachments/assets/b83459ae-bde6-4470-83fe-330c3089d02b)
![image](https://github.com/user-attachments/assets/0a6b22c7-7ce9-4672-bb02-9e3984a7d3b9)

200%:
![image](https://github.com/user-attachments/assets/98e35b28-730e-4411-a906-785c15e0c15e)
![image](https://github.com/user-attachments/assets/b6a07c2c-ddd8-4e96-8fda-174098ddf498)

