### PR TITLE
[Win32] Correct WebView environment initialization in Edge browser tests

### DIFF
--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_browser_Browser.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_browser_Browser.java
@@ -165,11 +165,15 @@ public Test_org_eclipse_swt_browser_Browser(int swtBrowserSettings) {
 
 @BeforeClass
 public static void setupEdgeEnvironment() {
-	// initialize Edge environment before any test runs to isolate environment setup
+	// Initialize Edge environment before any test runs to isolate environment setup
+	// as this takes quite long in GitHub Actions builds
 	if (SwtTestUtil.isWindows) {
 		Shell shell = new Shell();
-		new Browser(shell, SWT.EDGE);
+		Browser firstBrowser = new Browser(shell, SWT.EDGE);
+		// Ensure browser is initialized by calling blocking method
+		firstBrowser.getUrl();
 		shell.dispose();
+		processUiEvents();
 	}
 }
 


### PR DESCRIPTION
The browser tests contain a setup method that, on Windows, creates an Edge browser before any test is executed in order to set up the WebView environment. Since the first Edge browser instantiation takes rather long at least in the GitHub actions test environment, the initialization is extended to wait for the browser being initialized.