### PR TITLE
Fix Sash Layout Shaking in win32 #62

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Control.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Control.java
@@ -3635,8 +3635,8 @@ public void setRedraw (boolean redraw) {
 	 *
 	 * https://github.com/eclipse-platform/eclipse.platform.swt/issues/1122
 	 */
-	boolean isShown = isVisible() && !isDisposed();
-	if (!redraw && isShown && embedsWin32Control()) {
+	if (!redraw && embedsWin32Control()) {
+		drawCount++;
 		return;
 	}
 
@@ -3677,6 +3677,9 @@ public void setRedraw (boolean redraw) {
 }
 
 private boolean embedsWin32Control () {
+	if (this.isDisposed() || !this.isVisible()) {
+		return false;
+	}
 	if (this instanceof Browser browser) {
 		// The Edge browser embeds webView2
 		return "edge".equals(browser.getBrowserType());


### PR DESCRIPTION
This PR fixes the check for enabling and disabling the redraw of controls in a sashlayout which leads to a shaky sashlayout on resizing it.

contributes to
https://github.com/eclipse-platform/eclipse.platform.swt/issues/62 and https://github.com/eclipse-platform/eclipse.platform.swt/issues/127