### PR TITLE
[MacOS] Fix width/height of Images created via ImageGcDrawer

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/graphics/Image.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/graphics/Image.java
@@ -872,7 +872,9 @@ public Image(Device device, ImageGcDrawer imageGcDrawer, int width, int height) 
 	super(device);
 	if (imageGcDrawer == null) SWT.error(SWT.ERROR_NULL_ARGUMENT);
 	this.imageGcDrawer = imageGcDrawer;
-	ImageData data = drawWithImageGcDrawer(imageGcDrawer, width, height, 100);
+	this.width = width;
+	this.height = height;
+	ImageData data = drawWithImageGcDrawer(imageGcDrawer, width, height, DPIUtil.getDeviceZoom());
 	if (data == null) SWT.error(SWT.ERROR_INVALID_ARGUMENT);
 	NSAutoreleasePool pool = null;
 	if (!NSThread.isMainThread()) pool = (NSAutoreleasePool) new NSAutoreleasePool().alloc().init();


### PR DESCRIPTION
The current implementation of the Image constructor accepting an ImageGcDrawer does initialize the image with the given width and height but extracts them from the image data being initialized with the ImageGcDrawer. This does not take the current device zoom into account properly, leading to images unexpectedly being rendered for 100% scaling while they are supposed to be used at 200% scaling.

With this change, images are properly initialized with the given width and height and using the according device zoom for the image data generation, leading to a sharp initialization also on 200% monitors.

Serves as a fix for the MacOS part of issue https://github.com/eclipse-platform/eclipse.platform.ui/issues/2740

### Before fix
https://github.com/user-attachments/assets/6014d1e6-dff9-40a6-b1c4-58bc14d58f21

### After fix
https://github.com/user-attachments/assets/a6328910-298a-469f-8d04-cc5157a9025c