### PR TITLE
[win32] Dynamic handle creation for Path

### DIFF
--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/AllGraphicsTests.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/AllGraphicsTests.java
@@ -31,6 +31,7 @@ import org.junit.runners.Suite;
 		Test_org_eclipse_swt_graphics_Image.class,
 		Test_org_eclipse_swt_graphics_ImageData.class,
 		Test_org_eclipse_swt_graphics_PaletteData.class,
+		Test_org_eclipse_swt_graphics_Path.class,
 		Test_org_eclipse_swt_graphics_Point.class,
 		Test_org_eclipse_swt_graphics_Rectangle.class,
 		Test_org_eclipse_swt_graphics_Region.class,

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_Path.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_Path.java
@@ -1,0 +1,116 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Yatta and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Yatta - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.swt.tests.junit;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.fail;
+import static org.junit.Assume.assumeFalse;
+
+import org.eclipse.swt.graphics.Path;
+import org.eclipse.swt.graphics.PathData;
+import org.eclipse.swt.widgets.Display;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Automated Test Suite for class org.eclipse.swt.graphics.Path
+ *
+ * @see org.eclipse.swt.graphics.Path
+ */
+public class Test_org_eclipse_swt_graphics_Path {
+
+	private Display display;
+
+	@Before
+	public void setUp() {
+		display = Display.getDefault();
+	}
+
+	@Test
+	public void createTransform() {
+		Path path = new Path(display);
+		if (path.isDisposed()) {
+			fail("Constructor for Path didn't initialize");
+		}
+		path.dispose();
+	}
+
+	@Test
+	public void testClonePath() {
+		assumeFalse("Not currently working on macOS, cloning the path leads to not equal pathData.", SwtTestUtil.isCocoa);
+
+		Display display = Display.getDefault();
+
+		Path path = new Path(display);
+		path.addArc(0, 0, 10, 10, 0, 90);
+		path.addRectangle(10, 10, 50, 50);
+		path.quadTo(30, 30, 20, 40);
+
+		Path path2 = new Path(display);
+		path2.addArc(0, 0, 30, 30, 0, 270);
+		path.addPath(path2);
+
+		PathData pathData = path.getPathData();
+
+		// set flatness to null, so only cloning the path is tested
+		Path clonedPath = new Path(display, path, 0);
+		PathData clonedPathData = clonedPath.getPathData();
+
+		assertArrayEquals(pathData.points, clonedPathData.points, 0.001f);
+		path.dispose();
+		path2.dispose();
+		clonedPath.dispose();
+	}
+
+	@Test
+	public void disposePath() {
+		Path path = new Path(display);
+		path.addArc(0, 0, 10, 10, 0, 90);
+		if (path.isDisposed()) {
+			fail("Path should not be in the disposed state");
+		}
+
+		// dispose twice as this is allowed
+		for (int i = 0; i < 2; i++) {
+			path.dispose();
+			if (!path.isDisposed()) {
+				fail("Path should be in the disposed state");
+			}
+		}
+	}
+
+	@Test
+	public void testToString() {
+		Path path = new Path(display);
+		String s = path.toString();
+
+		if (s == null || s.length() == 0) {
+			fail("toString returns null or empty string");
+		}
+
+		path.addArc(0, 0, 10, 10, 0, 90);
+		s = path.toString();
+
+		if (s == null || s.length() == 0) {
+			fail("toString returns null or empty string");
+		}
+
+		path.dispose();
+		s = path.toString();
+
+		if (s == null || s.length() == 0) {
+			fail("toString returns null or empty string");
+		}
+	}
+}


### PR DESCRIPTION
This commit adapts Path in the win32 implementation to create handles only on demand. If a non-handle specific operation like getBounds() is called, a temporary handle will be created and disposed afterwards if no handle exists already.

It contains the branch used for https://github.com/eclipse-platform/eclipse.platform.swt/pull/1856 and is a second refactoring on transform, there it must be merged after https://github.com/eclipse-platform/eclipse.platform.swt/pull/1856