### PR TITLE
MenuItem Image Half Scaling to make sure there's no adverse effect

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT PI/win32/org/eclipse/swt/internal/win32/OS.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/win32/org/eclipse/swt/internal/win32/OS.java
@@ -1246,6 +1246,7 @@ public class OS extends C {
 	public static final int SM_CYFOCUSBORDER = 84;
 	public static final int SM_CYHSCROLL = 0x3;
 	public static final int SM_CYMENU = 0xf;
+	public static final int SM_CYMENUCHECK = 72;
 	public static final int SM_CXMINTRACK = 34;
 	public static final int SM_CYMINTRACK = 35;
 	public static final int SM_CXMAXTRACK = 59;

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/DPIUtil.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/DPIUtil.java
@@ -292,7 +292,7 @@ private static ImageData autoScaleImageData (Device device, final ImageData imag
 	int height = imageData.height;
 	int scaledWidth = Math.round (width * scaleFactor);
 	int scaledHeight = Math.round (height * scaleFactor);
-	boolean useSmoothScaling = autoScaleMethod == AutoScaleMethod.SMOOTH && imageData.getTransparencyType() != SWT.TRANSPARENCY_MASK;
+	boolean useSmoothScaling = isSmoothScalingEnabled() && imageData.getTransparencyType() != SWT.TRANSPARENCY_MASK;
 	if (useSmoothScaling) {
 		Image original = new Image (device, (ImageDataProvider) zoom -> imageData);
 		/* Create a 24 bit image data with alpha channel */
@@ -314,6 +314,10 @@ private static ImageData autoScaleImageData (Device device, final ImageData imag
 	} else {
 		return imageData.scaledTo (scaledWidth, scaledHeight);
 	}
+}
+
+public static boolean isSmoothScalingEnabled() {
+	return autoScaleMethod == AutoScaleMethod.SMOOTH;
 }
 
 /**
@@ -631,7 +635,19 @@ public static boolean useCairoAutoScale() {
 	return useCairoAutoScale;
 }
 
+public static int getZoomForMenuItemImage(int nativeDeviceZoom) {
+	String autoScaleValueForMenuItemImage = DPIUtil.autoScaleValue;
+	if(autoScaleValueForMenuItemImage.equals("quarter") || autoScaleValueForMenuItemImage.equals("exact")) {
+		autoScaleValueForMenuItemImage = "half";
+	}
+	return getZoomForAutoscaleProperty(nativeDeviceZoom, autoScaleValueForMenuItemImage);
+}
+
 public static int getZoomForAutoscaleProperty (int nativeDeviceZoom) {
+	return getZoomForAutoscaleProperty(nativeDeviceZoom, autoScaleValue);
+}
+
+private static int getZoomForAutoscaleProperty (int nativeDeviceZoom, String autoScaleValue) {
 	int zoom = 0;
 	if (autoScaleValue != null) {
 		if ("false".equalsIgnoreCase (autoScaleValue)) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/MenuItem.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/MenuItem.java
@@ -781,8 +781,7 @@ public void setImage (Image image) {
 		info.hbmpItem = OS.HBMMENU_CALLBACK;
 	} else {
 		if (OS.IsAppThemed ()) {
-			if (hBitmap != 0) OS.DeleteObject (hBitmap);
-			info.hbmpItem = hBitmap = image != null ? Display.create32bitDIB (image, getZoom()) : 0;
+			info.hbmpItem = hBitmap = getMenuItemIconBitmapHandle(image);
 		} else {
 			info.hbmpItem = image != null ? OS.HBMMENU_CALLBACK : 0;
 		}
@@ -790,6 +789,16 @@ public void setImage (Image image) {
 	long hMenu = parent.handle;
 	OS.SetMenuItemInfo (hMenu, id, false, info);
 	parent.redraw ();
+}
+
+private long getMenuItemIconBitmapHandle(Image image) {
+	if(image == null) {
+		return 0;
+	}
+	if (hBitmap != 0) OS.DeleteObject (hBitmap);
+	int desiredSize = getSystemMetrics(OS.SM_CYMENUCHECK);
+	int zoom = (int) (((double) desiredSize / image.getBounds().height) * 100);
+	return Display.create32bitDIB (image, zoom);
 }
 
 /**


### PR DESCRIPTION
This commit contributes to enforcing half scaling on the MenuItem Image. On Win32, the OS is responsible for painting the Image of a MenuItem and it expects images to be in standard sizes i.e. 16px, 24 px, 32 px, etc. If the images are not provided within these sizes, Windows tries to rescale them, leading to unexpected sizes and masking. Since, half scaling yields the images in standard sizes, MenuItems are scaled accordingly.

## Bug Description
- Start the IDE at a 125% zoom monitor (175, 225, 275, etc also work)
- Create a contect menu with a right-click
- The disabled images have a dark gray/black background
- The images might appear too small or too big.
![image](https://github.com/user-attachments/assets/4b375f03-f8ab-4196-bdc8-e2a0e224f75b)

## How to test
- Follow the same steps as described above
- The images should be scaled with half scaling strategy, i.e. 125% -> 100%, 175% -> 200%, 150% -> 150%
- There should not be any black background on disabled images.
![image](https://github.com/user-attachments/assets/79c8f1d4-a7df-48cf-ae85-fae0cba87e99)

contributes to
https://github.com/eclipse-platform/eclipse.platform.swt/issues/62 and https://github.com/eclipse-platform/eclipse.platform.swt/issues/127