### PR TITLE
Image type SWT.ICON loses its type during re-scale

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/graphics/ImagesWin32Tests.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/graphics/ImagesWin32Tests.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Yatta Solutions
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Yatta Solutions - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.swt.graphics;
+
+import static org.junit.Assert.assertEquals;
+
+import org.eclipse.swt.*;
+import org.eclipse.swt.internal.*;
+import org.eclipse.swt.widgets.*;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.*;
+
+@ExtendWith(PlatformSpecificExecutionExtension.class)
+@ExtendWith(WithMonitorSpecificScalingExtension.class)
+class ImagesWin32Tests {
+
+	@Test
+	public void testImageIconTypeShouldNotChangeAfterCallingGetHandleForDifferentZoom() {
+		Image icon = Display.getDefault().getSystemImage(SWT.ICON_ERROR);
+		try {
+			Image.win32_getHandle(icon, 200);
+			assertEquals("Image type should stay to SWT.ICON", SWT.ICON, icon.type);
+		} finally {
+			icon.dispose();
+		}
+	}
+}

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Image.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Image.java
@@ -783,7 +783,15 @@ private ImageHandle getImageMetadata(int zoom) {
 	} else {
 		ImageData resizedData = getImageData(zoom);
 		ImageData newData = adaptImageDataIfDisabledOrGray(resizedData);
-		init(newData, zoom);
+		if (type == SWT.ICON && newData.getTransparencyType() != SWT.TRANSPARENCY_MASK) {
+			// If the original type was an icon with transparency mask and re-scaling leads
+			// to image data without transparency mask, this will create invalid images
+			// so this fallback will "repair" the image data by explicitly passing
+			// the transparency mask created from the scaled image data
+			init(this.device, this, newData, newData.getTransparencyMask(), zoom);
+		} else {
+			init(newData, zoom);
+		}
 		init();
 	}
 	return zoomLevelToImageHandle.get(zoom);


### PR DESCRIPTION
Image initialized as SWT.ICON in `org.eclipse.swt.graphics.Image.Image(Device, ImageData, ImageData)` loses its "Icon" properties, i.e. type, mask etc., when handle for different zoom level is requested. This change adapts the initialization of the image when the handle is requested for image type SWT.ICON to preserve the properties. The unit test is added that was failing before the fix. You can also see it in action in the snippet provided below: 

```java
Display display = new Display();
Shell shell = new Shell(display);

InputStream stream = ShellImageExample.class.getResourceAsStream("yourImage.png");
ImageData imageData = new ImageData(stream);
ImageData mask = imageData.getTransparencyMask();
Image icon = new Image(display, imageData, mask);
System.out.println("Icon Type = " + icon.type);
Image.win32_getHandle(icon, 200);
System.out.println("Icon Type After = " + icon.type);
```

Fixes https://github.com/eclipse-platform/eclipse.platform.swt/issues/1805