### PR TITLE
Simplify scaling of ImageData with DPIUtil

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/DPIUtil.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/DPIUtil.java
@@ -346,10 +346,6 @@ public static ImageData autoScaleUp (Device device, final ImageData imageData) {
 	return autoScaleImageData(device, imageData, 100);
 }
 
-public static ImageData autoScaleUp (Device device, final ElementAtZoom<ImageData> elementAtZoom) {
-	return autoScaleImageData(device, elementAtZoom.element(), elementAtZoom.zoom());
-}
-
 public static int[] autoScaleUp(int[] pointArray) {
 	return scaleUp(pointArray, deviceZoom);
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Image.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Image.java
@@ -363,7 +363,7 @@ public Image(Device device, ImageData data) {
 	super(device);
 	if (data == null) SWT.error(SWT.ERROR_NULL_ARGUMENT);
 	initialNativeZoom = DPIUtil.getNativeDeviceZoom();
-	data = DPIUtil.autoScaleUp(device, new ElementAtZoom<>(data, 100));
+	data = DPIUtil.autoScaleImageData(device, data, 100);
 	init(data, getZoom());
 	init();
 	this.device.registerResourceWithZoomSupport(this);
@@ -471,7 +471,7 @@ public Image(Device device, ImageData source, ImageData mask) {
 public Image (Device device, InputStream stream) {
 	super(device);
 	initialNativeZoom = DPIUtil.getNativeDeviceZoom();
-	ImageData data = DPIUtil.autoScaleUp(device, new ElementAtZoom<>(new ImageData (stream), 100));
+	ImageData data = DPIUtil.autoScaleImageData(device, new ImageData (stream), 100);
 	init(data, getZoom());
 	init();
 	this.device.registerResourceWithZoomSupport(this);
@@ -513,7 +513,7 @@ public Image (Device device, String filename) {
 	super(device);
 	if (filename == null) SWT.error(SWT.ERROR_NULL_ARGUMENT);
 	initialNativeZoom = DPIUtil.getNativeDeviceZoom();
-	ImageData data = DPIUtil.autoScaleUp(device, new ElementAtZoom<>(new ImageData (filename), 100));
+	ImageData data = DPIUtil.autoScaleImageData(device, new ImageData (filename), 100);
 	init(data, getZoom());
 	init();
 	this.device.registerResourceWithZoomSupport(this);


### PR DESCRIPTION
Wrapping an `ImageData` object and its zoom into a `ElementAtZoom` object just to unwrap it seems to be unnecessary.

Or is this part of a greater plan @akoch-yatta or @HeikoKlare?