### PR TITLE
[win32] Scale up bounds as rectangle in canvas

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Canvas.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Canvas.java
@@ -104,11 +104,8 @@ public Canvas (Composite parent, int style) {
  */
 public void drawBackground (GC gc, int x, int y, int width, int height) {
 	int zoom = getZoom();
-	x = DPIUtil.scaleUp(x, zoom);
-	y = DPIUtil.scaleUp(y, zoom);
-	width = DPIUtil.scaleUp(width, zoom);
-	height = DPIUtil.scaleUp(height, zoom);
-	drawBackgroundInPixels(gc, x, y, width, height, 0, 0);
+	Rectangle rectangle = DPIUtil.scaleUp(new Rectangle(x, y, width, height), zoom);
+	drawBackgroundInPixels(gc, rectangle.x, rectangle.y, rectangle.width, rectangle.height, 0, 0);
 }
 
 /**


### PR DESCRIPTION
This PR addresses render artifacts visible in StyledText with monitor-specific scaling enabled e.g. on 175% with quarter scaling mode. Reason is that scaling up all attributes of bounds separately can lead to rounding errors e.g. between y and height (one being scaled up, the other one not). Scaling them together as a rectangle solves this limitation.

#### Before 
Black lines appear, because for each four lines the y is scaled up (e.g. from 50.5 to 51), but the height was not scaled up (25.25 is always 25) -> one pixel is skipped each four  lines when drawing the background
![Screenshot 2025-01-24 111846](https://github.com/user-attachments/assets/a13a1b75-d523-4068-bd20-be3ad80f6559)
#### After
![Screenshot 2025-01-24 111822](https://github.com/user-attachments/assets/7132733b-c1aa-4348-920c-48a82d4cdd02)

The effect is usually only visible if multiple connecting background chunks are drawn, but the wrong values would be produced in all scenarios.

The same issue is probably hidden in other places as well, e.g. in GC when something should be scaled as rectangle but is scaled independently. We will try to find use cases and fix them one by one.