### PR TITLE
Fixed Shell::setBounds scaling

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Shell.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Shell.java
@@ -1595,8 +1595,8 @@ public void setLocation(int x, int y) {
 public void setBounds(Rectangle rect) {
 	if (rect == null) error (SWT.ERROR_NULL_ARGUMENT);
 	checkWidget ();
-	Rectangle boundsInPixels = getDisplay().translateToDisplayCoordinates(rect, getZoom());
-	setBoundsInPixels(boundsInPixels.x, boundsInPixels.y, boundsInPixels.width, boundsInPixels.height);
+	Point topLeftInPixels = getDisplay().translateToDisplayCoordinates(new Point(rect.x, rect.y), getZoom());
+	setBoundsInPixels(topLeftInPixels.x, topLeftInPixels.y, DPIUtil.scaleUp(rect.width, getZoom()), DPIUtil.scaleUp(rect.height, getZoom()));
 }
 
 @Override


### PR DESCRIPTION
The previous scaling with the monitor context in Shell:setBounds would already scale the height and width of the Shell with respect to the monitor on which it is going to be placed. In case there is a monitor change, the monitor will be scaled with respect to the target monitor twice, i.e. in Shell::setBounds and then on the dpi changed message, leading to the effects, such as, shrinking or expanding shells on drag and drop to a different monitor with different zoom.

This PR contributes fixes that by scaling the x,y (top left coordinate) with the context of the whole rectangle but still using the zoom of the Shell for scaling the width and height. In case there's a monitor change the width and height will be scaled with respect to the target monitor on DPI_CHANGED event. Otherwise, the current zoom of the shell obtained from Shell::getZoom is enough for scaling the height and the width.

contributes to #62 and #127