### PR TITLE
Text in Dialog was cutoff due to invalid use of AdjustWindowRectEx

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT PI/win32/library/os.c
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/win32/library/os.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2024 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -120,6 +120,31 @@ JNIEXPORT jboolean JNICALL OS_NATIVE(AdjustWindowRectEx)
 fail:
 	if (arg0 && lparg0) setRECTFields(env, arg0, lparg0);
 	OS_NATIVE_EXIT(env, that, AdjustWindowRectEx_FUNC);
+	return rc;
+}
+#endif
+
+#ifndef NO_AdjustWindowRectExForDpi
+JNIEXPORT jboolean JNICALL OS_NATIVE(AdjustWindowRectExForDpi)
+	(JNIEnv *env, jclass that, jobject arg0, jint arg1, jboolean arg2, jint arg3, jint arg4)
+{
+	RECT _arg0, *lparg0=NULL;
+	jboolean rc = 0;
+	
+	OS_NATIVE_ENTER(env, that, AdjustWindowRectExForDpi_FUNC);
+	if (arg0) if ((lparg0 = getRECTFields(env, arg0, &_arg0)) == NULL) goto fail;
+/*
+	rc = (jboolean)AdjustWindowRectExForDpi(lparg0, arg1, arg2, arg3, arg4);
+*/
+	{
+		OS_LOAD_FUNCTION(fp, AdjustWindowRectExForDpi)
+		if (fp) {
+			rc = (jboolean)((jboolean (CALLING_CONVENTION*)(RECT *, jint, jboolean, jint, jint))fp)(lparg0, arg1, arg2, arg3, arg4);
+		}
+	}
+fail:
+	if (arg0 && lparg0) setRECTFields(env, arg0, lparg0);
+	OS_NATIVE_EXIT(env, that, AdjustWindowRectExForDpi_FUNC);
 	return rc;
 }
 #endif

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/win32/library/os_custom.h
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/win32/library/os_custom.h
@@ -25,3 +25,4 @@
 #define GetThreadDpiAwarenessContext_LIB "user32.dll"
 #define SetThreadDpiAwarenessContext_LIB "user32.dll"
 #define SystemParametersInfoForDpi_LIB "user32.dll"
+#define AdjustWindowRectExForDpi_LIB "user32.dll"

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/win32/library/os_stats.h
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/win32/library/os_stats.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2024 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -30,6 +30,7 @@ typedef enum {
 	ActivateKeyboardLayout_FUNC,
 	AddFontResourceEx_FUNC,
 	AdjustWindowRectEx_FUNC,
+	AdjustWindowRectExForDpi_FUNC,
 	AllowDarkModeForWindow_FUNC,
 	AllowSetForegroundWindow_FUNC,
 	AlphaBlend_FUNC,

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/win32/org/eclipse/swt/internal/win32/OS.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/win32/org/eclipse/swt/internal/win32/OS.java
@@ -2346,6 +2346,8 @@ public static final native long ActivateKeyboardLayout(long hkl, int Flags);
  */
 public static final native int AddFontResourceEx(char[] lpszFilename, int fl, long pdv);
 public static final native boolean AdjustWindowRectEx (RECT lpRect, int dwStyle, boolean bMenu, int dwExStyle);
+/** @method flags=dynamic */
+public static final native boolean AdjustWindowRectExForDpi (RECT lpRect, int dwStyle, boolean bMenu, int dwExStyle, int dpi);
 /** @method flags=no_gen */
 public static final native boolean AllowDarkModeForWindow(long hWnd, boolean allow);
 public static final native boolean AllowSetForegroundWindow (int dwProcessId);

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Decorations.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Decorations.java
@@ -313,7 +313,7 @@ Control computeTabRoot () {
 	int bits1 = OS.GetWindowLong (handle, OS.GWL_STYLE);
 	int bits2 = OS.GetWindowLong (handle, OS.GWL_EXSTYLE);
 	boolean hasMenu = OS.GetMenu (handle) != 0;
-	OS.AdjustWindowRectEx (rect, bits1, hasMenu, bits2);
+	adjustWindowRectEx(rect, bits1, hasMenu, bits2);
 
 	/* Get the size of the scroll bars */
 	if (horizontalBar != null) rect.bottom += getSystemMetrics (OS.SM_CYHSCROLL);
@@ -472,7 +472,7 @@ void fixDecorations (Decorations newDecorations, Control control, Menu [] menus)
 		int bits1 = OS.GetWindowLong (handle, OS.GWL_STYLE);
 		int bits2 = OS.GetWindowLong (handle, OS.GWL_EXSTYLE);
 		boolean hasMenu = OS.GetMenu (handle) != 0;
-		OS.AdjustWindowRectEx (rect, bits1, hasMenu, bits2);
+		adjustWindowRectEx(rect, bits1, hasMenu, bits2);
 		width = Math.max (0, width - (rect.right - rect.left));
 		height = Math.max (0, height - (rect.bottom - rect.top));
 		return new Rectangle (0, 0, width, height);

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Scrollable.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Scrollable.java
@@ -134,7 +134,7 @@ Rectangle computeTrimInPixels (int x, int y, int width, int height) {
 	OS.SetRect (rect, x, y, x + width, y + height);
 	int bits1 = OS.GetWindowLong (scrolledHandle, OS.GWL_STYLE);
 	int bits2 = OS.GetWindowLong (scrolledHandle, OS.GWL_EXSTYLE);
-	OS.AdjustWindowRectEx (rect, bits1, false, bits2);
+	adjustWindowRectEx(rect, bits1, false, bits2);
 	if (horizontalBar != null) rect.bottom += getSystemMetrics (OS.SM_CYHSCROLL);
 	if (verticalBar != null) rect.right += getSystemMetrics (OS.SM_CXVSCROLL);
 	int nWidth = rect.right - rect.left, nHeight = rect.bottom - rect.top;

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Shell.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Shell.java
@@ -1068,7 +1068,7 @@ Point getMaximumSizeInPixels () {
 			RECT rect = new RECT ();
 			int bits1 = OS.GetWindowLong (handle, OS.GWL_STYLE);
 			int bits2 = OS.GetWindowLong (handle, OS.GWL_EXSTYLE);
-			OS.AdjustWindowRectEx (rect, bits1, false, bits2);
+			adjustWindowRectEx(rect, bits1, false, bits2);
 			height = Math.min (height, rect.bottom - rect.top);
 		}
 	}
@@ -1109,7 +1109,7 @@ Point getMinimumSizeInPixels () {
 			RECT rect = new RECT ();
 			int bits1 = OS.GetWindowLong (handle, OS.GWL_STYLE);
 			int bits2 = OS.GetWindowLong (handle, OS.GWL_EXSTYLE);
-			OS.AdjustWindowRectEx (rect, bits1, false, bits2);
+			adjustWindowRectEx(rect, bits1, false, bits2);
 			height = Math.max (height, rect.bottom - rect.top);
 		}
 	}
@@ -1815,7 +1815,7 @@ void setMaximumSizeInPixels (int width, int height) {
 			RECT rect = new RECT ();
 			int bits1 = OS.GetWindowLong (handle, OS.GWL_STYLE);
 			int bits2 = OS.GetWindowLong (handle, OS.GWL_EXSTYLE);
-			OS.AdjustWindowRectEx (rect, bits1, false, bits2);
+			adjustWindowRectEx(rect, bits1, false, bits2);
 			heightLimit = rect.bottom - rect.top;
 		}
 	}
