### PR TITLE
Remove obsolete hashCode/equals for Region

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/graphics/Region.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/graphics/Region.java
@@ -436,9 +436,7 @@ void destroy() {
  */
 @Override
 public boolean equals(Object object) {
-	if (this == object) return true;
-	if (!(object instanceof Region region)) return false;
-	return handle == region.handle;
+	return super.equals(object);
 }
 
 /**
@@ -511,7 +509,7 @@ long regionToRects(long message, long rgn, long r, long path) {
  */
 @Override
 public int hashCode() {
-	return (int)handle;
+	return super.hashCode();
 }
 
 /**

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/graphics/Region.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/graphics/Region.java
@@ -310,10 +310,7 @@ void destroy() {
  */
 @Override
 public boolean equals(Object object) {
-	if (this == object) return true;
-	if (!(object instanceof Region)) return false;
-	Region region = (Region)object;
-	return handle == region.handle;
+	return super.equals(object);
 }
 
 /**
@@ -371,7 +368,7 @@ public static Region gtk_new(Device device, long handle) {
  */
 @Override
 public int hashCode() {
-	return (int)handle;
+	return super.hashCode();
 }
 
 /**

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Region.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Region.java
@@ -253,10 +253,7 @@ void destroyHandlesExcept(Set<Integer> zoomLevels) {
  */
 @Override
 public boolean equals (Object object) {
-	if (this == object) return true;
-	if (!(object instanceof Region)) return false;
-	Region rgn = (Region)object;
-	return getHandleForInitialZoom() == rgn.getHandleForInitialZoom();
+	return super.equals(object);
 }
 
 /**
@@ -295,7 +292,7 @@ Rectangle getBoundsInPixels() {
  */
 @Override
 public int hashCode () {
-	return (int)getHandleForInitialZoom();
+	return super.hashCode();
 }
 
 /**


### PR DESCRIPTION
This PR removes the obsolete equals and hashCode methods for Region. For the upcoming changes for win32 the current implementation cannot be used anymore because all handles will be created on demand. As the current implementation is equal in their behavior to the base behavior for these methods inherited from Object they will be removed.