### PR TITLE
[Win] Disallow autoscale mode "integer" for monitor-specific scaling

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/DPIUtil.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/DPIUtil.java
@@ -650,9 +650,50 @@ public static int getZoomForAutoscaleProperty (int nativeDeviceZoom) {
 	return zoom;
 }
 
-public static boolean isAutoScaleOnRuntimeActive() {
+public static boolean isMonitorSpecificScalingActive() {
 	boolean updateOnRuntimeValue = Boolean.getBoolean (SWT_AUTOSCALE_UPDATE_ON_RUNTIME);
 	return updateOnRuntimeValue;
+}
+
+public static void setAutoScaleForMonitorSpecificScaling() {
+	boolean isDefaultAutoScale = autoScaleValue == null;
+	if (isDefaultAutoScale) {
+		autoScaleValue = "quarter";
+	} else if (!isSupportedAutoScaleForMonitorSpecificScaling()) {
+		throw new SWTError(SWT.ERROR_NOT_IMPLEMENTED,
+				"monitor-specific scaling is only implemented for auto-scale values \"quarter\", \"exact\", \"false\" or a concrete zoom value, but \""
+						+ autoScaleValue + "\" has been specified");
+	}
+}
+
+/**
+ * Monitor-specific scaling on Windows only supports auto-scale modes in which
+ * all elements (font, images, control bounds etc.) are scaled equally or almost
+ * equally. The previously default mode "integer"/"integer200", which rounded
+ * the scale factor for everything but fonts to multiples of 100, is complex and
+ * difficult to realize with monitor-specific rescaling of UI elements. Since a
+ * uniform scale factor for everything should perspectively be used anyway,
+ * there will be support for complex auto-scale modes for monitor-specific
+ * scaling.
+ *
+ * The supported modes are "quarter" and "exact" or explicit zoom values given
+ * by the value itself or "false". Every other value will be treated as
+ * "integer"/"integer200" and is thus not supported.
+ */
+private static boolean isSupportedAutoScaleForMonitorSpecificScaling() {
+	if (autoScaleValue == null) {
+		return false;
+	}
+	switch (autoScaleValue.toLowerCase()) {
+		case "false", "quarter", "exact": return true;
+	}
+	try {
+		Integer.parseInt(autoScaleValue);
+		return true;
+	} catch (NumberFormatException e) {
+		// unsupported value, use default
+	}
+	return false;
 }
 
 /**

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Display.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Display.java
@@ -948,8 +948,9 @@ public void close () {
 protected void create (DeviceData data) {
 	checkSubclass ();
 	checkDisplay (thread = Thread.currentThread (), true);
-	if (DPIUtil.isAutoScaleOnRuntimeActive()) {
+	if (DPIUtil.isMonitorSpecificScalingActive()) {
 		setRescalingAtRuntime(true);
+		DPIUtil.setAutoScaleForMonitorSpecificScaling();
 	}
 	createDisplay (data);
 	register (this);


### PR DESCRIPTION
The default auto-scale value is "integer"/"integer200", which makes everything in the UI except fonts not scale according to the actual native zoom value but according to a value rounded to 100 or 200. While most code performing adaptations to zoom considers this for a static zoom value applied to the whole application, it leads to hard-to-resolve issues when scaling every shell according to the current monitor's zoom.

Since that autoscale mode is complex and should be replaced by uniform scaling of everything (in particular when images are based on vector graphics that can sharply be rendered for every zoom factor) anyway, this is not to be supported by the monitor-specific scaling feature currently being introduced for Windows. With this change, that mode will thus be limited to reasonable autoscale modes like "quarter" and "exact" or ones fixing the zoom value like specifying an explicit value or "false".