### PR TITLE
Unify internal strict mode flag for win32 and gtk

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Display.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Display.java
@@ -116,7 +116,7 @@ import org.eclipse.swt.internal.gtk4.*;
  */
 public class Display extends Device implements Executor {
 
-	static boolean strictChecks = System.getProperty("org.eclipse.swt.internal.gtk.enableStrictChecks") != null;
+	static boolean strictChecks = System.getProperty("org.eclipse.swt.internal.enableStrictChecks") != null;
 
 	private static final int SLOT_IN_USE = -2;
 	private static final int LAST_TABLE_INDEX = -1;

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Device.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Device.java
@@ -33,6 +33,8 @@ import org.eclipse.swt.widgets.*;
  */
 public abstract class Device implements Drawable {
 
+	static boolean strictChecks = System.getProperty("org.eclipse.swt.internal.enableStrictChecks") != null;
+
 	/* Debugging */
 	public static boolean DEBUG;
 	boolean debug = DEBUG;

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/GC.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/GC.java
@@ -3950,6 +3950,10 @@ void init(Drawable drawable, GCData data, long hDC) {
 }
 
 private static int extractZoom(long hDC) {
+	if (Device.strictChecks) {
+		System.err.println("***WARNING: GC is initialized with a missing zoom. This indicates an "
+				+ "incompatible custom Drawable implementation.");
+	}
 	long hwnd = OS.WindowFromDC(hDC);
 	long parentWindow = OS.GetAncestor(hwnd, OS.GA_ROOT);
 	long monitorParent = OS.MonitorFromWindow(parentWindow, OS.MONITOR_DEFAULTTONEAREST);

--- a/tests/org.eclipse.swt.tests/pom.xml
+++ b/tests/org.eclipse.swt.tests/pom.xml
@@ -51,7 +51,7 @@
               <argLine>@{tycho.testArgLine} -Dorg.eclipse.swt.internal.gtk.disablePrinting ${os-jvm-flags}</argLine>
               <systemPropertyVariables>
                 <user.home>${project.build.directory}</user.home> <!-- used as cache directory for SWT native libraries -->
-                <org.eclipse.swt.internal.gtk.enableStrictChecks>true</org.eclipse.swt.internal.gtk.enableStrictChecks> <!-- see bug 532632 -->
+                <org.eclipse.swt.internal.enableStrictChecks>true</org.eclipse.swt.internal.enableStrictChecks> <!-- see bug 532632 -->
                 <swt.autoScale>quarter</swt.autoScale>
               </systemPropertyVariables>
               <!-- Trim does not only remove the entries before entering the test method but

--- a/tests/org.eclipse.swt.tests/test.xml
+++ b/tests/org.eclipse.swt.tests/test.xml
@@ -31,7 +31,7 @@
       <property name="plugin-name" value="${plugin-name}"/>
       <property name="classname" value="org.eclipse.swt.tests.junit.AllNonBrowserTests"/>
       <!-- workaround for https://bugs.eclipse.org/502410 and checks for bug 532632 -->
-      <property name="vmargs" value="-Dorg.eclipse.swt.internal.gtk.disablePrinting -Dorg.eclipse.swt.internal.gtk.enableStrictChecks"/>
+      <property name="vmargs" value="-Dorg.eclipse.swt.internal.gtk.disablePrinting -Dorg.eclipse.swt.internal.enableStrictChecks"/>
     </ant>
   </target>
 	


### PR DESCRIPTION
This contribution renames the internal strict mode flag in GTK from org.eclipse.swt.internal.gtk.enableStrictChecks to org.eclipse.swt.internal.enableStrictChecks and adds it to win32 to be used to check for correctly configured GCs for monitor-specific-scaling. The helps tracing invalid custom Drawables or GCs that are created with an invalid configuration.