### PR TITLE
Follow-Up Feature: Icon-Enablement with Rasterization of SVGs

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/ImageDataLoader.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/ImageDataLoader.java
@@ -37,14 +37,14 @@ class ImageDataLoader {
 		return data[0];
 	}
 
-	public static ElementAtZoom<ImageData> load(InputStream stream, int fileZoom, int targetZoom) {
-		List<ElementAtZoom<ImageData>> data = new ImageLoader().load(stream, fileZoom, targetZoom);
+	public static ElementAtZoom<ImageData> load(InputStream stream, int fileZoom, int targetZoom, int flag) {
+		List<ElementAtZoom<ImageData>> data = new ImageLoader().load(stream, fileZoom, targetZoom, flag);
 		if (data.isEmpty()) SWT.error(SWT.ERROR_INVALID_IMAGE);
 		return data.get(0);
 	}
 
-	public static ElementAtZoom<ImageData> load(String filename, int fileZoom, int targetZoom) {
-		List<ElementAtZoom<ImageData>> data = new ImageLoader().load(filename, fileZoom, targetZoom);
+	public static ElementAtZoom<ImageData> load(String filename, int fileZoom, int targetZoom, int flag) {
+		List<ElementAtZoom<ImageData>> data = new ImageLoader().load(filename, fileZoom, targetZoom, flag);
 		if (data.isEmpty()) SWT.error(SWT.ERROR_INVALID_IMAGE);
 		return data.get(0);
 	}

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/ImageDataProvider.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/ImageDataProvider.java
@@ -43,4 +43,17 @@ public interface ImageDataProvider {
 	 */
 	ImageData getImageData (int zoom);
 
+//	/**
+//	* @since 4.0
+//	*/
+//	default ImageData getCustomizedImageData(int zoom, int flag) {
+//		throw new UnsupportedOperationException();
+//	}
+//
+//	/**
+//	* @since 4.0
+//	*/
+//	default boolean supportsRasterizationFlag(int flag) {
+//		return false;
+//	}
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/ImageLoader.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/ImageLoader.java
@@ -150,14 +150,14 @@ void reset() {
  * </ul>
  */
 public ImageData[] load(InputStream stream) {
-	load(stream, FileFormat.DEFAULT_ZOOM, FileFormat.DEFAULT_ZOOM);
+	load(stream, FileFormat.DEFAULT_ZOOM, FileFormat.DEFAULT_ZOOM, SWT.IMAGE_COPY);
 	return data;
 }
 
-List<ElementAtZoom<ImageData>> load(InputStream stream, int fileZoom, int targetZoom) {
+List<ElementAtZoom<ImageData>> load(InputStream stream, int fileZoom, int targetZoom, int flag) {
 	if (stream == null) SWT.error(SWT.ERROR_NULL_ARGUMENT);
 	reset();
-	List<ElementAtZoom<ImageData>> images = InternalImageLoader.load(stream, this, fileZoom, targetZoom);
+	List<ElementAtZoom<ImageData>> images = InternalImageLoader.load(stream, this, fileZoom, targetZoom, flag);
 	data = images.stream().map(ElementAtZoom::element).toArray(ImageData[]::new);
 	return images;
 }
@@ -181,14 +181,14 @@ List<ElementAtZoom<ImageData>> load(InputStream stream, int fileZoom, int target
  * </ul>
  */
 public ImageData[] load(String filename) {
-	load(filename, FileFormat.DEFAULT_ZOOM, FileFormat.DEFAULT_ZOOM);
+	load(filename, FileFormat.DEFAULT_ZOOM, FileFormat.DEFAULT_ZOOM, SWT.IMAGE_COPY);
 	return data;
 }
 
-List<ElementAtZoom<ImageData>> load(String filename, int fileZoom, int targetZoom) {
+List<ElementAtZoom<ImageData>> load(String filename, int fileZoom, int targetZoom, int flag) {
 	if (filename == null) SWT.error(SWT.ERROR_NULL_ARGUMENT);
 	try (InputStream stream = new FileInputStream(filename)) {
-		return load(stream, fileZoom, targetZoom);
+		return load(stream, fileZoom, targetZoom, flag);
 	} catch (IOException e) {
 		SWT.error(SWT.ERROR_IO, e);
 	}

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/image/FileFormat.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/image/FileFormat.java
@@ -82,7 +82,7 @@ public abstract class FileFormat {
 		abstract ImageData[] loadFromByteStream();
 
 		@Override
-		List<ElementAtZoom<ImageData>> loadFromByteStream(int fileZoom, int targetZoom) {
+		List<ElementAtZoom<ImageData>> loadFromByteStream(int fileZoom, int targetZoom, int flag) {
 			return Arrays.stream(loadFromByteStream()).map(d -> new ElementAtZoom<>(d, fileZoom)).toList();
 		}
 	}
@@ -102,16 +102,16 @@ public abstract class FileFormat {
 	 * Format that do not implement {@link StaticImageFileFormat} MUST return
 	 * {@link ImageData} with the specified {@code targetZoom}.
 	 */
-	abstract List<ElementAtZoom<ImageData>> loadFromByteStream(int fileZoom, int targetZoom);
+	abstract List<ElementAtZoom<ImageData>> loadFromByteStream(int fileZoom, int targetZoom, int flag);
 
 /**
  * Read the specified input stream, and return the
  * device independent image array represented by the stream.
  */
-public List<ElementAtZoom<ImageData>> loadFromStream(LEDataInputStream stream, int fileZoom, int targetZoom) {
+public List<ElementAtZoom<ImageData>> loadFromStream(LEDataInputStream stream, int fileZoom, int targetZoom, int flag) {
 	try {
 		inputStream = stream;
-		return loadFromByteStream(fileZoom, targetZoom);
+		return loadFromByteStream(fileZoom, targetZoom, flag);
 	} catch (Exception e) {
 		if (e instanceof IOException) {
 			SWT.error(SWT.ERROR_IO, e);
@@ -126,14 +126,14 @@ public List<ElementAtZoom<ImageData>> loadFromStream(LEDataInputStream stream, i
  * Read the specified input stream using the specified loader, and
  * return the device independent image array represented by the stream.
  */
-public static List<ElementAtZoom<ImageData>> load(InputStream is, ImageLoader loader, int fileZoom, int targetZoom) {
+public static List<ElementAtZoom<ImageData>> load(InputStream is, ImageLoader loader, int fileZoom, int targetZoom, int flag) {
 	LEDataInputStream stream = new LEDataInputStream(is);
 	FileFormat fileFormat = determineFileFormat(stream).orElseGet(() -> {
 		SWT.error(SWT.ERROR_UNSUPPORTED_FORMAT);
 		return null;
 	});
 	fileFormat.loader = loader;
-	return fileFormat.loadFromStream(stream, fileZoom, targetZoom);
+	return fileFormat.loadFromStream(stream, fileZoom, targetZoom, flag);
 }
 
 /**

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/image/SVGFileFormat.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/image/SVGFileFormat.java
@@ -43,7 +43,7 @@ public class SVGFileFormat extends FileFormat {
 	}
 
 	@Override
-	List<ElementAtZoom<ImageData>> loadFromByteStream(int fileZoom, int targetZoom) {
+	List<ElementAtZoom<ImageData>> loadFromByteStream(int fileZoom, int targetZoom, int flag) {
 		if (RASTERIZER == null) {
 			SWT.error(SWT.ERROR_UNSUPPORTED_FORMAT, null, " [No SVG rasterizer found]");
 		}
@@ -51,7 +51,7 @@ public class SVGFileFormat extends FileFormat {
 			SWT.error(SWT.ERROR_INVALID_ARGUMENT, null, " [Cannot rasterize SVG for zoom <= 0]");
 		}
 		try {
-			ImageData rasterizedImageData = RASTERIZER.rasterizeSVG(inputStream, 100 * targetZoom / fileZoom);
+			ImageData rasterizedImageData = RASTERIZER.rasterizeSVG(inputStream, 100 * targetZoom / fileZoom, flag);
 			return List.of(new ElementAtZoom<>(rasterizedImageData, targetZoom));
 		} catch (IOException e) {
 			SWT.error(SWT.ERROR_INVALID_IMAGE, e);

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/image/SVGRasterizer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/image/SVGRasterizer.java
@@ -31,5 +31,5 @@ public interface SVGRasterizer {
 	 * @return the {@link ImageData} for the rasterized image, or {@code null} if
 	 *         the input is not a valid SVG file or cannot be processed.
 	 */
-	public ImageData rasterizeSVG(InputStream stream, int zoom) throws IOException;
+	public ImageData rasterizeSVG(InputStream stream, int zoom, int flag) throws IOException;
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/image/WinICOFileFormat.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/image/WinICOFileFormat.java
@@ -133,7 +133,7 @@ ImageData loadIcon(int[] iconHeader) {
 		StaticImageFileFormat png = new PNGFileFormat();
 		if (png.isFileFormat(inputStream)) {
 			png.loader = this.loader;
-			return png.loadFromStream(inputStream, DEFAULT_ZOOM, DEFAULT_ZOOM).get(0).element();
+			return png.loadFromStream(inputStream, DEFAULT_ZOOM, DEFAULT_ZOOM, SWT.IMAGE_COPY).get(0).element();
 		}
 	} catch (Exception e) {
 	}

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/InternalImageLoader.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/InternalImageLoader.java
@@ -21,8 +21,8 @@ import org.eclipse.swt.internal.image.*;
 
 class InternalImageLoader {
 
-	static List<ElementAtZoom<ImageData>> load(InputStream stream, ImageLoader imageLoader, int fileZoom, int targetZoom) {
-		return FileFormat.load(stream, imageLoader, fileZoom, targetZoom);
+	static List<ElementAtZoom<ImageData>> load(InputStream stream, ImageLoader imageLoader, int fileZoom, int targetZoom, int flag) {
+		return FileFormat.load(stream, imageLoader, fileZoom, targetZoom, flag);
 	}
 
 	static void save(OutputStream stream, int format, ImageLoader imageLoader) {


### PR DESCRIPTION
This draft outlines the follow-up functionality for the [PR](https://github.com/eclipse-platform/eclipse.platform.swt/pull/1638) (Feature Proposal: Rasterization of SVGs at Runtime for Eclipse Icons).

The commit 4e6abc7c21d10d293a68288170ef91e086d6fef1 contains the new functionality that extends the base functionality of the mentioned PR. All future changes to the PR will be performed to this draft.

The new functionality extends the current automatic customization of icons in the `Image(Device device, Image srcImage, int flag)` constructor. While all of the core functionality is implemented within SWT, some changes are required in Platform UI, which can be found in the following [Draft](https://github.com/eclipse-platform/eclipse.platform.ui/pull/2621). 

When the `Image` constructor is invoked, the new functionality attempts to create a graphically customized icon by passing a specific flag (e.g., `SWT.IMAGE_DISABLE`) to the rasterization functionality introduced in the base PR. This functionality is enhanced by a preprocessing step that automatically adds a filter to the SVG before rasterization. These filters are designed to ensure that the resulting icons resemble the current pre-created disabled/gray icons loaded at runtime. 

It is important to note that the automatic icon customization differs between GTK and Cocoa/Win32. As such, the icons generated with the new functionality may not align perfectly with the automatically customized GTK icons. However, this discrepancy is also present with the current pre-created icons, so the impact is minimal. Additionally, most icons are pre-created and not automatically customized at runtime. 

Below is a comparison between the current pre-created icons and the icons customized automatically at runtime using the new functionality. The color/saturation/brightness can be changed by adjusting the filter:

**Pre-created and scaled down to 125% device zoom:**
![image](https://github.com/user-attachments/assets/7ba71c98-9370-4e98-b249-616385c04001)

**Automatically customized at runtime with the new functionality:**
![image](https://github.com/user-attachments/assets/c6b639ec-f824-449b-ad00-f111de71b530)

The following tasks need to be completed for this draft:

1. Decide whether the unification of the behavior across different operating systems should occur before merging the new functionality.
2. Merge the main feature upon which this draft is based.
3. Remove disabled icon paths from the `plugin.xml` files to ensure the automatic customization is triggered.
4. Write documentation (JavaDocs) for the new API.
5. Provide regression tests and a performance comparison between automatic customization and FileIO for pre-created icons. The possibility exists that the rasterization with pre-processing is faster than the additional FileIO to load the pre-created icons. 

Fixes https://github.com/eclipse-platform/eclipse.platform.swt/issues/1438.