### PR TITLE
Run the Github verification with GTK4 enabled if it has GTK4 label

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -11,6 +11,10 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+    types: [opened, reopened, synchronize, labeled]
+
+env:
+  SWT_GTK4: "${{ contains(github.event.pull_request.labels.*.name, 'gtk4') && '1' || '0' }}"
 
 jobs:
   event_file:
@@ -94,3 +98,4 @@ jobs:
         if-no-files-found: warn
         path: |
           ${{ github.workspace }}/**/target/surefire-reports/*.xml
+          ${{ github.workspace }}/**/hs_err_pid*.log


### PR DESCRIPTION
This is a different approach to

- https://github.com/eclipse-platform/eclipse.platform.swt/pull/1663

this should reuse the usual workflow, but set the `GTK4=1` when the PR is created with the gtk4 label ... as Jenkins is still running with gtk3 we still check both ways.