### PR TITLE
Store Edge instance in Environemnt record sync-ly

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Browser/win32/org/eclipse/swt/browser/Edge.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Browser/win32/org/eclipse/swt/browser/Edge.java
@@ -568,6 +568,7 @@ private String getDataDir(Display display) {
 @Override
 public void create(Composite parent, int style) {
 	containingEnvironment = createEnvironment();
+	containingEnvironment.instances().add(this);
 	long[] ppv = new long[1];
 	int hr = containingEnvironment.environment().QueryInterface(COM.IID_ICoreWebView2Environment2, ppv);
 	if (hr == COM.S_OK) environment2 = new ICoreWebView2Environment2(ppv[0]);
@@ -591,9 +592,11 @@ void setupBrowser(int hr, long pv) {
 	case COM.S_OK:
 		break;
 	case COM.E_WRONG_THREAD:
+		containingEnvironment.instances().remove(this);
 		error(SWT.ERROR_THREAD_INVALID_ACCESS, hr);
 		break;
 	default:
+		containingEnvironment.instances().remove(this);
 		error(SWT.ERROR_NO_HANDLES, hr);
 	}
 	long[] ppv = new long[] {pv};
@@ -688,7 +691,6 @@ void setupBrowser(int hr, long pv) {
 	browser.addListener(SWT.Move, this::browserMove);
 	scheduleMouseMovementHandling();
 
-	containingEnvironment.instances().add(this);
 	// Sometimes when the shell of the browser is opened before the browser is
 	// initialized, nothing is drawn on the shell. We need browserResize to force
 	// the shell to draw itself again.


### PR DESCRIPTION
This PR contributes to storing the edge instance on creation in the webenvironment record synchronously for the sake of the consistency of the record. Since the record can be read by the cookie manager for several purposes on client calls, we need to make sure the record is in a consistent state, i.e. Linking the Edge instances (completely initialized or not) to their webview environment in the create method (synchronously).

In the bug #1592 the error occurs because we wait for the browser to initialize before it can be added to the record. It is safe to add it synchronously in the record since, all the further API calls of Edge browser is guarded by waitForFutureToFinish method.

contributes to https://github.com/eclipse-platform/eclipse.platform.swt/issues/1592