### PR TITLE
Remove type hierarchy of Win32AutoscaleTestBase

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/graphics/GCWin32Tests.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/graphics/GCWin32Tests.java
@@ -20,12 +20,18 @@ import java.util.concurrent.atomic.*;
 
 import org.eclipse.swt.*;
 import org.eclipse.swt.internal.*;
+import org.eclipse.swt.widgets.*;
 import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.*;
 
-class GCWin32Tests extends Win32AutoscaleTestBase {
+@ExtendWith(PlatformSpecificExecutionExtension.class)
+@ExtendWith(WithMonitorSpecificScalingExtension.class)
+class GCWin32Tests {
 
 	@Test
 	public void gcZoomLevelMustChangeOnShellZoomChange() {
+		Shell shell = new Shell(Display.getDefault());
+
 		CompletableFuture<Integer> gcNativeZoom = new CompletableFuture<>();
 		CompletableFuture<Integer> scaledGcNativeZoom = new CompletableFuture<>();
 		int zoom = DPIUtil.getDeviceZoom();
@@ -42,7 +48,7 @@ class GCWin32Tests extends Win32AutoscaleTestBase {
 		assertEquals("GCData must have a zoom level equal to the actual zoom level of the widget/shell", DPIUtil.getNativeDeviceZoom(), (int) gcNativeZoom.join());
 
 		int newSWTZoom = zoom * 2;
-		changeDPIZoom(newSWTZoom);
+		DPITestUtil.changeDPIZoom(shell, newSWTZoom);
 		isScaled.set(true);
 		shell.setVisible(false);
 		shell.setVisible(true);
@@ -52,6 +58,8 @@ class GCWin32Tests extends Win32AutoscaleTestBase {
 
 	@Test
 	public void drawnElementsShouldScaleUpToTheRightZoomLevel() {
+		Shell shell = new Shell(Display.getDefault());
+
 		int zoom = DPIUtil.getDeviceZoom();
 		int scalingFactor = 2;
 		GC gc = GC.win32_new(shell, new GCData());

--- a/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/graphics/PathWin32Tests.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/graphics/PathWin32Tests.java
@@ -19,15 +19,20 @@ import java.util.*;
 
 import org.eclipse.swt.internal.*;
 import org.eclipse.swt.internal.gdip.*;
+import org.eclipse.swt.widgets.*;
 import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.*;
 
-class PathWin32Tests extends Win32AutoscaleTestBase {
+@ExtendWith(PlatformSpecificExecutionExtension.class)
+@ExtendWith(WithMonitorSpecificScalingExtension.class)
+class PathWin32Tests {
 
 	int zoom = 100;
 	int scaledZoom = 200;
 
 	@Test
 	public void testPathMustBeScaledOnZoomLevelChange() {
+		Display display = Display.getDefault();
 		Path path = new Path(display);
 		path.addArc(0, 0, 10, 10, 0, 90);
 		PathData pathData = path.getPathData();
@@ -40,6 +45,7 @@ class PathWin32Tests extends Win32AutoscaleTestBase {
 
 	@Test
 	public void testHandlesExistForEachZoomLevelInHashMap() {
+		Display display = Display.getDefault();
 		DPIUtil.setDeviceZoom(zoom);
 		Path path = new Path(display);
 		path.addArc(0, 0, 10, 10, 0, 90);
@@ -50,6 +56,7 @@ class PathWin32Tests extends Win32AutoscaleTestBase {
 
 	@Test
 	public void testBoundsAreScaledWRTZoomLevel() {
+		Display display = Display.getDefault();
 		DPIUtil.setDeviceZoom(zoom);
 		int scalingFactor = scaledZoom/zoom;
 		Path path = new Path(display);

--- a/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/graphics/RegionWin32Tests.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/graphics/RegionWin32Tests.java
@@ -17,12 +17,18 @@ import static org.junit.Assert.assertEquals;
 
 import org.eclipse.swt.internal.*;
 import org.eclipse.swt.internal.win32.*;
+import org.eclipse.swt.widgets.*;
 import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.*;
 
-class RegionWin32Tests extends Win32AutoscaleTestBase {
+@ExtendWith(PlatformSpecificExecutionExtension.class)
+@ExtendWith(WithMonitorSpecificScalingExtension.class)
+class RegionWin32Tests {
 
 	@Test
 	public void testRegionMustBeScaledOnHandleOfScaledZoomLevel() {
+		Display display = Display.getDefault();
+
 		int zoom = DPIUtil.getDeviceZoom();
 		int scalingFactor = 2;
 

--- a/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/graphics/TextLayoutWin32Tests.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/graphics/TextLayoutWin32Tests.java
@@ -17,13 +17,19 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 import org.eclipse.swt.internal.*;
+import org.eclipse.swt.widgets.*;
 import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.*;
 
-class TextLayoutWin32Tests extends Win32AutoscaleTestBase {
+@ExtendWith(PlatformSpecificExecutionExtension.class)
+@ExtendWith(WithMonitorSpecificScalingExtension.class)
+class TextLayoutWin32Tests {
 	final static String text = "This is a text for testing.";
 
 	@Test
 	public void testGetBoundPublicAPIshouldReturnTheSameValueRegardlessOfZoomLevel() {
+		Display display = Display.getDefault();
+
 		final TextLayout layout = new TextLayout(display);
 		GCData unscaledData = new GCData();
 		unscaledData.nativeZoom = DPIUtil.getNativeDeviceZoom();
@@ -44,6 +50,9 @@ class TextLayoutWin32Tests extends Win32AutoscaleTestBase {
 
 	@Test
 	public void testCalculateGetBoundsWithVerticalIndent() {
+		Display display = Display.getDefault();
+		Shell shell = new Shell(display);
+
 		TextLayout layout = new TextLayout(display);
 		layout.setVerticalIndent(16);
 		layout.setText(text);
@@ -51,7 +60,7 @@ class TextLayoutWin32Tests extends Win32AutoscaleTestBase {
 
 		int scalingFactor = 2;
 		int newZoom = DPIUtil.getNativeDeviceZoom() * scalingFactor;
-		changeDPIZoom(newZoom);
+		DPITestUtil.changeDPIZoom(shell, newZoom);
 		TextLayout scaledLayout = new TextLayout(display);
 		scaledLayout.setVerticalIndent(16);
 		scaledLayout.setText(text);

--- a/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/graphics/TransformWin32Tests.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/graphics/TransformWin32Tests.java
@@ -18,12 +18,17 @@ import static org.junit.Assert.assertNotEquals;
 
 import org.eclipse.swt.internal.*;
 import org.eclipse.swt.internal.gdip.*;
+import org.eclipse.swt.widgets.*;
 import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.*;
 
-class TransformWin32Tests extends Win32AutoscaleTestBase {
+@ExtendWith(PlatformSpecificExecutionExtension.class)
+@ExtendWith(WithMonitorSpecificScalingExtension.class)
+class TransformWin32Tests {
 
 	@Test
 	public void testShouldHaveDifferentHandlesAtDifferentZoomLevels() {
+		Display display = Display.getDefault();
 		int zoom = DPIUtil.getDeviceZoom();
 		Transform transform = new Transform(display);
 		long scaledHandle = transform.getHandle(zoom * 2);
@@ -34,6 +39,7 @@ class TransformWin32Tests extends Win32AutoscaleTestBase {
 
 	@Test
 	public void testScaledTrasformMustHaveScaledValues() {
+		Display display = Display.getDefault();
 		int zoom = DPIUtil.getDeviceZoom();
 		Transform transform = new Transform(display, 0, 0, 0, 0, 4, 2);
 		float[] elements = new float[6];

--- a/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/internal/DPITestUtil.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/internal/DPITestUtil.java
@@ -14,35 +14,16 @@
 package org.eclipse.swt.internal;
 
 import org.eclipse.swt.widgets.*;
-import org.junit.jupiter.api.*;
 
-public abstract class Win32AutoscaleTestBase {
-	protected Display display;
-	protected Shell shell;
+public final class DPITestUtil {
 
-	@BeforeAll
-	public static void assumeIsFittingPlatform() {
-		PlatformSpecificExecution.assumeIsFittingPlatform();
+	private DPITestUtil() {
 	}
 
-	@BeforeEach
-	public void setUpTest() {
-		display = Display.getDefault();
-		display.setRescalingAtRuntime(true);
-		shell = new Shell(display);
-	}
-
-	@AfterEach
-	public void tearDownTest() {
-		if (shell != null) {
-			shell.dispose();
-		}
-		display.dispose();
-	}
-
-	protected void changeDPIZoom (int nativeZoom) {
+	public static void changeDPIZoom (Shell shell, int nativeZoom) {
 		DPIUtil.setDeviceZoom(nativeZoom);
 		float scalingFactor = 1f * DPIUtil.getZoomForAutoscaleProperty(nativeZoom) / DPIUtil.getZoomForAutoscaleProperty(shell.nativeZoom);
 		DPIZoomChangeRegistry.applyChange(shell, nativeZoom, scalingFactor);
 	}
+
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/internal/DefaultSWTFontRegistryTests.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/internal/DefaultSWTFontRegistryTests.java
@@ -20,16 +20,13 @@ import org.eclipse.swt.*;
 import org.eclipse.swt.graphics.*;
 import org.eclipse.swt.widgets.*;
 import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.*;
 
+@ExtendWith(PlatformSpecificExecutionExtension.class)
 class DefaultSWTFontRegistryTests {
 	private static String TEST_FONT = "Helvetica";
 	private Display display;
 	private SWTFontRegistry fontRegistry;
-
-	@BeforeAll
-	public static void assumeIsFittingPlatform() {
-		PlatformSpecificExecution.assumeIsFittingPlatform();
-	}
 
 	@BeforeEach
 	public void setUp() {
@@ -42,6 +39,7 @@ class DefaultSWTFontRegistryTests {
 		if (this.fontRegistry != null) {
 			this.fontRegistry.dispose();
 		}
+		display.dispose();
 	}
 
 	@Test

--- a/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/internal/PlatformSpecificExecutionExtension.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/internal/PlatformSpecificExecutionExtension.java
@@ -14,11 +14,14 @@ import static org.junit.Assume.assumeTrue;
 
 import java.net.*;
 
-public final class PlatformSpecificExecution {
-	private PlatformSpecificExecution()  {
+import org.junit.jupiter.api.extension.*;
+
+public final class PlatformSpecificExecutionExtension implements BeforeAllCallback {
+	private PlatformSpecificExecutionExtension()  {
 	}
 
-	public static void assumeIsFittingPlatform() {
+	@Override
+	public void beforeAll(ExtensionContext context) throws Exception {
 		assumeTrue("test is specific for Windows", isFittingOS());
 		assumeTrue("architecture of platform does not match", isFittingArchitecture());
 	}
@@ -28,7 +31,7 @@ public final class PlatformSpecificExecution {
 	}
 
 	private static boolean isFittingArchitecture() {
-		Class<?> thisClass = PlatformSpecificExecution.class;
+		Class<?> thisClass = PlatformSpecificExecutionExtension.class;
 		String thisClassResourcePath = thisClass.getName().replace('.', '/')  + ".class";
 		URL thisClassURL = thisClass.getClassLoader().getResource(thisClassResourcePath); //$NON-NLS-1$
 		return thisClassURL.toString().contains(Library.arch());

--- a/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/internal/ResetMonitorSpecificScalingExtension.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/internal/ResetMonitorSpecificScalingExtension.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Vector Informatik GmbH
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.swt.internal;
+
+import org.eclipse.swt.widgets.*;
+import org.junit.jupiter.api.extension.*;
+
+/**
+ * Resets the monitor-specific scaling configuration after the test has been executed.
+ * Disposes the default display before and after test execution.
+ */
+public sealed class ResetMonitorSpecificScalingExtension implements BeforeEachCallback, AfterEachCallback permits WithMonitorSpecificScalingExtension {
+	private boolean wasMonitorSpecificScalingActive;
+
+	protected ResetMonitorSpecificScalingExtension() {
+	}
+
+	@Override
+	public void beforeEach(ExtensionContext context) throws Exception {
+		wasMonitorSpecificScalingActive = DPIUtil.isMonitorSpecificScalingActive();
+		Display.getDefault().dispose();
+	}
+
+	@Override
+	public void afterEach(ExtensionContext context) throws Exception {
+		DPIUtil.setMonitorSpecificScaling(wasMonitorSpecificScalingActive);
+		Display.getDefault().dispose();
+	}
+
+}

--- a/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/internal/ScalingSWTFontRegistryTests.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/internal/ScalingSWTFontRegistryTests.java
@@ -19,15 +19,12 @@ import org.eclipse.swt.*;
 import org.eclipse.swt.graphics.*;
 import org.eclipse.swt.widgets.*;
 import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.*;
 
+@ExtendWith(PlatformSpecificExecutionExtension.class)
 class ScalingSWTFontRegistryTests {
 	private static String TEST_FONT = "Helvetica";
 	private SWTFontRegistry fontRegistry;
-
-	@BeforeAll
-	public static void assumeIsFittingPlatform() {
-		PlatformSpecificExecution.assumeIsFittingPlatform();
-	}
 
 	@BeforeEach
 	public void setUp() {

--- a/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/internal/WithMonitorSpecificScalingExtension.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/internal/WithMonitorSpecificScalingExtension.java
@@ -1,0 +1,30 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Vector Informatik GmbH
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.swt.internal;
+
+import org.junit.jupiter.api.extension.*;
+
+/**
+ * Runs a test with monitor specific scaling. Disposes the default display before and after execution.
+ */
+public final class WithMonitorSpecificScalingExtension extends ResetMonitorSpecificScalingExtension {
+
+	private WithMonitorSpecificScalingExtension() {
+		super();
+	}
+
+	@Override
+	public void beforeEach(ExtensionContext context) throws Exception {
+		super.beforeEach(context);
+		DPIUtil.setMonitorSpecificScaling(true);
+	}
+
+}

--- a/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/widgets/DisplayWin32Test.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/widgets/DisplayWin32Test.java
@@ -5,15 +5,12 @@ import static org.junit.jupiter.api.Assertions.*;
 import org.eclipse.swt.internal.*;
 import org.eclipse.swt.internal.win32.*;
 import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.*;
 
+@ExtendWith(PlatformSpecificExecutionExtension.class)
 public class DisplayWin32Test {
 
 	private Display display;
-
-	@BeforeAll
-	public static void assumeIsFittingPlatform() {
-		PlatformSpecificExecution.assumeIsFittingPlatform();
-	}
 
 	@BeforeEach
 	public void createDisplay() {

--- a/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/widgets/WidgetWin32Tests.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/widgets/WidgetWin32Tests.java
@@ -22,11 +22,16 @@ import org.eclipse.swt.internal.*;
 import org.eclipse.swt.internal.win32.*;
 import org.eclipse.swt.layout.*;
 import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.*;
 
-class WidgetWin32Tests extends Win32AutoscaleTestBase {
+@ExtendWith(PlatformSpecificExecutionExtension.class)
+@ExtendWith(WithMonitorSpecificScalingExtension.class)
+class WidgetWin32Tests {
 
 	@Test
 	public void testWidgetZoomShouldChangeOnZoomLevelChange() {
+		Display display = Display.getDefault();
+		Shell shell = new Shell(display);
 		int zoom = DPIUtil.getDeviceZoom();
 		int scaledZoom = zoom * 2;
 
@@ -36,17 +41,18 @@ class WidgetWin32Tests extends Win32AutoscaleTestBase {
 		button.setBackground(shell.getDisplay().getSystemColor(SWT.COLOR_CYAN));
 		shell.open();
 		assertEquals("The initial zoom is wrong", zoom, button.getZoom()); // pre-condition
-		changeDPIZoom(scaledZoom);
+		DPITestUtil.changeDPIZoom(shell, scaledZoom);
 		assertEquals("The Zoom Level should be updated for button on zoom change event on its shell", scaledZoom,
 				button.getZoom());
 	}
 
 	@Test
 	public void testButtonPointsAfterZooming() throws NoSuchMethodException, IllegalAccessException {
+		Display display = Display.getDefault();
 		int zoom = DPIUtil.getDeviceZoom();
 		int scaledZoom = zoom * 2;
 
-		shell = new Shell(display);
+		Shell shell = new Shell(display);
 		shell.setBounds(0, 0, 100, 160);
 		shell.setLayout(new FillLayout());
 		shell.pack();
@@ -56,7 +62,7 @@ class WidgetWin32Tests extends Win32AutoscaleTestBase {
 		button.setBounds(0, 0, 100, 200);
 		Point sizeBeforeEvent = button.getSize();
 		Point p1 = button.computeSizeInPixels(sizeBeforeEvent.x, sizeBeforeEvent.y, false);
-		changeDPIZoom(scaledZoom);
+		DPITestUtil.changeDPIZoom(shell, scaledZoom);
 		Point sizeAfterEvent = button.getSize();
 		Point p2 = button.computeSizeInPixels(sizeAfterEvent.x, sizeAfterEvent.y, false);
 
@@ -66,6 +72,7 @@ class WidgetWin32Tests extends Win32AutoscaleTestBase {
 
 	@Test
 	public void testImagePixelsWithDoubleZoomLevel() {
+		Display display = Display.getDefault();
 		int zoom = DPIUtil.getDeviceZoom();
 		int scaledZoom = zoom * 2;
 
@@ -91,10 +98,11 @@ class WidgetWin32Tests extends Win32AutoscaleTestBase {
 
 	@Test
 	public void testButtonFontAfterZooming() {
+		Display display = Display.getDefault();
 		int zoom = DPIUtil.getDeviceZoom();
 		int scaledZoom = zoom * 2;
 
-		shell = new Shell(display);
+		Shell shell = new Shell(display);
 		shell.setBounds(0, 0, 100, 160);
 		shell.setLayout(new FillLayout());
 		shell.pack();
@@ -106,7 +114,7 @@ class WidgetWin32Tests extends Win32AutoscaleTestBase {
 		button.setFont(font);
 
 		int heightBeforeZoom = button.getFont().getFontData()[0].data.lfHeight;
-		changeDPIZoom(scaledZoom);
+		DPITestUtil.changeDPIZoom(shell, scaledZoom);
 		int heightAfterZoom = button.getFont().getFontData()[0].data.lfHeight;
 
 		assertEquals("Height of a font of the button should be doubled after zooming to 200",
@@ -115,10 +123,11 @@ class WidgetWin32Tests extends Win32AutoscaleTestBase {
 
 	@Test
 	public void testCoolItemAfterZooming() {
+		Display display = Display.getDefault();
 		int zoom = DPIUtil.getDeviceZoom();
 		int scaledZoom = zoom * 2;
 
-		shell = new Shell(display);
+		Shell shell = new Shell(display);
 		shell.setBounds(0, 0, 100, 160);
 		shell.setLayout(new FillLayout());
 		shell.pack();
@@ -135,7 +144,7 @@ class WidgetWin32Tests extends Win32AutoscaleTestBase {
 		var preferredControlSize = item1.getPreferredSizeInPixels();
 		int xBeforeZoom = preferredControlSize.x;
 		int yBeforeZoom = preferredControlSize.y;
-		changeDPIZoom(scaledZoom);
+		DPITestUtil.changeDPIZoom(shell, scaledZoom);
 		var preferredControlSize2 = item1.getPreferredSizeInPixels();
 		int xAfterZoom = preferredControlSize2.x;
 		int yAfterZoom = preferredControlSize2.y;
@@ -153,10 +162,11 @@ class WidgetWin32Tests extends Win32AutoscaleTestBase {
 
 	@Test
 	public void testExpandItemAfterZooming() {
+		Display display = Display.getDefault();
 		int zoom = DPIUtil.getDeviceZoom();
 		int scaledZoom = zoom * 2;
 
-		shell = new Shell(display);
+		Shell shell = new Shell(display);
 		shell.setBounds(0, 0, 100, 160);
 		shell.setLayout(new FillLayout());
 		shell.pack();
@@ -170,7 +180,7 @@ class WidgetWin32Tests extends Win32AutoscaleTestBase {
 		item1.setExpanded(true);
 
 		var heightBeforeZoom = item1.getHeightInPixels();
-		changeDPIZoom(scaledZoom);
+		DPITestUtil.changeDPIZoom(shell, scaledZoom);
 		var heightAfterZoom = item1.getHeightInPixels();
 
 		assertEquals("Height of a font of the button should be doubled after zooming to 200",
@@ -179,10 +189,11 @@ class WidgetWin32Tests extends Win32AutoscaleTestBase {
 
 	@Test
 	public void testTabFolderSizeAfterZooming() {
+		Display display = Display.getDefault();
 		int zoom = DPIUtil.getDeviceZoom();
 		int scaledZoom = zoom * 2;
 
-		shell = new Shell(display);
+		Shell shell = new Shell(display);
 		shell.setBounds(0, 0, 100, 160);
 		shell.setLayout(new FillLayout());
 		shell.pack();
@@ -197,7 +208,7 @@ class WidgetWin32Tests extends Win32AutoscaleTestBase {
 		tabItem.setControl(label);
 
 		Point tabItemSizeBeforeEvent = tabItem.getControl().getSize();
-		changeDPIZoom(scaledZoom);
+		DPITestUtil.changeDPIZoom(shell, scaledZoom);
 		Point tabItemSizeAfterEvent = tabItem.getControl().getSize();
 
 		assertEquals("Width of a tab folder item should be halved in points after zooming to 200",
@@ -208,10 +219,11 @@ class WidgetWin32Tests extends Win32AutoscaleTestBase {
 
 	@Test
 	public void testTableAfterZooming() {
+		Display display = Display.getDefault();
 		int zoom = DPIUtil.getDeviceZoom();
 		int scaledZoom = zoom * 2;
 
-		shell = new Shell(display);
+		Shell shell = new Shell(display);
 		shell.setBounds(0, 0, 100, 160);
 		shell.setLayout(new FillLayout());
 		shell.pack();
@@ -236,7 +248,7 @@ class WidgetWin32Tests extends Win32AutoscaleTestBase {
 		}
 
 		int fontHeightBefore = item1.getFont().getFontData()[0].data.lfHeight;
-		changeDPIZoom(scaledZoom);
+		DPITestUtil.changeDPIZoom(shell, scaledZoom);
 		int fontHeightAfter = item1.getFont().getFontData()[0].data.lfHeight;
 
 		assertEquals("Height of a font for table item should be doubled after zooming to 200",
@@ -245,10 +257,11 @@ class WidgetWin32Tests extends Win32AutoscaleTestBase {
 
 	@Test
 	public void testTreeAfterZooming() {
+		Display display = Display.getDefault();
 		int zoom = DPIUtil.getDeviceZoom();
 		int scaledZoom = zoom * 2;
 
-		shell = new Shell(display);
+		Shell shell = new Shell(display);
 		shell.setBounds(0, 0, 100, 160);
 		shell.setLayout(new FillLayout());
 		shell.pack();
@@ -271,7 +284,7 @@ class WidgetWin32Tests extends Win32AutoscaleTestBase {
 		}
 
 		int fontHeightBefore = item1.getFont().getFontData()[0].data.lfHeight;
-		changeDPIZoom(scaledZoom);
+		DPITestUtil.changeDPIZoom(shell, scaledZoom);
 		int fontHeightAfter = item1.getFont().getFontData()[0].data.lfHeight;
 
 		assertEquals("Height of a font for tree item should be doubled after zooming to 200",
@@ -280,10 +293,11 @@ class WidgetWin32Tests extends Win32AutoscaleTestBase {
 
 	@Test
 	public void testCaretInStyledTextAfterZooming() {
+		Display display = Display.getDefault();
 		int zoom = DPIUtil.getDeviceZoom();
 		int scaledZoom = zoom * 2;
 
-		shell = new Shell(display);
+		Shell shell = new Shell(display);
 		shell.setBounds(0, 0, 100, 160);
 		shell.setLayout(new FillLayout());
 		shell.pack();
@@ -311,7 +325,7 @@ class WidgetWin32Tests extends Win32AutoscaleTestBase {
 
 		// Get the caret size
 		Point caretSize = styledText.getCaret().getSizeInPixels();
-		changeDPIZoom(scaledZoom);
+		DPITestUtil.changeDPIZoom(shell, scaledZoom);
 		Point caretSize2 = styledText.getCaret().getSizeInPixels();
 
 		assertEquals("Height of a Caret for Styled Text should be doubled after zooming to 200", caretSize.y * 2,

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/DPIUtil.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/DPIUtil.java
@@ -650,6 +650,10 @@ public static int getZoomForAutoscaleProperty (int nativeDeviceZoom) {
 	return zoom;
 }
 
+public static void setMonitorSpecificScaling(boolean activate) {
+	System.setProperty(SWT_AUTOSCALE_UPDATE_ON_RUNTIME, Boolean.toString(activate));
+}
+
 public static boolean isMonitorSpecificScalingActive() {
 	boolean updateOnRuntimeValue = Boolean.getBoolean (SWT_AUTOSCALE_UPDATE_ON_RUNTIME);
 	return updateOnRuntimeValue;


### PR DESCRIPTION
Auto-scale related, Windows-specific tests are currently organized in a class hierarchy based on Win32AutoscaleTestBase. This leads to unnecessarily initialized objects (e.g., shells or displays without any need for a test) and the strict necessity to use activated monitor-specific scaling in actual tests or to revert the setup logic affecting that value by hand.

This change removes the Win32AutoscaleTestBase and moves the common test functionality into extensions (PlatformSpecificExecution, ResetMonitorSpecificScaling and WithMonitorSpecificScaling) as well as the utility class DPITestUtil.

This serves as a preparation for #1720.