### PR TITLE
Prepare the implementation of dynamically sized image file-formats

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/graphics/InternalImageLoader.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/graphics/InternalImageLoader.java
@@ -14,13 +14,15 @@
 package org.eclipse.swt.graphics;
 
 import java.io.*;
+import java.util.*;
 
+import org.eclipse.swt.internal.DPIUtil.*;
 import org.eclipse.swt.internal.image.*;
 
 class InternalImageLoader {
 
-	static ImageData[] load(InputStream stream, ImageLoader imageLoader) {
-		return FileFormat.load(stream, imageLoader);
+	static List<ElementAtZoom<ImageData>> load(InputStream stream, ImageLoader imageLoader, int fileZoom, int targetZoom) {
+		return FileFormat.load(stream, imageLoader, fileZoom, targetZoom);
 	}
 
 	static void save(OutputStream stream, int format, ImageLoader imageLoader) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/ImageLoader.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/ImageLoader.java
@@ -18,6 +18,8 @@ import java.io.*;
 import java.util.*;
 
 import org.eclipse.swt.*;
+import org.eclipse.swt.internal.DPIUtil.*;
+import org.eclipse.swt.internal.image.*;
 
 /**
  * Instances of this class are used to load images from,
@@ -148,10 +150,16 @@ void reset() {
  * </ul>
  */
 public ImageData[] load(InputStream stream) {
+	load(stream, FileFormat.DEFAULT_ZOOM, FileFormat.DEFAULT_ZOOM);
+	return data;
+}
+
+List<ElementAtZoom<ImageData>> load(InputStream stream, int fileZoom, int targetZoom) {
 	if (stream == null) SWT.error(SWT.ERROR_NULL_ARGUMENT);
 	reset();
-	data = InternalImageLoader.load(stream, this);
-	return data;
+	List<ElementAtZoom<ImageData>> images = InternalImageLoader.load(stream, this, fileZoom, targetZoom);
+	data = images.stream().map(ElementAtZoom::element).toArray(ImageData[]::new);
+	return images;
 }
 
 /**
@@ -173,9 +181,14 @@ public ImageData[] load(InputStream stream) {
  * </ul>
  */
 public ImageData[] load(String filename) {
+	load(filename, FileFormat.DEFAULT_ZOOM, FileFormat.DEFAULT_ZOOM);
+	return data;
+}
+
+List<ElementAtZoom<ImageData>> load(String filename, int fileZoom, int targetZoom) {
 	if (filename == null) SWT.error(SWT.ERROR_NULL_ARGUMENT);
 	try (InputStream stream = new FileInputStream(filename)) {
-		return load(stream);
+		return load(stream, fileZoom, targetZoom);
 	} catch (IOException e) {
 		SWT.error(SWT.ERROR_IO, e);
 	}

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/image/GIFFileFormat.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/image/GIFFileFormat.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2012 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -14,11 +14,13 @@
 package org.eclipse.swt.internal.image;
 
 
-import org.eclipse.swt.*;
-import org.eclipse.swt.graphics.*;
 import java.io.*;
 
-public final class GIFFileFormat extends FileFormat {
+import org.eclipse.swt.*;
+import org.eclipse.swt.graphics.*;
+import org.eclipse.swt.internal.image.FileFormat.*;
+
+public final class GIFFileFormat extends StaticImageFileFormat {
 	String signature;
 	int screenWidth, screenHeight, backgroundPixel, bitsPerPixel, defaultDepth;
 	int disposalMethod = 0;
@@ -51,15 +53,11 @@ public final class GIFFileFormat extends FileFormat {
 	}
 
 	@Override
-	boolean isFileFormat(LEDataInputStream stream) {
-		try {
-			byte[] signature = new byte[3];
-			stream.read(signature);
-			stream.unread(signature);
-			return signature[0] == 'G' && signature[1] == 'I' && signature[2] == 'F';
-		} catch (Exception e) {
-			return false;
-		}
+	boolean isFileFormat(LEDataInputStream stream) throws IOException {
+		byte[] signature = new byte[3];
+		stream.read(signature);
+		stream.unread(signature);
+		return signature[0] == 'G' && signature[1] == 'I' && signature[2] == 'F';
 	}
 
 	/**

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/image/JPEGFileFormat.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/image/JPEGFileFormat.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2014 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -18,11 +18,13 @@
 package org.eclipse.swt.internal.image;
 
 
-import org.eclipse.swt.*;
-import org.eclipse.swt.graphics.*;
 import java.io.*;
 
-public final class JPEGFileFormat extends FileFormat {
+import org.eclipse.swt.*;
+import org.eclipse.swt.graphics.*;
+import org.eclipse.swt.internal.image.FileFormat.*;
+
+public final class JPEGFileFormat extends StaticImageFileFormat {
 	int restartInterval;
 	JPEGFrameHeader frameHeader;
 	int imageWidth, imageHeight;
@@ -1362,16 +1364,14 @@ void inverseDCT(int[] dataUnit) {
 		}
 	}
 }
-@Override
-boolean isFileFormat(LEDataInputStream stream) {
-	try {
+
+	@Override
+	boolean isFileFormat(LEDataInputStream stream) throws IOException {
 		JPEGStartOfImage soi = new JPEGStartOfImage(stream);
 		stream.unread(soi.reference);
-		return soi.verify();  // we no longer check for appN
-	} catch (Exception e) {
-		return false;
+		return soi.verify(); // we no longer check for appN
 	}
-}
+
 boolean isZeroInColumn(int[] dataUnit, int col) {
 	return dataUnit[col + 8] == 0 && dataUnit[col + 16] == 0
 			&& dataUnit[col + 24] == 0 && dataUnit[col + 32] == 0

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/image/OS2BMPFileFormat.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/image/OS2BMPFileFormat.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2008 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -14,27 +14,26 @@
 package org.eclipse.swt.internal.image;
 
 
-import org.eclipse.swt.*;
-import org.eclipse.swt.graphics.*;
 import java.io.*;
 
-public final class OS2BMPFileFormat extends FileFormat {
+import org.eclipse.swt.*;
+import org.eclipse.swt.graphics.*;
+import org.eclipse.swt.internal.image.FileFormat.*;
+
+public final class OS2BMPFileFormat extends StaticImageFileFormat {
 	static final int BMPFileHeaderSize = 14;
 	static final int BMPHeaderFixedSize = 12;
 	int width, height, bitCount;
 
-@Override
-boolean isFileFormat(LEDataInputStream stream) {
-	try {
+	@Override
+	boolean isFileFormat(LEDataInputStream stream) throws IOException {
 		byte[] header = new byte[18];
 		stream.read(header);
 		stream.unread(header);
 		int infoHeaderSize = (header[14] & 0xFF) | ((header[15] & 0xFF) << 8) | ((header[16] & 0xFF) << 16) | ((header[17] & 0xFF) << 24);
 		return header[0] == 0x42 && header[1] == 0x4D && infoHeaderSize == BMPHeaderFixedSize;
-	} catch (Exception e) {
-		return false;
 	}
-}
+
 byte[] loadData(byte[] infoHeader) {
 	int stride = (width * bitCount + 7) / 8;
 	stride = (stride + 3) / 4 * 4; // Round up to 4 byte multiple

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/image/PNGFileFormat.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/image/PNGFileFormat.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2011 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -19,8 +19,9 @@ import java.util.zip.*;
 
 import org.eclipse.swt.*;
 import org.eclipse.swt.graphics.*;
+import org.eclipse.swt.internal.image.FileFormat.*;
 
-public final class PNGFileFormat extends FileFormat {
+public final class PNGFileFormat extends StaticImageFileFormat {
 	static final int SIGNATURE_LENGTH = 8;
 	static final int PRIME = 65521;
 	PngIhdrChunk headerChunk;
@@ -151,9 +152,9 @@ void unloadIntoByteStream(ImageLoader loader) {
 	PngEncoder encoder = new PngEncoder(loader);
 	encoder.encode(outputStream);
 }
-@Override
-boolean isFileFormat(LEDataInputStream stream) {
-	try {
+
+	@Override
+	boolean isFileFormat(LEDataInputStream stream) throws IOException {
 		byte[] signature = new byte[SIGNATURE_LENGTH];
 		stream.read(signature);
 		stream.unread(signature);
@@ -166,10 +167,8 @@ boolean isFileFormat(LEDataInputStream stream) {
 		if ((signature[6] & 0xFF) != 26) return false; //<CTRL/Z>
 		if ((signature[7] & 0xFF) != 10) return false; //<LINEFEED>
 		return true;
-	} catch (Exception e) {
-		return false;
 	}
-}
+
 /**
  * SWT does not support 16-bit depths. If this image uses
  * 16-bit depths, convert the data to an 8-bit depth.

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/image/TIFFFileFormat.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/image/TIFFFileFormat.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2009 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -14,19 +14,20 @@
 package org.eclipse.swt.internal.image;
 
 
+import java.io.*;
+
 import org.eclipse.swt.*;
 import org.eclipse.swt.graphics.*;
-import java.io.*;
+import org.eclipse.swt.internal.image.FileFormat.*;
 
 /**
  * Baseline TIFF decoder revision 6.0
  * Extension T4-encoding CCITT T.4 1D
  */
-public final class TIFFFileFormat extends FileFormat {
+public final class TIFFFileFormat extends StaticImageFileFormat {
 
-@Override
-boolean isFileFormat(LEDataInputStream stream) {
-	try {
+	@Override
+	boolean isFileFormat(LEDataInputStream stream) throws IOException {
 		byte[] header = new byte[4];
 		stream.read(header);
 		stream.unread(header);
@@ -36,10 +37,7 @@ boolean isFileFormat(LEDataInputStream stream) {
 			return false;
 		}
 		return true;
-	} catch (Exception e) {
-		return false;
 	}
-}
 
 @Override
 ImageData[] loadFromByteStream() {

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/image/WinBMPFileFormat.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/image/WinBMPFileFormat.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2011 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -14,11 +14,13 @@
 package org.eclipse.swt.internal.image;
 
 
-import org.eclipse.swt.*;
-import org.eclipse.swt.graphics.*;
 import java.io.*;
 
-public final class WinBMPFileFormat extends FileFormat {
+import org.eclipse.swt.*;
+import org.eclipse.swt.graphics.*;
+import org.eclipse.swt.internal.image.FileFormat.*;
+
+public final class WinBMPFileFormat extends StaticImageFileFormat {
 	static final int BMPFileHeaderSize = 14;
 	static final int BMPHeaderFixedSize = 40;
 
@@ -415,18 +417,16 @@ int decompressRLE8Data(byte[] src, int numBytes, int stride, byte[] dest, int de
 	}
 	return 1;
 }
-@Override
-boolean isFileFormat(LEDataInputStream stream) {
-	try {
+
+	@Override
+	boolean isFileFormat(LEDataInputStream stream) throws IOException {
 		byte[] header = new byte[18];
 		stream.read(header);
 		stream.unread(header);
 		int infoHeaderSize = (header[14] & 0xFF) | ((header[15] & 0xFF) << 8) | ((header[16] & 0xFF) << 16) | ((header[17] & 0xFF) << 24);
 		return header[0] == 0x42 && header[1] == 0x4D && infoHeaderSize >= BMPHeaderFixedSize;
-	} catch (Exception e) {
-		return false;
 	}
-}
+
 boolean isPaletteBMP(PaletteData pal, int depth) {
 	switch(depth) {
 		case 32:

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/image/WinICOFileFormat.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/image/WinICOFileFormat.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2012 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -18,8 +18,9 @@ import java.io.*;
 
 import org.eclipse.swt.*;
 import org.eclipse.swt.graphics.*;
+import org.eclipse.swt.internal.image.FileFormat.*;
 
-public final class WinICOFileFormat extends FileFormat {
+public final class WinICOFileFormat extends StaticImageFileFormat {
 
 byte[] bitInvertData(byte[] data, int startIndex, int endIndex) {
 	// Destructively bit invert data in the given byte array.
@@ -54,17 +55,15 @@ int iconSize(ImageData i) {
 	int paletteSize = i.palette.colors != null ? i.palette.colors.length * 4 : 0;
 	return WinBMPFileFormat.BMPHeaderFixedSize + paletteSize + dataSize;
 }
-@Override
-boolean isFileFormat(LEDataInputStream stream) {
-	try {
+
+	@Override
+	boolean isFileFormat(LEDataInputStream stream) throws IOException {
 		byte[] header = new byte[4];
 		stream.read(header);
 		stream.unread(header);
 		return header[0] == 0 && header[1] == 0 && header[2] == 1 && header[3] == 0;
-	} catch (Exception e) {
-		return false;
 	}
-}
+
 boolean isValidIcon(ImageData i) {
 	switch (i.depth) {
 		case 1:
@@ -131,10 +130,10 @@ ImageData[] loadFromByteStream() {
  */
 ImageData loadIcon(int[] iconHeader) {
 	try {
-		FileFormat png = new PNGFileFormat();
+		StaticImageFileFormat png = new PNGFileFormat();
 		if (png.isFileFormat(inputStream)) {
 			png.loader = this.loader;
-			return png.loadFromStream(inputStream)[0];
+			return png.loadFromStream(inputStream, DEFAULT_ZOOM, DEFAULT_ZOOM).get(0).element();
 		}
 	} catch (Exception e) {
 	}

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/InternalImageLoader.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/InternalImageLoader.java
@@ -14,13 +14,15 @@
 package org.eclipse.swt.graphics;
 
 import java.io.*;
+import java.util.*;
 
+import org.eclipse.swt.internal.DPIUtil.*;
 import org.eclipse.swt.internal.image.*;
 
 class InternalImageLoader {
 
-	static ImageData[] load(InputStream stream, ImageLoader imageLoader) {
-		return FileFormat.load(stream, imageLoader);
+	static List<ElementAtZoom<ImageData>> load(InputStream stream, ImageLoader imageLoader, int fileZoom, int targetZoom) {
+		return FileFormat.load(stream, imageLoader, fileZoom, targetZoom);
 	}
 
 	static void save(OutputStream stream, int format, ImageLoader imageLoader) {


### PR DESCRIPTION
Required for
- https://github.com/eclipse-platform/eclipse.platform.swt/pull/1638

This is a purely internal change that also reduces the number of places where `IOExceptions` are handled (all int the same way) in `FileFormat.isFileFormat()` implementations.

@HeikoKlare do you want to review this? Should we aim to land this for this release?
CC @Michael5601