### PR TITLE
Consider changes to system property for rescaling at runtime

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/DPIUtil.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/DPIUtil.java
@@ -45,7 +45,6 @@ public class DPIUtil {
 	private static enum AutoScaleMethod { AUTO, NEAREST, SMOOTH }
 	private static AutoScaleMethod autoScaleMethodSetting = AutoScaleMethod.AUTO;
 	private static AutoScaleMethod autoScaleMethod = AutoScaleMethod.NEAREST;
-	private static boolean autoScaleOnRuntime = false;
 
 	private static String autoScaleValue;
 	private static boolean useCairoAutoScale = false;
@@ -109,9 +108,6 @@ public class DPIUtil {
 				autoScaleMethod = autoScaleMethodSetting = AutoScaleMethod.SMOOTH;
 			}
 		}
-
-		String updateOnRuntimeValue = System.getProperty (SWT_AUTOSCALE_UPDATE_ON_RUNTIME);
-		autoScaleOnRuntime = Boolean.parseBoolean(updateOnRuntimeValue);
 	}
 
 /**
@@ -655,7 +651,8 @@ public static int getZoomForAutoscaleProperty (int nativeDeviceZoom) {
 }
 
 public static boolean isAutoScaleOnRuntimeActive() {
-	return autoScaleOnRuntime;
+	boolean updateOnRuntimeValue = Boolean.getBoolean (SWT_AUTOSCALE_UPDATE_ON_RUNTIME);
+	return updateOnRuntimeValue;
 }
 
 /**


### PR DESCRIPTION
The Windows-specific system property for activating monitor-specific scaling (or "rescaling at runtime") is currently only evaluated at application startup. With this change the property will be evaluated on every access, thus allowing to change the property at runtime.