### PR TITLE
Edge: Let WebView2 handle opening new windows by default

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Browser/win32/org/eclipse/swt/browser/Edge.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Browser/win32/org/eclipse/swt/browser/Edge.java
@@ -1315,7 +1315,7 @@ int handleNewWindowRequested(long pView, long pArgs) {
 			WindowEvent openEvent = new WindowEvent(browser);
 			openEvent.display = browser.getDisplay();
 			openEvent.widget = browser;
-			openEvent.required = true;
+			openEvent.required = false;
 			for (OpenWindowListener openListener : openWindowListeners) {
 				openListener.open(openEvent);
 				if (browser.isDisposed()) return;


### PR DESCRIPTION
With Edge, just as IE did, supports opening new windows on its own, unlike the WebKit implementation on Linux/macOS.

Therefore, to maximize compatibility with IE as the previous default, also let WebView2 handle opening new windows by default.

Fixes #1845.