### PR TITLE
Callback for dynamic drawing with a GC on images

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CTabFolder.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CTabFolder.java
@@ -17,6 +17,7 @@ import org.eclipse.swt.*;
 import org.eclipse.swt.accessibility.*;
 import org.eclipse.swt.events.*;
 import org.eclipse.swt.graphics.*;
+import org.eclipse.swt.internal.*;
 import org.eclipse.swt.widgets.*;
 
 /**
@@ -717,26 +718,25 @@ public Rectangle computeTrim (int x, int y, int width, int height) {
 	}
 	return trim;
 }
+
 Image createButtonImage(Display display, int button) {
-	return new Image(display, (ImageDataProvider) zoom -> {
-		GC tempGC = new GC (CTabFolder.this);
-		Point size = renderer.computeSize(button, SWT.NONE, tempGC, SWT.DEFAULT, SWT.DEFAULT);
-		tempGC.dispose();
+	final GC tempGC = new GC (CTabFolder.this);
+	final Point size = renderer.computeSize(button, SWT.NONE, tempGC, SWT.DEFAULT, SWT.DEFAULT);
+	tempGC.dispose();
 
-		Rectangle trim = renderer.computeTrim(button, SWT.NONE, 0, 0, 0, 0);
-		Image image = new Image (display, size.x - trim.width, size.y - trim.height);
-		GC gc = new GC (image);
-		Color transColor = renderer.parent.getBackground();
-		gc.setBackground(transColor);
-		gc.fillRectangle(image.getBounds());
-		renderer.draw(button, SWT.NONE, new Rectangle(trim.x, trim.y, size.x, size.y), gc);
-		gc.dispose ();
-
-		final ImageData imageData = image.getImageData (zoom);
-		imageData.transparentPixel = imageData.palette.getPixel(transColor.getRGB());
-		image.dispose();
-		return imageData;
-	});
+	final Rectangle trim = renderer.computeTrim(button, SWT.NONE, 0, 0, 0, 0);
+	final Point imageSize = new Point(size.x - trim.width, size.y - trim.height);
+	Color transColor = renderer.parent.getBackground();
+	final ImageGcDrawer imageGcDrawer = new TransparencyColorImageGcDrawer(transColor) {
+		@Override
+		public void drawOn(GC gc, int imageWidth, int imageHeight) {
+			Rectangle imageBounds = new Rectangle(0, 0, imageWidth, imageHeight);
+			gc.setBackground(transColor);
+			gc.fillRectangle(imageBounds);
+			renderer.draw(button, SWT.NONE, imageBounds, gc);
+		}
+	};
+	return new Image(display, imageGcDrawer, imageSize.x, imageSize.y);
 }
 
 private void notifyItemCountChange() {

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/ImageGcDrawer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/ImageGcDrawer.java
@@ -1,0 +1,48 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Yatta and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Yatta - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.swt.graphics;
+
+/**
+ * Interface to provide a callback mechanism to draw on different GC instances
+ * depending on the zoom the image will be used for. A common use case is when
+ * the application is moved from a low DPI monitor to a high DPI monitor. This
+ * provides API which will be called by SWT during the image rendering.
+ *
+ * This interface needs to be implemented by client code to provide logic that
+ * draws on the empty GC on demand.
+ *
+ * @since 3.129
+ */
+public interface ImageGcDrawer {
+
+	/**
+	 * Draws an image on a GC for a requested zoom level.
+	 *
+	 * @param gc          The GC will draw on the underlying Image and is configured
+	 *                    for the targeted zoom
+	 * @param imageWidth  The width of the image in points to draw on
+	 * @param imageHeight The height of the image in points to draw on
+	 */
+	void drawOn(GC gc, int imageWidth, int imageHeight);
+
+	/**
+	 * Executes post processing on ImageData. This method will always be called
+	 * after <code>drawOn</code> and contain the resulting ImageData.
+	 *
+	 * @param imageData The resulting ImageData after <code>drawOn</code> was called
+	 */
+	default void postProcess(ImageData imageData) {
+	}
+
+}

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/TransparencyColorImageGcDrawer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/TransparencyColorImageGcDrawer.java
@@ -1,0 +1,31 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Yatta and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Yatta - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.swt.internal;
+
+import org.eclipse.swt.graphics.*;
+
+public abstract class TransparencyColorImageGcDrawer implements ImageGcDrawer {
+
+	private final Color transparencyColor;
+
+	public TransparencyColorImageGcDrawer(Color transparencyColor) {
+		this.transparencyColor = transparencyColor;
+	}
+
+	@Override
+	public void postProcess(ImageData imageData) {
+		imageData.transparentPixel = imageData.palette.getPixel(transparencyColor.getRGB());
+	}
+
+}

