### PR TITLE
[Build] Only archive the built native-fragment jars

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -326,7 +326,7 @@ pipeline {
 			post {
 				always {
 					junit 'eclipse.platform.swt/tests/*.test*/target/surefire-reports/*.xml'
-					archiveArtifacts artifacts: '**/*.log,**/*.html,**/target/*.jar,**/target/*.zip'
+					archiveArtifacts artifacts: '**/*.log,*/binaries/*/target/*.jar', excludes: '**/*-sources.jar'
 					discoverGitReferenceBuild referenceJob: 'eclipse.platform.swt/master'
 					// To accept unstable builds (test errors or new warnings introduced by third party changes) as reference using "ignoreQualityGate:true"
 					recordIssues publishAllIssues: true, ignoreQualityGate:true, tools: [eclipse(name: 'Compiler and API Tools', pattern: '**/target/compilelogs/*.xml'), javaDoc()], qualityGates: [[threshold: 1, type: 'DELTA', unstable: true]]


### PR DESCRIPTION
All other jar and html files are usually not of interest and just complicate the build archive and significantly increase its size.
