### PR TITLE
Remove restriction of browser test to Edge

### DIFF
--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_browser_Browser.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_browser_Browser.java
@@ -342,11 +342,10 @@ public void test_Constructor_asyncParentDisposal() {
 
 @Test
 public void test_Constructor_multipleInstantiationsInDifferentShells() {
-	assumeTrue("This test is intended for Edge only", isEdge);
 	final int numberOfBrowsers = 5;
 	for (int i = 0; i < numberOfBrowsers; i++) {
 		Shell browserShell = new Shell(Display.getCurrent());
-		Browser browser = createBrowser(browserShell, SWT.EDGE);
+		Browser browser = createBrowser(browserShell, swtBrowserSettings);
 		assertFalse(browser.isDisposed());
 		browser.dispose();
 		assertTrue(browser.isDisposed());


### PR DESCRIPTION
Test case was executed for every browser on every OS and was unnecessarily restricted to Edge.

Revises https://github.com/eclipse-platform/eclipse.platform.swt/pull/1792

See https://github.com/eclipse-platform/eclipse.platform.swt/pull/1792#pullrequestreview-2590944929