### PR TITLE
Fix Combo crash with Bug379271_ComboCaretLocationOffset on Gtk 4

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/gtk4.c
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/gtk4.c
@@ -706,6 +706,18 @@ JNIEXPORT jlong JNICALL GTK4_NATIVE(gtk_1editable_1get_1text)
 }
 #endif
 
+#ifndef NO_gtk_1entry_1buffer_1get_1text
+JNIEXPORT jlong JNICALL GTK4_NATIVE(gtk_1entry_1buffer_1get_1text)
+	(JNIEnv *env, jclass that, jlong arg0)
+{
+	jlong rc = 0;
+	GTK4_NATIVE_ENTER(env, that, gtk_1entry_1buffer_1get_1text_FUNC);
+	rc = (jlong)gtk_entry_buffer_get_text((GtkEntryBuffer *)arg0);
+	GTK4_NATIVE_EXIT(env, that, gtk_1entry_1buffer_1get_1text_FUNC);
+	return rc;
+}
+#endif
+
 #ifndef NO_gtk_1entry_1get_1buffer
 JNIEXPORT jlong JNICALL GTK4_NATIVE(gtk_1entry_1get_1buffer)
 	(JNIEnv *env, jclass that, jlong arg0)

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/gtk4_stats.h
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/gtk4_stats.h
@@ -75,6 +75,7 @@ typedef enum {
 	gtk_1drop_1target_1async_1set_1formats_FUNC,
 	gtk_1editable_1get_1delegate_FUNC,
 	gtk_1editable_1get_1text_FUNC,
+	gtk_1entry_1buffer_1get_1text_FUNC,
 	gtk_1entry_1get_1buffer_FUNC,
 	gtk_1entry_1get_1text_1length_FUNC,
 	gtk_1entry_1set_1buffer_FUNC,

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/org/eclipse/swt/internal/gtk4/GTK4.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/org/eclipse/swt/internal/gtk4/GTK4.java
@@ -197,7 +197,7 @@ public class GTK4 {
 	public static final native long gtk_file_dialog_new();
 	/**
 	 * @method flags=dynamic
-	 * 
+	 *
 	 * @param parent cast=(GtkWindow *)
 	 * @param cancellable cast=(GCancellable *)
 	 * @param callback cast=(GAsyncReadyCallback)
@@ -206,55 +206,55 @@ public class GTK4 {
 	public static final native void gtk_file_dialog_select_folder(long self, long parent, long cancellable, long callback, long user_data);
 	/**
 	 * @method flags=dynamic
-	 * 
+	 *
 	 * @param result cast=(GAsyncResult *)
 	 * @param error cast=(GError **)
 	 */
 	public static final native long gtk_file_dialog_select_folder_finish(long self, long result, long[] error);
 	/**
 	 * @method flags=dynamic
-	 * 
+	 *
 	 * @param folder cast=(GFile *)
 	 */
 	public static final native void gtk_file_dialog_set_initial_folder(long self, long folder);
 	/**
 	 * @method flags=dynamic
-	 * 
+	 *
 	 * @param title cast=(char *)
 	 */
 	public static final native void gtk_file_dialog_set_initial_name(long self, byte[] title);
 	/**
 	 * @method flags=dynamic
-	 * 
+	 *
 	 * @param file cast=(GFile *)
 	 */
 	public static final native void gtk_file_dialog_set_initial_file(long self, long file);
 	/**
 	 * @method flags=dynamic
-	 * 
+	 *
 	 * @param title cast=(char *)
 	 */
 	public static final native void gtk_file_dialog_set_title(long self, byte[] title);
 	/**
 	 * @method flags=dynamic
-	 * 
+	 *
 	 * @param filter cast=(GtkFileFilter *)
 	 */
 	public static final native void gtk_file_dialog_set_default_filter(long self, long filter);
 	/**
 	 * @method flags=dynamic
-	 * 
+	 *
 	 * @param filters cast=(GListModel *)
 	 */
 	public static final native void gtk_file_dialog_set_filters(long self, long filters);
 	/**
 	 * @method flags=dynamic
-	 * 
+	 *
 	 */
 	public static final native long gtk_file_dialog_get_default_filter(long self);
 	/**
 	 * @method flags=dynamic
-	 * 
+	 *
 	 * @param parent cast=(GtkWindow *)
 	 * @param cancellable cast=(GCancellable *)
 	 * @param callback cast=(GAsyncReadyCallback)
@@ -263,13 +263,13 @@ public class GTK4 {
 	public static final native void gtk_file_dialog_open_multiple(long self, long parent, long cancellable, long callback, long user_data);
 	/**
 	 * @method flags=dynamic
-	 * 
+	 *
 	 * @param result cast=(GAsyncResult *)
 	 * @param error cast=(GError **)
 	 */
 	public static final native long gtk_file_dialog_open_multiple_finish(long self, long result, long[] error);
 	/**
-	 * 
+	 *
 	 * @param parent cast=(GtkWindow *)
 	 * @param cancellable cast=(GCancellable *)
 	 * @param callback cast=(GAsyncReadyCallback)
@@ -279,14 +279,14 @@ public class GTK4 {
 	public static final native void gtk_file_dialog_open(long self, long parent, long cancellable, long callback, long user_data);
 	/**
 	 * @method flags=dynamic
-	 * 
+	 *
 	 * @param result cast=(GAsyncResult *)
 	 * @param error cast=(GError **)
 	 */
 	public static final native long gtk_file_dialog_open_finish(long self, long result, long[] error);
 	/**
 	 * @method flags=dynamic
-	 * 
+	 *
 	 * @param parent cast=(GtkWindow *)
 	 * @param cancellable cast=(GCancellable *)
 	 * @param callback cast=(GAsyncReadyCallback)
@@ -295,7 +295,7 @@ public class GTK4 {
 	public static final native void gtk_file_dialog_save(long self, long parent, long cancellable, long callback, long user_data);
 	/**
 	 * @method flags=dynamic
-	 * 
+	 *
 	 * @param result cast=(GAsyncResult *)
 	 * @param error cast=(GError **)
 	 */
@@ -534,6 +534,8 @@ public class GTK4 {
 	 * @param buffer cast=(GtkEntryBuffer *)
 	 */
 	public static final native void gtk_entry_set_buffer(long entry, long buffer);
+	/** @param entry cast=(GtkEntryBuffer *) */
+	public static final native long gtk_entry_buffer_get_text(long entry);
 	/** @param entry cast=(GtkEntry *) */
 	public static final native long gtk_entry_get_buffer(long entry);
 	/** @param entry cast=(GtkEntry *) */

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Combo.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Combo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -1091,16 +1091,21 @@ Point getCaretLocationInPixels () {
 		return new Point (0, 0);
 	}
 	int index = GTK.gtk_editable_get_position (entryHandle);
-	index = GTK3.gtk_entry_text_index_to_layout_index (entryHandle, index);
 	int [] offset_x = new int [1], offset_y = new int [1];
-	GTK3.gtk_entry_get_layout_offsets (entryHandle, offset_x, offset_y);
-	long layout = GTK3.gtk_entry_get_layout (entryHandle);
-	PangoRectangle pos = new PangoRectangle ();
-	OS.pango_layout_index_to_pos (layout, index, pos);
-	Point thickness = getThickness (entryHandle);
-	int x = offset_x [0] + OS.PANGO_PIXELS (pos.x) - getBorderWidthInPixels () - thickness.x;
-	int y = offset_y [0] + OS.PANGO_PIXELS (pos.y) - thickness.y;
-	return new Point (x, y);
+	if (GTK.GTK4) {
+		// TODO GTK 4.x implementation
+		return new Point (0, 0);
+	} else {
+		index = GTK3.gtk_entry_text_index_to_layout_index (entryHandle, index);
+		GTK3.gtk_entry_get_layout_offsets (entryHandle, offset_x, offset_y);
+		long layout = GTK3.gtk_entry_get_layout (entryHandle);
+		PangoRectangle pos = new PangoRectangle ();
+		OS.pango_layout_index_to_pos (layout, index, pos);
+		Point thickness = getThickness (entryHandle);
+		int x = offset_x [0] + OS.PANGO_PIXELS (pos.x) - getBorderWidthInPixels () - thickness.x;
+		int y = offset_y [0] + OS.PANGO_PIXELS (pos.y) - thickness.y;
+		return new Point (x, y);
+	}
 }
 
 /**
@@ -1123,7 +1128,7 @@ public int getCaretPosition () {
 	if ((style & SWT.READ_ONLY) != 0) {
 		return 0;
 	}
-	long ptr = GTK3.gtk_entry_get_text (entryHandle);
+	long ptr = GTK.GTK4? GTK4.gtk_entry_buffer_get_text(GTK4.gtk_entry_get_buffer(entryHandle)) : GTK3.gtk_entry_get_text (entryHandle);
 	return (int)OS.g_utf8_offset_to_utf16_offset (ptr, GTK.gtk_editable_get_position (entryHandle));
 }
 


### PR DESCRIPTION
Method getCaretPosition is implemented with Gtk 4. The other method getCaredLocation is simply bypassed on Gtk 4 with TODO to prevent the crash for now.