### PR TITLE
[GTK4] Stop handling expose events directly

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Display.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Display.java
@@ -1015,6 +1015,9 @@ static void checkDisplay (Thread thread, boolean multiple) {
 }
 
 long checkIfEventProc (long display, long xEvent, long userData) {
+	if (GTK.GTK4) {
+		return 0;
+	}
 	int type = OS.X_EVENT_TYPE (xEvent);
 	switch (type) {
 		case OS.Expose:


### PR DESCRIPTION
The handling of expose events has been internalized with GTK4 making it impossible to e.g. invalidate an area of a surface. Furthermore, the native method that are called no longer exist in GTK4, leading to an UnsatisfiedLinkError.

From the documentation:
Application and widget code should not handle expose events directly; invalidation should use the GtkWidget API, and drawing should only happen inside GtkWidget::draw implementations.

Closes https://github.com/eclipse-platform/eclipse.platform.swt/issues/1794