### PR TITLE
Add exception to setImageMetadataForHandle

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Image.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Image.java
@@ -1788,9 +1788,12 @@ static long [] init(Device device, Image image, ImageData i, Integer zoom) {
 }
 
 private void setImageMetadataForHandle(ImageHandle imageMetadata, Integer zoom) {
-	if (zoom != null && !zoomLevelToImageHandle.containsKey(zoom)) {
-		zoomLevelToImageHandle.put(zoom, imageMetadata);
+	if (zoom == null)
+		return;
+	if (zoomLevelToImageHandle.containsKey(zoom)) {
+		SWT.error(SWT.ERROR_ITEM_NOT_ADDED);
 	}
+	zoomLevelToImageHandle.put(zoom, imageMetadata);
 }
 
 static long [] init(Device device, Image image, ImageData source, ImageData mask, Integer zoom) {


### PR DESCRIPTION
This contribution adds a check for imageMetadata for handle in case there already exists an entry in the zoomLeveltoImageHandle map for a zoom level and it must throw an exception in that case.

contributes to #62 and #127