### PR TITLE
Deprecate insufficient Display#setRescalingAtRuntime() method

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/widgets/DisplayWin32Test.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/widgets/DisplayWin32Test.java
@@ -8,36 +8,46 @@ import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.*;
 
 @ExtendWith(PlatformSpecificExecutionExtension.class)
+@ExtendWith(ResetMonitorSpecificScalingExtension.class)
 public class DisplayWin32Test {
 
-	private Display display;
-
-	@BeforeEach
-	public void createDisplay() {
-		display = new Display();
-	}
-
-	@AfterEach
-	public void destroyDisplay() {
-		display.dispose();
+	@Test
+	public void monitorSpecificScaling_activate() {
+		DPIUtil.setMonitorSpecificScaling(true);
+		Display display = Display.getDefault();
+		assertTrue(display.isRescalingAtRuntime());
+		assertEquals(OS.DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2, OS.GetThreadDpiAwarenessContext());
 	}
 
 	@Test
+	public void monitorSpecificScaling_deactivate() {
+		DPIUtil.setMonitorSpecificScaling(false);
+		Display display = Display.getDefault();
+		assertFalse(display.isRescalingAtRuntime());
+	}
+
+	@Test
+	@SuppressWarnings("removal")
 	public void setRescaleAtRuntime_activate() {
+		Display display = Display.getDefault();
 		display.setRescalingAtRuntime(true);
 		assertTrue(display.isRescalingAtRuntime());
 		assertEquals(OS.DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2, OS.GetThreadDpiAwarenessContext());
 	}
 
 	@Test
+	@SuppressWarnings("removal")
 	public void setRescaleAtRuntime_deactivate() {
+		Display display = Display.getDefault();
 		display.setRescalingAtRuntime(false);
 		assertFalse(display.isRescalingAtRuntime());
 		assertEquals(OS.DPI_AWARENESS_CONTEXT_SYSTEM_AWARE, OS.GetThreadDpiAwarenessContext());
 	}
 
 	@Test
+	@SuppressWarnings("removal")
 	public void setRescaleAtRuntime_toggling() {
+		Display display = Display.getDefault();
 		display.setRescalingAtRuntime(false);
 		assertFalse(display.isRescalingAtRuntime());
 		assertEquals(OS.DPI_AWARENESS_CONTEXT_SYSTEM_AWARE, OS.GetThreadDpiAwarenessContext());

--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Display.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Display.java
@@ -6858,7 +6858,10 @@ public boolean isRescalingAtRuntime() {
  * @param activate whether rescaling shall be activated or deactivated
  * @return whether activating or deactivating the rescaling was successful
  * @since 3.127
+ * @deprecated this method should not be used as it needs to be called already
+ *             during instantiation to take proper effect
  */
+@Deprecated(since = "2025-03", forRemoval = true)
 public boolean setRescalingAtRuntime(boolean activate) {
 	// not implemented for Cocoa
 	return false;

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Display.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Display.java
@@ -6294,7 +6294,10 @@ public boolean isRescalingAtRuntime() {
  * @param activate whether rescaling shall be activated or deactivated
  * @return whether activating or deactivating the rescaling was successful
  * @since 3.127
+ * @deprecated this method should not be used as it needs to be called already
+ *             during instantiation to take proper effect
  */
+@Deprecated(since = "2025-03", forRemoval = true)
 public boolean setRescalingAtRuntime(boolean activate) {
 	// not implemented for GTK
 	return false;

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Display.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Display.java
@@ -949,7 +949,7 @@ protected void create (DeviceData data) {
 	checkSubclass ();
 	checkDisplay (thread = Thread.currentThread (), true);
 	if (DPIUtil.isMonitorSpecificScalingActive()) {
-		setRescalingAtRuntime(true);
+		setMonitorSpecificScaling(true);
 		DPIUtil.setAutoScaleForMonitorSpecificScaling();
 	}
 	createDisplay (data);
@@ -5263,6 +5263,7 @@ private class ThemeData {
 		return OS.OpenThemeData(hwndMessage, themeName, dpi);
 	}
 }
+
 /**
  * {@return whether rescaling of shells at runtime when the DPI scaling of a
  * shell's monitor changes is activated for this device}
@@ -5288,8 +5289,15 @@ public boolean isRescalingAtRuntime() {
  * @param activate whether rescaling shall be activated or deactivated
  * @return whether activating or deactivating the rescaling was successful
  * @since 3.127
+ * @deprecated this method should not be used as it needs to be called already
+ *             during instantiation to take proper effect
  */
+@Deprecated(since = "2025-03", forRemoval = true)
 public boolean setRescalingAtRuntime(boolean activate) {
+	return setMonitorSpecificScaling(activate);
+}
+
+private boolean setMonitorSpecificScaling(boolean activate) {
 	int desiredApiAwareness = activate ? OS.DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2 : OS.DPI_AWARENESS_CONTEXT_SYSTEM_AWARE;
 	if (setDPIAwareness(desiredApiAwareness)) {
 		rescalingAtRuntime = activate;


### PR DESCRIPTION
The method Display#setRescalingAtRuntime() allows to activate the monitor-specific scaling mechanism on Windows. This must, however, actually be activated before the Display is instantiated, like it is done during the Display constructor execution if the system property for global activation of monitor-specific scaling is specified. In consequence, calling #setRescalingAtRuntime() does not take the full intended effect.

This change deprecates the method so that the system property needs to be set for proper initialization of the monitor-specific scaling functionality. It also adapts the according tests to the deprecation of
the API and alternatives to be used.

⚠️ #1728 has been added as a preparation for this