--- a/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet367.java
+++ b/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet367.java
@@ -60,6 +60,10 @@ public class Snippet367 {
 				return null;
 			}
 		};
+		final ImageGcDrawer imageGcDrawer = gc -> {
+			gc.drawRectangle(1, 1, 18, 18);
+			gc.drawLine(3, 3, 17, 17);
+		};
 
 		final Display display = new Display ();
 		final Shell shell = new Shell (display);
@@ -97,6 +101,10 @@ public class Snippet367 {
 		new Label (shell, SWT.NONE).setText ("ImageDataProvider:");
 		new Label (shell, SWT.NONE).setImage (new Image (display, imageDataProvider));
 		new Button(shell, SWT.NONE).setImage (new Image (display, imageDataProvider));
+
+		new Label (shell, SWT.NONE).setText ("ImageGcDrawer:");
+		new Label (shell, SWT.NONE).setImage (new Image (display, imageGcDrawer, 20, 20));
+		new Button(shell, SWT.NONE).setImage (new Image (display, imageGcDrawer, 20, 20));
 
 		createSeparator(shell);
 

--- a/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet382.java
+++ b/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet382.java
@@ -63,6 +63,14 @@ public class Snippet382 {
 		};
 
 		final Display display = new Display ();
+
+		final ImageGcDrawer imageGcDrawer = gc -> {
+			gc.setBackground(display.getSystemColor(SWT.COLOR_RED));
+			gc.fillRectangle(0, 0, 16, 16);
+			gc.setForeground(display.getSystemColor(SWT.COLOR_YELLOW));
+			gc.drawRectangle(4, 4, 8, 8);
+		};
+
 		final Shell shell = new Shell (display);
 		shell.setText("Snippet382");
 		shell.setLayout (new GridLayout (3, false));
@@ -84,6 +92,10 @@ public class Snippet382 {
 					final Image disabledImageWithData = new Image (display,imageWithData, SWT.IMAGE_DISABLE);
 					final Image greyImageWithData = new Image (display,imageWithData, SWT.IMAGE_GRAY);
 
+					final Image imageWithGcDrawer = new Image (display, imageGcDrawer, 16, 16);
+					final Image disabledImageWithGcDrawer = new Image (display, imageWithGcDrawer, SWT.IMAGE_DISABLE);
+					final Image greyImageWithGcDrawer = new Image (display, imageWithGcDrawer, SWT.IMAGE_GRAY);
+
 					try {
 						drawImages(mainGC, gcData, "Normal",40, imageWithFileNameProvider);
 						drawImages(mainGC, gcData, "Disabled",80, disabledImageWithFileNameProvider);
@@ -96,6 +108,10 @@ public class Snippet382 {
 						drawImages(mainGC, gcData, "Normal",280, imageWithDataProvider);
 						drawImages(mainGC, gcData, "Disabled",320, disabledImageWithData);
 						drawImages(mainGC, gcData, "Greyed",360, greyImageWithData);
+
+						drawImages(mainGC, gcData, "Normal", 400, imageWithGcDrawer);
+						drawImages(mainGC, gcData, "Disabled", 440, disabledImageWithGcDrawer);
+						drawImages(mainGC, gcData, "Greyed", 480, greyImageWithGcDrawer);
 					} finally {
 						mainGC.dispose ();
 					}
@@ -114,7 +130,7 @@ public class Snippet382 {
 		};
 		shell.addListener(SWT.Paint, l);
 
-		shell.setSize(400, 500);
+		shell.setSize(400, 550);
 		shell.open ();
 		while (!shell.isDisposed ()) {
 			if (!display.readAndDispatch ()) display.sleep ();

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_Image.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_Image.java
@@ -37,6 +37,7 @@ import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.graphics.ImageData;
 import org.eclipse.swt.graphics.ImageDataProvider;
 import org.eclipse.swt.graphics.ImageFileNameProvider;
+import org.eclipse.swt.graphics.ImageGcDrawer;
 import org.eclipse.swt.graphics.PaletteData;
 import org.eclipse.swt.graphics.RGB;
 import org.eclipse.swt.graphics.Rectangle;
@@ -97,6 +98,7 @@ ImageDataProvider imageDataProvider1xOnly = zoom -> {
 	}
 	return new ImageData(getPath(fileName));
 };
+ImageGcDrawer imageGcDrawer = (gc, width, height) -> {};
 
 @Before
 public void setUp() {
@@ -608,6 +610,23 @@ public void test_ConstructorLorg_eclipse_swt_graphics_Device_ImageDataProvider()
 }
 
 @Test
+public void test_ConstructorLorg_eclipse_swt_graphics_Device_ImageGcDrawer() {
+	// Null provider
+	ImageGcDrawer drawer = null;
+	try {
+		Image image = new Image(display, drawer, 20, 20);
+		image.dispose();
+		fail("No exception thrown for ImageGcDrawer == null");
+	} catch (IllegalArgumentException e) {
+		assertSWTProblem("Incorrect exception thrown for ImageGcDrawer == null", SWT.ERROR_NULL_ARGUMENT, e);
+	}
+
+	// Valid provider
+	Image image = new Image(display, imageGcDrawer, 20, 20);
+	image.dispose();
+}
+
+@Test
 public void test_equalsLjava_lang_Object() {
 	Image image = null;
 	Image image1 = null;
@@ -671,6 +690,22 @@ public void test_equalsLjava_lang_Object() {
 
 		image1 = new Image(display, imageDataProvider);
 		assertTrue(":i:", image.equals(image1));
+	} finally {
+		image.dispose();
+		image1.dispose();
+	}
+
+	// ImageGcDrawer
+	try {
+		image = new Image(display, imageGcDrawer, 10, 10);
+		image1 = image;
+
+		assertFalse(image.equals(null));
+
+		assertTrue(image.equals(image1));
+
+		image1 = new Image(display, imageGcDrawer, 10, 10);
+		assertTrue(image.equals(image1));
 	} finally {
 		image.dispose();
 		image1.dispose();
@@ -760,6 +795,13 @@ public void test_getBoundsInPixels() {
 	bounds = image.getBounds();
 	image.dispose();
 	assertEquals(":d: Image.getBoundsInPixels method doesn't return bounds in Pixel values.", boundsInPixels, DPIUtil.autoScaleUp(bounds));
+
+	// create image with ImageGcDrawer
+	image = new Image(display, imageGcDrawer, bounds.width, bounds.height);
+	boundsInPixels = image.getBoundsInPixels();
+	bounds = image.getBounds();
+	image.dispose();
+	assertEquals("Image.getBoundsInPixels method doesn't return bounds in Pixel values for ImageGcDrawer.", boundsInPixels, DPIUtil.autoScaleUp(bounds));
 }
 
 @SuppressWarnings("deprecation")
@@ -964,6 +1006,16 @@ public void test_hashCode() {
 		image = new Image(display, imageDataProvider);
 		image1 = new Image(display, imageDataProvider);
 		assertEquals(":d:", image1.hashCode(), image.hashCode());
+	} finally {
+		image.dispose();
+		image1.dispose();
+	}
+
+	// ImageGcDrawer
+	try {
+		image = new Image(display, imageGcDrawer, 10, 10);
+		image1 = new Image(display, imageGcDrawer, 10, 10);
+		assertEquals(image1.hashCode(), image.hashCode());
 	} finally {
 		image.dispose();
 		image1.dispose();


### PR DESCRIPTION
This PR adds a new interface to be used to provide dynamic drawing on GCs created with Images. It is mostly targeted at solving the following use cases:

```
Image image = new Image (display, width, height);
GC gc = new GC (image);
// draw on the gc
otherGc.drawImage(image, ...);
```
or in combination with a ImageDataProvider
```
return new Image(display, (ImageDataProvider) zoom -> {
     Image image = new Image (display, width, height);
     GC gc = new GC (image);
     // draw on the gc
     gc.dispose ();

     final ImageData imageData = image.getImageData (zoom);
     image.dispose();
     return imageData;
});
```

Both use cases have the problem, that they do not work properly in a multi-zoom setting. Not properly working means that there will be a destructive up- or downscaling on the created image data in the background. This PR moves the initialization of the GC into the implementation of each image and can therefor be handled properly for all platforms.

I saw those use cases with two different settings: with and without transparency necessary. To address the use case with transparency we added the TransparancyColorImageGcDrawer as internal class to be used for CTabFolder::createButtonImage.