### PR TITLE
[Win32] Spin event loop in Edge instead of only processing OS messages

### DIFF
--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_browser_Browser.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_browser_Browser.java
@@ -430,6 +430,27 @@ public void test_evalute_Cookies () {
 }
 
 @Test
+public void test_evaluate_callingIntoSwt() throws Exception {
+	AtomicBoolean initialLoad = new AtomicBoolean();
+	AtomicBoolean openWindowListenerCalled = new AtomicBoolean();
+	browser.addProgressListener(ProgressListener.completedAdapter(e -> initialLoad.set(true)));
+	browser.addOpenWindowListener(event -> {
+		event.required = true; // block default
+		openWindowListenerCalled.set(true);
+	});
+	browser.setText("""
+			<button id="button" onClick="window.open('https://eclipse.org');">open eclipse.org</button>
+			""");
+	waitForPassCondition(initialLoad::get);
+
+	browser.evaluate("""
+				document.getElementById("button").click();
+			""");
+
+	waitForPassCondition(openWindowListenerCalled::get);
+}
+
+@Test
 public void test_ClearAllSessionCookies () {
 	// clearSessions will only work for Webkit2 when >= 2.16
 	assumeTrue(webkitGtkVersionInts[1] >= 16);

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_browser_Browser.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_browser_Browser.java
@@ -81,7 +81,6 @@ import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.Text;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.FixMethodOrder;
 import org.junit.Ignore;
 import org.junit.Rule;
@@ -156,16 +155,6 @@ public static Collection<Object[]> browserFlagsToTest() {
 
 public Test_org_eclipse_swt_browser_Browser(int swtBrowserSettings) {
 	this.swtBrowserSettings = swtBrowserSettings;
-}
-
-@BeforeClass
-public static void setupEdgeEnvironment() {
-	// initialize Edge environment before any test runs to isolate environment setup
-	if (SwtTestUtil.isWindows) {
-		Shell shell = new Shell();
-		new Browser(shell, SWT.EDGE);
-		shell.dispose();
-	}
 }
 
 @Override
@@ -302,11 +291,17 @@ private int reportOpenedDescriptors() {
 }
 
 private Browser createBrowser(Shell s, int flags) {
+	return createBrowser(s, flags, true);
+}
+
+private Browser createBrowser(Shell s, int flags, boolean expectSuccess) {
 	long maximumBrowserCreationMilliseconds = 90_000;
 	long createStartTime = System.currentTimeMillis();
 	Browser b = new Browser(s, flags);
 	// Wait for asynchronous initialization via getting URL
-	b.getUrl();
+	if (expectSuccess) {
+		b.getUrl();
+	}
 	createdBroswers.add(b);
 	long createDuration = System.currentTimeMillis() - createStartTime;
 	assertTrue("creating browser took too long: " + createDuration + "ms", createDuration < maximumBrowserCreationMilliseconds);
@@ -334,7 +329,7 @@ public void test_Constructor_asyncParentDisposal() {
 	Display.getCurrent().asyncExec(() -> {
 		shell.dispose();
 	});
-	Browser browser = createBrowser(shell, swtBrowserSettings);
+	Browser browser = createBrowser(shell, swtBrowserSettings, false);
 	assertFalse(browser.isDisposed());
 }
 


### PR DESCRIPTION
Before recent improvements of the Edge implementation, it was possible that a browser instance was disposed during WebView initialization, which made the initialization fail exceptionally. This has been worked around by not processing all kinds of asynchronously scheduled events (like a disposal) while waiting for WebView initialization but only those being processes by the OS event queue. This was still necessary to process the OS callbacks for WebView initialization and other operations.

In some cases, this may lead to an Edge browser instance blocking the UI thread, as some asynchronously scheduled tasks need to be processed but are not. In addition, enhancements of the Edge implementation made the initialization happen synchronously anyway, such that the browser instantiation itself cannot throw an error anymore, but the asynchronously happening initialization is now capable of processing asynchronous browser disposals.

This change simplifies the event processing inside Edge to not only process the next OS message but to just ordinarily spin the event loop. This reduces the risk of operations executed on an Edge browser to block execution.