### PR TITLE
Edge: correct URL to local resource in tests #1670

### DIFF
--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_browser_Browser.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_browser_Browser.java
@@ -762,7 +762,7 @@ private String getValidUrl() {
 	testLogAppend("PLUGIN_PATH: " + pluginPath);
 	// When test is run via Ant, URL needs to be acquired differently. In that case the PLUGIN_PATH property is set and used.
 	if (pluginPath != null) {
-		return pluginPath + "/data/testWebsiteWithTitle.html";
+		return Path.of(pluginPath, "data/testWebsiteWithTitle.html").toUri().toString();
 	} else {
 		// used when ran from Eclipse gui.
 		return Test_org_eclipse_swt_browser_Browser.class.getClassLoader().getResource("testWebsiteWithTitle.html").toString();


### PR DESCRIPTION
The URL used for the `test_setUrl_Local()` browser test case currently only consists of a file path when provided via the `PLUGIN_PATH` environment variable, e.g., during I-Build test execution. Edge does, however, require a valid URL with an according protocol prefix. Currently, the drive prefix of the file path is erroneously treated as the protocol.

This change properly converts the path to a URL.

Fixes https://github.com/eclipse-platform/eclipse.platform.swt/issues/1670

Note that this change will not have any effect in the PR validation, but only in the I-Build test execution (or if locally executed with the `PLUGIN_PATH` variable specified. I locally executed the tests with that variable specified to validate that it works as expected.