### PR TITLE
Independent of initial version, revision version needs to be appended.

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT PI/common/org/eclipse/swt/internal/Library.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/common/org/eclipse/swt/internal/Library.java
@@ -373,8 +373,8 @@ public static String getVersionString () {
 			if (MINOR_VERSION < 100) version += "0"; //$NON-NLS-1$
 		}
 		version += MINOR_VERSION;
-		/* No "r" until first revision */
-		if (REVISION > 0) version += "r" + REVISION; //$NON-NLS-1$
+		/* "r" followed by respective revision version starting with zero(0) */
+		version += "r" + REVISION; //$NON-NLS-1$
 	}
 	return version;
 }


### PR DESCRIPTION
After this pr change :
From now on swt-win32-4969r0 followed by swt-win32-4969r1 and so on should come.

Before this pr
It was swt-win32-4969 followed by swt-win32-4969r1 and so on.

@HeikoKlare 
This is done. Thank you for your opinion(as i was also on the same) to do this change in a different pr.