### PR TITLE
Calculate Scaling for Font without Device#getDPI() 

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/StyledText.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/StyledText.java
@@ -304,9 +304,11 @@ public class StyledText extends Canvas {
 				}
 			}
 		}
-		Point screenDPI = styledText.getDisplay().getDPI();
+
 		Point printerDPI = printer.getDPI();
 		resources = new HashMap<> ();
+		int scaleFactorX = printerDPI.x / 100;
+		int scaleFactorY = printerDPI.y / 100;
 		for (int i = 0; i < lineCount; i++) {
 			Color color = printerRenderer.getLineBackground(i, null);
 			if (color != null) {
@@ -323,7 +325,7 @@ public class StyledText extends Canvas {
 			}
 			int indent = printerRenderer.getLineIndent(i, 0);
 			if (indent != 0) {
-				printerRenderer.setLineIndent(i, 1, indent * printerDPI.x / screenDPI.x);
+				printerRenderer.setLineIndent(i, 1, indent * scaleFactorX);
 			}
 		}
 		StyleRange[] styles = printerRenderer.styles;
@@ -367,17 +369,17 @@ public class StyledText extends Canvas {
 			if (!printOptions.printTextFontStyle) {
 				style.fontStyle = SWT.NORMAL;
 			}
-			style.rise = style.rise * printerDPI.y / screenDPI.y;
+			style.rise = style.rise * scaleFactorY;
 			GlyphMetrics metrics = style.metrics;
 			if (metrics != null) {
-				metrics.ascent = metrics.ascent * printerDPI.y / screenDPI.y;
-				metrics.descent = metrics.descent * printerDPI.y / screenDPI.y;
-				metrics.width = metrics.width * printerDPI.x / screenDPI.x;
+				metrics.ascent = metrics.ascent * scaleFactorY;
+				metrics.descent = metrics.descent * scaleFactorY;
+				metrics.width = metrics.width * scaleFactorX;
 			}
 		}
-		lineSpacing = styledText.lineSpacing * printerDPI.y / screenDPI.y;
+		lineSpacing = styledText.lineSpacing * scaleFactorY;
 		if (printOptions.printLineNumbers) {
-			printMargin = 3 * printerDPI.x / screenDPI.x;
+			printMargin = 3 * scaleFactorX;
 		}
 	}
 	/**

--- a/bundles/org.eclipse.swt/Eclipse SWT Printing/win32/org/eclipse/swt/printing/Printer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Printing/win32/org/eclipse/swt/printing/Printer.java
@@ -268,6 +268,12 @@ protected void create(DeviceData deviceData) {
 	if (handle == 0) SWT.error(SWT.ERROR_NO_HANDLES);
 }
 
+@Override
+protected int getDeviceZoom() {
+	// Printer directly renders on pixel basis, so the zoom must be fixed to 100
+	return 100;
+}
+
 /**
  * Invokes platform specific functionality to allocate a new GC handle.
  * <p>
@@ -295,8 +301,9 @@ public long internal_new_GC(GCData data) {
 			data.style |= SWT.LEFT_TO_RIGHT;
 		}
 		data.device = this;
-		data.font = Font.win32_new(this, OS.GetCurrentObject(handle, OS.OBJ_FONT));
+		data.font = Font.win32_new(this, OS.GetCurrentObject(handle, OS.OBJ_FONT), getDeviceZoom());
 		isGCCreated = true;
+		data.nativeZoom = getDeviceZoom();
 	}
 	return handle;
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Font.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Font.java
@@ -213,7 +213,7 @@ public FontData[] getFontData() {
 	if (isDisposed()) SWT.error(SWT.ERROR_GRAPHIC_DISPOSED);
 	LOGFONT logFont = new LOGFONT ();
 	OS.GetObject(handle, LOGFONT.sizeof, logFont);
-	float heightInPoints = device.computePoints(logFont, handle, DPIUtil.mapZoomToDPI(zoom));
+	float heightInPoints = device.computePoints(logFont, handle, zoom);
 	return new FontData[] {FontData.win32_new(logFont, heightInPoints)};
 }
 
@@ -280,7 +280,7 @@ private static int extractZoom(Device device) {
 	if (device == null) {
 		return DPIUtil.getNativeDeviceZoom();
 	}
-	return DPIUtil.mapDPIToZoom(device._getDPIx());
+	return device.getDeviceZoom();
 }
 
 /**
@@ -331,8 +331,15 @@ public static Font win32_new(Device device, long handle) {
  * @since 3.126
  */
 public static Font win32_new(Device device, long handle, int zoom) {
-	Font font = win32_new(device, handle);
+	Font font = new Font(device);
 	font.zoom = zoom;
+	font.handle = handle;
+	/*
+	 * When created this way, Font doesn't own its .handle, and
+	 * for this reason it can't be disposed. Tell leak detector
+	 * to just ignore it.
+	 */
+	font.ignoreNonDisposed();
 	return font;
 }
 


### PR DESCRIPTION
getDPI always returns points for primary monitor and can produce faulty behavior. Printing the code is broken because Printer DPI (400) is different from the Monitor DPI (100). Now we compute points from the zoom level instead of currentFontDPI.

### How to Test

1.  Run the runtime Workspace
2.  Move the shell from 100% primary monitor to 200% secondary monitor
3. Press Ctrl + P 
4. Save the preview as pdf
5. See if the code is printed with correct formatting. 

### Before Fix

![image](https://github.com/user-attachments/assets/780fd8f4-283a-46b2-9e5a-3f1229e35c1d)

### After Fix

![image](https://github.com/user-attachments/assets/35a53088-e736-4d61-bd20-d06e9d6d9051)
