### PR TITLE
don't modify topIndex in handleTextChanged if control has not the focus

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/StyledText.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/StyledText.java
@@ -6046,7 +6046,7 @@ void handleTextChanged(TextChangedEvent event) {
 	}
 	int firstLine = content.getLineAtOffset(lastTextChangeStart);
 	resetCache(firstLine, 0);
-	if (!isFixedLineHeight() && topIndex > firstLine) {
+	if (!isFixedLineHeight() && isFocusControl() && topIndex > firstLine) {
 		topIndex = firstLine;
 		if (topIndex < 0) {
 			// TODO: This logging is in place to determine why topIndex is getting set to negative values.

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_custom_StyledText.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_custom_StyledText.java
@@ -4792,6 +4792,11 @@ public void test_notFixedLineHeightDoesntChangeLinePixelIfUnnecessary() {
 	int firstLinePixel = text.getLinePixel(line);
 	text.setWordWrap(true); // make non fixed line height
 	assertEquals(firstLinePixel, text.getLinePixel(line));
+	shell.setVisible(true);
+	shell.forceActive();
+	text.setVisible(true);
+	assertTrue("setFocus failed",text.setFocus());
+	assertTrue("text has not focus",text.isFocusControl());
 	text.replaceTextRange(0, 1, "X");
 	assertEquals(0, text.getTopIndex());
 	assertEquals(0, text.getLinePixel(0));


### PR DESCRIPTION
fix split screen issue https://github.com/eclipse-platform/eclipse.platform.ui/issues/2142 by not setting StyledText#topIndex if the control has not the focus.