### PR TITLE
Using native zoom to compute size for width and height

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Control.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Control.java
@@ -618,8 +618,8 @@ public Point computeSize (int wHint, int hHint) {
 public Point computeSize (int wHint, int hHint, boolean changed){
 	checkWidget ();
 	int zoom = getZoom();
-	wHint = (wHint != SWT.DEFAULT ? DPIUtil.scaleUp(wHint, zoom) : wHint);
-	hHint = (hHint != SWT.DEFAULT ? DPIUtil.scaleUp(hHint, zoom) : hHint);
+	wHint = (wHint != SWT.DEFAULT ? DPIUtil.scaleUp(wHint, nativeZoom) : wHint);
+	hHint = (hHint != SWT.DEFAULT ? DPIUtil.scaleUp(hHint, nativeZoom) : hHint);
 	return DPIUtil.scaleDown(computeSizeInPixels(wHint, hHint, changed), zoom);
 }
 


### PR DESCRIPTION
When autoScale is int200 the size compute for width and height is not scaled for the following buttons correctly during DPI change. Using native zoom instead of corrected zoom fixes the issue.

**Scenario**
Moving from Secondary (200) to Primary (150) Project -> Properties -> Save actions. (autoScale = Int200)

**Before Fix**
![image](https://github.com/user-attachments/assets/79babf78-a160-4eb7-bc26-4635a6261515)

**After Fix**
![image](https://github.com/user-attachments/assets/9885b2ce-a177-434a-a617-3451d5edeef1)
