### PR TITLE
WebViewWrapperFuture handling on job termination timeout

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Browser/win32/org/eclipse/swt/browser/Edge.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Browser/win32/org/eclipse/swt/browser/Edge.java
@@ -294,6 +294,33 @@ class WebViewWrapper {
 	private ICoreWebView2_11 webView_11;
 	private ICoreWebView2_12 webView_12;
 	private ICoreWebView2_13 webView_13;
+
+	void releaseWebViews() {
+		if(webView != null) {
+			webView.Release();
+			webView = null;
+		}
+		if(webView_2 != null) {
+			webView_2.Release();
+			webView_2 = null;
+		}
+		if(webView_10 != null) {
+			webView_10.Release();
+			webView_10 = null;
+		}
+		if(webView_11 != null) {
+			webView_11.Release();
+			webView_11 = null;
+		}
+		if(webView_12 != null) {
+			webView_12.Release();
+			webView_12 = null;
+		}
+		if(webView_13 != null) {
+			webView_13.Release();
+			webView_13 = null;
+		}
+	}
 }
 
 class WebViewProvider {
@@ -318,6 +345,10 @@ class WebViewProvider {
 
 	private void abortInitialization() {
 		webViewWrapperFuture.cancel(true);
+	}
+
+	void releaseWebView() {
+		getWebViewWrapper().releaseWebViews();
 	}
 
 	private ICoreWebView2_2 initializeWebView_2(ICoreWebView2 webView) {
@@ -748,14 +779,9 @@ void setupBrowser(int hr, long pv) {
 void browserDispose(Event event) {
 	containingEnvironment.instances.remove(this);
 	webViewProvider.scheduleWebViewTask(() -> {
-		webViewProvider.getWebView(false).Release();
+		webViewProvider.releaseWebView();
 		if (environment2 != null) environment2.Release();
 		if (settings != null) settings.Release();
-		if (webViewProvider.isWebView_2Available()) webViewProvider.getWebView_2(false).Release();
-		if (webViewProvider.isWebView_10Available()) webViewProvider.getWebView_10(false).Release();
-		if (webViewProvider.isWebView_11Available()) webViewProvider.getWebView_11(false).Release();
-		if (webViewProvider.isWebView_12Available()) webViewProvider.getWebView_12(false).Release();
-		if (webViewProvider.isWebView_13Available()) webViewProvider.getWebView_13(false).Release();
 		if(controller != null) {
 			// Bug in WebView2. Closing the controller from an event handler results
 			// in a crash. The fix is to delay the closure with asyncExec.


### PR DESCRIPTION
This Pull Request introduces following behaviour in Edge browser:

- Encapsulates the ICoreWebView*::Release for all the different webView* instances in the WebViewWrapper in a method WebViewWrapper::releaseWebViews
- The futures complete exceptionally if there occurs a timeout at processOSMessagesUntil
- If the webViewWrapperFuture finishes exceptionally (during the initialization of webViews), there's a streamlined rollback of all the resources.

contributes to #1466 and [#2734](https://github.com/eclipse-platform/eclipse.platform.ui/issues/2734)