### PR TITLE
[Mac] [Printer] Fix "Print to PDF" low resolution

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT PI/cocoa/org/eclipse/swt/internal/cocoa/OS.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/cocoa/org/eclipse/swt/internal/cocoa/OS.java
@@ -73,6 +73,7 @@ public class OS extends C {
 	public static final int kAXUnderlineStyleThick = 0x2;
 	public static final int kAXUnderlineStyleDouble = 0x9;
 	public static final int kPMDestinationPrinter = 1;
+	public static final int kPMDestinationFile = 2;
 	public static final int kPMDuplexNone = 0x0001;
 	public static final int kPMDuplexNoTumble = 0x0002;
 	public static final int kPMDuplexTumble = 0x0003;

--- a/bundles/org.eclipse.swt/Eclipse SWT Printing/cocoa/org/eclipse/swt/printing/Printer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Printing/cocoa/org/eclipse/swt/printing/Printer.java
@@ -593,7 +593,7 @@ public Point getDPI() {
 			long printSettings = printInfo.PMPrintSettings();
 			short[] destType = new short[1];
 			if (OS.PMSessionGetDestinationType(pmPrintSession, printSettings, destType) == OS.noErr) {
-				if (destType[0] == OS.kPMDestinationPrinter) {
+				if (destType[0] == OS.kPMDestinationPrinter || destType[0] == OS.kPMDestinationFile) {
 					PMResolution resolution =  new PMResolution();
 
 					if (OS.PMPrinterGetOutputResolution(printer[0], printSettings, resolution) != OS.noErr) {


### PR DESCRIPTION
The changes make the "Print to PDF" option rely on the selected printer's resolution. In the current flow, it defaults to the screen DPI which results in lower print area for some devices.

Even if no printer is selected / available, this results to higher DPI than using the screen's DPI.