### PR TITLE
Backport Fix AllowDarkModeForWindowWithTelemetryId to 4.23 maintenance branch 

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT PI/win32/library/os_custom.c
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/win32/library/os_custom.c
@@ -114,6 +114,27 @@ BOOL Validate_AllowDarkModeForWindowWithTelemetryId(const BYTE* functionPtr)
 		return TRUE;
 	}
 
+	/* Win11 builds from 22621 */
+	if ((functionPtr[0x15] == 0xBA) &&                      // mov      edx,
+		(*(const DWORD*)(functionPtr + 0x16) == 0xA91E))    //              0A91Eh
+	{
+		return TRUE;
+	}
+
+	/* Win11 builds from 26100 */
+	if ((functionPtr[0x16] == 0xBE) &&                      // mov      esi,
+		(*(const DWORD*)(functionPtr + 0x17) == 0xA91E))    //              0A91Eh
+	{
+		return TRUE;
+	}
+
+	return FALSE;
+#elif defined(_M_ARM64)
+	if (*(const DWORD*)(&functionPtr[0x18]) == 0xD29523C1) // mov x1,#0xA91E
+	{
+		return TRUE;
+	}
+
 	return FALSE;
 #else
 	#error Unsupported processor type

--- a/bundles/org.eclipse.swt/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.swt/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.swt; singleton:=true
-Bundle-Version: 3.119.200.qualifier
+Bundle-Version: 3.119.201.qualifier
 Bundle-ManifestVersion: 2
 Bundle-Localization: plugin
 DynamicImport-Package: org.eclipse.swt.accessibility2

--- a/bundles/org.eclipse.swt/pom.xml
+++ b/bundles/org.eclipse.swt/pom.xml
@@ -21,7 +21,7 @@
     </parent>
     <groupId>org.eclipse.swt</groupId>
     <artifactId>org.eclipse.swt</artifactId>
-    <version>3.119.200-SNAPSHOT</version>
+    <version>3.119.201-SNAPSHOT</version>
     <packaging>eclipse-plugin</packaging>
 
     <properties>


### PR DESCRIPTION
Back port fix : https://github.com/eclipse-platform/eclipse.platform.swt/issues/1546 to R4_23 maintenance branch

Eclipse is displaying errors indicating "Not properly disposed SWT resource" and encountering issues with CSS. As a result, the dark theme is not functioning correctly on the latest version of Windows.

Fix : https://github.com/eclipse-platform/eclipse.platform.swt/pull/1547Win32
Update search for AllowDarkModeForWindowWithTelemetryId for 24H2