### PR TITLE
Allow smooth scaling for 100% monitors too

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/DPIUtil.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/DPIUtil.java
@@ -603,7 +603,10 @@ public static void setDeviceZoom (int nativeDeviceZoom) {
 
 	DPIUtil.deviceZoom = deviceZoom;
 	System.setProperty("org.eclipse.swt.internal.deviceZoom", Integer.toString(deviceZoom));
-	if (deviceZoom != 100 && autoScaleMethodSetting == AutoScaleMethod.AUTO) {
+
+	// in GTK, preserve the current method when switching to a 100% monitor
+	boolean preserveScalingMethod = SWT.getPlatform().equals("gtk") && deviceZoom == 100;
+	if (!preserveScalingMethod && autoScaleMethodSetting == AutoScaleMethod.AUTO) {
 		if (sholdUseSmoothScaling()) {
 			autoScaleMethod = AutoScaleMethod.SMOOTH;
 		} else {


### PR DESCRIPTION
Smooth scaling is used if:
- (in Windows) Monitor-specific scaling is active
- (in Linux) if the zoom level of the monitor is not divisible by 100
- (in Mac) never

In Linux, once the mode changes to smooth, it stays in smooth.

# How to test
- One 100% monitor and another in a "fractional" zoom _e.g._ 150%
- Start the `ControlExample` with the following VM parameters:
```
-Dswt.autoScale.updateOnRuntime=true
```
- (Linux) Drag the application back and forth between monitors

# Expected result
## In Windows
The `autoScaleMethod` should **always** be set to `SMOOTH` (in `org.eclipse.swt.internal.DPIUtil.setDeviceZoom(int)`)

## In Linux
- If the application starts in the monitor with the "non fractional" zoom level (_e.g._ 100% or 200%) then the mode should be `NEAREST`
- The `autoScaleMethod` should be set to `SMOOTH` when starting at/switching to a monitor with a "fractional" zoom level (_e.g._ 150%). 
- Once in `SMOOTH` mode, it should never switch back to `NEAREST`

## In Mac
No changes: never `SMOOTH`.