### PR TITLE
Device getDPI scaling fix

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Device.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Device.java
@@ -519,7 +519,7 @@ public Point getDPI () {
 	int dpiX = OS.GetDeviceCaps (hDC, OS.LOGPIXELSX);
 	int dpiY = OS.GetDeviceCaps (hDC, OS.LOGPIXELSY);
 	internal_dispose_GC (hDC, null);
-	return DPIUtil.scaleDown(new Point (dpiX, dpiY), getDeviceZoom());
+	return DPIUtil.scaleDown(new Point (dpiX, dpiY), DPIUtil.getZoomForAutoscaleProperty(getDeviceZoom()));
 }
 
 /**


### PR DESCRIPTION
This contribution fixes the device getDPI calculation logic by usibg the device zoom to be used for scaling down the DPI values instead of the native zoom.

contributes to #62 and #127

Fixes #1671 