### PR TITLE
Do not use smooth scaling with 100% monitors

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/DPIUtil.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/DPIUtil.java
@@ -603,11 +603,11 @@ public static void setDeviceZoom (int nativeDeviceZoom) {
 
 	DPIUtil.deviceZoom = deviceZoom;
 	System.setProperty("org.eclipse.swt.internal.deviceZoom", Integer.toString(deviceZoom));
-	if (deviceZoom != 100 && autoScaleMethodSetting == AutoScaleMethod.AUTO) {
-		if (sholdUseSmoothScaling()) {
-			autoScaleMethod = AutoScaleMethod.SMOOTH;
-		} else {
+	if (autoScaleMethodSetting == AutoScaleMethod.AUTO) {
+		if (deviceZoom == 100 || !sholdUseSmoothScaling()) {
 			autoScaleMethod = AutoScaleMethod.NEAREST;
+		} else {
+			autoScaleMethod = AutoScaleMethod.SMOOTH;
 		}
 	}
 }


### PR DESCRIPTION
When switching back to a monitor with a zoom level of 100, switch back to the "nearest" scale method.

Smooth scaling is used if:
- (in Windows) Monitor-specific scaling is active and the zoom level is **not** 100
- (in Linux) if the zoom level of the monitor is divisible by 100 but it is **not** exactly 100
- (in Mac) never

# How to test
- 100% monitor 
- Other monitor with zoom level **!= 100**
- Start the `ControlExample` with the following VM parameters:
```
-Dswt.autoScale=quarter
-Dswt.autoScale.updateOnRuntime=true
```
- Move the application back and forth between the monitors

The `autoScaleMethod` should be set to `NEAREST` in `org.eclipse.swt.internal.DPIUtil.setDeviceZoom(int)` every time the application goes back the100% monitor.

## Important
- Either this PR or #1809 can be merged, but not both