### PR TITLE
[GTK3] Test Tree crash in SetData event

### DIFF
--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Tree.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Tree.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.swt.tests.junit;
 
+import static java.lang.System.currentTimeMillis;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -27,6 +28,7 @@ import java.util.List;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.TreeListener;
 import org.eclipse.swt.graphics.Color;
+import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.layout.FillLayout;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Event;
@@ -965,6 +967,57 @@ public void test_Virtual() {
 
 	// the "* 3" allows some surplus for platforms that pre-fetch items to improve scrolling performance:
 	assertTrue(dataCounter[0] > visibleCount / 2 && dataCounter[0] <= visibleCount * 3);
+}
+
+/** Ensure setText() and setImage() can be set from SetData handler.
+@see <a href="https://github.com/eclipse-platform/eclipse.platform.swt/issues/678">Issue 678</a>
+**/
+@Test
+public void test_setData() {
+	tree.dispose();
+	disposedIntentionally = true;
+	Image image = new Image(Display.getCurrent(), 20, 20);
+	try {
+		shell.setSize(200, 200);
+		shell.setLayout(new FillLayout());
+		shell.open();
+		waitUntilIdle();
+		for (int i = 0; i < 200; i++) {
+			Tree tree = new Tree(shell, SWT.VIRTUAL);
+			tree.addListener(SWT.SetData, e -> {
+				TreeItem item = (TreeItem) e.item;
+				item.setText(0, "A");
+				item.setImage(image); // <-- this is the critical line!
+			});
+			waitUntilIdle(); // slightly increase crash probability by preventing unrelated background processing on the next line
+			tree.setItemCount(1);
+
+			waitUntilIdle(); // may crash while processing asynchronous events
+
+			assertEquals("A", tree.getItem(0).getText(0));
+			assertEquals(image, tree.getItem(0).getImage());
+			tree.dispose();
+		}
+	} finally {
+		image.dispose();
+	}
+}
+
+private void waitUntilIdle() {
+	long lastActive = currentTimeMillis();
+	while (true) {
+		if (Thread.interrupted()) {
+			throw new AssertionError();
+		}
+		if (Display.getCurrent().readAndDispatch()) {
+			lastActive = currentTimeMillis();
+		} else {
+			if (lastActive + 10 < currentTimeMillis()) {
+				return;
+			}
+			Thread.yield();
+		}
+	}
 }
 
 @Test


### PR DESCRIPTION
The failure only happens in Ubuntu 24 (GTK 3.24.41)

This is a test for #678 

The fix is in #1612.