### PR TITLE
Make DPIZoomChangeHandlers concurrent R/W able #62

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/DPIZoomChangeRegistry.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/DPIZoomChangeRegistry.java
@@ -15,13 +15,14 @@ package org.eclipse.swt.internal;
 
 import java.util.*;
 import java.util.Map.*;
+import java.util.concurrent.*;
 
 import org.eclipse.swt.*;
 import org.eclipse.swt.widgets.*;
 
 public class DPIZoomChangeRegistry {
 
-	private static Map<Class<? extends Widget>, DPIZoomChangeHandler> dpiZoomChangeHandlers =  new TreeMap<>(
+	private static Map<Class<? extends Widget>, DPIZoomChangeHandler> dpiZoomChangeHandlers =  new ConcurrentSkipListMap<>(
 			(o1, o2) -> {
 	            if(o1.isAssignableFrom(o2)) {
 	            	return -1;


### PR DESCRIPTION
Issue: #62 and #127 

This PR changes the type of `DPIZoomChangeRegistry::dpiZoomChangeHandlers` from `TreeMap` to `ConcurrentSkipListMap` as at times there can be classes which can register their handlers amidst a DPI change event leading to concurrent read and write which can lead to a `ConcurrentModificationException`

### Reasoning
1. A `ConcurrentModificationException` happens because while we are processing the DPI change and going over the loop:
```java
for (Entry<Class<? extends Widget>, DPIZoomChangeHandler> entry : dpiZoomChangeHandlers.entrySet()) {
	Class<? extends Widget> clazz = entry.getKey();
	DPIZoomChangeHandler handler = entry.getValue();
	if (clazz.isInstance(widget)) {
		handler.handleDPIChange(widget, newZoom, scalingFactor);
	}
}
``` 
Some Classes which are getting loaded concurrently are trying to register their handler in the `dpiZoomChangeHandlers`. (Verified this that not all the handlers are registered in the first DPI changed event by debugging and counting the number of handlers available at that time and comparing that to the number of handlers at a later stage)

2. Who are these classes which are trying to register handler? Amidst a DPI change event being processed for a shell, all the components (classes) whose instances are contained as children of the shell are already loaded by construct, which means none of the children classes are the ones which are registering at the same time. This rules out the possibility of missing out on any handler during a DPI change handling process. So, these classes which are registering are those classes' instances which are definitely not in the shell and currently being loaded.

3. Which brings us to our third reasoning: making the `dpiZoomChangeHandlers` able to process R/W operations concurrently would fix the issue. We decided to use `ConcurrentSkipListMap` and tested out the following things:
- The order in which the classes are indexed is the same as `TreeMap`, _i.e._ the hierarchy of the classes holds.
- I did a performance test in terms of time in ms for put operation per handler for both the Structures. Here's the result: 

![Image](https://github.com/user-attachments/assets/769fae61-9f3d-4a06-9b54-a6f515062cd3)



contributes to https://github.com/eclipse-platform/eclipse.platform.swt/issues/62 and https://github.com/eclipse-platform/eclipse.platform.swt/issues/127

