### PR TITLE
[Win32] Thread-safe modification of Edge instances

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Browser/win32/org/eclipse/swt/browser/Edge.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Browser/win32/org/eclipse/swt/browser/Edge.java
@@ -20,6 +20,7 @@ import java.nio.file.*;
 import java.nio.file.Path;
 import java.time.*;
 import java.util.*;
+import java.util.List;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.*;
 import java.util.function.*;
@@ -62,9 +63,9 @@ class Edge extends WebBrowser {
 	private static final int MAXIMUM_CREATION_RETRIES = 5;
 	private static final Duration MAXIMUM_OPERATION_TIME = Duration.ofMillis(Integer.getInteger(WEB_VIEW_OPERATION_TIMEOUT, 5_000));
 
-	private record WebViewEnvironment(ICoreWebView2Environment environment, ArrayList<Edge> instances) {
+	private record WebViewEnvironment(ICoreWebView2Environment environment, List<Edge> instances) {
 		public WebViewEnvironment(ICoreWebView2Environment environment) {
-			this (environment, new ArrayList<>());
+			this (environment, new CopyOnWriteArrayList<>());
 		}
 	}
 


### PR DESCRIPTION
The WebView environment used for Edge manages a list of all currently used Edge instances inside an application. This data structure is modified at different places, which may be executed by different threads, such introducing a risk of race conditions on the unsynchronized data structure. In addition, when disposing a Display (such as at application shutdown), Edge instances are disposed in an according dispose listener. This can cause ConcurrentModificationExceptions as the listener iterates through the list of Edge instances and calls their disposal, which in turn removes the Edge instance from that list.

This change makes the data structure thread-safe and copy-on-write to avoid that ConcurrentModificationException occur when iterating over it while removing elements from it.