### PR TITLE
[Mac] GC#fillGradientRectangle don't color for y < 0 #1652

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/graphics/GC.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/graphics/GC.java
@@ -2003,7 +2003,7 @@ public void fillGradientRectangle(int x, int y, int width, int height, boolean v
 			NSGradient gradient = ((NSGradient)new NSGradient().alloc()).initWithStartingColor(startingColor, endingColor);
 			NSRect rect = new NSRect();
 			rect.x = x;
-			rect.y = y < 0 ? 0 : y;
+			rect.y = y;
 			rect.width = width;
 			rect.height = height;
 			gradient.drawInRect(rect, vertical ? 90 : 0);


### PR DESCRIPTION
GC#fillGradientRectangle must be applied for negative y too.

Fixes https://github.com/eclipse-platform/eclipse.platform.swt/issues/1652