### PR TITLE
Obtain ImageData for any requested zoom value, not only autoscaled values

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Image.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Image.java
@@ -1359,10 +1359,10 @@ public ImageData getImageData() {
  */
 public ImageData getImageData (int zoom) {
 	if (isDisposed()) SWT.error(SWT.ERROR_GRAPHIC_DISPOSED);
-	int currentZoom = getZoom();
-	if (zoom == currentZoom) {
-		return getImageDataAtCurrentZoom();
-	} else if (imageProvider != null) {
+	if (zoomLevelToImageHandle.containsKey(zoom)) {
+		return zoomLevelToImageHandle.get(zoom).getImageData();
+	}
+	if (imageProvider != null) {
 		return imageProvider.getImageData(zoom);
 	}
 
@@ -1371,7 +1371,9 @@ public ImageData getImageData (int zoom) {
 	if (memGC != null) {
 		return getImageDataAtCurrentZoom();
 	}
-	return DPIUtil.scaleImageData (device, getImageMetadata(currentZoom).getImageData(), zoom, currentZoom);
+	TreeSet<Integer> availableZooms = new TreeSet<>(zoomLevelToImageHandle.keySet());
+	int closestZoom = Optional.ofNullable(availableZooms.higher(zoom)).orElse(availableZooms.lower(zoom));
+	return DPIUtil.scaleImageData (device, getImageMetadata(closestZoom).getImageData(), zoom, closestZoom);
 }
 
 /**

--- a/tests/org.eclipse.swt.tests.win32/JUnit Tests/org/eclipse/swt/graphics/ImageWin32Tests.java
+++ b/tests/org.eclipse.swt.tests.win32/JUnit Tests/org/eclipse/swt/graphics/ImageWin32Tests.java
@@ -15,6 +15,7 @@ package org.eclipse.swt.graphics;
 
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 
 import org.eclipse.swt.internal.DPIUtil;
 import org.eclipse.swt.widgets.Display;
@@ -34,6 +35,19 @@ public class ImageWin32Tests {
 	@Before
 	public void setUp() {
 		display = Display.getDefault();
+	}
+
+	@Test
+	public void testImageDataForDifferentFractionalZoomsShouldBeDifferent() {
+		Image image = new Image(display, 10, 10);
+		int zoom1 = 125;
+		int zoom2 = 150;
+		ImageData imageDataAtZoom1 = image.getImageData(zoom1);
+		ImageData imageDataAtZoom2 = image.getImageData(zoom2);
+		assertNotEquals("ImageData::height should not be the same for imageData at different zoom levels",
+				imageDataAtZoom1.height, imageDataAtZoom2.height);
+		assertNotEquals("ImageData::width should not be the same for imageData at different zoom levels",
+				imageDataAtZoom1.width, imageDataAtZoom2.width);
 	}
 
 	@Test


### PR DESCRIPTION
This contribution helps retrieve the imageData for the requested zoom by searching for the zoom in the zoomToHandleMap followed by (if not available) scaling the handle at the zoom nearest to it while getting rid of only searching among the autoscaled zoom values.

Contributes to #62 and #127