### PR TITLE
Reset Table::itemHeight on DPI change #62

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Table.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Table.java
@@ -7357,6 +7357,12 @@ private static void handleDPIChange(Widget widget, int newZoom, float scalingFac
 		table.imageList = null;
 	}
 
+	// if the item height was set at least once programmatically with CDDS_SUBITEMPREPAINT,
+	// the item height of the table is not managed by the OS anymore e.g. when the zoom
+	// on the monitor is changed, the height of the item will stay at the fixed size.
+	// Resetting it will re-enable the default behavior again
+	table.setItemHeight(-1);
+
 	for (TableItem item : table.getItems()) {
 		DPIZoomChangeRegistry.applyChange(item, newZoom, scalingFactor);
 	}


### PR DESCRIPTION
This PR resets the Table::itemHeight to -1 on DPI change to make sure that TableItem's height is still managed by the OS as it can be changed by CDDS_SUBITEMPREPAINT callback and once it is changed to some value, it will always remain the same and not recalculated by the OS leading to inconsistent behaviour on different zooms.

### How to reproduce the issue

- Start the OpenType Dialog on 100% monitor.
- Move to 150% monitor on the right side.
- A CDDS_SUBITEMPREPAINT callback is executed, changing table.itemHeight to some value from -1.
- Move it back to 100% monitor
- The Items have more height
- Move it to 250% monitor on the left.
- The items are too small.

Initially at 100%: 

![Image](https://github.com/user-attachments/assets/707ebb88-3a9f-4e68-b08e-f46b184c38bc)

After moving to 150% and back to 100%:

![Image](https://github.com/user-attachments/assets/773315fc-2107-4367-929d-421b4393827a)

After moving to 250%:

![Image](https://github.com/user-attachments/assets/d87daf25-7b1b-4088-8c54-34a2d79e0072)

With this PR, the shown behaviour is fixed.

contributes to
https://github.com/eclipse-platform/eclipse.platform.swt/issues/62 and https://github.com/eclipse-platform/eclipse.platform.swt/issues/127