### PR TITLE
Improve readme formatting and add information on Initiative 31 #1580

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,3 +123,14 @@ You can register bugs and feature requests in the Github Issue Tracker. Remember
 - [New SWT issue](https://github.com/eclipse-platform/eclipse.platform.swt/issues/new)
 
 Please bear in mind that this project is almost entirely developed by volunteers. If you do not provide the implementation yourself (or pay someone to do it for you), the bug might never get fixed. If it is a serious bug, other people than you might care enough to provide a fix.
+
+
+# Prototyping on a Single, Cross-Platform SWT Implementation
+
+There is current work on evaluating the feasibility of achieving a single, OS-agnostic implementation of SWT in order to reduce maintenance efforts, enable better look and feel, and improve configurability.
+The work on these prototypes and their documentation can currently be found in a dedicated GitHub organization: https://github.com/swt-initiative31
+
+Actual prototyping work has been started on four technologies: Skia with Visual Class Library (VCL), Skia with custom-rendered widgets, GTK, and Swing\
+The prototypes for the following technologies are still under investigation, are further developed and can be tried out here:
+- Skia with custom-drawn widgets: https://github.com/swt-initiative31/prototype-skija
+- Cross-platform GTK: https://github.com/swt-initiative31/prototype-gtk

--- a/README.md
+++ b/README.md
@@ -76,22 +76,19 @@ Finally, we set the window's size determines by its child controls and open the 
 The `while`-loop processes all GUI related events until the shell is disposed which happens when closing.
 Before exiting, any claimed GUI resources needs to be freed.
 
-Contributing to SWT
-===================
+
+# Contributing to SWT
 
 Thanks for your interest in this project.
 
 For information about contributing to Eclipse Platform in general, see the general [CONTRIBUTING](https://github.com/eclipse-platform/.github/blob/main/CONTRIBUTING.md) page.
-
 
 [![Create Eclipse Development Environment for Eclipse SWT](https://download.eclipse.org/oomph/www/setups/svg/SWT.svg)](
 https://www.eclipse.org/setups/installer/?url=https://raw.githubusercontent.com/eclipse-platform/eclipse.platform.swt/master/bundles/org.eclipse.swt.tools/Oomph/PlatformSWTConfiguration.setup&show=true
 "Click to open Eclipse-Installer Auto Launch or drag into your running installer")
 
 
-
-Developer resources:
---------------------
+## Developer Resources
 
 See the following description for how to contribute a feature or a bug fix to SWT.
 
@@ -101,29 +98,25 @@ Information regarding source code management, builds, coding standards, and more
 
 - <https://projects.eclipse.org/projects/eclipse.platform.swt/developer>
 
-Contributor License Agreement:
-------------------------------
+## Contributor License Agreement
 
 Before your contribution can be accepted by the project, you need to create and electronically sign the Eclipse Foundation Contributor License Agreement (CLA).
 
 - <http://www.eclipse.org/legal/CLA.php>
 
-Contact:
---------
+## Contact
 
 Contact the project developers via the project's "dev" list.
 
 - <https://accounts.eclipse.org/mailing-list/platform-dev>
 
-Search for bugs:
-----------------
+## Search for Bugs
 
 SWT used to track ongoing development and issues in Bugzilla .
 
 - <https://bugs.eclipse.org/bugs/buglist.cgi?product=Platform&component=SWT>
 
-Create a new bug:
------------------
+## Create a New Bug
 
 You can register bugs and feature requests in the Github Issue Tracker. Remember that contributions are always welcome!
 - [View existing SWT issues](https://github.com/eclipse-platform/eclipse.platform.swt/issues)


### PR DESCRIPTION
This enhances the readme in the following ways:
- Use consistent markdown formatting throughout the document and change all headlines to title case
- Add a section on prototyping work for a single, OS-agnostic SWT implementation with links to the according prototype repositories (Initiative 31)

Fixes https://github.com/eclipse-platform/eclipse.platform.swt/issues/1580