### PR TITLE
[Win32] Replace autoScaleUp of ImageData with proper scaleImageData

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/DPIUtil.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/DPIUtil.java
@@ -346,10 +346,6 @@ public static ImageData autoScaleUp (Device device, final ImageData imageData) {
 	return autoScaleImageData(device, imageData, 100);
 }
 
-public static ImageData autoScaleUp (Device device, final ElementAtZoom<ImageData> elementAtZoom) {
-	return autoScaleImageData(device, elementAtZoom.element(), elementAtZoom.zoom());
-}
-
 public static int[] autoScaleUp(int[] pointArray) {
 	return scaleUp(pointArray, deviceZoom);
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Image.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Image.java
@@ -363,8 +363,9 @@ public Image(Device device, ImageData data) {
 	super(device);
 	if (data == null) SWT.error(SWT.ERROR_NULL_ARGUMENT);
 	initialNativeZoom = DPIUtil.getNativeDeviceZoom();
-	data = DPIUtil.autoScaleUp(device, new ElementAtZoom<>(data, 100));
-	init(data, getZoom());
+	int deviceZoom = getZoom();
+	data = DPIUtil.scaleImageData(device, new ElementAtZoom<>(data, 100), deviceZoom);
+	init(data, deviceZoom);
 	init();
 	this.device.registerResourceWithZoomSupport(this);
 }
@@ -471,8 +472,9 @@ public Image(Device device, ImageData source, ImageData mask) {
 public Image (Device device, InputStream stream) {
 	super(device);
 	initialNativeZoom = DPIUtil.getNativeDeviceZoom();
-	ImageData data = DPIUtil.autoScaleUp(device, new ElementAtZoom<>(new ImageData (stream), 100));
-	init(data, getZoom());
+	int deviceZoom = getZoom();
+	ImageData data = DPIUtil.scaleImageData(device, new ElementAtZoom<>(new ImageData (stream), 100), deviceZoom);
+	init(data, deviceZoom);
 	init();
 	this.device.registerResourceWithZoomSupport(this);
 }
@@ -513,8 +515,9 @@ public Image (Device device, String filename) {
 	super(device);
 	if (filename == null) SWT.error(SWT.ERROR_NULL_ARGUMENT);
 	initialNativeZoom = DPIUtil.getNativeDeviceZoom();
-	ImageData data = DPIUtil.autoScaleUp(device, new ElementAtZoom<>(new ImageData (filename), 100));
-	init(data, getZoom());
+	int deviceZoom = getZoom();
+	ImageData data = DPIUtil.scaleImageData(device, new ElementAtZoom<>(new ImageData (filename), 100), deviceZoom);
+	init(data, deviceZoom);
 	init();
 	this.device.registerResourceWithZoomSupport(this);
 }


### PR DESCRIPTION
In some image constructors, image data are currently auto-scaled. This works by accident, as the device zoom used for auto scaling conforms to the zoom of the image to be initialized.

However, to make this explicit, with this change the proper zoom is passed to scale method. It also makes the autoScaleUp method in DPIUtil obsolete and removes it.

This supcedes
- #1867

which migrated to a different but likely inaccurate autoScale operation.

Required to keep changes in https://github.com/eclipse-platform/eclipse.platform.swt/pull/1828 simple.