### PR TITLE
[Build] Inherit basic config from 'basic' image for linux.x86_64 builder

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,7 +18,7 @@
 def runOnNativeBuildAgent(String platform, Closure body) {
 	def final nativeBuildStageName = 'Build SWT-native binaries'
 	if (platform == 'gtk.linux.x86_64') {
-		podTemplate(inheritFrom: 'ubuntu-latest' /* inhert general configuration */, containers: [
+		podTemplate(inheritFrom: 'basic' /* inherit general configuration */, containers: [
 			containerTemplate(name: 'swtbuild', image: 'eclipse/platformreleng-debian-swtnativebuild:12',
 				resourceRequestCpu:'1000m', resourceRequestMemory:'512Mi',
 				resourceLimitCpu:'2000m', resourceLimitMemory:'4096Mi',


### PR DESCRIPTION
The image is just specified to inherit basic configuration from it and higher level images are not necessary.

Image description:
https://github.com/eclipse-cbi/jiro-agents/blob/b816db0ea7b1c4f574be1e8d28bd31dafa47f8d4/basic/README.md