### PR TITLE
Improve scaling of SystemImage #62

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT PI/win32/library/os.c
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/win32/library/os.c
@@ -4745,6 +4745,22 @@ fail:
 }
 #endif
 
+#ifndef NO_LoadIconWithScaleDown
+JNIEXPORT jlong JNICALL OS_NATIVE(LoadIconWithScaleDown)
+	(JNIEnv *env, jclass that, jlong arg0, jlong arg1, jint arg2, jint arg3, jlongArray arg4)
+{
+	jlong *lparg4=NULL;
+	jlong rc = 0;
+	OS_NATIVE_ENTER(env, that, LoadIconWithScaleDown_FUNC);
+	if (arg4) if ((lparg4 = (*env)->GetLongArrayElements(env, arg4, NULL)) == NULL) goto fail;
+	rc = (jlong)LoadIconWithScaleDown((HINSTANCE)arg0, (LPWSTR)arg1, arg2, arg3, (HICON *)lparg4);
+fail:
+	if (arg4 && lparg4) (*env)->ReleaseLongArrayElements(env, arg4, lparg4, 0);
+	OS_NATIVE_EXIT(env, that, LoadIconWithScaleDown_FUNC);
+	return rc;
+}
+#endif
+
 #ifndef NO_LoadImage
 JNIEXPORT jlong JNICALL OS_NATIVE(LoadImage)
 	(JNIEnv *env, jclass that, jlong arg0, jlong arg1, jint arg2, jint arg3, jint arg4, jint arg5)

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/win32/library/os_stats.h
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/win32/library/os_stats.h
@@ -366,6 +366,7 @@ typedef enum {
 	LoadCursor_FUNC,
 	LoadIcon_FUNC,
 	LoadIconMetric_FUNC,
+	LoadIconWithScaleDown_FUNC,
 	LoadImage_FUNC,
 	LoadKeyboardLayout_FUNC,
 	LocalFree_FUNC,

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/win32/org/eclipse/swt/internal/win32/OS.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/win32/org/eclipse/swt/internal/win32/OS.java
@@ -3303,6 +3303,12 @@ public static final native int LoadIconMetric (long hinst, long pszName, int lim
  */
 public static final native long LoadImage (long hinst, long lpszName, int uType, int cxDesired, int cyDesired, int fuLoad);
 /**
+ * @param hinst cast=(HINSTANCE)
+ * @param lpszName cast=(LPWSTR)
+ * @param phico cast=(HICON *)
+ */
+public static final native long LoadIconWithScaleDown (long hinst, long lpszName, int cxDesired, int cyDesired, long [] phico);
+/**
  * @param pwszKLID cast=(LPCWSTR)
  * @param Flags cast=(UINT)
  */


### PR DESCRIPTION
This PR contributes to better scaling of Images obtained from Display::getSystemImage using better windows API LoadIconWithScaleDown for scaling. The new API also changes the old system icons to the modern Windows System Icons.
The idea is to have an ImageDataProvider for such Images which retrieve the image from the OS for the specified dimensions relevant to the zoom level and obtain its imageData instead of scaling the ImageData obtained from the handle of initialNativeZoom.

Standard Icons loaded using LoadImage (using user32.dll): 
![image](https://github.com/user-attachments/assets/4a4ae642-196f-4f55-ac20-8e4769fa57c3)

Standard Icons loaded using LoadIconWithScaleDown (using imageres.dll):
<img width="140" alt="image" src="https://github.com/user-attachments/assets/213b23a8-cd0e-4cd8-857c-e1c3bf932881" />

Contributes to
https://github.com/eclipse-platform/eclipse.platform.swt/issues/62 and https://github.com/eclipse-platform/eclipse.platform.swt/issues/127