### PR TITLE
[win32] Fix scaling inside Region::intersect

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/graphics/RegionWin32Tests.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/graphics/RegionWin32Tests.java
@@ -14,6 +14,8 @@
 package org.eclipse.swt.graphics;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.swt.internal.*;
 import org.eclipse.swt.internal.win32.*;
@@ -53,6 +55,33 @@ class RegionWin32Tests {
 		assertEquals("scaled region's width should be double of unscaled region", bounds.width * scalingFactor, scaledBounds.width);
 		assertEquals("scaled region's x position should be double of unscaled region", bounds.x * scalingFactor, scaledBounds.x);
 		assertEquals("scaled region's y position should be double of unscaled region", bounds.y * scalingFactor, scaledBounds.y);
+	}
+
+
+	@Test
+	public void testRegionMustIntersectProperlyOn175Zoom() {
+		Display display = Display.getDefault();
+		Shell shell = new Shell(display);
+		DPITestUtil.changeDPIZoom(shell, 150);
+
+		Region region = new Region(display);
+		region.add(0, 0, 100, 51);
+		boolean intersectWhenOverlapping = region.intersects(0, 50, 100, 50);
+		assertTrue(intersectWhenOverlapping);
+
+		region = new Region(display);
+		region.add(0, 0, 100, 50);
+		boolean dontIntersectWhenNotOverlapping = region.intersects(0, 50, 100, 50);
+		assertFalse(dontIntersectWhenNotOverlapping);
+
+		region = new Region(display);
+		 // 58 * 150 equals to 87
+		region.add(0, 58, 100, 20);
+		// (27 + 31) should equal to 87, but will be 88 if 27 and 31 will
+		// be rounded independently
+		boolean shouldNotIntersect = region.intersects(0, 27, 100, 31);
+		assertFalse(shouldNotIntersect);
+
 	}
 
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Region.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Region.java
@@ -389,7 +389,7 @@ public void intersect (Region region) {
  */
 public boolean intersects (int x, int y, int width, int height) {
 	if (isDisposed()) SWT.error(SWT.ERROR_GRAPHIC_DISPOSED);
-	return 	intersectsInPixels(DPIUtil.scaleUp(x, initialZoom), DPIUtil.scaleUp(y, initialZoom), DPIUtil.scaleUp(width, initialZoom), DPIUtil.scaleUp(height, initialZoom));
+	return intersects(new Rectangle(x, y, width, height));
 }
 
 boolean intersectsInPixels (int x, int y, int width, int height) {


### PR DESCRIPTION
This commit adresses possibly invalid result when using Region::intersects on a zoom not dividable by 100. Reason is that scaling up all attributes of the rectangle separately can lead to rounding errors. Scaling them together as a rectangle solves this limitation.