### PR TITLE
Correct formatting of Win32 Display class

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Display.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Display.java
@@ -5163,7 +5163,7 @@ String wrapText (String text, long handle, int width) {
 
 static String withCrLf (String string) {
 	/* Create a new string with the CR/LF line terminator. */
-	int i = 0;	
+	int i = 0;
 	int length = string.length();
 	StringBuilder result = new StringBuilder (length);
 	while (i < length) {
@@ -5180,7 +5180,7 @@ static String withCrLf (String string) {
 			}
 		}
 	}
-	
+
 	/* Avoid creating a copy of the string if it has not changed */
 	if (string.length()== result.length()) return string;
 	return result.toString ();


### PR DESCRIPTION
This fixes wrong formatting introduced to the Win32 display class in https://github.com/eclipse-platform/eclipse.platform.swt/pull/1722