### PR TITLE
Disable test_TabTraversalOutOfBrowser

### DIFF
--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_browser_Browser.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_browser_Browser.java
@@ -2609,7 +2609,8 @@ public void test_BrowserFunction_multiprocess() {
 	browser2.dispose();
 }
 
-@Test
+//@Test
+// FIXME This test should at least work for Edge on Windows.
 public void test_TabTraversalOutOfBrowser() {
 	assumeFalse("Not currently working on macOS, see https://github.com/eclipse-platform/eclipse.platform.swt/issues/1644", SwtTestUtil.isCocoa);
 	assumeFalse("Not currently working on Linux, see https://github.com/eclipse-platform/eclipse.platform.swt/issues/1644", SwtTestUtil.isGTK);


### PR DESCRIPTION
See #1656 

The test doesn't work on Windows, neither for Edge nor for IE.

Until the test is fixed, it will remain disabled.