### PR TITLE
Shell Icon disappears on zoom change

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Decorations.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Decorations.java
@@ -1699,7 +1699,7 @@ private static void handleDPIChange(Widget widget, int newZoom, float scalingFac
 	}
 
 	Image[] images = decorations.getImages();
-	if (images != null) {
+	if (images != null && images.length > 0) {
 		decorations.setImages(images);
 	}
 


### PR DESCRIPTION
Setting an image for a shell on top left disappears on monitor change in monitor specific scaling mode. The reason behind it was that the image was being disposed by setImages method called after setImage in handleDPIChanged. The setImages method should not have been called if there are no images present in the array. The solution is to check whether we have any images in the in the array with the null check.

### How to Reproduce

- Run the following snippet with the following arguments
  ```
  -Dswt.autoScale.updateOnRuntime=true
  -Dswt.autoScale=quarter
  ```
 ```
  Display display = new Display();
  Image image1 = display.getSystemImage(SWT.ICON_WORKING);
  Shell shell = new Shell(display);
  shell.setText("My Snippet");
  shell.setImage(image1);
  shell.open();
  while (!shell.isDisposed()) {
	  if (!display.readAndDispatch()) {
		  display.sleep();
	  }
  }
  display.dispose();
  ```

- Move the shell from one monitor to another (with different zoom levels) 
- The icon on top left of the shell will disappear

![image](https://github.com/user-attachments/assets/08dce221-4a30-4a05-ab92-9f6c056da7cc)

### Expected Result

The icon on top left should remain intact after the zoom change