### PR TITLE
[Win32] Correct wrong formatting in os.c

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT PI/win32/library/os.c
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/win32/library/os.c
@@ -130,7 +130,6 @@ JNIEXPORT jboolean JNICALL OS_NATIVE(AdjustWindowRectExForDpi)
 {
 	RECT _arg0, *lparg0=NULL;
 	jboolean rc = 0;
-	
 	OS_NATIVE_ENTER(env, that, AdjustWindowRectExForDpi_FUNC);
 	if (arg0) if ((lparg0 = getRECTFields(env, arg0, &_arg0)) == NULL) goto fail;
 /*


### PR DESCRIPTION
Whenever the os.c file is auto-updated (e.g., due to changes in the OS class), a change is generated that fixes an inconsistent formatting. This change updates the os.c file to incorporate that formatting fix.