### PR TITLE
PatternWin32ManualTest: suppress Discouraged access warning

### DIFF
--- a/tests/org.eclipse.swt.tests.win32/ManualTests/org/eclipse/swt/widgets/PatternWin32ManualTest.java
+++ b/tests/org.eclipse.swt.tests.win32/ManualTests/org/eclipse/swt/widgets/PatternWin32ManualTest.java
@@ -33,6 +33,7 @@ public class PatternWin32ManualTest {
 	private static Display display = Display.getDefault();
 
 	public static void main (String [] args) {
+		@SuppressWarnings("restriction")
 		int zoom = DPIUtil.getDeviceZoom();
 		int scalingFactor = 3;
 		int scaledZoom = zoom * scalingFactor;


### PR DESCRIPTION
`The type 'DPIUtil' is not API (restriction on required project 'org.eclipse.swt.win32.win32.x86_64')`