### PR TITLE
Use ImageGcDrawer for bgimages in CTabFolder

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CTabFolder.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CTabFolder.java
@@ -4007,10 +4007,7 @@ void updateBkImages(boolean colorChanged) {
 						if (colorChanged || !bounds.equals(bkImageBounds[i])) {
 							bkImageBounds[i] = bounds;
 							if (controlBkImages[i] != null) controlBkImages[i].dispose();
-							controlBkImages[i] = new Image(control.getDisplay(), bounds);
-							GC gc = new GC(controlBkImages[i]);
-							renderer.draw(CTabFolderRenderer.PART_BACKGROUND, 0, bounds, gc);
-							gc.dispose();
+							controlBkImages[i] = new Image(control.getDisplay(), (gc, imageWidth, imageHeight) -> renderer.draw(CTabFolderRenderer.PART_BACKGROUND, 0, bounds, gc), bounds.width, bounds.height);
 							control.setBackground(null);
 							control.setBackgroundImage(controlBkImages[i]);
 						}


### PR DESCRIPTION
This commit addresses rendering fragments that can occur when the background images of CTabFolder will be scaled with the monitor-specific scaling active in win32. Using the ImageGcDrawer to redraw the images on demand for the correct zoom removed the fragments.

### How to reproduce

Activate monitor-specific scaling
Open the IDE on a monitor with 125%
Move the IDE to a monitor with 150%

You will see some fragments in the CTabFolders
![image](https://github.com/user-attachments/assets/4b207d39-170b-4e4f-bb11-605f42cd48c2)
