### PR TITLE
[win32] Unify scaling inside Control::setBounds

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/widgets/ControlWin32Tests.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/widgets/ControlWin32Tests.java
@@ -55,6 +55,25 @@ class ControlWin32Tests {
 				fontComparison.originalFontHeight, fontComparison.currentFontHeight);
 	}
 
+	@Test
+	public void testCorrectScaleUpUsingDifferentSetBoundsMethod() {
+		DPIUtil.setMonitorSpecificScaling(true);
+		Display display = Display.getDefault();
+		Shell shell = new Shell(display);
+		DPITestUtil.changeDPIZoom(shell, 175);
+
+		Button button = new Button(shell, SWT.PUSH);
+		button.setText("Widget Test");
+		button.setBounds(new Rectangle(0, 47, 200, 47));
+		shell.open();
+		assertEquals("Control::setBounds(Rectangle) doesn't scale up correctly",
+				new Rectangle(0, 82, 350, 83), button.getBoundsInPixels());
+
+		button.setBounds(0, 47, 200, 47);
+		assertEquals("Control::setBounds(int, int, int, int) doesn't scale up correctly",
+				new Rectangle(0, 82, 350, 83), button.getBoundsInPixels());
+	}
+
 	record FontComparison(int originalFontHeight, int currentFontHeight) {
 	}
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Control.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Control.java
@@ -3168,13 +3168,7 @@ void setBackgroundPixel (int pixel) {
  * </ul>
  */
 public void setBounds(int x, int y, int width, int height) {
-	checkWidget ();
-	int zoom = getZoom();
-	x = DPIUtil.scaleUp(x, zoom);
-	y = DPIUtil.scaleUp(y, zoom);
-	width = DPIUtil.scaleUp(width, zoom);
-	height = DPIUtil.scaleUp(height, zoom);
-	setBoundsInPixels(x, y, width, height);
+	setBounds(new Rectangle(x, y, width, height));
 }
 
 void setBoundsInPixels (int x, int y, int width, int height) {


### PR DESCRIPTION
This commit unifies scale up results in Control::setBounds. With zoom values not dividable by 100 different result depending on using setBounds(Rectangle) or setBounds(int, int, int, int) were possible. Scaling the bounds always as rectangle solves this limitation.