### PR TITLE
Fix blurry shell icon #62

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Decorations.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Decorations.java
@@ -899,7 +899,7 @@ void setImages (Image image, Image [] images) {
 				System.arraycopy (images, 0, bestImages, 0, images.length);
 				datas = new ImageData [images.length];
 				for (int i=0; i<datas.length; i++) {
-					datas [i] = images [i].getImageData (getZoom());
+					datas [i] = images [i].getImageData ();
 				}
 				images = bestImages;
 				sort (images, datas, getSystemMetrics (OS.SM_CXSMICON), getSystemMetrics (OS.SM_CYSMICON), depth);


### PR DESCRIPTION
Windows only: wse the original width and height of the images set to the shell when searching for the best fit instead of adapting them to the zoom, otherwise the smallest image will always be picked and it will result in a blurry shell icon when scaling up for monitors with a higher zoom levels.

contributes to
https://github.com/eclipse-platform/eclipse.platform.swt/issues/62 and https://github.com/eclipse-platform/eclipse.platform.swt/issues/127

## How to test
- Start the _Runtime Application_ with **Monitor-specific UI scaling** active
- Move it to a 200% monitor: the shell (window) icon should look sharper

**Before this PR**
![image](https://github.com/user-attachments/assets/38a172c7-5909-4c27-9c2a-502efbc25256)

**After this PR**
![image](https://github.com/user-attachments/assets/53392a0e-d26a-4878-8315-32aecc7571c9)

## Is this a regression?
~**Yes**~ Sort of (one needs to activate the experimental feature _Monitor-specific UI scaling_ in order to experience this behavior), introduced when we started using the `SMOOTH` scaling method (instead of `NEAREST`) on Windows (df0ae71aa5a5e6b1016cd4207c630196b6e7e394 / ffa10849c52645026eb96daca7a8194d48017abb). 

As demonstration, here's how the shell icon looks like **without** this PR and using the `NEAREST` scaling method:

![image](https://github.com/user-attachments/assets/cccc5bf4-f826-4529-b160-ab5f372c8b8c)

And this is how it looks like in **4.34** (identical):
![image](https://github.com/user-attachments/assets/b1b49a3b-358a-4d40-b03c-83fd76c0a311)

Since reverting back to the `NEAREST` scaling method has other implications (and overall the scaling method `SMOOTH` is better), I still propose to accept this PR as a regression fix even though it technically doesn't restore the previous behavior but it makes it better.