### PR TITLE
Fixed Shell::setBounds scaling

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Shell.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Shell.java
@@ -1596,7 +1596,12 @@ public void setBounds(Rectangle rect) {
 	if (rect == null) error (SWT.ERROR_NULL_ARGUMENT);
 	checkWidget ();
 	Rectangle boundsInPixels = getDisplay().translateToDisplayCoordinates(rect, getZoom());
-	setBoundsInPixels(boundsInPixels.x, boundsInPixels.y, boundsInPixels.width, boundsInPixels.height);
+	// The scaling of the width and height in case of a monitor change is handled by
+	// the WM_DPICHANGED event processing. So to avoid duplicate scaling, we always
+	// have to scale width and height with the zoom of the original monitor (still
+	// returned by getZoom()) here.
+	setBoundsInPixels(boundsInPixels.x, boundsInPixels.y, DPIUtil.scaleUp(rect.width, getZoom()),
+			DPIUtil.scaleUp(rect.height, getZoom()));
 }
 
 @Override


### PR DESCRIPTION
The previous scaling with the monitor context in Shell:setBounds would already scale the height and width of the Shell with respect to the monitor on which it is going to be placed. In case there is a monitor change, the monitor will be scaled with respect to the target monitor twice, i.e. in Shell::setBounds and then on the dpi changed message, leading to the effects, such as, shrinking or expanding shells on drag and drop to a different monitor with different zoom.

This PR contributes fixes that by scaling the x,y (top left coordinate) with the context of the whole rectangle but still using the zoom of the Shell for scaling the width and height. In case there's a monitor change the width and height will be scaled with respect to the target monitor on DPI_CHANGED event. Otherwise, the current zoom of the shell obtained from Shell::getZoom is enough for scaling the height and the width.

contributes to https://github.com/eclipse-platform/eclipse.platform.swt/issues/62 and https://github.com/eclipse-platform/eclipse.platform.swt/issues/127