### PR TITLE
Calculate chevron size in CTabFolderRenderer without Device#getDPI()

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CTabFolder.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CTabFolder.java
@@ -341,6 +341,7 @@ void init(int style) {
 			case SWT.Selection:        onSelection(event); break;
 			case SWT.Activate:         onActivate(event); break;
 			case SWT.Deactivate:       onDeactivate(event); break;
+			case SWT.ZoomChanged:	   onZoomChange(event); break;
 		}
 	};
 
@@ -362,7 +363,8 @@ void init(int style) {
 		SWT.Resize,
 		SWT.Traverse,
 		SWT.Activate,
-		SWT.Deactivate
+		SWT.Deactivate,
+		SWT.ZoomChanged
 	};
 	for (int folderEvent : folderEvents) {
 		addListener(folderEvent, listener);
@@ -370,6 +372,11 @@ void init(int style) {
 
 	initAccessible();
 }
+
+private void onZoomChange(Event event) {
+	update();
+}
+
 void onDeactivate(Event event) {
 	if (!highlightEnabled) {
 		return;

--- a/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CTabFolderRenderer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CTabFolderRenderer.java
@@ -102,7 +102,8 @@ public class CTabFolderRenderer {
 	static final int FLAGS = SWT.DRAW_TRANSPARENT | SWT.DRAW_MNEMONIC | SWT.DRAW_DELIMITER;
 	static final String ELLIPSIS = "..."; //$NON-NLS-1$
 	private static final String CHEVRON_ELLIPSIS = "99+"; //$NON-NLS-1$
-	private static final int CHEVRON_FONT_HEIGHT = 10;
+	private static final float CHEVRON_FONT_SIZE_FACTOR = 0.7f;
+	private static final int CHEVRON_BOTTOM_INDENT = 4;
 
 	//Part constants
 	/**
@@ -926,7 +927,7 @@ public class CTabFolderRenderer {
 		Display display = parent.getDisplay();
 		Font font = getChevronFont(display);
 		int fontHeight = font.getFontData()[0].getHeight();
-		int indent = Math.max(2, (chevronRect.height - fontHeight - 4) /2);
+		int indent = Math.max(2, (chevronRect.height - fontHeight - CHEVRON_BOTTOM_INDENT) /2);
 		int x = chevronRect.x + 2;
 		int y = chevronRect.y + indent;
 		int count = parent.getChevronCount();
@@ -1696,9 +1697,8 @@ public class CTabFolderRenderer {
 
 	private Font getChevronFont(Display display) {
 		if (chevronFont == null) {
-			Point dpi = display.getDPI();
-			int fontHeight = 72 * CHEVRON_FONT_HEIGHT / dpi.y;
 			FontData fd = parent.getFont().getFontData()[0];
+			int fontHeight = (int) (fd.height * CHEVRON_FONT_SIZE_FACTOR);
 			fd.setHeight(fontHeight);
 			chevronFont = new Font(display, fd);
 		}


### PR DESCRIPTION
getDPI always returns the points for primary monitor and can produce faulty behavior. Replacing the logic to calculate the chevron font size. Visibly 70% size of the font used for CTabItem is now used. Also adjusting the indent and adding the ZoomChange event to trigger redraw during DPI change.

**NOTE: Needs to be tested on linux and macOS**

### Steps to Reproduce

- Run the CustomControlExample with following arguments in 150% primary monitor
 > -Dswt.autoScale.updateOnRuntime=true
 > -Dswt.autoScale=quarter

- Change the tab to "**CTabFolder**"
- Change the Size to **100x100**
- Move the shell to other monitor with (100 or 200%) 
- The number along with chevron image should look fine.
- **Additional**: The tabs should be aligned correctly as well. 

### Before Fix

![image](https://github.com/user-attachments/assets/ef56692c-2d25-490d-8417-4677f52f9a16)

### After Fix
![image](https://github.com/user-attachments/assets/5ee77d0e-657e-4285-8aa9-173f1daaad49)

Scenarios Tested yet:
Case 	    Quarter   no args
150 -> 100 	OK	   OK
150 -> 200	OK	   OK

















































