### PR TITLE
Destroying unnecessary zoom level handles

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT PI/win32/org/eclipse/swt/internal/win32/OS.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/win32/org/eclipse/swt/internal/win32/OS.java
@@ -1752,6 +1752,7 @@ public class OS extends C {
 	public static final int WM_DEADCHAR = 0x103;
 	public static final int WM_DESTROY = 0x2;
 	public static final int WM_DPICHANGED = 0x02E0;
+	public static final int WM_DISPLAYCHANGE = 0x7E;
 	public static final int WM_DRAWITEM = 0x2b;
 	public static final int WM_ENDSESSION = 0x16;
 	public static final int WM_ENTERIDLE = 0x121;

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Control.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Control.java
@@ -4856,6 +4856,7 @@ long windowProc (long hwnd, int msg, long wParam, long lParam) {
 		case OS.WM_XBUTTONDOWN:			result = WM_XBUTTONDOWN (wParam, lParam); break;
 		case OS.WM_XBUTTONUP:			result = WM_XBUTTONUP (wParam, lParam); break;
 		case OS.WM_DPICHANGED:			result = WM_DPICHANGED (wParam, lParam); break;
+		case OS.WM_DISPLAYCHANGE:		result = WM_DISPLAYCHANGE(wParam, lParam); break;
 	}
 	if (result != null) return result.value;
 	// widget could be disposed at this point
@@ -4963,6 +4964,14 @@ LRESULT WM_DPICHANGED (long wParam, long lParam) {
 			notifyListeners(SWT.ZoomChanged, event);
 			return LRESULT.ZERO;
 		}
+	}
+	return LRESULT.ONE;
+}
+
+LRESULT WM_DISPLAYCHANGE (long wParam, long lParam) {
+	if (getDisplay().isRescalingAtRuntime()) {
+		Device.win32_destroyUnusedHandles(getDisplay());
+		return LRESULT.ZERO;
 	}
 	return LRESULT.ONE;
 }


### PR DESCRIPTION
Add display change event triggered by display zoom changes, regardless of window presence on the monitor. 

When the zoom level is changed for a monitor where the window is not present, we still need to trigger the event to clear resources for the old zoom level on the non-active monitor.  

For example, if there are two monitors with zoom levels 100% and 200%, and the window is on the 200% zoom monitor, changing the zoom level of the 100% monitor to 150% should destroy the handles for the old 100% zoom level, as they are no longer needed.