### PR TITLE
[GTK4] Fix segmentation fault when creating multiple displays

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Display.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Display.java
@@ -4817,26 +4817,28 @@ void releaseDisplay () {
 	keysChangedProc = 0;
 
 	/* Dispose subclass */
-	long pangoLayoutType = OS.PANGO_TYPE_LAYOUT ();
-	long pangoLayoutClass = OS.g_type_class_ref (pangoLayoutType);
-	OS.G_OBJECT_CLASS_SET_CONSTRUCTOR (pangoLayoutClass, pangoLayoutNewProc);
-	OS.g_type_class_unref (pangoLayoutClass);
-	pangoLayoutNewProc = 0;
-	long imContextType = GTK.GTK_TYPE_IM_MULTICONTEXT ();
-	long imContextClass = OS.g_type_class_ref (imContextType);
-	OS.G_OBJECT_CLASS_SET_CONSTRUCTOR (imContextClass, imContextNewProc);
-	OS.g_type_class_unref (imContextClass);
-	imContextNewProc = 0;
-	long pangoFontFamilyType = OS.PANGO_TYPE_FONT_FAMILY ();
-	long pangoFontFamilyClass = OS.g_type_class_ref (pangoFontFamilyType);
-	OS.G_OBJECT_CLASS_SET_CONSTRUCTOR (pangoFontFamilyClass, pangoFontFamilyNewProc);
-	OS.g_type_class_unref (pangoFontFamilyClass);
-	pangoFontFamilyNewProc = 0;
-	long pangoFontFaceType = OS.PANGO_TYPE_FONT_FACE ();
-	long pangoFontFaceClass = OS.g_type_class_ref (pangoFontFaceType);
-	OS.G_OBJECT_CLASS_SET_CONSTRUCTOR (pangoFontFaceClass, pangoFontFaceNewProc);
-	OS.g_type_class_unref (pangoFontFaceClass);
-	pangoFontFaceNewProc = 0;
+	if (!GTK.GTK4) {
+		long pangoLayoutType = OS.PANGO_TYPE_LAYOUT ();
+		long pangoLayoutClass = OS.g_type_class_ref (pangoLayoutType);
+		OS.G_OBJECT_CLASS_SET_CONSTRUCTOR (pangoLayoutClass, pangoLayoutNewProc);
+		OS.g_type_class_unref (pangoLayoutClass);
+		pangoLayoutNewProc = 0;
+		long imContextType = GTK.GTK_TYPE_IM_MULTICONTEXT ();
+		long imContextClass = OS.g_type_class_ref (imContextType);
+		OS.G_OBJECT_CLASS_SET_CONSTRUCTOR (imContextClass, imContextNewProc);
+		OS.g_type_class_unref (imContextClass);
+		imContextNewProc = 0;
+		long pangoFontFamilyType = OS.PANGO_TYPE_FONT_FAMILY ();
+		long pangoFontFamilyClass = OS.g_type_class_ref (pangoFontFamilyType);
+		OS.G_OBJECT_CLASS_SET_CONSTRUCTOR (pangoFontFamilyClass, pangoFontFamilyNewProc);
+		OS.g_type_class_unref (pangoFontFamilyClass);
+		pangoFontFamilyNewProc = 0;
+		long pangoFontFaceType = OS.PANGO_TYPE_FONT_FACE ();
+		long pangoFontFaceClass = OS.g_type_class_ref (pangoFontFaceType);
+		OS.G_OBJECT_CLASS_SET_CONSTRUCTOR (pangoFontFaceClass, pangoFontFaceNewProc);
+		OS.g_type_class_unref (pangoFontFaceClass);
+		pangoFontFaceNewProc = 0;
+	}
 
 	/* Release the sleep resources */
 	max_priority = timeout = null;


### PR DESCRIPTION
Subclasses are not created in GTK4, leading to the assignment of NULL pointers when disposing the display. If a second display is created afterwards, this leads to a segmentation fault.

Contributes to
https://github.com/eclipse-platform/eclipse.platform.swt/pull/1663