### PR TITLE
Add Null check before assigning coordinateMapper

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Display.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Display.java
@@ -2772,7 +2772,9 @@ protected void init () {
 	// Field initialization happens after super constructor
 	controlByHandle = new HashMap<>();
 	this.synchronizer = new Synchronizer (this);
-	this.coordinateSystemMapper = new SingleZoomCoordinateSystemMapper();
+	if (this.coordinateSystemMapper == null) {
+		this.coordinateSystemMapper = new SingleZoomCoordinateSystemMapper();
+	}
 	super.init ();
 	DPIUtil.setDeviceZoom (getDeviceZoom ());
 


### PR DESCRIPTION
This contribution adds a null check before assigning the coordinate mapper in the Device::init since it might already be assigned in coordinateMapper.

As of the current implementation, the MultiZoomCoordinateMapper is assigned to coordinateMapper (if rescalingAtRuntime is active) in setRescalingAtRuntime and then it is overwritten in Device:init and always reset to SingleZoomCoordinateSystemMapper which is not the intended behaviour.

Fixes #1686 
contributes to #62 and #127