@@ -1861,7 +1861,7 @@ void setMinimumSizeInPixels (int width, int height) {
 			RECT rect = new RECT ();
 			int bits1 = OS.GetWindowLong (handle, OS.GWL_STYLE);
 			int bits2 = OS.GetWindowLong (handle, OS.GWL_EXSTYLE);
-			OS.AdjustWindowRectEx (rect, bits1, false, bits2);
+			adjustWindowRectEx(rect, bits1, false, bits2);
 			heightLimit = rect.bottom - rect.top;
 		}
 	}
@@ -2671,7 +2671,7 @@ LRESULT WM_WINDOWPOSCHANGING (long wParam, long lParam) {
 				RECT rect = new RECT ();
 				int bits1 = OS.GetWindowLong (handle, OS.GWL_STYLE);
 				int bits2 = OS.GetWindowLong (handle, OS.GWL_EXSTYLE);
-				OS.AdjustWindowRectEx (rect, bits1, false, bits2);
+				adjustWindowRectEx(rect, bits1, false, bits2);
 				lpwp.cy = Math.max (lpwp.cy, rect.bottom - rect.top);
 			}
 		}

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Spinner.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Spinner.java
@@ -320,7 +320,7 @@ void addVerifyListener (VerifyListener listener) {
 		bits0 &= ~OS.WS_BORDER;
 		bits1 |= OS.WS_EX_CLIENTEDGE;
 	}
-	OS.AdjustWindowRectEx (rect, bits0, false, bits1);
+	adjustWindowRectEx(rect, bits0, false, bits1);
 	width = rect.right - rect.left;
 	height = rect.bottom - rect.top;
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Widget.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Widget.java
@@ -2708,5 +2708,15 @@ int getSystemMetrics(int nIndex) {
 	return OS.GetSystemMetrics(nIndex);
 }
 
+boolean adjustWindowRectEx(RECT lpRect, int dwStyle, boolean bMenu, int dwExStyle) {
+	/*
+	 * DPI-dependent version of the method was introduced with Windows 10 Version 1607
+	 */
+	if (OS.WIN32_BUILD >= OS.WIN32_BUILD_WIN10_1607) {
+		return OS.AdjustWindowRectExForDpi (lpRect, dwStyle, bMenu, dwExStyle, DPIUtil.mapZoomToDPI(nativeZoom));
+	}
+	return OS.AdjustWindowRectEx(lpRect, dwStyle, bMenu, dwExStyle);
+}
+
 
 }


### PR DESCRIPTION
AdjustWindowRectEx does not take DPI into account. So using AdjustWindowRectExForDpi and passing the zoom level to retrieve correct coordinates and scaling accordingly.

### How to Reproduce

- Run the Runtime Workspace with the following VM Arguments on 200% monitor

```
-Dswt.autoScale=quarter
-Dswt.autoScale.updateOnRuntime=true
```
- Add a class and create a **conditional breakpoint**
- Double click on Breakpoint to remove it
- Maximize the main IDE window
- The dialog will appear with the text cutoff
![image](https://github.com/user-attachments/assets/2f7cec68-ff4d-4c51-9e78-9fd0be4f3727)



### **Note**

Replacing AdjustWindowRectEx in Decoration fixes the issue for dialogs but replacing all the non-dpi calls for AdjustWindowRectEx even though there is no visible difference (but slight difference in returned coordinates) right now but having it DPI dependent makes it consistent. 