### PR TITLE
Non system cursors adaption to DPI scale changes

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Control.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Control.java
@@ -5417,7 +5417,7 @@ LRESULT WM_SETCURSOR (long wParam, long lParam) {
 		if (control == null) return null;
 		Cursor cursor = control.findCursor ();
 		if (cursor != null) {
-			OS.SetCursor (cursor.handle);
+			OS.SetCursor (Cursor.win32_getHandle(cursor, getZoom()));
 			return LRESULT.ONE;
 		}
 	}

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Shell.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Shell.java
@@ -2624,7 +2624,7 @@ LRESULT WM_SETCURSOR (long wParam, long lParam) {
 				RECT rect = new RECT ();
 				OS.GetClientRect (handle, rect);
 				if (OS.PtInRect (rect, pt)) {
-					OS.SetCursor (cursor.handle);
+					OS.SetCursor (Cursor.win32_getHandle(cursor, getZoom()));
 					switch (msg) {
 						case OS.WM_LBUTTONDOWN:
 						case OS.WM_RBUTTONDOWN:

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Tracker.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Tracker.java
@@ -823,7 +823,7 @@ public void setCursor(Cursor newCursor) {
 	checkWidget();
 	clientCursor = newCursor;
 	if (newCursor != null) {
-		if (inEvent) OS.SetCursor (clientCursor.handle);
+		if (inEvent) OS.SetCursor (Cursor.win32_getHandle(clientCursor, getZoom()));
 	}
 }
 
@@ -892,7 +892,7 @@ long transparentProc (long hwnd, long msg, long wParam, long lParam) {
 			break;
 		case OS.WM_SETCURSOR:
 			if (clientCursor != null) {
-				OS.SetCursor (clientCursor.handle);
+				OS.SetCursor (Cursor.win32_getHandle(clientCursor, getZoom()));
 				return 1;
 			}
 			if (resizeCursor != 0) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Tree.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Tree.java
@@ -4663,7 +4663,7 @@ void setCursor () {
 	* is IDC_ARROW.
 	*/
 	Cursor cursor = findCursor ();
-	long hCursor = cursor == null ? OS.LoadCursor (0, OS.IDC_ARROW) : cursor.handle;
+	long hCursor = cursor == null ? OS.LoadCursor (0, OS.IDC_ARROW) : Cursor.win32_getHandle(cursor, getZoom());
 	OS.SetCursor (hCursor);
 }
 


### PR DESCRIPTION
Creating a map to provide different handle w.r.t the current zoom of the display. The method win32_getHandle provides the appropriate handle for the scaled image as per requested by the client.

## HOW TO TEST
- Run the `Snippet92` (Image) or `Snippet119` (Icon) with the following **VM Arguments**
```
-Dswt.autoScale=quarter
-Dswt.autoScale.updateOnRuntime=true
```
- Run the example
- Move the mouse pointer to the window
- See if the mouse pointer is scaled to the current monitor zoom level. 
- Now move the window to another monitor with different zoom level (i.e. 200%)
- Move the mouse pointer to the window again
- See if the pointer still scaled correctly according to 200% zoom level