### PR TITLE
[Win32] Make Edge only process relevant OS messages #1789

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Browser/win32/org/eclipse/swt/browser/Edge.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Browser/win32/org/eclipse/swt/browser/Edge.java
@@ -510,7 +510,7 @@ private static void processOSMessagesUntil(Supplier<Boolean> condition, Consumer
 	// The timer call also wakes up the display to avoid being stuck in display.sleep()
 	display.timerExec((int) MAXIMUM_OPERATION_TIME.toMillis(), () -> timeoutOccurred.set(true));
 	while (!display.isDisposed() && !condition.get() && !timeoutOccurred.get()) {
-		if (OS.PeekMessage(msg, 0, 0, 0, OS.PM_NOREMOVE)) {
+		if (OS.PeekMessage(msg, 0, 0, 0, OS.PM_NOREMOVE | OS.PM_QS_POSTMESSAGE)) {
 			display.readAndDispatch();
 		} else {
 			display.sleep();


### PR DESCRIPTION
When waiting for initialization of the WebView2 component in the Edge implementation, OS messages are processed by peeking the queue and performing a display.readAndDispatch() in case a message is present. The call to OS.PeekMessage() does, however, already perform some processing of the messages. In fact, Edge is not supposed to process all kinds of OS messages at all (like paint or input events) but should rather only process the WebView2 initialization callback message, arriving as a posted OS message. This change thus limits the message peeking inside Edge to only process the message type PM_QS_POSTMESSAGE.

Fixes https://github.com/eclipse-platform/eclipse.platform.swt/issues/1789