### PR TITLE
Skip some Edge test when testing IE

### DIFF
--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_browser_Browser.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_browser_Browser.java
@@ -342,6 +342,7 @@ public void test_Constructor_asyncParentDisposal() {
 
 @Test
 public void test_Constructor_multipleInstantiationsInDifferentShells() {
+	assumeTrue("This test is intended for Edge only", isEdge);
 	final int numberOfBrowsers = 5;
 	for (int i = 0; i < numberOfBrowsers; i++) {
 		Shell browserShell = new Shell(Display.getCurrent());
@@ -396,7 +397,7 @@ private class EdgeBrowserApplication extends Thread {
 
 @Test
 public void test_Constructor_multipleInstantiationsInDifferentThreads() {
-	assumeTrue("test case is only relevant on Windows", SwtTestUtil.isWindows);
+	assumeTrue("This test is intended for Edge only", isEdge);
 
 	int numberOfApplication = 5;
 	List<EdgeBrowserApplication> browserApplications = new ArrayList<>();


### PR DESCRIPTION
2 tests for Edge were running for IE. This PR corrects that.

## Expected result
The GH Actions shouldn't show these tests running for IE. If you see something like this in the output then it's wrong:

```
Running Test_org_eclipse_swt_browser_Browser#test_Constructor_multipleInstantiationsInDifferentShells[browser flags: 524,288]
```

```
Running Test_org_eclipse_swt_browser_Browser#test_Constructor_multipleInstantiationsInDifferentThreads[browser flags: 524,288]
```