### PR TITLE
[Win32] Add SSO support for SWT Browser using Edge backend

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Browser/win32/org/eclipse/swt/browser/Edge.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Browser/win32/org/eclipse/swt/browser/Edge.java
@@ -49,6 +49,8 @@ class Edge extends WebBrowser {
 	// System.getProperty() keys
 	static final String BROWSER_DIR_PROP = "org.eclipse.swt.browser.EdgeDir";
 	static final String BROWSER_ARGS_PROP = "org.eclipse.swt.browser.EdgeArgs";
+	static final String ALLOW_SINGLE_SIGN_ON_USING_OS_PRIMARY_ACCOUNT_PROP = "org.eclipse.swt.browser.Edge.allowSingleSignOnUsingOSPrimaryAccount";
+	static final String ALLOW_SINGLE_SIGN_ON_USING_OS_PRIMARY_ACCOUNT_PROP_2 = "org.eclipse.swt.browser.Edge.allowSSO";
 	static final String DATA_DIR_PROP = "org.eclipse.swt.browser.EdgeDataDir";
 	static final String LANGUAGE_PROP = "org.eclipse.swt.browser.EdgeLanguage";
 	static final String VERSIONT_PROP = "org.eclipse.swt.browser.EdgeVersion";
@@ -563,6 +565,7 @@ WebViewEnvironment createEnvironment() {
 	String browserDir = System.getProperty(BROWSER_DIR_PROP);
 	String browserArgs = System.getProperty(BROWSER_ARGS_PROP);
 	String language = System.getProperty(LANGUAGE_PROP);
+	boolean allowSSO = Boolean.getBoolean(ALLOW_SINGLE_SIGN_ON_USING_OS_PRIMARY_ACCOUNT_PROP) || Boolean.getBoolean(ALLOW_SINGLE_SIGN_ON_USING_OS_PRIMARY_ACCOUNT_PROP_2);
 	String dataDir = getDataDir(display);
 
 	// Initialize options
@@ -578,6 +581,11 @@ WebViewEnvironment createEnvironment() {
 	if (language != null) {
 		char[] pLanguage = stringToWstr(language);
 		options.put_Language(pLanguage);
+	}
+
+	if (allowSSO) {
+		int[] pAllowSSO = new int[]{1};
+		options.put_AllowSingleSignOnUsingOSPrimaryAccount(pAllowSSO);
 	}
 
 	// Create the environment

--- a/bundles/org.eclipse.swt/Readme.WebView2.md
+++ b/bundles/org.eclipse.swt/Readme.WebView2.md
@@ -67,6 +67,14 @@ language+country code that defines the browser UI language and preferred
 language for HTTP requests (`Accept-Languages` header).
 Example values: `en`, `ja`, `en-GB`, `de-AT`.
 
+The properties `org.eclipse.swt.browser.Edge.allowSingleSignOnUsingOSPrimaryAccount` or its shorthand
+`org.eclipse.swt.browser.Edge.allowSSO` enable Single Sign-On with Azure Active Directory (AAD)
+resources using the logged-in Windows account. This also enables SSO with websites using
+Microsoft accounts associated with the Windows login. Setting either property to true enables
+this feature. The default value is false.
+
+See also: https://learn.microsoft.com/en-us/dotnet/api/microsoft.web.webview2.core.corewebview2environmentoptions.allowsinglesignonusingosprimaryaccount
+
 _Note_: All of the properties described above must be set before the first
 instance of the `Browser` with `SWT.EDGE` style is created.
 


### PR DESCRIPTION
## Overview
This PR adds support for Single Sign-On (SSO) in SWT Browser (using Edge backend), 
allowing the browser to leverage the user's Windows credentials for authentication with 
Azure AD resources and Microsoft account-enabled websites.

## Features
- Adds two new system properties to control SSO functionality:
  - `org.eclipse.swt.browser.Edge.allowSingleSignOnUsingOSPrimaryAccount`
  - `org.eclipse.swt.browser.Edge.allowSSO` (shorthand alternative)
- Updates README documentation with new property descriptions
- Implements support for Single Sign-On through the Edge backend

## Implementation Details
- SSO is disabled by default (matches WebView2's default behavior)
- Either property can be set to `true` to enable the feature

## Documentation
- Added new section in README explaining the SSO properties and their effects

## Related Links
- [Microsoft WebView2 SSO Documentation](https://learn.microsoft.com/en-us/dotnet/api/microsoft.web.webview2.core.corewebview2environmentoptions.allowsinglesignonusingosprimaryaccount)