### PR TITLE
Updated bundles with comparator errors

### DIFF
--- a/binaries/org.eclipse.swt.gtk.linux.aarch64/forceQualifierUpdate.txt
+++ b/binaries/org.eclipse.swt.gtk.linux.aarch64/forceQualifierUpdate.txt
@@ -1,0 +1,1 @@
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2595

--- a/binaries/org.eclipse.swt.gtk.linux.ppc64le/forceQualifierUpdate.txt
+++ b/binaries/org.eclipse.swt.gtk.linux.ppc64le/forceQualifierUpdate.txt
@@ -1,0 +1,1 @@
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2595

--- a/binaries/org.eclipse.swt.gtk.linux.riscv64/forceQualifierUpdate.txt
+++ b/binaries/org.eclipse.swt.gtk.linux.riscv64/forceQualifierUpdate.txt
@@ -1,0 +1,1 @@
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2595

--- a/binaries/org.eclipse.swt.gtk.linux.x86_64/forceQualifierUpdate.txt
+++ b/binaries/org.eclipse.swt.gtk.linux.x86_64/forceQualifierUpdate.txt
@@ -1,0 +1,1 @@
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2595

--- a/binaries/org.eclipse.swt.win32.win32.aarch64/forceQualifierUpdate.txt
+++ b/binaries/org.eclipse.swt.win32.win32.aarch64/forceQualifierUpdate.txt
@@ -1,0 +1,1 @@
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2595

--- a/binaries/org.eclipse.swt.win32.win32.x86_64/forceQualifierUpdate.txt
+++ b/binaries/org.eclipse.swt.win32.win32.x86_64/forceQualifierUpdate.txt
@@ -1,0 +1,1 @@
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2595

--- a/bundles/org.eclipse.swt/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.swt/forceQualifierUpdate.txt
@@ -1,2 +1,3 @@
 https://github.com/eclipse-platform/eclipse.platform.swt/issues/1093
 Pick-up legal file unification in native fragments from: https://github.com/eclipse-platform/eclipse.platform.swt/pull/1144
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2595


### PR DESCRIPTION
Changes to ecj are for handling of switch on String.

See: https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2595