### PR TITLE
No need to check that webkit is used on gtk in tests

### DIFF
--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_browser_Browser.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_browser_Browser.java
@@ -180,7 +180,7 @@ public void setUp() {
 	isEdge = browser.getBrowserType().equals("edge");
 
 	String shellTitle = name.getMethodName();
-	if (SwtTestUtil.isGTK && browser.getBrowserType().equals("webkit")) {
+	if (SwtTestUtil.isGTK) {
 
 		// Note, webkitGtk version is only available once Browser is instantiated.
 		String webkitGtkVersionStr = System.getProperty("org.eclipse.swt.internal.webkitgtk.version"); //$NON-NLS-1$


### PR DESCRIPTION
It's the only option.