### PR TITLE
Build GTK3 support for linux x86-64 to maximize compatibility

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/build.sh
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/build.sh
@@ -97,6 +97,7 @@ if [ "${MODEL}" = "" ]; then
 	else
 		MODEL=`uname -m`
 	fi
+	export MODEL
 fi
 case $MODEL in
 	"x86_64")

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/check_dependencies.sh
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/check_dependencies.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+###############################################################################
+# Copyright (c) 2020, 2025 Kichwa Coders Canada Inc and others.
+#
+# This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+###############################################################################
+
+set -eu
+set -o pipefail
+
+SCRIPT=$( basename "${BASH_SOURCE[0]}" )
+
+###
+# Check that executable/so ${FILE}
+# use glibc symbols no greater than ${ALLOWED_GLIBC_VERSION} and depend on
+# no libs other than ${ALLOWED_LIBS}
+FILE=$1; shift
+ALLOWED_GLIBC_VERSION=$1; shift
+ALLOWED_LIBS="$@"; shift
+
+# grep that doesn't exit 1 on 0 matches
+mygrep() { grep "$@" || test $? = 1; }
+
+# Check for permitted libraries using `readelf -d` looking for shared
+# libraries that are listed as needed. e.g. lines like:
+#  0x0000000000000001 (NEEDED)             Shared library: [libpthread.so.0]
+readelf -d ${FILE} | mygrep -E '\(NEEDED\)' | while read needed; do
+    needed=${needed//*Shared library: [/}
+    needed=${needed//]*/}
+    if [[ ! " ${ALLOWED_LIBS} " =~ " ${needed} " ]]; then
+        echo "ERROR: $FILE has illegal dependency of ${needed}"
+        exit 1
+    fi
+done
+
+# The way the version check is done is that all symbol version info is extracted
+# from relocations match @GLIBC_*, the versions are sorted with the max
+# allowed version added to the list too. And then we check the last entry in
+# the list to make sure it is == to max allowed version.
+objdump -R ${FILE} | mygrep @GLIBC_ | while read version; do
+    echo ${version//*@GLIBC_}
+done > /tmp/version_check
+echo ${ALLOWED_GLIBC_VERSION} >> /tmp/version_check
+max_version_in_use=$(cat /tmp/version_check | sort --unique --version-sort | tail -n1)
+if [ "$max_version_in_use" != "$ALLOWED_GLIBC_VERSION" ]; then
+    echo "ERROR: $FILE has dependency on glibc greater than allowed version of ${ALLOWED_GLIBC_VERSION} for at least the following symbols"
+    # This only lists greatest version number symbols
+    objdump -R ${FILE} | grep @GLIBC_${max_version_in_use}
+    exit 1
+fi


### PR DESCRIPTION
Build GTK3 support for linux x86-64 to maximize compatibility

Recently all SWT builds for Linux x86-64 have been done on a new Debian image. This leads to requiring such a new distro to be able to run SWT successfully.

This change builds GTK3 and common code on an older debian container to increase the range of versions we support. Only GTK4's key library, libswt-pi4-gtk*.so is shipped from a build on the new debian container.

We continue to build all of the natives on latest debian so we benefit from compiler warnings/errors and other such tooling.

As part of the build all .so files are checked to ensure their dependencies are as expected. In particular glibc version is checked for all symbols and all libraries are checked.

The version of glibc 2.14 was chosen as that is what the effective requirement has been for a while for SWT (at least since Eclipse 4.26/2022-12)

Fixes https://github.com/eclipse-platform/eclipse.platform.swt/issues/1791

The way I have tested this concept locally is to run the build.sh twice on my local machine using the two docker containers mentioned in runOnNativeBuildAgent of the Jenkinsfile*:

0. Start in root of SWT repo: `cd /scratch/eclipse/oomph/swt-master/git/eclipse.platform.swt/`
1. Collect the sources to build `java -Dws=gtk build-scripts/CollectSources.java -nativeSources 'target/natives-build-temp/gtk'`
3. `cd 'target/natives-build-temp/gtk'`
4. Build GTK4 version: `docker run --rm -it -v/scratch:/scratch -w$PWD -e SWT_JAVA_HOME=/scratch/java/jdk-17.0.13+11 -e OUTPUT_DIR=/scratch/eclipse/oomph/swt-master/git/eclipse.platform.swt/binaries/org.eclipse.swt.gtk.linux.x86_64 swtnativebuild ./build.sh -gtk4 install`
5. Build GTK3 version `docker run --rm -it -v/scratch:/scratch -w$PWD -e SWT_JAVA_HOME=/scratch/java/jdk-17.0.13+11 -e OUTPUT_DIR=/scratch/eclipse/oomph/swt-master/git/eclipse.platform.swt/binaries/org.eclipse.swt.gtk.linux.x86_64 swtgtk3nativebuild ./build.sh -gtk3 install`
6. Then try running various snippets with GTK3 and GTK4 in the IDE
7. Using "Show Command Line" option in launch configuration extract full command line and reproduce the run with x11docker

\* Note that I actually built them manually with USER 1000 at the end of the file so I can share directories with the container. There are more details in the step-by-step in https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/2802#issue-2826046468

 