### PR TITLE
Use Edge/WebView2 as the default browser on Windows #1466

### DIFF
--- a/binaries/org.eclipse.swt.cocoa.macosx.aarch64/.settings/.api_filters
+++ b/binaries/org.eclipse.swt.cocoa.macosx.aarch64/.settings/.api_filters
@@ -456,6 +456,14 @@
             </message_arguments>
         </filter>
     </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/SWT.java" type="org.eclipse.swt.SWT">
+        <filter id="336658481">
+            <message_arguments>
+                <message_argument value="org.eclipse.swt.SWT"/>
+                <message_argument value="IE"/>
+            </message_arguments>
+        </filter>
+    </resource>
     <resource path="META-INF/MANIFEST.MF">
         <filter id="926941240">
             <message_arguments>

--- a/binaries/org.eclipse.swt.cocoa.macosx.x86_64/.settings/.api_filters
+++ b/binaries/org.eclipse.swt.cocoa.macosx.x86_64/.settings/.api_filters
@@ -456,6 +456,14 @@
             </message_arguments>
         </filter>
     </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/SWT.java" type="org.eclipse.swt.SWT">
+        <filter id="336658481">
+            <message_arguments>
+                <message_argument value="org.eclipse.swt.SWT"/>
+                <message_argument value="IE"/>
+            </message_arguments>
+        </filter>
+    </resource>
     <resource path="META-INF/MANIFEST.MF">
         <filter id="926941240">
             <message_arguments>

--- a/binaries/org.eclipse.swt.gtk.linux.aarch64/.settings/.api_filters
+++ b/binaries/org.eclipse.swt.gtk.linux.aarch64/.settings/.api_filters
@@ -456,6 +456,14 @@
             </message_arguments>
         </filter>
     </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/SWT.java" type="org.eclipse.swt.SWT">
+        <filter id="336658481">
+            <message_arguments>
+                <message_argument value="org.eclipse.swt.SWT"/>
+                <message_argument value="IE"/>
+            </message_arguments>
+        </filter>
+    </resource>
     <resource path="META-INF/MANIFEST.MF">
         <filter id="926941240">
             <message_arguments>

--- a/binaries/org.eclipse.swt.gtk.linux.loongarch64/.settings/.api_filters
+++ b/binaries/org.eclipse.swt.gtk.linux.loongarch64/.settings/.api_filters
@@ -456,6 +456,14 @@
             </message_arguments>
         </filter>
     </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/SWT.java" type="org.eclipse.swt.SWT">
+        <filter id="336658481">
+            <message_arguments>
+                <message_argument value="org.eclipse.swt.SWT"/>
+                <message_argument value="IE"/>
+            </message_arguments>
+        </filter>
+    </resource>
     <resource path="META-INF/MANIFEST.MF">
         <filter id="926941240">
             <message_arguments>

--- a/binaries/org.eclipse.swt.gtk.linux.ppc64le/.settings/.api_filters
+++ b/binaries/org.eclipse.swt.gtk.linux.ppc64le/.settings/.api_filters
@@ -456,6 +456,14 @@
             </message_arguments>
         </filter>
     </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/SWT.java" type="org.eclipse.swt.SWT">
+        <filter id="336658481">
+            <message_arguments>
+                <message_argument value="org.eclipse.swt.SWT"/>
+                <message_argument value="IE"/>
+            </message_arguments>
+        </filter>
+    </resource>
     <resource path="META-INF/MANIFEST.MF">
         <filter id="926941240">
             <message_arguments>

--- a/binaries/org.eclipse.swt.gtk.linux.riscv64/.settings/.api_filters
+++ b/binaries/org.eclipse.swt.gtk.linux.riscv64/.settings/.api_filters
@@ -456,6 +456,14 @@
             </message_arguments>
         </filter>
     </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/SWT.java" type="org.eclipse.swt.SWT">
+        <filter id="336658481">
+            <message_arguments>
+                <message_argument value="org.eclipse.swt.SWT"/>
+                <message_argument value="IE"/>
+            </message_arguments>
+        </filter>
+    </resource>
     <resource path="META-INF/MANIFEST.MF">
         <filter id="926941240">
             <message_arguments>

--- a/binaries/org.eclipse.swt.gtk.linux.x86_64/.settings/.api_filters
+++ b/binaries/org.eclipse.swt.gtk.linux.x86_64/.settings/.api_filters
@@ -8,6 +8,14 @@
             </message_arguments>
         </filter>
     </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/SWT.java" type="org.eclipse.swt.SWT">
