### PR TITLE
Fixed Program Icon Scaling for Multi Zoom

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/win32/org/eclipse/swt/dnd/ImageTransfer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/win32/org/eclipse/swt/dnd/ImageTransfer.java
@@ -184,7 +184,7 @@ public Object nativeToJava(TransferData transferData) {
 					pSourceBits -= scanline;
 				}
 			}
-			Image image = Image.win32_new(null, SWT.BITMAP, memDib);
+			Image image = Image.win32_new(null, SWT.BITMAP, memDib, DPIUtil.getNativeDeviceZoom());
 			ImageData data = image.getImageData (DPIUtil.getDeviceZoom ());
 			OS.DeleteObject(memDib);
 			image.dispose();

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/win32/org/eclipse/swt/internal/win32/OS.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/win32/org/eclipse/swt/internal/win32/OS.java
@@ -1210,6 +1210,7 @@ public class OS extends C {
 	public static final int SHADEBLENDCAPS = 120;
 	public static final int SHGFI_ICON = 0x000000100;
 	public static final int SHGFI_SMALLICON= 0x1;
+	public static final int SHGFI_LARGEICON= 0x0;
 	public static final int SHGFI_USEFILEATTRIBUTES = 0x000000010;
 	public static final int SIGDN_FILESYSPATH = 0x80058000;
 	public static final int SIF_ALL = 0x17;

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Image.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Image.java
@@ -127,8 +127,12 @@ public final class Image extends Resource implements Drawable {
  * Prevents uninitialized instances from being created outside the package.
  */
 Image (Device device) {
+	this(device, DPIUtil.getNativeDeviceZoom());
+}
+
+private Image (Device device, int nativeZoom) {
 	super(device);
-	initialNativeZoom = DPIUtil.getNativeDeviceZoom();
+	initialNativeZoom = nativeZoom;
 	this.device.registerResourceWithZoomSupport(this);
 }
 
@@ -2030,10 +2034,10 @@ public String toString () {
  *
  * @noreference This method is not intended to be referenced by clients.
  */
-public static Image win32_new(Device device, int type, long handle) {
-	Image image = new Image(device);
+public static Image win32_new(Device device, int type, long handle, int nativeZoom) {
+	Image image = new Image(device, nativeZoom);
 	image.type = type;
-	image.new ImageHandle(handle, image.getZoom());
+	image.new ImageHandle(handle, nativeZoom);
 	return image;
 }
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Display.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Display.java
@@ -1204,7 +1204,7 @@ static Image createIcon (Image image, int zoom) {
 	if (hIcon == 0) SWT.error(SWT.ERROR_NO_HANDLES);
 	OS.DeleteObject (hBitmap);
 	OS.DeleteObject (hMask);
-	return Image.win32_new (device, SWT.ICON, hIcon);
+	return Image.win32_new (device, SWT.ICON, hIcon, zoom);
 }
 
 long getTextSearchIcon(int size) {
@@ -2543,27 +2543,28 @@ Font getSystemFont (int zoom) {
  */
 public Image getSystemImage (int id) {
 	checkDevice ();
+	int primaryMonitorNativeZoom = getPrimaryMonitor().getZoom();
 	switch (id) {
 		case SWT.ICON_ERROR: {
 			if (errorImage != null) return errorImage;
 			long hIcon = OS.LoadImage (0, OS.OIC_HAND, OS.IMAGE_ICON, 0, 0, OS.LR_SHARED);
-			return errorImage = Image.win32_new (this, SWT.ICON, hIcon);
+			return errorImage = Image.win32_new (this, SWT.ICON, hIcon, primaryMonitorNativeZoom);
 		}
 		case SWT.ICON_WORKING:
 		case SWT.ICON_INFORMATION: {
 			if (infoImage != null) return infoImage;
 			long hIcon = OS.LoadImage (0, OS.OIC_INFORMATION, OS.IMAGE_ICON, 0, 0, OS.LR_SHARED);
-			return infoImage = Image.win32_new (this, SWT.ICON, hIcon);
+			return infoImage = Image.win32_new (this, SWT.ICON, hIcon, primaryMonitorNativeZoom);
 		}
 		case SWT.ICON_QUESTION: {
 			if (questionImage != null) return questionImage;
 			long hIcon = OS.LoadImage (0, OS.OIC_QUES, OS.IMAGE_ICON, 0, 0, OS.LR_SHARED);
-			return questionImage = Image.win32_new (this, SWT.ICON, hIcon);
+			return questionImage = Image.win32_new (this, SWT.ICON, hIcon, primaryMonitorNativeZoom);
 		}
 		case SWT.ICON_WARNING: {
 			if (warningIcon != null) return warningIcon;
 			long hIcon = OS.LoadImage (0, OS.OIC_BANG, OS.IMAGE_ICON, 0, 0, OS.LR_SHARED);
-			return warningIcon = Image.win32_new (this, SWT.ICON, hIcon);
+			return warningIcon = Image.win32_new (this, SWT.ICON, hIcon, primaryMonitorNativeZoom);
 		}
 	}
 	return null;

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TaskBar.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TaskBar.java
@@ -166,7 +166,7 @@ IShellLink createShellLink (MenuItem item) {
 				ImageData data;
 				if (item.hBitmap != 0) {
 					long handle = OS.CopyImage(item.hBitmap, SWT.BITMAP, 0, 0, 0);
-					Image image2 = Image.win32_new (display, SWT.BITMAP, handle);
+					Image image2 = Image.win32_new (display, SWT.BITMAP, handle, nativeZoom);
 					data = image2.getImageData (DPIUtil.getDeviceZoom ());
 					image2.dispose();
 				} else {


### PR DESCRIPTION
In the previous implementation, according to the documentation, SHGetFileInfo retrieves a system icon at the primary monitor native zoom. It means if the primary monitor is 175%, the dimension of the icon will be 56 x 56 (considering the standard dimension of 16 x 16 at 100%). Previously, the Image::win32_new was used to create an image object by passing the handle. Since the support of multi zoom, we know that now an image can have multiple handles, each for a zoom level. Image::win32_new used to assign the handle to the image at DPIUtil::getDeviceZoom regarless of what zoom level the handle was created for (in our case primary monitor native zoom, e.g. 175%). And it used to do some calcultation what proportion of primary monitor zoom would be this assigned zoom of the image. In other words, if you wanna obtain an image for 100% zoom, it will be 57% of 175%. Since, it used to call image.getImageData(57), which kinda seems like a hack to obtain the icon with the right dimension.

Another problem that was quite visible was that if the monitor to draw the icon has a higher zoom level (say 300%) than the primary monitor zoom, the icon will be pixelated because the retrieved icon from SHGetFileInfo  is 175% (primary montior native zoom)

This contribution reimplements the logic for scaling the Program Icons while getting rid of the DPIUtil::getDeviceZoom usage and enhancing the image quality of icons on scaling up using the Small Icon in case we have to scale down and using the Large Icon in case we have to scale up.

contributes to #62 and #127