### PR TITLE
Updated bundles with comparator errors

### DIFF
--- a/binaries/org.eclipse.swt.gtk.linux.aarch64/META-INF/MANIFEST.MF
+++ b/binaries/org.eclipse.swt.gtk.linux.aarch64/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Fragment-Host: org.eclipse.swt;bundle-version="[3.128.0,4.0.0)"
 Bundle-Name: %fragmentName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.swt.gtk.linux.aarch64; singleton:=true
-Bundle-Version: 3.128.0.qualifier
+Bundle-Version: 3.128.100.qualifier
 Bundle-ManifestVersion: 2
 Bundle-Localization: fragment
 Export-Package: 

--- a/binaries/org.eclipse.swt.gtk.linux.aarch64/forceQualifierUpdate.txt
+++ b/binaries/org.eclipse.swt.gtk.linux.aarch64/forceQualifierUpdate.txt
@@ -1,0 +1,2 @@
+
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2595

--- a/binaries/org.eclipse.swt.gtk.linux.ppc64le/META-INF/MANIFEST.MF
+++ b/binaries/org.eclipse.swt.gtk.linux.ppc64le/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Fragment-Host: org.eclipse.swt;bundle-version="[3.128.0,4.0.0)"
 Bundle-Name: %fragmentName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.swt.gtk.linux.ppc64le;singleton:=true
-Bundle-Version: 3.128.0.qualifier
+Bundle-Version: 3.128.100.qualifier
 Bundle-ManifestVersion: 2
 Bundle-Localization: fragment
 Export-Package: 

--- a/binaries/org.eclipse.swt.gtk.linux.ppc64le/forceQualifierUpdate.txt
+++ b/binaries/org.eclipse.swt.gtk.linux.ppc64le/forceQualifierUpdate.txt
@@ -1,0 +1,2 @@
+
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2595

--- a/binaries/org.eclipse.swt.gtk.linux.riscv64/META-INF/MANIFEST.MF
+++ b/binaries/org.eclipse.swt.gtk.linux.riscv64/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Fragment-Host: org.eclipse.swt;bundle-version="[3.128.0,4.0.0)"
 Bundle-Name: %fragmentName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.swt.gtk.linux.riscv64; singleton:=true
-Bundle-Version: 3.128.0.qualifier
+Bundle-Version: 3.128.100.qualifier
 Bundle-ManifestVersion: 2
 Bundle-Localization: fragment
 Export-Package: 

--- a/binaries/org.eclipse.swt.gtk.linux.riscv64/forceQualifierUpdate.txt
+++ b/binaries/org.eclipse.swt.gtk.linux.riscv64/forceQualifierUpdate.txt
@@ -1,0 +1,2 @@
+
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2595

--- a/binaries/org.eclipse.swt.gtk.linux.x86_64/META-INF/MANIFEST.MF
+++ b/binaries/org.eclipse.swt.gtk.linux.x86_64/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Fragment-Host: org.eclipse.swt;bundle-version="[3.128.0,4.0.0)"
 Bundle-Name: %fragmentName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.swt.gtk.linux.x86_64; singleton:=true
-Bundle-Version: 3.128.0.qualifier
+Bundle-Version: 3.128.100.qualifier
 Bundle-ManifestVersion: 2
 Bundle-Localization: fragment
 Export-Package: 

--- a/binaries/org.eclipse.swt.gtk.linux.x86_64/forceQualifierUpdate.txt
+++ b/binaries/org.eclipse.swt.gtk.linux.x86_64/forceQualifierUpdate.txt
@@ -1,0 +1,2 @@
+
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2595

--- a/binaries/org.eclipse.swt.win32.win32.aarch64/META-INF/MANIFEST.MF
+++ b/binaries/org.eclipse.swt.win32.win32.aarch64/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Fragment-Host: org.eclipse.swt;bundle-version="[3.128.0,4.0.0)"
 Bundle-Name: %fragmentName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.swt.win32.win32.aarch64; singleton:=true
-Bundle-Version: 3.128.0.qualifier
+Bundle-Version: 3.128.100.qualifier
 Bundle-ManifestVersion: 2
 Bundle-Localization: fragment
 Export-Package: 

--- a/binaries/org.eclipse.swt.win32.win32.aarch64/forceQualifierUpdate.txt
+++ b/binaries/org.eclipse.swt.win32.win32.aarch64/forceQualifierUpdate.txt
@@ -1,0 +1,2 @@
+
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2595

--- a/binaries/org.eclipse.swt.win32.win32.x86_64/META-INF/MANIFEST.MF
+++ b/binaries/org.eclipse.swt.win32.win32.x86_64/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Fragment-Host: org.eclipse.swt;bundle-version="[3.128.0,4.0.0)"
 Bundle-Name: %fragmentName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.swt.win32.win32.x86_64; singleton:=true
-Bundle-Version: 3.128.0.qualifier
+Bundle-Version: 3.128.100.qualifier
 Bundle-ManifestVersion: 2
 Bundle-Localization: fragment
 Export-Package: 

--- a/binaries/org.eclipse.swt.win32.win32.x86_64/forceQualifierUpdate.txt
+++ b/binaries/org.eclipse.swt.win32.win32.x86_64/forceQualifierUpdate.txt
@@ -1,0 +1,2 @@
+
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2595


### PR DESCRIPTION
Changes to ecj are for handling of switch on String.

See: https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2595