### PR TITLE
Feature/new dirty indicator bullet

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CTabFolderRenderer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CTabFolderRenderer.java
@@ -877,44 +877,59 @@ public class CTabFolderRenderer {
 		}
 	}
 
-	void drawClose(GC gc, Rectangle closeRect, int closeImageState) {
+	void drawClose(GC gc, Rectangle closeRect, int closeImageState, boolean showDirtyIndicator) {
 		if (closeRect.width == 0 || closeRect.height == 0) return;
 
-		// draw X with length of this constant
-		final int lineLength = 8;
-		int x = closeRect.x + Math.max(1, (closeRect.width-lineLength)/2);
-		int y = closeRect.y + Math.max(1, (closeRect.height-lineLength)/2);
-		y += parent.onBottom ? -1 : 1;
 		int originalLineWidth = gc.getLineWidth();
 		Color originalForeground = gc.getForeground();
-		switch (closeImageState & (SWT.HOT | SWT.SELECTED | SWT.BACKGROUND)) {
-			case SWT.NONE: {
-				drawCloseLines(gc, x, y , lineLength, false);
-				break;
+	    int state = closeImageState & (SWT.HOT | SWT.SELECTED | SWT.BACKGROUND);
+	    if (state == SWT.NONE) {
+	        if (showDirtyIndicator) drawDirtyIndicator(gc, closeRect, originalForeground, false);
+	        drawCloseButton(gc, closeRect, false);
+	    } else if (state == SWT.HOT || state == SWT.SELECTED) {
+			if (showDirtyIndicator) {
+				drawDirtyIndicator(gc, closeRect, originalForeground, true);
+				drawCloseButton(gc, closeRect, false);
+			} else {
+				drawCloseButton(gc, closeRect, true);
 			}
-			case SWT.HOT: {
-				drawCloseLines(gc, x, y , lineLength, true);
-				break;
-			}
-			case SWT.SELECTED: {
-				drawCloseLines(gc, x, y , lineLength, true);
-				break;
-			}
-			case SWT.BACKGROUND: {
-				int[] shape = new int[] {x,y, x+10,y, x+10,y+10, x,y+10};
-				drawBackground(gc, shape, false);
-				break;
-			}
-		}
-		gc.setLineWidth(originalLineWidth);
+	    } else if (state == SWT.BACKGROUND) {
+	        if (showDirtyIndicator)
+	        	drawDirtyIndicator(gc, closeRect, originalForeground, false);
+	        else
+		    	drawBackground(gc, closeRect, SWT.BACKGROUND);
+
+	    }
+	    gc.setLineWidth(originalLineWidth);
 		gc.setForeground(originalForeground);
 	}
 
-	private void drawCloseLines(GC gc, int x, int y, int lineLength, boolean hot) {
+	private void drawDirtyIndicator(GC gc, Rectangle closeRect, Color originalForeground, boolean hot) {
+		Color indicatorColor = hot ? getFillColor() : originalForeground;
+		drawCloseBackground(gc, closeRect, indicatorColor);
+	}
+
+	private void drawCloseBackground(GC gc, Rectangle closeRect, Color backgroundColor) {
+		Color originalBackground = gc.getBackground();
+		gc.setBackground(backgroundColor);
+		gc.setForeground(originalBackground);
+		gc.fillRoundRectangle(closeRect.x + 3, closeRect.y + 4, closeRect.width - 5, closeRect.height - 5, 4, 4);
+		gc.setBackground(originalBackground);
+	}
+
+
+	private void drawCloseButton(GC gc, Rectangle closeRect, boolean hot) {
 		if (hot) {
-			gc.setLineWidth(gc.getLineWidth() + 2);
-			gc.setForeground(getFillColor());
+			drawCloseBackground(gc, closeRect, parent.getDisplay().getSystemColor(SWT.COLOR_WIDGET_NORMAL_SHADOW));
+//			gc.setLineWidth(gc.getLineWidth() + 2);
+			gc.setForeground(gc.getBackground());
 		}
+		// draw X with length of this constant
+		final int lineLength = 6;
+		int x = closeRect.x + Math.max(1, (closeRect.width-lineLength)/2);
+		int y = closeRect.y + Math.max(1, (closeRect.height-lineLength)/2);
+		y += parent.onBottom ? -1 : 1;
+
 		gc.setLineCap(SWT.CAP_ROUND);
 		gc.drawLine(x, y, x + lineLength, y + lineLength);
 		gc.drawLine(x, y + lineLength, x + lineLength, y);
@@ -1463,7 +1478,7 @@ public class CTabFolderRenderer {
 					gc.setBackground(orginalBackground);
 				}
 			}
-			if (shouldDrawCloseIcon(item)) drawClose(gc, item.closeRect, item.closeImageState);
+			if (shouldDrawCloseIcon(item)) drawClose(gc, item.closeRect, item.closeImageState, item.showDirty);
 		}
 	}
 
@@ -1672,7 +1687,7 @@ public class CTabFolderRenderer {
 				gc.setFont(gcFont);
 			}
 			// draw close
-			if (shouldDrawCloseIcon(item)) drawClose(gc, item.closeRect, item.closeImageState);
+			if (shouldDrawCloseIcon(item)) drawClose(gc, item.closeRect, item.closeImageState, item.showDirty);
 		}
 	}
 

