### PR TITLE
[GTK4] Fix GtkWidget warning when calculating initial shell bounds

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/gtk4.c
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/gtk4.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2024 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -1866,6 +1866,18 @@ JNIEXPORT jlong JNICALL GTK4_NATIVE(gtk_1window_1get_1icon_1name)
 	GTK4_NATIVE_ENTER(env, that, gtk_1window_1get_1icon_1name_FUNC);
 	rc = (jlong)gtk_window_get_icon_name((GtkWindow *)arg0);
 	GTK4_NATIVE_EXIT(env, that, gtk_1window_1get_1icon_1name_FUNC);
+	return rc;
+}
+#endif
+
+#ifndef NO_gtk_1window_1get_1titlebar
+JNIEXPORT jlong JNICALL GTK4_NATIVE(gtk_1window_1get_1titlebar)
+	(JNIEnv *env, jclass that, jlong arg0)
+{
+	jlong rc = 0;
+	GTK4_NATIVE_ENTER(env, that, gtk_1window_1get_1titlebar_FUNC);
+	rc = (jlong)gtk_window_get_titlebar((GtkWindow *)arg0);
+	GTK4_NATIVE_EXIT(env, that, gtk_1window_1get_1titlebar_FUNC);
 	return rc;
 }
 #endif

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/gtk4_stats.h
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/gtk4_stats.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2024 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -164,6 +164,7 @@ typedef enum {
 	gtk_1widget_1translate_1coordinates_FUNC,
 	gtk_1window_1destroy_FUNC,
 	gtk_1window_1get_1icon_1name_FUNC,
+	gtk_1window_1get_1titlebar_FUNC,
 	gtk_1window_1is_1maximized_FUNC,
 	gtk_1window_1maximize_FUNC,
 	gtk_1window_1minimize_FUNC,

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/org/eclipse/swt/internal/gtk4/GTK4.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/org/eclipse/swt/internal/gtk4/GTK4.java
@@ -324,6 +324,8 @@ public class GTK4 {
 	 * @param name cast=(const char *)
 	 * */
 	public static final native void gtk_window_set_icon_name(long window, long name);
+	/** @param window cast=(GtkWindow *) */
+	public static final native long gtk_window_get_titlebar(long window);
 
 	/* GtkShortcutController */
 	public static final native long gtk_shortcut_controller_new();

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Shell.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Shell.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -2541,9 +2541,11 @@ void setInitialBounds() {
 				 * On GTK4, GtkWindow size includes the header bar. In order to keep window size allocation of the client area
 				 * consistent with previous versions of SWT, we need to include the header bar height in addition to the given height value.
 				 */
-				long header = GTK4.gtk_widget_get_next_sibling(GTK4.gtk_widget_get_first_child(shellHandle));
+				long header = GTK4.gtk_window_get_titlebar(shellHandle);
 				int[] headerNaturalHeight = new int[1];
-				GTK4.gtk_widget_measure(header, GTK.GTK_ORIENTATION_VERTICAL, 0, null, headerNaturalHeight, null, null);
+				if (header != 0) {
+					GTK4.gtk_widget_measure(header, GTK.GTK_ORIENTATION_VERTICAL, 0, null, headerNaturalHeight, null, null);
+				}
 
 				GTK.gtk_window_set_default_size(shellHandle, width, height + headerNaturalHeight[0]);
 			}


### PR DESCRIPTION
It might be possible that no (custom) titlebar is set for the newly created shell. In such a case, gtk_widget_measure() must not be called with the NULL handle, in order to avoid the following error:

> gtk_widget_measure: assertion 'GTK_IS_WIDGET (widget)' failed

Furthermore, the header is now retrieved via gtk_window_get_titlebar(), rather than assuming that it's the second child of the shell handle.