### PR TITLE
Fix Caret Rescaling for win32 #62

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Caret.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Caret.java
@@ -663,9 +663,10 @@ public void setVisible (boolean visible) {
  */
 public static void win32_setHeight(Caret caret, int height) {
 	caret.checkWidget();
-	if(caret.height == height && caret.isCurrentCaret()) return;
-	caret.height = height;
-	caret.resized = true;
+	if(caret.height != height) {
+		caret.height = height;
+		caret.resized = true;
+	}
 	if(caret.isVisible && caret.hasFocus()) caret.resize();
 }
 


### PR DESCRIPTION
This PR fixes caret rescaling by making sure the the field height is updated for every caret and Caret::resize is called for those carets where applicable.

contributes to
https://github.com/eclipse-platform/eclipse.platform.swt/issues/62 and https://github.com/eclipse-platform/eclipse.platform.swt/issues/127

## To reproduce
This is my configuration and how I reproduce the error in my current Eclipse IDE.
- Activate _Monitor-specific UI scaling_ either via the preferences (`General > Appearance`) or by using the flag `-Dswt.autoScale.updateOnRuntime=true`
- 125% monitor on the left (primary)
- 175% monitor on the right
- Open editor, click somewhere -> caret appears
- Move to the other monitor -> caret broken: it's in the wrong position and has the wrong size

In this [video](https://github.com/user-attachments/assets/95b20774-b2e4-4f45-95f7-25bf97a519c6) you can see how I moved from the monitor on the right to the one on the left and then back. The caret is broken after I move to the monitor on the left and stays broken when I come back to the monitor on the right.


