### PR TITLE
Improve Program Icon Scaling

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT PI/win32/library/os.c
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/win32/library/os.c
@@ -7534,6 +7534,28 @@ JNIEXPORT jint JNICALL OS_NATIVE(SHDRAGIMAGE_1sizeof)
 }
 #endif
 
+#ifndef NO_SHDefExtractIcon
+JNIEXPORT jint JNICALL OS_NATIVE(SHDefExtractIcon)
+	(JNIEnv *env, jclass that, jcharArray arg0, jint arg1, jint arg2, jlongArray arg3, jlongArray arg4, jint arg5)
+{
+	jchar *lparg0=NULL;
+	jlong *lparg3=NULL;
+	jlong *lparg4=NULL;
+	jint rc = 0;
+	OS_NATIVE_ENTER(env, that, SHDefExtractIcon_FUNC);
+	if (arg0) if ((lparg0 = (*env)->GetCharArrayElements(env, arg0, NULL)) == NULL) goto fail;
+	if (arg3) if ((lparg3 = (*env)->GetLongArrayElements(env, arg3, NULL)) == NULL) goto fail;
+	if (arg4) if ((lparg4 = (*env)->GetLongArrayElements(env, arg4, NULL)) == NULL) goto fail;
+	rc = (jint)SHDefExtractIcon((LPWSTR)lparg0, arg1, arg2, (HICON FAR *)lparg3, (HICON FAR *)lparg4, arg5);
+fail:
+	if (arg4 && lparg4) (*env)->ReleaseLongArrayElements(env, arg4, lparg4, 0);
+	if (arg3 && lparg3) (*env)->ReleaseLongArrayElements(env, arg3, lparg3, 0);
+	if (arg0 && lparg0) (*env)->ReleaseCharArrayElements(env, arg0, lparg0, 0);
+	OS_NATIVE_EXIT(env, that, SHDefExtractIcon_FUNC);
+	return rc;
+}
+#endif
+
 #ifndef NO_SHELLEXECUTEINFO_1sizeof
 JNIEXPORT jint JNICALL OS_NATIVE(SHELLEXECUTEINFO_1sizeof)
 	(JNIEnv *env, jclass that)

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/win32/library/os_stats.h
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/win32/library/os_stats.h
@@ -569,6 +569,7 @@ typedef enum {
 	SCROLLBARINFO_1sizeof_FUNC,
 	SCROLLINFO_1sizeof_FUNC,
 	SHDRAGIMAGE_1sizeof_FUNC,
+	SHDefExtractIcon_FUNC,
 	SHELLEXECUTEINFO_1sizeof_FUNC,
 	SHFILEINFO_1sizeof_FUNC,
 	SHGetFileInfo_FUNC,

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/win32/library/os_structs.c
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/win32/library/os_structs.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2022 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/win32/library/os_structs.h
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/win32/library/os_structs.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/win32/org/eclipse/swt/internal/win32/OS.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/win32/org/eclipse/swt/internal/win32/OS.java
@@ -2302,6 +2302,11 @@ public static final boolean SetWindowText (long hWnd, TCHAR lpString) {
 	return SetWindowText (hWnd, lpString1);
 }
 
+public static final int SHDefExtractIcon (TCHAR lpszFile, int iIndex, int uFlags, long [] phiconLarge, long [] phiconSmall, int nIconSize) {
+	char [] lpszFile1 = lpszFile == null ? null : lpszFile.chars;
+	return SHDefExtractIcon (lpszFile1, iIndex, uFlags, phiconLarge, phiconSmall, nIconSize);
+}
+
 public static final boolean UnregisterClass (TCHAR lpClassName, long hInstance) {
 	char [] lpClassName1 = lpClassName == null ? null : lpClassName.chars;
 	return UnregisterClass (lpClassName1, hInstance);
@@ -4455,6 +4460,12 @@ public static final native long SetWindowsHookEx (int idHook, long lpfn,  long h
  * @param lpXform cast=(XFORM *),flags=no_out
  */
 public static final native boolean SetWorldTransform(long hdc, float[] lpXform);
+/**
+ * @param lpszFile cast=(LPWSTR)
+ * @param phiconLarge cast=(HICON FAR *)
+ * @param phiconSmall cast=(HICON FAR *)
+ */
+public static final native int SHDefExtractIcon (char [] lpszFile, int iIndex, int uFlags, long [] phiconLarge, long [] phiconSmall, int nIconSize);
 /** @param pszPath cast=(LPCWSTR),flags=no_out */
 public static final native long SHGetFileInfo (char [] pszPath, int dwFileAttributes, SHFILEINFO psfi, int cbFileInfo, int uFlags);
 public static final native boolean ShellExecuteEx (SHELLEXECUTEINFO lpExecInfo);


### PR DESCRIPTION
This PR contributes to the improvement in the scaling of program icons. The implementation uses a windows API SHGetImageList to obtain imagelists at small, large and extra large sizes. Then the icon nearest to the required size is retrieved and its image data is scaled up returned.

Typically the small, large and extra large icons are supposed to have 16, 32 and 48 px of sizes respectively. But apparently, the API SHGetImageList turns out to be System-DPI aware. It means if the primary monitor zoom at app startup was 100% then those scaled values are valid but for instance if it was 200% then the sizes from small, large and extra large would be 32, 64 and 128 px. Hence, with this approach we do get a room to scale up with better image quality since, the retrieved images are usually, 1x, 2x and 3x the size of the primary monitor zoom at startup. However, if there exists a monitor with significantly lower zoom than the primary monitor zoom at startup, then the 1x zoom (small) icon will be used, which will end up in compressed images.

This approach still opens headspace in one direction (scale up), hence, the quality is indeed better while scaling up. However, while scaling down below the primary monitor zoom at app startup, it will compress the icon.

contributes to #62 and #127