### PR TITLE
[win32] Init nativeZoom for taskbar

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TaskBar.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TaskBar.java
@@ -65,6 +65,7 @@ public class TaskBar extends Widget {
 
 TaskBar (Display display, int style) {
 	this.display = display;
+	this.nativeZoom = display.getDeviceZoom();
 	createHandle ();
 	reskinWidget ();
 }


### PR DESCRIPTION
This commit initializes the nativeZoom attribute of the taskbar. As TaskBar is not calling a super constructor setting this attribute will be zero and can lead to issues with Images created with a zero zoom factor.

This PR is providing a subset of the already open PR #1269 

contributes to #1742

@HeikoKlare have a look