### PR TITLE
[Win32] Simplify cleanup after Edge test execution

### DIFF
--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_browser_Browser.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_browser_Browser.java
@@ -251,13 +251,7 @@ protected void afterDispose(Display display) {
 	}
 	if (isEdge) {
 		// wait for and process pending events to properly cleanup Edge browser resources
-		do {
-			processUiEvents();
-			try {
-				Thread.sleep(100);
-			} catch (InterruptedException e) {
-			}
-		} while (Display.getCurrent().readAndDispatch());
+		processUiEvents();
 	}
 	if (SwtTestUtil.isGTK) {
 		int descriptorDiff = reportOpenedDescriptors();


### PR DESCRIPTION
When executing tests for Edge, UI events are processed on teardown of the test (or more precisely on widget disposal) as there may still be resources related to the OS WebView component being cleaned up. The current implementation was only supposed to be used for testing purposes as an attempt to address non-deterministic timeouts in tests. However, the timeouts still occur and the current implementation is prone to break as it may never terminate when new events to be process arrive frequently.

This change simplifies the cleanup functionality to process UI events only once instead of looping it. This mitigates the risk of a long-running loop and reduces unnecessary complexity.