### PR TITLE
[win32] Cache font height to prevent inconsistency

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Font.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Font.java
@@ -14,6 +14,8 @@
 package org.eclipse.swt.graphics;
 
 
+import java.util.*;
+
 import org.eclipse.swt.*;
 import org.eclipse.swt.internal.*;
 import org.eclipse.swt.internal.win32.*;
@@ -55,6 +57,9 @@ public final class Font extends Resource {
 	 * (Warning: This field is platform dependent)
 	 */
 	int zoom;
+
+	private static Map<Long, Float> fontHeightCache = new HashMap<>();
+
 /**
  * Prevents uninitialized instances from being created outside the package.
  */
@@ -176,6 +181,7 @@ public Font(Device device, String name, int height, int style) {
 @Override
 void destroy() {
 	OS.DeleteObject(handle);
+	fontHeightCache.remove(handle);
 	handle = 0;
 }
 
@@ -213,7 +219,13 @@ public FontData[] getFontData() {
 	if (isDisposed()) SWT.error(SWT.ERROR_GRAPHIC_DISPOSED);
 	LOGFONT logFont = new LOGFONT ();
 	OS.GetObject(handle, LOGFONT.sizeof, logFont);
-	float heightInPoints = device.computePoints(logFont, handle, zoom);
+
+	float heightInPoints;
+	if (fontHeightCache.containsKey(handle)) {
+		heightInPoints = fontHeightCache.get(handle);
+	} else {
+		heightInPoints = device.computePoints(logFont, handle, zoom);
+	}
 	return new FontData[] {FontData.win32_new(logFont, heightInPoints)};
 }
 
@@ -240,6 +252,7 @@ void init (FontData fd) {
 	handle = OS.CreateFontIndirect(logFont);
 	logFont.lfHeight = lfHeight;
 	if (handle == 0) SWT.error(SWT.ERROR_NO_HANDLES);
+	fontHeightCache.put(handle, fd.height);
 }
 
 /**

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/ScalingSWTFontRegistry.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/ScalingSWTFontRegistry.java
@@ -53,8 +53,6 @@ final class ScalingSWTFontRegistry implements SWTFontRegistry {
 
 		private Font scaleFont(int zoom) {
 			FontData fontData = baseFont.getFontData()[0];
-			int baseZoom = computeZoom(fontData);
-			fontData.data.lfHeight = Math.round(1.0f * fontData.data.lfHeight * zoom / baseZoom);
 			Font scaledFont = Font.win32_new(device, fontData, zoom);
 			addScaledFont(zoom, scaledFont);
 			return scaledFont;
@@ -134,9 +132,8 @@ final class ScalingSWTFontRegistry implements SWTFontRegistry {
 		if (fontKeyMap.containsKey(fontData)) {
 			container = fontKeyMap.get(fontData);
 		} else {
-			int calculatedZoom = computeZoom(fontData);
-			Font newFont = Font.win32_new(device, fontData, calculatedZoom);
-			container = new ScaledFontContainer(newFont, calculatedZoom);
+			Font newFont = Font.win32_new(device, fontData, zoom);
+			container = new ScaledFontContainer(newFont, zoom);
 			fontHandleMap.put(newFont.handle, container);
 			fontKeyMap.put(fontData, container);
 		}
@@ -166,16 +163,5 @@ final class ScalingSWTFontRegistry implements SWTFontRegistry {
 			fontKeyMap.put(scaledFont.getFontData()[0], container);
 		}
 		return scaledFont;
-	}
-
-	private int computeZoom(FontData fontData) {
-		int pixelHeight = fontData.data.lfHeight;
-		float currentPointHeight = fontData.height;
-		if (pixelHeight == 0 || Math.abs(currentPointHeight) < 0.001) {
-			// if there is no font yet available, we use a defined zoom
-			return 100;
-		}
-		float pointHeightOn100 = -(pixelHeight / 96f * 72f);
-		return Math.round(100.0f * pointHeightOn100 / currentPointHeight);
 	}
 }


### PR DESCRIPTION
When a font is initialized with FontData the height in points of it and the desired target zoom will be used to calculate the font height in pixels, e.g. font height 10.0 pt on zoom 175 results in pixel height of 23.333, rounded down to 23px.
When the FontData of an existing font is retrieved (Font::getFontData) the Logfont data from the OS together with the font zoom (Font.zoom) are used to recalculate the original font height, e.g. 23px results in 9.86 pt 
As the conversion to pixels involved rounding, information is lost and the reversed calculation will most likely result in a different value than was used on creation time

With monitor-specific scaling a font for a different zoom will be calculated on the basis of the FontData of an existing base font. This can lead to font heights in pixels that differ from the "correct" value. To solve this limitation each font handle and its original font height in points are cached in a static Map to recreate the original value when Font::getFontData is called.