### PR TITLE
[Win32] Fix faulty HRESULT_FROM_WIN32 comparison in Edge

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Browser/win32/org/eclipse/swt/browser/Edge.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Browser/win32/org/eclipse/swt/browser/Edge.java
@@ -601,7 +601,8 @@ private IUnknown createControllerInitializationCallback(int previousAttempts) {
 		webViewProvider.abortInitialization();
 		initializationRollback.run();
 	};
-	return newCallback((result, pv) -> {
+	return newCallback((resultAsLong, pv) -> {
+		int result = (int) resultAsLong;
 		if (browser.isDisposed()) {
 			initializationAbortion.run();
 			return COM.S_OK;
@@ -611,14 +612,14 @@ private IUnknown createControllerInitializationCallback(int previousAttempts) {
 			SWT.error(SWT.ERROR_INVALID_ARGUMENT, null,
 					" Edge instance with same data folder but different environment options already exists");
 		}
-		switch ((int) result) {
+		switch (result) {
 		case COM.S_OK:
 			new IUnknown(pv).AddRef();
-			setupBrowser((int) result, pv);
+			setupBrowser(result, pv);
 			break;
 		case COM.E_WRONG_THREAD:
 			initializationAbortion.run();
-			error(SWT.ERROR_THREAD_INVALID_ACCESS, (int) result);
+			error(SWT.ERROR_THREAD_INVALID_ACCESS, result);
 			break;
 		case COM.E_ABORT:
 			initializationAbortion.run();


### PR DESCRIPTION
Edge compares the result of WebView initialization with an HRESULT created from a Windows error code via the HRESULT_FROM_WIN32 macro. The actual result in that initialization callback is a long while the HRESULT returned from the macro is represented as integer in SWT. The current comparison of long and integer does not take into account that the values are signed. In this specific case, the actual HRESULT to compare against is 2147947423 while the HRESULT_FROM_WIN32 macro returns the signed value -2147019873. The actual result needs to be converted into a signed integer as well, as otherwise it will be considered as 2147947423, thus never matching the expected HRESULT value.

This change converts the processed result into an integer to correct the comparison.