### PR TITLE
Adapt Snippet367 and Snippet382 to ImageGcDrawer

### DIFF
--- a/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet367.java
+++ b/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet367.java
@@ -60,9 +60,9 @@ public class Snippet367 {
 				return null;
 			}
 		};
-		final ImageGcDrawer imageGcDrawer = gc -> {
-			gc.drawRectangle(1, 1, 18, 18);
-			gc.drawLine(3, 3, 17, 17);
+		final ImageGcDrawer imageGcDrawer = (gc, width, height) -> {
+			gc.drawRectangle(1, 1, width - 2, height - 2);
+			gc.drawLine(3, 3, width - 3, height - 3);
 		};
 
 		final Display display = new Display ();

--- a/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet382.java
+++ b/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet382.java
@@ -64,11 +64,11 @@ public class Snippet382 {
 
 		final Display display = new Display ();
 
-		final ImageGcDrawer imageGcDrawer = gc -> {
+		final ImageGcDrawer imageGcDrawer = (gc, width, height) -> {
 			gc.setBackground(display.getSystemColor(SWT.COLOR_RED));
-			gc.fillRectangle(0, 0, 16, 16);
+			gc.fillRectangle(0, 0, width, height);
 			gc.setForeground(display.getSystemColor(SWT.COLOR_YELLOW));
-			gc.drawRectangle(4, 4, 8, 8);
+			gc.drawRectangle(4, 4, width - 8, height - 8);
 		};
 
 		final Shell shell = new Shell (display);


### PR DESCRIPTION
Two snippets refer to an old signature of the ImageGcDrawer interface, leading to compilation issues. This change change adapts them accordingly.