### PR TITLE
Guard Image Type Icon from Smooth Scaling

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/DPIUtil.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/DPIUtil.java
@@ -292,8 +292,8 @@ private static ImageData autoScaleImageData (Device device, final ImageData imag
 	int height = imageData.height;
 	int scaledWidth = Math.round (width * scaleFactor);
 	int scaledHeight = Math.round (height * scaleFactor);
-	return switch (autoScaleMethod) {
-	case SMOOTH -> {
+	boolean useSmoothScaling = autoScaleMethod == AutoScaleMethod.SMOOTH && imageData.getTransparencyType() != SWT.TRANSPARENCY_MASK;
+	if (useSmoothScaling) {
 		Image original = new Image (device, (ImageDataProvider) zoom -> imageData);
 		/* Create a 24 bit image data with alpha channel */
 		final ImageData resultData = new ImageData (scaledWidth, scaledHeight, 24, new PaletteData (0xFF, 0xFF00, 0xFF0000));
@@ -310,10 +310,10 @@ private static ImageData autoScaleImageData (Device device, final ImageData imag
 		original.dispose ();
 		ImageData result = resultImage.getImageData (getDeviceZoom ());
 		resultImage.dispose ();
-		yield result;
+		return result;
+	} else {
+		return imageData.scaledTo (scaledWidth, scaledHeight);
 	}
-	default -> imageData.scaledTo (scaledWidth, scaledHeight);
-	};
 }
 
 /**


### PR DESCRIPTION
Enabling the smooth scaling for icon produce erroneous result. Resulting in icon losing its transparency.

### How to Test

Use the snippet to see the difference in behavior of the Image and Icon during the DPI change. 
```
Display display = new Display();
Shell shell = new Shell(display);
shell.setText("Image and Icon Example");
shell.setLayout(new RowLayout());

Image icon = display.getSystemImage(SWT.ICON_WORKING);
InputStream is = ImageExample.class.getResourceAsStream("eclipse.png");
Image image = new Image(display, is);

new Label(shell, SWT.NONE).setImage(icon);
new Label(shell, SWT.NONE).setImage(image);
shell.pack();

shell.open();

while (!shell.isDisposed()) {
	if (!display.readAndDispatch()) {
		display.sleep();
	}
}
display.dispose();
```

- Run the snippet with -Dswt.autoScale.updateOnRuntime=true
- Move the shell from primary (100%) monitor to secondary (200%) Or use any other combination of zooms
- See if the icons losing transparency. 

### Before Fix

![image](https://github.com/user-attachments/assets/098894ca-d8ac-4cf1-9629-5b725403fdae)

### After Fix 

![image](https://github.com/user-attachments/assets/8020b4bb-0249-4300-aa1e-492877e39192)

**Note: Image is only added in snippet to show smooth scaling still applicable for bitmap images.** 
