### PR TITLE
Deprecate TypedListener for removal to make it strongly internal later

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/DefaultContent.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/DefaultContent.java
@@ -749,6 +749,7 @@ public String getTextRange(int start, int length) {
  * </ul>
  */
 @Override
+@SuppressWarnings("removal")
 public void removeTextChangeListener(TextChangeListener listener){
 	if (listener == null) error(SWT.ERROR_NULL_ARGUMENT);
 	for (int i = 0; i < textListeners.size(); i++) {

--- a/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/StyledTextListener.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/StyledTextListener.java
@@ -17,6 +17,7 @@ import org.eclipse.swt.events.*;
 import org.eclipse.swt.internal.*;
 import org.eclipse.swt.widgets.*;
 
+@SuppressWarnings("removal")
 class StyledTextListener extends TypedListener {
 StyledTextListener(SWTEventListener listener) {
 	super(listener);

--- a/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/common/org/eclipse/swt/dnd/DNDListener.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/common/org/eclipse/swt/dnd/DNDListener.java
@@ -16,7 +16,7 @@ package org.eclipse.swt.dnd;
 import org.eclipse.swt.internal.*;
 import org.eclipse.swt.widgets.*;
 
-
+@SuppressWarnings("removal")
 class DNDListener extends TypedListener {
 	Widget dndWidget;
 /**

--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Widget.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Widget.java
@@ -500,6 +500,7 @@ protected void addTypedListener (EventListener listener, int... eventTypes) {
 	if (listener == null) {
 		SWT.error(SWT.ERROR_NULL_ARGUMENT);
 	}
+	@SuppressWarnings("removal")
 	TypedListener typedListener = new TypedListener(listener);
 	for (int eventType : eventTypes) {
 		_addListener(eventType, typedListener);
@@ -1028,6 +1029,7 @@ public Listener[] getListeners (int eventType) {
  *
  * @since 3.126
  */
+@SuppressWarnings("removal")
 public <L extends EventListener> Stream<L> getTypedListeners (int eventType, Class<L> listenerType) {
 	return Arrays.stream(getListeners(eventType)) //
 			.filter(TypedListener.class::isInstance).map(l -> ((TypedListener) l).eventListener)

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/EventTable.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/EventTable.java
@@ -147,6 +147,7 @@ public void unhook (int eventType, Listener listener) {
 	}
 }
 
+@SuppressWarnings("removal")
 public void unhook (int eventType, EventListener listener) {
 	if (types == null) return;
 	for (int i=0; i<types.length; i++) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/TypedListener.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/TypedListener.java
@@ -36,7 +36,13 @@ import org.eclipse.swt.internal.*;
  * @noreference This class is not intended to be referenced by clients.
  * @noextend This class is not intended to be subclassed by clients.
  * @noinstantiate This class is not intended to be instantiated by clients.
+ * @deprecated This class will become 'strongly' internal. For custom widgets
+ *             {@link Widget#addTypedListener(EventListener, int...)},
+ *             {@link Widget#getTypedListeners(int, Class)} or
+ *             {@link Widget#removeTypedListener(int, EventListener)} can
+ *             probably be used instead.
  */
+@Deprecated(forRemoval = true, since = "3.129.0 (removal in 2027-03 or later)")
 public class TypedListener implements Listener {
 
 	/**

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Widget.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Widget.java
@@ -361,6 +361,7 @@ protected void addTypedListener (EventListener listener, int... eventTypes) {
 	if (listener == null) {
 		SWT.error(SWT.ERROR_NULL_ARGUMENT);
 	}
+	@SuppressWarnings("removal")
 	TypedListener typedListener = new TypedListener(listener);
 	for (int eventType : eventTypes) {
 		_addListener(eventType, typedListener);
@@ -730,6 +731,7 @@ public Listener[] getListeners (int eventType) {
  *
  * @since 3.126
  */
+@SuppressWarnings("removal")
 public <L extends EventListener> Stream<L> getTypedListeners (int eventType, Class<L> listenerType) {
 	return Arrays.stream(getListeners(eventType)) //
 			.filter(TypedListener.class::isInstance).map(l -> ((TypedListener) l).eventListener)

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Widget.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Widget.java
@@ -256,6 +256,7 @@ protected void addTypedListener (EventListener listener, int... eventTypes) {
 	if (listener == null) {
 		SWT.error(SWT.ERROR_NULL_ARGUMENT);
 	}
+	@SuppressWarnings("removal")
 	TypedListener typedListener = new TypedListener(listener);
 	for (int eventType : eventTypes) {
 		_addListener(eventType, typedListener);
@@ -668,6 +669,7 @@ public Listener[] getListeners (int eventType) {
  *
  * @since 3.126
  */
+@SuppressWarnings("removal")
 public <L extends EventListener> Stream<L> getTypedListeners (int eventType, Class<L> listenerType) {
 	return Arrays.stream(getListeners(eventType)) //
 			.filter(TypedListener.class::isInstance).map(l -> ((TypedListener) l).eventListener)


### PR DESCRIPTION
The class `TypedListener` is intended to be internal even if it's in a public package and because there were cases where it has to be used for custom widges it happened that it was still used. With the APIs introduced in https://github.com/eclipse-platform/eclipse.platform.swt/pull/1112 there are better solutions using only public APIs for the cases it was still used.

Together with https://github.com/eclipse-platform/eclipse.platform.swt/pull/1615 this is the continuation of https://github.com/eclipse-platform/eclipse.platform.swt/pull/1101#issuecomment-1995483340 to deprecate `TypedListener` for removal so that it can later be moved into an internal package to strengthen the statement that it's internal.

Eclipse Nebula also does not use 

- https://github.com/eclipse/nebula/pull/582
- https://github.com/eclipse/nebula/pull/583
- https://github.com/eclipse/nebula/pull/602
- https://github.com/eclipse/nebula/pull/613
