### PR TITLE
[win32] do not call getImageData on getBounds call

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Image.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Image.java
@@ -2185,9 +2185,9 @@ private class ImageDataProviderWrapper extends AbstractImageProviderWrapper {
 
 	@Override
 	protected Rectangle getBounds(int zoom) {
-		ElementAtZoom<ImageData> data = DPIUtil.validateAndGetImageDataAtZoom (provider, zoom);
-		Rectangle rectangle = new Rectangle(0, 0, data.element().width, data.element().height);
-		return DPIUtil.scaleBounds(rectangle, zoom, data.zoom());
+		ImageHandle imageHandle = zoomLevelToImageHandle.values().iterator().next();
+		Rectangle rectangle = new Rectangle(0, 0, imageHandle.width, imageHandle.height);
+		return DPIUtil.scaleBounds(rectangle, zoom, imageHandle.zoom);
 	}
 
 	@Override


### PR DESCRIPTION
This commit unifies the getBounds calculation for ImageDataProvider and ImageFileNameProvider by always scaling the bounds of an existing handle of an image, if the bounds for a different zoom are requested.

fixes https://github.com/eclipse-platform/eclipse.platform.swt/issues/1639