### PR TITLE
[win32] different coordinate system strategies

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Control.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Control.java
@@ -4007,7 +4007,9 @@ void subclass () {
 public Point toControl (int x, int y) {
 	checkWidget ();
 	int zoom = getZoom();
-	return DPIUtil.scaleDown(toControlInPixels(DPIUtil.scaleUp(x, zoom), DPIUtil.scaleUp(y, zoom)), zoom);
+	Point displayPointInPixels = getDisplay().translateToDisplayCoordinates(new Point(x, y), zoom);
+	final Point controlPointInPixels = toControlInPixels(displayPointInPixels.x, displayPointInPixels.y);
+	return DPIUtil.scaleDown(controlPointInPixels, zoom);
 }
 
 Point toControlInPixels (int x, int y) {
@@ -4040,9 +4042,7 @@ Point toControlInPixels (int x, int y) {
 public Point toControl (Point point) {
 	checkWidget ();
 	if (point == null) error (SWT.ERROR_NULL_ARGUMENT);
-	int zoom = getZoom();
-	point = DPIUtil.scaleUp(point, zoom);
-	return DPIUtil.scaleDown(toControlInPixels(point.x, point.y), zoom);
+	return toControl(point.x, point.y);
 }
 
 /**
@@ -4068,7 +4068,8 @@ public Point toControl (Point point) {
 public Point toDisplay (int x, int y) {
 	checkWidget ();
 	int zoom = getZoom();
-	return DPIUtil.scaleDown(toDisplayInPixels(DPIUtil.scaleUp(x, zoom), DPIUtil.scaleUp(y, zoom)), zoom);
+	Point displayPointInPixels = toDisplayInPixels(DPIUtil.scaleUp(x, zoom), DPIUtil.scaleUp(y, zoom));
+	return getDisplay().translateFromDisplayCoordinates(displayPointInPixels, zoom);
 }
 
 Point toDisplayInPixels (int x, int y) {
@@ -4101,9 +4102,7 @@ Point toDisplayInPixels (int x, int y) {
 public Point toDisplay (Point point) {
 	checkWidget ();
 	if (point == null) error (SWT.ERROR_NULL_ARGUMENT);
-	int zoom = getZoom();
-	point = DPIUtil.scaleUp(point, zoom);
-	return DPIUtil.scaleDown(toDisplayInPixels(point.x, point.y), zoom);
+	return toDisplay(point.x, point.y);
 }
 
 long topHandle () {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Control.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Control.java
@@ -4007,11 +4007,6 @@ void subclass () {
 public Point toControl (int x, int y) {
 	checkWidget ();
 	int zoom = getZoom();
-	if (getDisplay().isRescalingAtRuntime()) {
-		Point displayPointInPixels = getDisplay().translateLocationInPixelsInDisplayCoordinateSystem(x, y);
-		final Point controlPointInPixels = toControlInPixels(displayPointInPixels.x, displayPointInPixels.y);
-		return DPIUtil.scaleDown(controlPointInPixels, zoom);
-	}
 	return DPIUtil.scaleDown(toControlInPixels(DPIUtil.scaleUp(x, zoom), DPIUtil.scaleUp(y, zoom)), zoom);
 }
 
@@ -4045,7 +4040,9 @@ Point toControlInPixels (int x, int y) {
 public Point toControl (Point point) {
 	checkWidget ();
 	if (point == null) error (SWT.ERROR_NULL_ARGUMENT);
-	return toControl(point.x, point.y);
+	int zoom = getZoom();
+	point = DPIUtil.scaleUp(point, zoom);
+	return DPIUtil.scaleDown(toControlInPixels(point.x, point.y), zoom);
 }
 
 /**
@@ -4071,10 +4068,6 @@ public Point toControl (Point point) {
 public Point toDisplay (int x, int y) {
 	checkWidget ();
 	int zoom = getZoom();
-	if (getDisplay().isRescalingAtRuntime()) {
-		Point displayPointInPixels = toDisplayInPixels(DPIUtil.scaleUp(x, zoom), DPIUtil.scaleUp(y, zoom));
-		return getDisplay().translateLocationInPointInDisplayCoordinateSystem(displayPointInPixels.x, displayPointInPixels.y);
-	}
 	return DPIUtil.scaleDown(toDisplayInPixels(DPIUtil.scaleUp(x, zoom), DPIUtil.scaleUp(y, zoom)), zoom);
 }
 
@@ -4108,7 +4101,9 @@ Point toDisplayInPixels (int x, int y) {
 public Point toDisplay (Point point) {
 	checkWidget ();
 	if (point == null) error (SWT.ERROR_NULL_ARGUMENT);
-	return toDisplay(point.x, point.y);
+	int zoom = getZoom();
+	point = DPIUtil.scaleUp(point, zoom);
+	return DPIUtil.scaleDown(toDisplayInPixels(point.x, point.y), zoom);
 }
 
 long topHandle () {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Menu.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Menu.java
@@ -1225,8 +1225,8 @@ void setLocationInPixels (int x, int y) {
 public void setLocation (Point location) {
 	checkWidget ();
 	if (location == null) error (SWT.ERROR_NULL_ARGUMENT);
-	location = getDisplay().translateLocationInPixelsInDisplayCoordinateSystem(location.x, location.y);
-	setLocationInPixels(location.x, location.y);
+	Point locationInPixels = getDisplay().translateToDisplayCoordinates(location, getZoom());
+	setLocationInPixels(locationInPixels.x, locationInPixels.y);
 }
 
 /**

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Shell.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Shell.java
@@ -1567,56 +1567,6 @@ public void setAlpha (int alpha) {
 }
 
 @Override
-public Rectangle getBounds() {
-	if (getDisplay().isRescalingAtRuntime()) {
-		Rectangle boundsInPixels = getBoundsInPixels();
-		return display.translateRectangleInPointsInDisplayCoordinateSystemByContainment(boundsInPixels.x, boundsInPixels.y, boundsInPixels.width, boundsInPixels.height);
-	}
-	return super.getBounds();
-}
-
-@Override
-public Point getLocation() {
-	if (getDisplay().isRescalingAtRuntime()) {
-		Point locationInPixels = getLocationInPixels();
-		return display.translateLocationInPointInDisplayCoordinateSystem(locationInPixels.x, locationInPixels.y);
-	}
-	return super.getLocation();
-}
-
-@Override
-public void setLocation(Point location) {
-	if (location == null) error (SWT.ERROR_NULL_ARGUMENT);
-	setLocation(location.x, location.y);
-}
-
-@Override
-public void setLocation(int x, int y) {
-	if (getDisplay().isRescalingAtRuntime()) {
-		Point location = display.translateLocationInPixelsInDisplayCoordinateSystem(x, y);
-		setLocationInPixels(location.x, location.y);
-	} else {
-		super.setLocation(x, y);
-	}
-}
-
-@Override
-public void setBounds(Rectangle rect) {
-	if (rect == null) error (SWT.ERROR_NULL_ARGUMENT);
-	setBounds(rect.x, rect.y, rect.width, rect.height);
-}
-
-@Override
-public void setBounds(int x, int y, int width, int height) {
-	if (getDisplay().isRescalingAtRuntime()) {
-		Rectangle boundsInPixels = display.translateRectangleInPixelsInDisplayCoordinateSystemByContainment(x, y, width, height);
-		setBoundsInPixels(boundsInPixels.x, boundsInPixels.y, boundsInPixels.width, boundsInPixels.height);
-	} else {
-		super.setBounds(x, y, width, height);
-	}
-}
-
-@Override
 void setBoundsInPixels (int x, int y, int width, int height, int flags, boolean defer) {
 	if (fullScreen) setFullScreen (false);
 	/*

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Shell.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Shell.java
@@ -1567,6 +1567,44 @@ public void setAlpha (int alpha) {
 }
 
 @Override
+public Rectangle getBounds() {
+	checkWidget ();
+	return getDisplay().translateFromDisplayCoordinates(getBoundsInPixels(), getZoom());
+}
+
+@Override
+public Point getLocation() {
+	checkWidget ();
+	return getDisplay().translateFromDisplayCoordinates(getLocationInPixels(), getZoom());
+}
+
+@Override
+public void setLocation(Point location) {
+	if (location == null) error (SWT.ERROR_NULL_ARGUMENT);
+	checkWidget ();
+	Point locationInPixels = getDisplay().translateToDisplayCoordinates(location, getZoom());
+	setLocationInPixels(locationInPixels.x, locationInPixels.y);
+}
+
+@Override
+public void setLocation(int x, int y) {
+	setLocation(new Point(x, y));
+}
+
+@Override
+public void setBounds(Rectangle rect) {
+	if (rect == null) error (SWT.ERROR_NULL_ARGUMENT);
+	checkWidget ();
+	Rectangle boundsInPixels = getDisplay().translateToDisplayCoordinates(rect, getZoom());
+	setBoundsInPixels(boundsInPixels.x, boundsInPixels.y, boundsInPixels.width, boundsInPixels.height);
+}
+
+@Override
+public void setBounds(int x, int y, int width, int height) {
+	setBounds(new Rectangle(x, y, width, height));
+}
+
+@Override
 void setBoundsInPixels (int x, int y, int width, int height, int flags, boolean defer) {
 	if (fullScreen) setFullScreen (false);
 	/*

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Widget.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Widget.java
@@ -1686,7 +1686,7 @@ boolean showMenu (int x, int y) {
 
 boolean showMenu (int x, int y, int detail) {
 	Event event = new Event ();
-	Point mappedLocation = getDisplay().translateLocationInPointInDisplayCoordinateSystem(x, y);
+	Point mappedLocation = getDisplay().translateFromDisplayCoordinates(new Point(x, y), getZoom());
 	event.setLocation(mappedLocation.x, mappedLocation.y);
 	event.detail = detail;
 	if (event.detail == SWT.MENU_KEYBOARD) {


### PR DESCRIPTION
This contributes extracts two different strategies to provide a consistent coordinate system in the win32 implemenentation for a single-zoom and a multi-zoom environment. The existing logic remains unchanged in this commit. It is only moved and consolidated in the new inner classes in Display. 

This PR fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/2595 as well