### PR TITLE
Rasterization of SVGs at Runtime for Eclipse Icons 

### DIFF
--- a/bundles/org.eclipse.swt.svg/.classpath
+++ b/bundles/org.eclipse.swt.svg/.classpath
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
+	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/bundles/org.eclipse.swt.svg/.project
+++ b/bundles/org.eclipse.swt.svg/.project
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>org.eclipse.swt.svg</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ManifestBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.SchemaBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.pde.PluginNature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/bundles/org.eclipse.swt.svg/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.eclipse.swt.svg/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/bundles/org.eclipse.swt.svg/.settings/org.eclipse.jdt.core.prefs
+++ b/bundles/org.eclipse.swt.svg/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,10 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=17
+org.eclipse.jdt.core.compiler.compliance=17
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=warning
+org.eclipse.jdt.core.compiler.release=enabled
+org.eclipse.jdt.core.compiler.source=17
+org.eclipse.jdt.core.incompleteClasspath=warning

--- a/bundles/org.eclipse.swt.svg/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.swt.svg/META-INF/MANIFEST.MF
@@ -1,0 +1,13 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-SymbolicName: org.eclipse.swt.svg
+Bundle-Version: 3.130.0.qualifier
+Automatic-Module-Name: org.eclipse.swt.svg
+Bundle-Name: %fragmentName
+Bundle-Vendor: %providerName
+Bundle-RequiredExecutionEnvironment: JavaSE-17
+Fragment-Host: org.eclipse.swt
+Import-Package: com.github.weisj.jsvg;version="[1.7.0,2.0.0)",
+ com.github.weisj.jsvg.geometry.size;version="[1.7.0,2.0.0)",
+ com.github.weisj.jsvg.parser;version="[1.7.0,2.0.0)"
+Export-Package: org.eclipse.swt.svg

--- a/bundles/org.eclipse.swt.svg/META-INF/services/org.eclipse.swt.internal.image.SVGRasterizer
+++ b/bundles/org.eclipse.swt.svg/META-INF/services/org.eclipse.swt.internal.image.SVGRasterizer
@@ -1,0 +1,1 @@
+org.eclipse.swt.svg.JSVGRasterizer

--- a/bundles/org.eclipse.swt.svg/build.properties
+++ b/bundles/org.eclipse.swt.svg/build.properties
@@ -1,0 +1,15 @@
+source.. = src/
+output.. = bin/
+bin.includes = META-INF/,\
+               .,\
+               fragment.properties
+
+tycho.pomless.parent = ../../local-build/local-build-parent
+jars.extra.classpath = platform:/plugin/org.eclipse.swt.cocoa.macosx.aarch64,\
+                       platform:/plugin/org.eclipse.swt.cocoa.macosx.x86_64,\
+                       platform:/plugin/org.eclipse.swt.gtk.linux.aarch64,\
+                       platform:/plugin/org.eclipse.swt.gtk.linux.ppc64le,\
+                       platform:/plugin/org.eclipse.swt.gtk.linux.riscv64,\
+                       platform:/plugin/org.eclipse.swt.gtk.linux.x86_64,\
+                       platform:/plugin/org.eclipse.swt.win32.win32.aarch64,\
+                       platform:/plugin/org.eclipse.swt.win32.win32.x86_64

--- a/bundles/org.eclipse.swt.svg/fragment.properties
+++ b/bundles/org.eclipse.swt.svg/fragment.properties
@@ -1,0 +1,14 @@
+###############################################################################
+# Copyright (c) 2025 Vector Informatik GmbH and others.
+#
+# This program and the accompanying materials are made available under the terms of the Eclipse
+# Public License 2.0 which accompanies this distribution, and is available at
+# https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#     Michael Bangas (Vector Informatik GmbH) - initial API and implementation
+###############################################################################
+fragmentName = SWT SVG Rendering Support
+providerName = Eclipse.org

