### PR TITLE
[MacOS] Fix getBounds for Image based on ImageGcDrawer

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/graphics/Image.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/graphics/Image.java
@@ -874,13 +874,20 @@ public Image(Device device, ImageGcDrawer imageGcDrawer, int width, int height) 
 	this.imageGcDrawer = imageGcDrawer;
 	this.width = width;
 	this.height = height;
-	ImageData data = drawWithImageGcDrawer(imageGcDrawer, width, height, DPIUtil.getDeviceZoom());
+	ImageData data = drawWithImageGcDrawer(imageGcDrawer, width, height, 100);
 	if (data == null) SWT.error(SWT.ERROR_INVALID_ARGUMENT);
 	NSAutoreleasePool pool = null;
 	if (!NSThread.isMainThread()) pool = (NSAutoreleasePool) new NSAutoreleasePool().alloc().init();
 	try {
 		init (data);
-		init ();		
+		init ();
+		ImageData data2x = drawWithImageGcDrawer(imageGcDrawer, width, height, 200);
+		if (data2x != null) {
+			alphaInfo_200 = new AlphaInfo();
+			NSBitmapImageRep rep = createRepresentation (data2x, alphaInfo_200);
+			handle.addRepresentation(rep);
+			rep.release();
+		}
 	} finally {
 		if (pool != null) pool.release();
 	}

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_Image.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_Image.java
@@ -759,8 +759,8 @@ public void test_getBounds() {
 @SuppressWarnings("deprecation")
 @Test
 public void test_getBoundsInPixels() {
-	Rectangle bounds = new Rectangle(0, 0, 10, 20);
-	Image image = new Image(display, bounds.width, bounds.height);
+	Rectangle initialBounds = new Rectangle(0, 0, 10, 20);
+	Image image = new Image(display, initialBounds.width, initialBounds.height);
 	image.dispose();
 	try {
 		image.getBoundsInPixels();
@@ -770,38 +770,43 @@ public void test_getBoundsInPixels() {
 	}
 
 	// creates bitmap image
-	image = new Image(display, bounds.width, bounds.height);
+	image = new Image(display, initialBounds.width, initialBounds.height);
 	Rectangle boundsInPixels = image.getBoundsInPixels();
+	Rectangle bounds = image.getBounds();
 	image.dispose();
-	assertEquals(":a: Image.getBoundsInPixels method doesn't return bounds in Pixel values.", boundsInPixels, DPIUtil.autoScaleUp(bounds));
+	assertEquals("Image.getBounds method doesn't return original bounds.", initialBounds, bounds);
+	assertEquals("Image.getBoundsInPixels method doesn't return bounds in Pixel values.", DPIUtil.autoScaleUp(initialBounds), boundsInPixels);
 
 	// create icon image
-	ImageData imageData = new ImageData(bounds.width, bounds.height, 1, new PaletteData(new RGB[] {new RGB(0, 0, 0)}));
+	ImageData imageData = new ImageData(initialBounds.width, initialBounds.height, 1, new PaletteData(new RGB[] {new RGB(0, 0, 0)}));
 	image = new Image(display, imageData);
 	boundsInPixels = image.getBoundsInPixels();
+	bounds = image.getBounds();
 	image.dispose();
-	assertEquals(":b: Image.getBoundsInPixels method doesn't return bounds in Pixel values.", boundsInPixels, DPIUtil.autoScaleUp(bounds));
+	assertEquals("Image.getBounds method doesn't return original bounds.", initialBounds, bounds);
+	assertEquals("Image.getBoundsInPixels method doesn't return bounds in Pixel values.", DPIUtil.autoScaleUp(initialBounds), boundsInPixels);
 
 	// create image with FileNameProvider
 	image = new Image(display, imageFileNameProvider);
 	boundsInPixels = image.getBoundsInPixels();
 	bounds = image.getBounds();
 	image.dispose();
-	assertEquals(":c: Image.getBoundsInPixels method doesn't return bounds in Pixel values.", boundsInPixels, DPIUtil.autoScaleUp(bounds));
+	assertEquals("Image.getBoundsInPixels method doesn't return bounds in Pixel values.", DPIUtil.autoScaleUp(bounds), boundsInPixels);
 
 	// create image with ImageDataProvider
 	image = new Image(display, imageDataProvider);
 	boundsInPixels = image.getBoundsInPixels();
 	bounds = image.getBounds();
 	image.dispose();
-	assertEquals(":d: Image.getBoundsInPixels method doesn't return bounds in Pixel values.", boundsInPixels, DPIUtil.autoScaleUp(bounds));
+	assertEquals("Image.getBoundsInPixels method doesn't return bounds in Pixel values.", DPIUtil.autoScaleUp(bounds), boundsInPixels);
 
 	// create image with ImageGcDrawer
-	image = new Image(display, imageGcDrawer, bounds.width, bounds.height);
+	image = new Image(display, imageGcDrawer, initialBounds.width, initialBounds.height);
 	boundsInPixels = image.getBoundsInPixels();
 	bounds = image.getBounds();
 	image.dispose();
-	assertEquals("Image.getBoundsInPixels method doesn't return bounds in Pixel values for ImageGcDrawer.", boundsInPixels, DPIUtil.autoScaleUp(bounds));
+	assertEquals("Image.getBounds method doesn't return original bounds.", initialBounds, bounds);
+	assertEquals("Image.getBoundsInPixels method doesn't return bounds in Pixel values for ImageGcDrawer.", DPIUtil.autoScaleUp(initialBounds), boundsInPixels);
 }
 
 @SuppressWarnings("deprecation")


### PR DESCRIPTION
When running with a device zoom of 200, the bounds of images created with an ImageGcDrawer have double the expected size. The reason is that the image is initialized with image data at zoom 200, from which also the width and height are retrieved. The used initialization logic does, however, always expect image data at zoom 100 to be passed.

This change fixes the initialization of images based on ImageGcDrawer to create both the 100 and 200 image data version and correctly initialize the image metadata with the former. The according test case is extended to validate the bounds in pixels of images not only against the bounds if the image but also against the expected/initial bounds.

This API was introduced with the previous release and is yet only used for minimize/maximize icons of part stacks and the the line number ruler of editors. They do not use the bounds returned by these images, which is why the bug did not lead to any visible derivation of expected behavior yet. Once such images are used in a context whether the returned bounds matters, the issue will be visible by images having the double the expected size if used on a monitor with a zoom of 200.