### PR TITLE
[win32] fix to use zoom dpi for fonts via display

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Device.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Device.java
@@ -260,9 +260,9 @@ void checkGDIP() {
 protected void create (DeviceData data) {
 }
 
-int computePixels(float height) {
+int computePixels(float height, int zoom) {
 	long hDC = internal_new_GC (null);
-	int pixels = -(int)(0.5f + (height * OS.GetDeviceCaps(hDC, OS.LOGPIXELSY) / 72f));
+	int pixels = -(int)(0.5f + (height / calculateFontConversionFactor(hDC, zoom)));
 	internal_dispose_GC (hDC, null);
 	return pixels;
 }
@@ -271,9 +271,7 @@ float computePoints(LOGFONT logFont, long hFont) {
 	return computePoints(logFont, hFont, SWT.DEFAULT);
 }
 
-float computePoints(LOGFONT logFont, long hFont, int zoom) {
-	long hDC = internal_new_GC (null);
-
+private float calculateFontConversionFactor(long hDC, int zoom) {
 	float conversionFactor = 72f;
 	if (isAutoScalable() && zoom != SWT.DEFAULT) {
 		// For auto scalable devices we need to use a dynamic
@@ -282,6 +280,13 @@ float computePoints(LOGFONT logFont, long hFont, int zoom) {
 	} else {
 		conversionFactor /= OS.GetDeviceCaps(hDC, OS.LOGPIXELSY);
 	}
+	return conversionFactor;
+}
+
+float computePoints(LOGFONT logFont, long hFont, int zoom) {
+	long hDC = internal_new_GC (null);
+
+	float conversionFactor = calculateFontConversionFactor(hDC, zoom);
 	int pixels = 0;
 	if (logFont.lfHeight > 0) {
 		/*

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Font.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Font.java
@@ -236,14 +236,7 @@ void init (FontData fd) {
 	if (fd == null) SWT.error(SWT.ERROR_NULL_ARGUMENT);
 	LOGFONT logFont = fd.data;
 	int lfHeight = logFont.lfHeight;
-	logFont.lfHeight = device.computePixels(fd.height);
-
-	int primaryZoom = extractZoom(device);
-	if (zoom != primaryZoom) {
-		float scaleFactor = 1f * zoom / primaryZoom;
-		logFont.lfHeight *= scaleFactor;
-	}
-
+	logFont.lfHeight = device.computePixels(fd.height, zoom);
 	handle = OS.CreateFontIndirect(logFont);
 	logFont.lfHeight = lfHeight;
 	if (handle == 0) SWT.error(SWT.ERROR_NO_HANDLES);

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/ScalingSWTFontRegistry.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/ScalingSWTFontRegistry.java
@@ -54,8 +54,7 @@ final class ScalingSWTFontRegistry implements SWTFontRegistry {
 		private Font scaleFont(int zoom) {
 			FontData fontData = baseFont.getFontData()[0];
 			int baseZoom = computeZoom(fontData);
-			int zoomScaleFactor = Math.round(1.0f * zoom / baseZoom);
-			fontData.data.lfHeight *= zoomScaleFactor;
+			fontData.data.lfHeight = Math.round(1.0f * fontData.data.lfHeight * zoom / baseZoom);
 			Font scaledFont = Font.win32_new(device, fontData, zoom);
 			addScaledFont(zoom, scaledFont);
 			return scaledFont;


### PR DESCRIPTION
With commit cd8bb13 we adapted the calculation how to scale up fonts to fix the calculation for fonts used by the Printer. This introduced an issue if monitor-specific scaling is active and the primary monitor zoom is changed, because two different calculation were mixed now. This commit fixes this inconsistency.

## How to reproduce

- Activate the experimental monitor-specific scaling flag
- Open a text editor
- change the primary zoom

Some fonts will be scaled by the wrong factor
![image](https://github.com/user-attachments/assets/af6d9cd5-08b7-4510-a141-1235b886b6a0)

@HeikoKlare Can you have a look