--- a/bundles/org.eclipse.swt.svg/src/org/eclipse/swt/svg/JSVGRasterizer.java
+++ b/bundles/org.eclipse.swt.svg/src/org/eclipse/swt/svg/JSVGRasterizer.java
@@ -1,0 +1,136 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Vector Informatik GmbH and others.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse
+ * Public License 2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Michael Bangas (Vector Informatik GmbH) - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.swt.svg;
+
+import static java.awt.RenderingHints.KEY_ALPHA_INTERPOLATION;
+import static java.awt.RenderingHints.KEY_ANTIALIASING;
+import static java.awt.RenderingHints.KEY_COLOR_RENDERING;
+import static java.awt.RenderingHints.KEY_DITHERING;
+import static java.awt.RenderingHints.KEY_FRACTIONALMETRICS;
+import static java.awt.RenderingHints.KEY_INTERPOLATION;
+import static java.awt.RenderingHints.KEY_RENDERING;
+import static java.awt.RenderingHints.KEY_STROKE_CONTROL;
+import static java.awt.RenderingHints.KEY_TEXT_ANTIALIASING;
+import static java.awt.RenderingHints.VALUE_ALPHA_INTERPOLATION_QUALITY;
+import static java.awt.RenderingHints.VALUE_ANTIALIAS_ON;
+import static java.awt.RenderingHints.VALUE_COLOR_RENDER_QUALITY;
+import static java.awt.RenderingHints.VALUE_DITHER_DISABLE;
+import static java.awt.RenderingHints.VALUE_FRACTIONALMETRICS_ON;
+import static java.awt.RenderingHints.VALUE_INTERPOLATION_BICUBIC;
+import static java.awt.RenderingHints.VALUE_RENDER_QUALITY;
+import static java.awt.RenderingHints.VALUE_STROKE_PURE;
+import static java.awt.RenderingHints.VALUE_TEXT_ANTIALIAS_ON;
+
+import java.awt.Graphics2D;
+import java.awt.RenderingHints.Key;
+import java.awt.image.BufferedImage;
+import java.awt.image.DataBufferInt;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Map;
+
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.graphics.ImageData;
+import org.eclipse.swt.graphics.PaletteData;
+import org.eclipse.swt.internal.image.SVGRasterizer;
+
+import com.github.weisj.jsvg.SVGDocument;
+import com.github.weisj.jsvg.geometry.size.FloatSize;
+import com.github.weisj.jsvg.parser.LoaderContext;
+import com.github.weisj.jsvg.parser.SVGLoader;
+
+/**
+ * A rasterizer implementation for converting SVG data into rasterized images.
+ * This class uses the third party library JSVG for the raterization of SVG
+ * images.
+ */
+public class JSVGRasterizer implements SVGRasterizer {
+
+	private static final SVGLoader SVG_LOADER = new SVGLoader();
+
+	private final static Map<Key, Object> RENDERING_HINTS = Map.of( //
+			KEY_ANTIALIASING, VALUE_ANTIALIAS_ON, //
+			KEY_ALPHA_INTERPOLATION, VALUE_ALPHA_INTERPOLATION_QUALITY, //
+			KEY_COLOR_RENDERING, VALUE_COLOR_RENDER_QUALITY, //
+			KEY_DITHERING, VALUE_DITHER_DISABLE, //
+			KEY_FRACTIONALMETRICS, VALUE_FRACTIONALMETRICS_ON, //
+			KEY_INTERPOLATION, VALUE_INTERPOLATION_BICUBIC, //
+			KEY_RENDERING, VALUE_RENDER_QUALITY, //
+			KEY_STROKE_CONTROL, VALUE_STROKE_PURE, //
+			KEY_TEXT_ANTIALIASING, VALUE_TEXT_ANTIALIAS_ON //
+	);
+
+	@Override
+	public ImageData rasterizeSVG(InputStream inputStream, int zoom) throws IOException {
+		SVGDocument svgDocument = loadSVG(inputStream);
+		if (svgDocument == null) {
+			SWT.error(SWT.ERROR_INVALID_IMAGE);
+		}
+		BufferedImage rasterizedImage = renderSVG(svgDocument, zoom);
+		return convertToSWTImageData(rasterizedImage);
+	}
+
+	private SVGDocument loadSVG(InputStream inputStream) {
+		return SVG_LOADER.load(inputStream, null, LoaderContext.createDefault());
+	}
+
+	private BufferedImage renderSVG(SVGDocument svgDocument, int zoom) {
+		float scalingFactor = zoom / 100.0f;
+		BufferedImage image = createImageBase(svgDocument, scalingFactor);
+		Graphics2D g = configureRenderingOptions(scalingFactor, image);
+		svgDocument.render(null, g);
+		g.dispose();
+		return image;
+	}
+
+	private BufferedImage createImageBase(SVGDocument svgDocument, float scalingFactor) {
+		FloatSize sourceImageSize = svgDocument.size();
+		int targetImageWidth = calculateTargetWidth(scalingFactor, sourceImageSize);
+		int targetImageHeight = calculateTargetHeight(scalingFactor, sourceImageSize);
+		return new BufferedImage(targetImageWidth, targetImageHeight, BufferedImage.TYPE_INT_ARGB);
+	}
+
+	private int calculateTargetWidth(float scalingFactor, FloatSize sourceImageSize) {
+		double sourceImageWidth = sourceImageSize.getWidth();
+		return (int) Math.round(sourceImageWidth * scalingFactor);
+	}
+
+	private int calculateTargetHeight(float scalingFactor, FloatSize sourceImageSize) {
+		double sourceImageHeight = sourceImageSize.getHeight();
+		return (int) Math.round(sourceImageHeight * scalingFactor);
+	}
+
+	private Graphics2D configureRenderingOptions(float scalingFactor, BufferedImage image) {
+		Graphics2D g = image.createGraphics();
+		g.setRenderingHints(RENDERING_HINTS);
+		g.scale(scalingFactor, scalingFactor);
+		return g;
+	}
+
+	private ImageData convertToSWTImageData(BufferedImage rasterizedImage) {
+		int width = rasterizedImage.getWidth();
+		int height = rasterizedImage.getHeight();
+		int[] pixels = ((DataBufferInt) rasterizedImage.getRaster().getDataBuffer()).getData();
+		PaletteData paletteData = new PaletteData(0x00FF0000, 0x0000FF00, 0x000000FF);
+		ImageData imageData = new ImageData(width, height, 32, paletteData);
+		int index = 0;
+		for (int y = 0; y < imageData.height; y++) {
+			for (int x = 0; x < imageData.width; x++) {
+				int alpha = (pixels[index] >> 24) & 0xFF;
+				imageData.setAlpha(x, y, alpha);
+				imageData.setPixel(x, y, pixels[index++]);
+			}
+		}
+		return imageData;
+	}
+}

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/SWT.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/SWT.java
@@ -4465,7 +4465,6 @@ public class SWT {
 
 	/**
 	 * Image format constant indicating a SVG format image (value is 8).
-	 * <br>Note that this is a <em>HINT</em> and is currently only supported on GTK.
 	 *
 	 * @since 3.113
 	 */

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/image/FileFormat.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/image/FileFormat.java
@@ -53,6 +53,9 @@ public abstract class FileFormat {
 		try {
 			FORMAT_FACTORIES.add(OS2BMPFileFormat::new);
 		} catch (NoClassDefFoundError e) { } // ignore format
+		try {
+			FORMAT_FACTORIES.add(SVGFileFormat::new);
+		} catch (NoClassDefFoundError e) { } // ignore format
 	}
 
 	public static final int DEFAULT_ZOOM = 100;

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/image/SVGFileFormat.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/image/SVGFileFormat.java
@@ -1,0 +1,66 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Vector Informatik GmbH and others.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse
+ * Public License 2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Michael Bangas (Vector Informatik GmbH) - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.swt.internal.image;
+
+import java.io.*;
+import java.nio.charset.*;
+import java.util.*;
+
+import org.eclipse.swt.*;
+import org.eclipse.swt.graphics.*;
+import org.eclipse.swt.internal.DPIUtil.*;
+
+/**
+ * A {@link FileFormat} implementation for handling SVG (Scalable Vector
+ * Graphics) files.
+ * <p>
+ * This class detects SVG files based on their header and uses a registered
+ * {@link SVGRasterizer} service to rasterize SVG content.
+ * </p>
+ */
+public class SVGFileFormat extends FileFormat {
+
+	/** The instance of the registered {@link SVGRasterizer}. */
+	private static final SVGRasterizer RASTERIZER = ServiceLoader.load(SVGRasterizer.class).findFirst().orElse(null);
+
+	@Override
+	boolean isFileFormat(LEDataInputStream stream) throws IOException {
+		byte[] firstBytes = new byte[5];
+		int bytesRead = stream.read(firstBytes);
+		stream.unread(firstBytes);
+		String header = new String(firstBytes, 0, bytesRead, StandardCharsets.UTF_8).trim();
+		return header.startsWith("<?xml") || header.startsWith("<svg");
+	}
+
+	@Override
+	List<ElementAtZoom<ImageData>> loadFromByteStream(int fileZoom, int targetZoom) {
+		if (RASTERIZER == null) {
+			SWT.error(SWT.ERROR_UNSUPPORTED_FORMAT, null, " [No SVG rasterizer found]");
+		}
+		if (targetZoom <= 0) {
+			SWT.error(SWT.ERROR_INVALID_ARGUMENT, null, " [Cannot rasterize SVG for zoom <= 0]");
+		}
+		try {
+			ImageData rasterizedImageData = RASTERIZER.rasterizeSVG(inputStream, 100 * targetZoom / fileZoom);
+			return List.of(new ElementAtZoom<>(rasterizedImageData, targetZoom));
+		} catch (IOException e) {
+			SWT.error(SWT.ERROR_INVALID_IMAGE, e);
+			return List.of();
+		}
+	}
+
+	@Override
+	void unloadIntoByteStream(ImageLoader loader) {
+		throw new UnsupportedOperationException();
+	}
+}

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/image/SVGRasterizer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/image/SVGRasterizer.java
@@ -1,0 +1,35 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Vector Informatik GmbH and others.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse
+ * Public License 2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Michael Bangas (Vector Informatik GmbH) - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.swt.internal.image;
+
+import java.io.*;
+
+import org.eclipse.swt.graphics.*;
+
+/**
+ * Defines the interface for an SVG rasterizer, responsible for converting SVG
+ * data into rasterized images.
+ */
+public interface SVGRasterizer {
+	/**
+	 * Rasterizes an SVG image from the provided {@code InputStream} using the
+	 * specified zoom.
+	 *
+	 * @param stream the SVG image as an {@link InputStream}.
+	 * @param zoom   the scaling factor (in percent) e.g. {@code 200} for doubled
+	 *               size. This value must be greater zero.
+	 * @return the {@link ImageData} for the rasterized image, or {@code null} if
+	 *         the input is not a valid SVG file or cannot be processed.
+	 */
+	public ImageData rasterizeSVG(InputStream stream, int zoom) throws IOException;
+}

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/AllNonBrowserTests.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/AllNonBrowserTests.java
@@ -45,6 +45,7 @@ import org.junit.platform.suite.api.Suite;
 		Test_org_eclipse_swt_accessibility_AccessibleControlEvent.class,
 		Test_org_eclipse_swt_accessibility_AccessibleEvent.class,
 		Test_org_eclipse_swt_accessibility_AccessibleTextEvent.class,
+		Test_org_eclipse_swt_internal_SVGRasterizer.class,
 		DPIUtilTests.class})
 public class AllNonBrowserTests {
 	private static List<Error> leakedResources;

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_internal_SVGRasterizer.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_internal_SVGRasterizer.java
@@ -1,0 +1,95 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Vector Informatik GmbH and others.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse
+ * Public License 2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Michael Bangas (Vector Informatik GmbH) - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.swt.tests.junit;
+
+import static org.eclipse.swt.tests.junit.SwtTestUtil.assertSWTProblem;
+import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.SWTException;
+import org.eclipse.swt.graphics.Image;
+import org.eclipse.swt.graphics.ImageData;
+import org.eclipse.swt.graphics.ImageDataProvider;
+import org.eclipse.swt.graphics.ImageFileNameProvider;
+import org.eclipse.swt.widgets.Display;
+import org.junit.Test;
+
+/**
+ * When executed locally (outside Tycho build), this tests needs to be run as
+ * JUnit plug-in test in order to have the SVGRasterizer fragment on the
+ * classpath.
+ */
+public class Test_org_eclipse_swt_internal_SVGRasterizer {
+
+	@Test
+	public void test_ConstructorLorg_eclipse_swt_graphics_Device_ImageFileNameProvider() {
+		ImageFileNameProvider validImageFileNameProvider = zoom -> getPath("collapseall.svg");
+		Image image = new Image(Display.getDefault(), validImageFileNameProvider);
+		image.dispose();
+
+		ImageFileNameProvider corruptImageFileNameProvider = zoom -> getPath("corrupt.svg");
+		SWTException e = assertThrows(SWTException.class,
+				() -> new Image(Display.getDefault(), corruptImageFileNameProvider));
+		assertSWTProblem("Incorrect exception thrown for provider with corrupt images", SWT.ERROR_INVALID_IMAGE, e);
+	}
+
+	@Test
+	public void test_ConstructorLorg_eclipse_swt_graphics_Device_ImageDataProvider() {
+		ImageDataProvider validImageDataProvider = zoom -> {
+			String fileName = "collapseall.svg";
+			return new ImageData(getPath(fileName));
+		};
+		Image image = new Image(Display.getDefault(), validImageDataProvider);
+		image.dispose();
+
+		ImageDataProvider corruptImageDataProvider = zoom -> {
+			String fileName = "corrupt.svg";
+			return new ImageData(getPath(fileName));
+		};
+		SWTException e = assertThrows(SWTException.class,
+				() -> new Image(Display.getDefault(), corruptImageDataProvider));
+		assertSWTProblem("Incorrect exception thrown for provider with corrupt images", SWT.ERROR_INVALID_IMAGE, e);
+	}
+
+	String getPath(String fileName) {
+		String urlPath = "";
+		String pluginPath = System.getProperty("PLUGIN_PATH");
+		if (pluginPath == null) {
+			URL url = getClass().getClassLoader().getResource(fileName);
+			if (url == null) {
+				fail("URL == null for file " + fileName);
+			}
+			urlPath = url.getFile();
+		} else {
+			urlPath = pluginPath + "/data/" + fileName;
+		}
+		if (File.separatorChar != '/')
+			urlPath = urlPath.replace('/', File.separatorChar);
+		if (SwtTestUtil.isWindows && urlPath.indexOf(File.separatorChar) == 0)
+			urlPath = urlPath.substring(1);
+		urlPath = urlPath.replaceAll("%20", " ");
+		// Fallback when test is locally executed as plug-in test
+		if (!Files.exists(Path.of(urlPath))) {
+			urlPath = Path.of("data/" + fileName).toAbsolutePath().toString();
+		}
+		assertTrue(Files.exists(Path.of(urlPath)), "file not found: " + urlPath);
+		return urlPath;
+	}
+}

--- a/tests/org.eclipse.swt.tests/META-INF/p2.inf
+++ b/tests/org.eclipse.swt.tests/META-INF/p2.inf
@@ -1,0 +1,4 @@
+# pull in the applicable implementation fragment at build time (bug 461427)
+requires.0.namespace = org.eclipse.equinox.p2.iu
+requires.0.name = org.eclipse.swt.svg
+requires.0.range = 0.0.0

--- a/tests/org.eclipse.swt.tests/data/collapseall.svg
+++ b/tests/org.eclipse.swt.tests/data/collapseall.svg
@@ -1,0 +1,223 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="collapseall.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       y2="1047.3622"
+       x2="-15"
+       y1="1047.3622"
+       x1="-12"
+       gradientTransform="translate(18,-3)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5062-9"
+       xlink:href="#blue_gradient_left"
+       inkscape:collect="always" />
+           <linearGradient
+       y2="1047.3622"
+       x2="-15"
+       y1="1047.3622"
+       x1="-12"
+       gradientTransform="translate(20,-1)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5062-9-5"
+       xlink:href="#blue_gradient_left"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="blue_gradient_left">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="0"
+         id="blue_gradient_left_stop_0" />
+      <stop
+         style="stop-color:#c3e9ff;stop-opacity:1"
+         offset="1"
+         id="blue_gradient_left_stop_1" />
+    </linearGradient>
+       
+    <linearGradient
+       y2="1045.3622"
+       x2="-11"
+       y1="1042.3622"
+       x1="-11"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4975-2-1"
+       xlink:href="#blue_gradient_top"
+       inkscape:collect="always"
+       gradientTransform="translate(18,-3)" />
+       
+    <linearGradient
+       y2="1045.3622"
+       x2="-11"
+       y1="1042.3622"
+       x1="-11"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4975-2-1-1"
+       xlink:href="#blue_gradient_top"
+       inkscape:collect="always"
+       gradientTransform="translate(20,-1)" />
+    <linearGradient
+       id="blue_gradient_top"
+       inkscape:collect="always">
+      <stop
+         id="blue_gradient_top_stop_0"
+         offset="0"
+         style="stop-color:#c3e9ff;stop-opacity:1" />
+      <stop
+         id="blue_gradient_top_stop_1"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+       
+    <linearGradient
+       y2="1043.3622"
+       x2="-11"
+       y1="1042.3622"
+       x1="-11"
+       gradientTransform="translate(22,4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4970"
+       xlink:href="#minus_shadow_gradient"
+       inkscape:collect="always" />
+    <linearGradient
+       id="minus_shadow_gradient">
+      <stop
+         style="stop-color:#c3e9ff;stop-opacity:0.49019608;"
+         offset="0"
+         id="minus_shadow_gradient_stop_0" />
+      <stop
+         id="minus_shadow_gradient_stop_1"
+         offset="0.5"
+         style="stop-color:#c3e9ff;stop-opacity:1;" />
+      <stop
+         style="stop-color:#c3e9ff;stop-opacity:0.49019608;"
+         offset="1"
+         id="minus_shadow_gradient_stop_2" />
+    </linearGradient>
+
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="22.627417"
+     inkscape:cx="8.1029364"
+     inkscape:cy="7.6300717"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     inkscape:window-width="1138"
+     inkscape:window-height="951"
+     inkscape:window-x="1043"
+     inkscape:window-y="364"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3999" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <path
+       style="color:#ffffff;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
+       d="m 3,1039.2997 8.971875,0 0.02812,9.1563 -8.971875,0 z"
+       id="front_background-5"
+       inkscape:connector-curvature="0" />
+    <path
+       style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#a6afc4;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+       d="m 2,1038.3622 0,11 11,0 0,-11 z m 1,1 9,0 0,9 -9,0 z"
+       id="back_rect"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccc"
+       inkscape:export-xdpi="90"
+       inkscape:export-ydpi="90" />
+    <path
+       style="fill:url(#linearGradient5062-9);fill-opacity:1.0;stroke:none;display:inline"
+       d="m 5,1041.3622 0,7 -2,0 0,-9 z"
+       id="back_left_shadow"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       style="fill:url(#linearGradient4975-2-1);fill-opacity:1.0;stroke:none;display:inline"
+       d="m 5,1041.3622 7,0 0,-2 -9,0 z"
+       id="back_top_shadow"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#8b96ab;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+       d="m 4,1040.3622 0,11 11,0 0,-11 z m 1,1 9,0 0,9 -9,0 z"
+       id="front_rect"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccc"
+       inkscape:export-xdpi="90"
+       inkscape:export-ydpi="90" />
+    <path
+       style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+       d="m 5,1041.3622 8.971875,0 0.02812,9 -8.971875,0 z"
+       id="front_background"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:url(#linearGradient4970);fill-opacity:1.0;stroke:none;display:inline"
+       d="m 8,1047.3622 5,0 c 1,0 1,-1 0,-1 l -5,0 c -1,0 -1,1 0,1 z"
+       id="minus_sign_shadow"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       style="fill:url(#linearGradient5062-9-5);fill-opacity:1;stroke:none;display:inline"
+       d="m 7,1043.3622 0,7 -2,0 0,-9 z"
+       id="left_top_shadow"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       style="fill:url(#linearGradient4975-2-1-1);fill-opacity:1;stroke:none;display:inline"
+       d="m 7,1043.3622 7,0 0,-2 -9,0 z"
+       id="front_top_shadow"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <rect
+       style="fill:#01467a;fill-opacity:1;stroke:none;display:inline"
+       id="minus_sign"
+       width="1"
+       height="7"
+       x="1045.3622"
+       y="-13"
+       transform="matrix(0,1,-1,0,0,0)" />
+  </g>
+</svg>

--- a/tests/org.eclipse.swt.tests/data/corrupt.svg
+++ b/tests/org.eclipse.swt.tests/data/corrupt.svg
@@ -1,0 +1,210 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<   inkscape:version="0.91 r13725"
+   sodipodi:docname="collapseall.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       y2="1047.3622"
+       x2="-15"
+       y1="1047.3622"
+       x1="-12"
+       gradientTransform="translate(18,-3)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5062-9"
+       xlink:href="#blue_gradient_left"
+       inkscape:collect="always" />
+           <linearGradient
+       y2="1047.3622"
+       x2="-15"
+       y1="1047.3622"
+       x1="-12"
+       gradientTransform="translate(20,-1)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5062-9-5"
+       xlink:href="#blue_gradient_left"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="blue_gradient_left">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="0"
+         id="blue_gradient_left_stop_0" />
+      <stop
+         style="stop-color:#c3e9ff;stop-opacity:1"
+         offset="1"
+         id="blue_gradient_left_stop_1" />
+    </linearGradient>
+       
+    <linearGradient
+       y2="1045.3622"
+       x2="-11"
+       y1="1042.3622"
+       x1="-11"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4975-2-1"
+       xlink:href="#blue_gradient_top"
+       inkscape:collect="always"
+       gradientTransform="translate(18,-3)" />
+       
+    <linearGradient
+       y2="1045.3622"
+       x2="-11"
+       y1="1042.3622"
+       x1="-11"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4975-2-1-1"
+       xlink:href="#blue_gradient_top"
+       inkscape:collect="always"
+       gradientTransform="translate(20,-1)" />
+    <linearGradient
+       id="blue_gradient_top"
+       inkscape:collect="always">
+      <stop
+         id="blue_gradient_top_stop_0"
+         offset="0"
+         style="stop-color:#c3e9ff;stop-opacity:1" />
+      <stop
+         id="blue_gradient_top_stop_1"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+       
+    <linearGradient
+       y2="1043.3622"
+       x2="-11"
+       y1="1042.3622"
+       x1="-11"
+       gradientTransform="translate(22,4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4970"
+       xlink:href="#minus_shadow_gradient"
+       inkscape:collect="always" />
+    <linearGradient
+       id="minus_shadow_gradient">
+      <stop
+         style="stop-color:#c3e9ff;stop-opacity:0.49019608;"
+         offset="0"
+         id="minus_shadow_gradient_stop_0" />
+      <stop
+         id="minus_shadow_gradient_stop_1"
+         offset="0.5"
+         style="stop-color:#c3e9ff;stop-opacity:1;" />
+      <stop
+         style="stop-color:#c3e9ff;stop-opacity:0.49019608;"
+         offset="1"
+         id="minus_shadow_gradient_stop_2" />
+    </linearGradient>
+
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="22.627417"
+     inkscape:cx="8.1029364"
+     inkscape:cy="7.6300717"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     inkscape:window-width="1138"
+     inkscape:window-height="951"
+     inkscape:window-x="1043"
+     inkscape:window-y="364"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3999" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <path
+       style="color:#ffffff;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
+       d="m 3,1039.2997 8.971875,0 0.02812,9.1563 -8.971875,0 z"
+       id="front_background-5"
+       inkscape:connector-curvature="0" />
+    <path
+       style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#a6afc4;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+       d="m 2,1038.3622 0,11 11,0 0,-11 z m 1,1 9,0 0,9 -9,0 z"
+       id="back_rect"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccc"
+       inkscape:export-xdpi="90"
+       inkscape:export-ydpi="90" />
+    <path
+       style="fill:url(#linearGradient5062-9);fill-opacity:1.0;stroke:none;display:inline"
+       d="m 5,1041.3622 0,7 -2,0 0,-9 z"
+       id="back_left_shadow"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       style="fill:url(#linearGradient4975-2-1);fill-opacity:1.0;stroke:none;display:inline"
+       d="m 5,1041.3622 7,0 0,-2 -9,0 z"
+       id="back_top_shadow"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#8b96ab;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+       d="m 4,1040.3622 0,11 11,0 0,-11 z m 1,1 9,0 0,9 -9,0 z"
+       id="front_rect"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccc"
+       inkscape:export-xdpi="90"
+       inkscape:export-ydpi="90" />
+    <path
+       style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+       d="m 5,1041.3622 8.971875,0 0.02812,9 -8.971875,0 z"
+       id="front_background"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:url(#linearGradient4970);fill-opacity:1.0;stroke:none;display:inline"
+       d="m 8,1047.3622 5,0 c 1,0 1,-1 0,-1 l -5,0 c -1,0 -1,1 0,1 z"
+       id="minus_sign_shadow"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       style="fill:url(#linearGradient5062-9-5);fill-opacity:1;stroke:none;display:inline"
+       d="m 7,1043.3622 0,7 -2,0 0,-9 z"
+       id="left_top_shadow"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       style="fill:url(#linearGradient4975-2-1-1);fill-opacity:1;stroke:none;display:inline"
+       d="m 7,1043.3622 7,0 0,-2 -9,0 z"
+       id="front_top_shadow"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <rect
+       style="fill:#01467a;fill-opacity:1;stroke:none;display:inline"
+       id="minus_sign"
+       width="1"
+       height="7"
+       x="1045.3622"
+       y="-13"
+       transform="matrix(0,1,-1,0,0,0)" />
+  </g>
+</svg>


### PR DESCRIPTION
Eclipse currently loads icons exclusively as raster graphics (e.g., `.png`), without support for vector formats like `.svg`. A major drawback of raster graphics is their inability to scale without degrading image quality. Additionally, generating icons of different sizes requires manually rasterizing SVGs outside Eclipse, leading to unnecessary effort and many icon files.

This PR introduces support for vector graphics in Eclipse, enabling SVGs to be used for icons. Existing PNG icons will continue to be loaded alongside SVGs, allowing the use of the new functionality without the need to replace all PNG files at once.

---

### **Key Features**

- **Example Images**:  
  Screenshots showcasing the new functionality can be found below. These screenshots were taken with 125% monitor-zoom and scaling enabled with the flag `-Dswt.autoScale=quarter`.
  
| PNG      | SVG      |
|---------------|---------------|
| ![PNG](https://github.com/user-attachments/assets/6ecd1eb2-8716-465f-9206-e64ae9e17e7a)  | ![SVG](https://github.com/user-attachments/assets/44d69279-18a0-46de-9972-a529eff5da66)  |
| ![PNG2](https://github.com/user-attachments/assets/0ba6c210-1b0e-4f75-8fc5-f8b40d5c97b4)  | ![SVG2](https://github.com/user-attachments/assets/d8892fd4-c374-4152-9458-b7d50ed54157)  |
| ![PNG3](https://github.com/user-attachments/assets/d3c5668f-a4a3-4b9f-8ad4-73072c258abc)  | ![SVG3](https://github.com/user-attachments/assets/8f20bbf6-30d8-41cb-9775-ddbdad7398a4)  |
| ![PNG4](https://github.com/user-attachments/assets/dbbd7b6c-4e58-415e-8a13-ba3557f2dca6)  | ![SVG4](https://github.com/user-attachments/assets/95270a6b-b550-4652-afe5-43d35444b1df)  |

  

- **How It Works**:  
  - To use SVG icons, simply place the SVG file in the bundle and reference it in the `plugin.xml` and other necessary locations, as is done for PNGs. No additional configuration is required.  
  - At runtime, Eclipse uses the library JSVG to rasterize the SVG into a raster image of the desired size, eliminating the need for scaling. My analysis shows that JSVG is the most suitable Java library for this purpose.
  - You need to write the flag `-Dswt.autoScale=quarter` into your `eclipse.ini` file or into the run arguments of a new configuration.

- **Demonstration**:  
  This PR includes SVG versions of icons for the following bundles:  
  - `org.eclipse.search`  
  - `org.eclipse.ui`  
  - `org.eclipse.ui.ide`  
  - `org.eclipse.ui.ide.application`  
  - `org.eclipse.ui.editors`  
  - `org.eclipse.ui.navigator`  

Due to this the PR of Platform UI is very large. If preferred, I can limit the changes to `org.eclipse.search`, allowing SVG icons to be tested specifically in the search result window.
I did not delete any exisiting PNGs. 

---

### **Architecture**

Eclipse icons fall into three categories, all three adressed by this PR:

1. **Standard Icons**:  
   These is the most common type of icons. They are loaded, scaled if needed, and displayed in the UI.

2. **Composite Icons**:  
   Composite icons combine a base icon with up to four overlay icons. Each component is loaded separately and then combined for display.

3. **Graphically Customized Icons**:  
   These icons represent disabled or "grayed-out" states. They can either be provided as pre-designed raster images or generated dynamically at runtime by applying transformations to the "enabled" version of the icon. Eclipse does not have no pre-designed SVGs. As soon as the path of the pre-designed raster graphic is removed the icon will be created at runtime. 

**Standard-Icons** and **Composite Icons** are fully supported by this PR. **Graphically Customized Icons** are only supported if the pre-designed raster graphic is removed. The original image loaded before the customization, is generated by rasterizing a SVG. Afterwards the current automatic customization functionality creates the "grayed-out" style. This currenct functionality for customization produces bad results as seen [here](https://github.com/eclipse-platform/eclipse.platform.swt/discussions/1619#discussioncomment-11408347). This is why I want to change this behaviour in a future PR.
 
The solution of my future PR applies a runtime filter to SVGs before rasterization (pre-processing), which can emulate GTK or Cocoa (macOS)/Windows styles. Specifically, GTK uses a unique style for disabled icons and I can only produce results that fit to either GTK or Windows and Cocoa. I will release this feature as a follow up to this PR as soon as a solution is found for the different styles for different OS. As discussion for this topic can be found [here](https://github.com/eclipse-platform/eclipse.platform.swt/discussions/1619). Alternatively I can release the PR before and we live with the other visuals for one OS. For now I recommend to use the pre-designed PNGs as usual. The future PR for the customization of icons with SVGs is nearly complete but requires further refinement before release. 

The sequence diagrams below illustrate the architecture for loading **Standard** and **Composite Icons**. The new functionality introduced in this PR is highlighted in blue. The new functionality changes the ImageLoader process on the right side of the diagramms. You can see that the implementation can happen in the same place for these two icon groups:

**Sequence-Diagram: Standard-Icons (Currenct Workflow)**
![20241206_Standard-Icons_Current](https://github.com/user-attachments/assets/b90fcf52-62df-4e18-8107-c7a4bd6174a7)

**Sequence-Diagram: Standard-Icons (Improved Workflow)**
![20241206_Standard-Icons_Improved](https://github.com/user-attachments/assets/4f6c0027-a6df-412f-9b44-24cda8c3a55c)

**Sequence-Diagram: Composite-Icons (Currenct Workflow. See also the two little referenced workflows below)**
![20241206_Composite-Icons_Current-1](https://github.com/user-attachments/assets/ada6a411-74b2-4f43-986f-b6e333e24743)
![20241206_Composite-Icons_Current-2](https://github.com/user-attachments/assets/fdeb4a40-0f96-422e-a760-8807b7585bfc)

**Sequence-Diagram: Composite-Icons (Improved Workflow)**
![20241206_Composite-Icons_Improved](https://github.com/user-attachments/assets/e4d84074-3082-4121-9f60-6e1c019412c4)

For **Graphically Customized Icons**, only the current workflow will be shown in a sequence diagram here. The new workflow as described above will be part of the follow up PR. You can see that by calling `URLImageDescriptor.createImage()` the Standard-Icons workflow is called. 

**Sequence-Diagram: Disabled-Icons (Current Workflow)**
![20241206_Disabled-Icons_Current](https://github.com/user-attachments/assets/2816f5c2-2518-4475-9a3c-ca8b76020be5)

---

### **Dependency Management**

To enable SVG rasterization, the library JSVG is required as an external dependency. Since all rasterization logic needs to be part of Eclipse SWT, the dependency must also be included in SWT. However, SWT currently has no external dependencies, which created challenges for the integration of the Dependency:

#### **Unsuccessful Approaches**:
1. **Fragment Approach**:  
   Adding a fragment to SWT with the JSVG dependency failed, as SWT itself is composed of fragments, and fragments cannot depend on other fragments.

2. **Service Loader Approach**:  
   Adding a new bundle with the functionality and the dependency failed because SWT fragments lack a class loader to locate the new bundle. (I am not sure if this reason is correct but I tried for some hours and it did not work)

#### **Successful Approach**:  
I created a new bundle containing the rasterization logic and the JSVG dependency. This bundle registers itself via a hook mechanism during initialization. To ensure the bundle is loaded, I added an initialization line to `Workbench.createAndRunWorkbench(Display, WorkbenchAdvisor)`.

Once JSVG is included in the target platform (with help from @HannesWell), this functionality will become fully operational.

---

### **Outstanding Issues**

~~1. **Target Platform**:  
   The JSVG library must be included in the target platform.~~

2. **Existing PNGs**:  
   PNG files cannot yet be deleted, as some are referenced across bundles via hardcoded paths e.g. in platform code. Removing these files would result in errors.

~~3. **Early-Loaded Icons**:  
   A few icons (e.g., `eclipse16.png`) are loaded before the workbench is initialized. At this point, the rasterizer has not yet been registered. I only experienced three icons that were loaded this early but there might be more.~~

4. **Scaling Support for Composite Icons**:  
I modified the behavior of the `CompositeImageDescriptor.supportsZoomLevel(int zoom)` method in Platform UI to address a limitation where it only allowed zoom levels that were exact multiples of 100 (e.g., 100, 200, 300). This restriction, caused by an unresolved bug, prevented scaling to zoom levels such as 125. Although I haven't analyzed the underlying bug yet, this change was necessary to enable proper scaling functionality.

5. **Missing or broken SVGs**
There are some icons that don't have a SVG-File or the SVG-File needs to be improved. The feature can still be used as there will be raster graphics that are loaded instead but finally this issue needs to be fixed. I will provide PRs if I find these icons. 
---

### **Planned Tasks for this PR**

~~1. **Regression Testing**:  
   I will add regression tests that allow automatic testing of the feature.~~

~~2. **Performance Evaluation**:  
   I will perform performance tests to find out if this feature is faster or slower than the current implementation. From manual testing I can say that it feels rather the same.~~

3. **Testing for different OS**
The `ImageLoader` class has specific implementations for cocoa, win32 and gtk that I needed to change. All three implementations are very similar, so I don't think there will be an issue but the cocoa and gtk implementation was no yet tested by me. I only tested on a windows system. 

---

See also this [PR](https://github.com/eclipse-platform/eclipse.platform.ui/pull/2593) for the necessary changes in Platform UI. All changes for this feature were performed in SWT and Platform UI. 

Fixes https://github.com/eclipse-platform/eclipse.platform.swt/issues/1438.

Let me know if you'd like further clarification or additional adjustments!
