### PR TITLE
[GTK] Initialize text-antialias when initializing GC object

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/graphics/GC.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/graphics/GC.java
@@ -2659,6 +2659,9 @@ void init(Drawable drawable, GCData data, long gdkGC) {
 	Cairo.cairo_set_fill_rule(cairo, Cairo.CAIRO_FILL_RULE_EVEN_ODD);
 	data.state &= ~(BACKGROUND | FOREGROUND | FONT | LINE_WIDTH | LINE_CAP | LINE_JOIN | LINE_STYLE | DRAW_OFFSET);
 	setClipping(data.clipRgn);
+	if (image != null) {
+		setTextAntialias(SWT.DEFAULT);
+	}
 	initCairo();
 	if ((data.style & SWT.MIRRORED) != 0) {
 		// Don't overwrite the Cairo transformation matrix in GTK 3.14 and above; it contains a translation relative to the parent widget.

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_Image.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_Image.java
@@ -1257,4 +1257,46 @@ public void test_updateWidthHeightAfterDPIChange() {
 		DPIUtil.setDeviceZoom(deviceZoom);
 	}
 }
+
+@Test
+public void test_paintWithTextAntialias() {
+	// Must be executed on e.g. a Gnome system
+	// where anti-alias is set to use Grayscale
+	// whereas Cairo is using RGB by default
+	int[] modes = {SWT.ON, SWT.OFF, SWT.DEFAULT};
+	int width = (modes.length + 1) * 100;
+	int height = 100;
+
+	Image image1 = new Image(display, width, height);
+	GC g1 = new GC(image1);
+	g1.setAdvanced(true);
+
+	g1.drawString("OWVO", 35, 20);
+	for (int i = 0 ; i < modes.length; ++i) {
+		g1.setTextAntialias(modes[i]);
+		g1.drawString("OWVO", 135 + i * 100, 20);
+	}
+
+	Image image2 = new Image(display, width, height);
+	GC g2 = new GC(image2);
+	g2.setAdvanced(true);
+
+	for (int i = modes.length - 1 ; i >= 0; --i) {
+		g2.setTextAntialias(modes[i]);
+		g2.drawString("OWVO", 135 + i * 100, 20);
+	}
+	g2.setTextAntialias(SWT.DEFAULT);
+	g2.drawString("OWVO", 35, 20);
+
+	ImageData data1 = image1.getImageData();
+	ImageData data2 = image2.getImageData();
+
+	g1.dispose();
+	g2.dispose();
+	image1.dispose();
+	image2.dispose();
+
+	ImageTestUtil.assertImagesEqual(data1, data2);
+}
+
 }


### PR DESCRIPTION
On some platforms, the default text-antialias of the system might differ from Cairo. When creating a new GC object is created, the Cairo default is used. But when setTextAntialias(SWT.DEFAULT) is called, the system default is used instead.

To avoid this ambiguity, setTextAntialias(SWT.DEFAULT) should always be called when creating a GC object, in order to always use the system default.