### PR TITLE
[win32] fallback for missing DPI change event

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/widgets/ControlWin32Tests.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/widgets/ControlWin32Tests.java
@@ -60,12 +60,12 @@ class ControlWin32Tests {
 		DPIUtil.setMonitorSpecificScaling(true);
 		Display display = Display.getDefault();
 		Shell shell = new Shell(display);
-		DPITestUtil.changeDPIZoom(shell, 175);
-
 		Button button = new Button(shell, SWT.PUSH);
 		button.setText("Widget Test");
-		button.setBounds(new Rectangle(0, 47, 200, 47));
 		shell.open();
+		DPITestUtil.changeDPIZoom(shell, 175);
+
+		button.setBounds(new Rectangle(0, 47, 200, 47));
 		assertEquals("Control::setBounds(Rectangle) doesn't scale up correctly",
 				new Rectangle(0, 82, 350, 83), button.getBoundsInPixels());
 


### PR DESCRIPTION
This commit adds a fallback mechanism if the OS doesn't send a DPI change as expected. When the process is started with System DPI awareness and only the thread is PerMonitorV2 aware, there are some scenarios, when the OS does not send a DPI change event when a child Shell is positioned and opened on another monitor as its parent Shell. To work around that limitation a check is added to Shell::WM_WINDOWPOSCHANGED to trigger a dpi change event if an unexpected DPI value is detected.

This PR needs #1862 to be merged before

**Important for testing:** You will **not** run into the handleMonitorSpecificDpiChange in Shell::WM_WINDOWPOSCHANGED when testing this PR on runtime. To me this scenario only appears, when starting the RCP from the Explorer (e.g. **not** a command prompt!)