### PR TITLE
[Win32] Add OS result to failing Edge initialization after retries

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Browser/win32/org/eclipse/swt/browser/Edge.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Browser/win32/org/eclipse/swt/browser/Edge.java
@@ -627,7 +627,7 @@ private IUnknown createControllerInitializationCallback(int previousAttempts) {
 				createInstance(previousAttempts + 1);
 			} else {
 				SWT.error(SWT.ERROR_UNSPECIFIED, null,
-						String.format(" Aborting Edge initialiation after %d retries", MAXIMUM_CREATION_RETRIES));
+						String.format(" Aborting Edge initialiation after %d retries with result %d", MAXIMUM_CREATION_RETRIES, result));
 			}
 			break;
 		}


### PR DESCRIPTION
The Edge implementation contains retry functionality according to the ICoreWebView2Environment documentation. After five retries, the initialization is aborted with an error.
In order to ease debugging of potential causes, this change adds the OS result of the last retry attempt to the error logged by the initialization abortion.