+        <filter id="336658481">
+            <message_arguments>
+                <message_argument value="org.eclipse.swt.SWT"/>
+                <message_argument value="IE"/>
+            </message_arguments>
+        </filter>
+    </resource>
     <resource path="META-INF/MANIFEST.MF">
         <filter id="926941240">
             <message_arguments>

--- a/binaries/org.eclipse.swt.win32.win32.aarch64/.settings/.api_filters
+++ b/binaries/org.eclipse.swt.win32.win32.aarch64/.settings/.api_filters
@@ -329,6 +329,14 @@
             </message_arguments>
         </filter>
     </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/SWT.java" type="org.eclipse.swt.SWT">
+        <filter id="336658481">
+            <message_arguments>
+                <message_argument value="org.eclipse.swt.SWT"/>
+                <message_argument value="IE"/>
+            </message_arguments>
+        </filter>
+    </resource>
     <resource path="Eclipse SWT OLE Win32/win32/org/eclipse/swt/ole/win32/OleControlSite.java" type="org.eclipse.swt.ole.win32.OleControlSite">
         <filter id="643846161">
             <message_arguments>

--- a/binaries/org.eclipse.swt.win32.win32.x86_64/.settings/.api_filters
+++ b/binaries/org.eclipse.swt.win32.win32.x86_64/.settings/.api_filters
@@ -375,6 +375,14 @@
             </message_arguments>
         </filter>
     </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/SWT.java" type="org.eclipse.swt.SWT">
+        <filter id="336658481">
+            <message_arguments>
+                <message_argument value="org.eclipse.swt.SWT"/>
+                <message_argument value="IE"/>
+            </message_arguments>
+        </filter>
+    </resource>
     <resource path="Eclipse SWT/common/org/eclipse/swt/events/ArmListener.java" type="org.eclipse.swt.events.ArmListener">
         <filter id="576720909">
             <message_arguments>

--- a/bundles/org.eclipse.swt/Eclipse SWT Browser/common/org/eclipse/swt/browser/Browser.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Browser/common/org/eclipse/swt/browser/Browser.java
@@ -182,10 +182,10 @@ static int checkStyle(int style) {
 				if (current.equalsIgnoreCase ("webkit")) { //$NON-NLS-1$
 					DefaultType = SWT.WEBKIT;
 					break;
+				} else if (current.equalsIgnoreCase ("ie") && "win32".equals (platform)) { //$NON-NLS-1$ //$NON-NLS-2$
+					DefaultType = SWT.IE;
 				} else if (current.equalsIgnoreCase ("edge") && "win32".equals (platform)) { //$NON-NLS-1$ //$NON-NLS-2$
 					DefaultType = SWT.EDGE;
-				} else if (current.equalsIgnoreCase ("ie") && "win32".equals (platform)) { //$NON-NLS-1$ //$NON-NLS-2$
-					DefaultType = SWT.NONE;
 					break;
 				}
 				index = newIndex + 1;
@@ -196,7 +196,7 @@ static int checkStyle(int style) {
 		}
 	}
 	/* If particular backend isn't specified, use the value from the system property. */
