### PR TITLE
Backport Fix AllowDarkModeForWindowWithTelemetryId to 4.31 maintenance branch

### DIFF
--- a/bundles/org.eclipse.swt/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.swt/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.swt; singleton:=true
-Bundle-Version: 3.125.1.qualifier
+Bundle-Version: 3.125.2.qualifier
 Bundle-ManifestVersion: 2
 Bundle-Localization: plugin
 DynamicImport-Package: org.eclipse.swt.accessibility2


### PR DESCRIPTION
Back port fix : https://github.com/eclipse-platform/eclipse.platform.swt/issues/1546

clipse shows errors, stating that Not properly disposed SWT resource and having problems with css. I believe due to this dark theme does not work properly now on newest Windows.

Fix : https://github.com/eclipse-platform/eclipse.platform.swt/pull/1547Win32
Update search for AllowDarkModeForWindowWithTelemetryId for 24H2 