--- a/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CTabFolderRenderer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CTabFolderRenderer.java
@@ -884,15 +884,12 @@ public class CTabFolderRenderer {
 		Color originalForeground = gc.getForeground();
 	    int state = closeImageState & (SWT.HOT | SWT.SELECTED | SWT.BACKGROUND);
 	    if (state == SWT.NONE) {
-	        if (showDirtyIndicator) drawDirtyIndicator(gc, closeRect, originalForeground, false);
-	        drawCloseButton(gc, closeRect, false);
+	        if (showDirtyIndicator)
+	        	drawDirtyIndicator(gc, closeRect, originalForeground, false);
+	        else
+	        	drawCloseButton(gc, closeRect, false);
 	    } else if (state == SWT.HOT || state == SWT.SELECTED) {
-			if (showDirtyIndicator) {
-				drawDirtyIndicator(gc, closeRect, originalForeground, true);
-				drawCloseButton(gc, closeRect, false);
-			} else {
-				drawCloseButton(gc, closeRect, true);
-			}
+			drawCloseButton(gc, closeRect, true);
 	    } else if (state == SWT.BACKGROUND) {
 	        if (showDirtyIndicator)
 	        	drawDirtyIndicator(gc, closeRect, originalForeground, false);
@@ -905,15 +902,17 @@ public class CTabFolderRenderer {
 	}
 
 	private void drawDirtyIndicator(GC gc, Rectangle closeRect, Color originalForeground, boolean hot) {
-		Color indicatorColor = hot ? getFillColor() : originalForeground;
-		drawCloseBackground(gc, closeRect, indicatorColor);
+		Color originalBackground = gc.getBackground();
+		gc.setBackground(originalForeground);
+		gc.fillOval(closeRect.x + 3, closeRect.y + 4, closeRect.width - 6, closeRect.height - 6);
+		gc.setBackground(originalBackground);
 	}
 
 	private void drawCloseBackground(GC gc, Rectangle closeRect, Color backgroundColor) {
 		Color originalBackground = gc.getBackground();
 		gc.setBackground(backgroundColor);
 		gc.setForeground(originalBackground);
-		gc.fillRoundRectangle(closeRect.x + 3, closeRect.y + 4, closeRect.width - 5, closeRect.height - 5, 4, 4);
+		gc.fillRoundRectangle(closeRect.x + 1, closeRect.y + 2, closeRect.width - 2, closeRect.height - 2, 4, 4);
 		gc.setBackground(originalBackground);
 	}
 
@@ -925,7 +924,7 @@ public class CTabFolderRenderer {
 			gc.setForeground(gc.getBackground());
 		}
 		// draw X with length of this constant
-		final int lineLength = 6;
+		final int lineLength = 9;
 		int x = closeRect.x + Math.max(1, (closeRect.width-lineLength)/2);
 		int y = closeRect.y + Math.max(1, (closeRect.height-lineLength)/2);
 		y += parent.onBottom ? -1 : 1;

--- a/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CTabItem.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CTabItem.java
@@ -55,6 +55,7 @@ public class CTabItem extends Item {
 	int closeImageState = SWT.BACKGROUND;
 	int state = SWT.NONE;
 	boolean showClose = false;
+	boolean showDirty = false;
 	boolean showing = false;
 
 /**
@@ -276,6 +277,12 @@ public boolean getShowClose() {
 	checkWidget();
 	return showClose;
 }
+
+public boolean getShowDirty() {
+	checkWidget();
+	return showClose;
+}
+
 /**
  * Returns the receiver's tool tip text, or null if it has
  * not been set.
@@ -490,6 +497,14 @@ public void setShowClose(boolean close) {
 	showClose = close;
 	parent.updateFolder(CTabFolder.REDRAW_TABS);
 }
+
+public void setShowDirty(boolean dirty) {
+	checkWidget();
+	if (showDirty == dirty) return;
+	showDirty = dirty;
+	parent.updateFolder(CTabFolder.REDRAW_TABS);
+}
+
 /**
  * Sets the text to display on the tab.
  * A carriage return '\n' allows to display multi line text.


### PR DESCRIPTION
Before this change: If a part is dirty (has unsaved changes), this will be indicated by an `*` in front of a tab's name. 

With this change, the `*` is removed and dirty parts are indicated by a bullet at the location of closing a tab. As soon as, the bullet is hovered, the "button" to close the tab is shown.

Furthermore, the rendering of the close button of tabs is lightly changed.

**Examples**

Tabs unchanged:
<img width="259" alt="image" src="https://github.com/user-attachments/assets/0997172d-dd9c-4b55-a5a0-0e35e69c9c40">

Tabs unchanged (hovered):
<img width="252" alt="image" src="https://github.com/user-attachments/assets/722268d4-977b-4d5b-8e9e-b531d5966df9">

Tab "Test.java" (dirty; selected):
<img width="252" alt="image" src="https://github.com/user-attachments/assets/11a71764-fa24-43fd-9731-3c387f968c08">

Tab "Test.java" (dirty; not selected):
<img width="267" alt="image" src="https://github.com/user-attachments/assets/20f323ba-c439-4c52-93e5-bf4bb6182bcb">

Tab "Test.java" (dirty; hovered)
<img width="264" alt="image" src="https://github.com/user-attachments/assets/7f43d8a4-a765-42f9-b7e7-04919b788162">

Complete flow:
![2024-12-02_20-52-27](https://github.com/user-attachments/assets/8d2389a7-e6f6-4eac-8015-5f4a5b562dab)




To enable this behavior, changes in PR <tbd> are required, too.