-	if ((style & (SWT.WEBKIT | SWT.EDGE)) == 0) {
+	if ((style & (SWT.WEBKIT | SWT.IE | SWT.EDGE)) == 0) {
 		style |= DefaultType;
 	}
 	if ("win32".equals (platform) && (style & SWT.EDGE) != 0) { //$NON-NLS-1$

--- a/bundles/org.eclipse.swt/Eclipse SWT Browser/win32/org/eclipse/swt/browser/BrowserFactory.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Browser/win32/org/eclipse/swt/browser/BrowserFactory.java
@@ -19,13 +19,13 @@ class BrowserFactory {
 
 WebBrowser createWebBrowser (int style) {
 	// This function can't throw, otherwise the Browser will be left in inconsistent state.
-	if ((style & SWT.EDGE) != 0) {
+	if ((style & SWT.IE) != 0) {
 		try {
-			return new Edge();
+			return new IE();
 		} catch (SWTError e) {
 			System.err.println(e);
 		}
 	}
-	return new IE ();
+	return new Edge ();
 }
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/SWT.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/SWT.java
@@ -2564,8 +2564,6 @@ public class SWT {
 	/**
 	 * Style constant specifying that a Browser should use Edge (WebView2)
 	 * for rendering its content (value is 1&lt;&lt;18).
-	 * <p>NOTE: Edge integration is experimental, it isn't a drop-in replacement
-	 * for Internet Explorer.</p>
 	 * <p><b>Used By:</b></p>
 	 * <ul>
 	 * <li><code>Browser</code></li>
@@ -2574,6 +2572,18 @@ public class SWT {
 	 * @since 3.116
 	 */
 	public static final int EDGE = 1 << 18;
+
+	/**
+	 * Style constant specifying that a Browser should use Internet Explorer
+	 * for rendering its content (value is 1&lt;&lt;19).
+	 * <p><b>Used By:</b></p>
+	 * <ul>
+	 * <li><code>Browser</code></li>
+	 * </ul>
+	 *
+	 * @since 3.129
+	 */
+	public static final int IE = 1 << 19;
 
 	/**
 	 * Style constant for balloon behavior (value is 1&lt;&lt;12).

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Control.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Control.java
@@ -3686,9 +3686,9 @@ public void setRedraw (boolean redraw) {
 }
 
 private boolean embedsWin32Control () {
-	if (this instanceof Browser) {
+	if (this instanceof Browser browser) {
 		// The Edge browser embeds webView2
-		return (getStyle() & SWT.EDGE) != 0;
+		return "edge".equals(browser.getBrowserType());
 	}
 
 	if (this instanceof OleClientSite) {

--- a/examples/org.eclipse.swt.examples/src/org/eclipse/swt/examples/controlexample/BrowserTab.java
+++ b/examples/org.eclipse.swt.examples/src/org/eclipse/swt/examples/controlexample/BrowserTab.java
@@ -49,6 +49,7 @@ class BrowserTab extends Tab {
 	/* Style widgets added to the "Style" group */
 	Button webKitButton;
 	Button edgeButton;
+	Button ieButton;
 
 	String errorMessage, lastText, lastUrl;
 
@@ -94,6 +95,7 @@ class BrowserTab extends Tab {
 		if (borderButton.getSelection ()) style |= SWT.BORDER;
 		if (webKitButton.getSelection ()) style |= SWT.WEBKIT;
 		if (edgeButton.getSelection ()) style |= SWT.EDGE;
+		if (ieButton.getSelection ()) style |= SWT.IE;
 
 		/* Create the example widgets */
 		try {
@@ -168,6 +170,8 @@ class BrowserTab extends Tab {
 		webKitButton.setText ("SWT.WEBKIT");
 		edgeButton = new Button (styleGroup, SWT.RADIO);
 		edgeButton.setText ("SWT.EDGE");
+		ieButton = new Button (styleGroup, SWT.RADIO);
+		ieButton.setText ("SWT.IE");
 		borderButton = new Button (styleGroup, SWT.CHECK);
 		borderButton.setText ("SWT.BORDER");
 	}
@@ -345,6 +349,7 @@ class BrowserTab extends Tab {
 		super.setExampleWidgetState ();
 		webKitButton.setSelection (browser == null ? false : (browser.getStyle () & SWT.WEBKIT) != 0);
 		edgeButton.setSelection (browser == null ? false : (browser.getStyle () & SWT.EDGE) != 0);
+		ieButton.setSelection (browser == null ? false : (browser.getStyle () & SWT.IE) != 0);
 		borderButton.setSelection (browser == null ? false : (browser.getStyle () & SWT.BORDER) != 0);
 	}
 }

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_browser_Browser.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_browser_Browser.java
@@ -149,8 +149,10 @@ public static Collection<Object[]> browserFlagsToTest() {
 		// NOTE: This is currently disabled due to test issues in the CI
 		// Execute Edge tests first, because IE starts some OS timer that conflicts with Edge event handling
 		// browserFlags.add(0, new Object[] {SWT.EDGE});
+		browserFlags.add(new Object[] {SWT.IE});
+	} else {
+		browserFlags.add(new Object[] {SWT.NONE});
 	}
-	browserFlags.add(new Object[] {SWT.NONE});
 	return browserFlags;
 }
 


### PR DESCRIPTION
This change replaces Internet Explorer as the default browser used on Windows with Edge/WebView2.

Internet Explorer is progressively taken out of support while Edge/WebView2 and replace by Edge/WebView2. It provides a more future-proof browser integration capability for SWT on Windows, with better capabilities, performance, and development tooling support.

This change consists of the following:
- Introduce SWT flag SWT.IE to be used for Browser to create an Internet Explorer instance
- Adapt mapping of existing VM argument for default browser to map "ie" to new Internet Explorer flag and use Edge as default
- Make SWT Browser instantiate Edge on Windows by default, i.e., unless the flag SWT.IE is specified
- Adapt the SWT ControlExample to represent the SWT.IE flag and properly switch between Edge, Internet Explorer and default
- Adapt Browser tests to consider to new default configuration

Contributes to https://github.com/eclipse-platform/eclipse.platform.swt/issues/1466
Fixes https://github.com/eclipse-platform/eclipse.platform.swt/issues/840

