### PR TITLE
Adopt usage of zoom-aware ImageLoader methods in Image class

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/ImageData.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/ImageData.java
@@ -331,9 +331,7 @@ public ImageData(int width, int height, int depth, PaletteData palette, int scan
  * @see ImageLoader#load(InputStream)
  */
 public ImageData(InputStream stream) {
-	ImageData[] data = ImageDataLoader.load(stream);
-	if (data.length < 1) SWT.error(SWT.ERROR_INVALID_IMAGE);
-	ImageData i = data[0];
+	ImageData i = ImageDataLoader.load(stream);
 	setAllFields(
 		i.width,
 		i.height,
@@ -377,9 +375,7 @@ public ImageData(InputStream stream) {
  * </ul>
  */
 public ImageData(String filename) {
-	ImageData[] data = ImageDataLoader.load(filename);
-	if (data.length < 1) SWT.error(SWT.ERROR_INVALID_IMAGE);
-	ImageData i = data[0];
+	ImageData i = ImageDataLoader.load(filename);
 	setAllFields(
 		i.width,
 		i.height,

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/ImageDataLoader.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/ImageDataLoader.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2006 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -14,6 +14,10 @@
 package org.eclipse.swt.graphics;
 
 import java.io.*;
+import java.util.*;
+
+import org.eclipse.swt.*;
+import org.eclipse.swt.internal.DPIUtil.*;
 
 /**
  * Internal class that separates ImageData from ImageLoader
@@ -21,12 +25,28 @@ import java.io.*;
  */
 class ImageDataLoader {
 
-	public static ImageData[] load(InputStream stream) {
-		return new ImageLoader().load(stream);
+	public static ImageData load(InputStream stream) {
+		ImageData[] data = new ImageLoader().load(stream);
+		if (data.length < 1) SWT.error(SWT.ERROR_INVALID_IMAGE);
+		return data[0];
 	}
 
-	public static ImageData[] load(String filename) {
-		return new ImageLoader().load(filename);
+	public static ImageData load(String filename) {
+		ImageData[] data = new ImageLoader().load(filename);
+		if (data.length < 1) SWT.error(SWT.ERROR_INVALID_IMAGE);
+		return data[0];
+	}
+
+	public static ElementAtZoom<ImageData> load(InputStream stream, int fileZoom, int targetZoom) {
+		List<ElementAtZoom<ImageData>> data = new ImageLoader().load(stream, fileZoom, targetZoom);
+		if (data.isEmpty()) SWT.error(SWT.ERROR_INVALID_IMAGE);
+		return data.get(0);
+	}
+
+	public static ElementAtZoom<ImageData> load(String filename, int fileZoom, int targetZoom) {
+		List<ElementAtZoom<ImageData>> data = new ImageLoader().load(filename, fileZoom, targetZoom);
+		if (data.isEmpty()) SWT.error(SWT.ERROR_INVALID_IMAGE);
+		return data.get(0);
 	}
 
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/graphics/Image.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/graphics/Image.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2022 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -22,6 +22,7 @@ import org.eclipse.swt.internal.*;
 import org.eclipse.swt.internal.DPIUtil.*;
 import org.eclipse.swt.internal.cairo.*;
 import org.eclipse.swt.internal.gtk.*;
+import org.eclipse.swt.internal.image.*;
 
 /**
  * Instances of this class are graphics which have been prepared
@@ -530,9 +531,9 @@ public Image(Device device, ImageData source, ImageData mask) {
  */
 public Image(Device device, InputStream stream) {
 	super(device);
-	ImageData data = new ImageData(stream);
 	currentDeviceZoom = DPIUtil.getDeviceZoom();
-	data = DPIUtil.autoScaleUp (device, data);
+	ElementAtZoom<ImageData> image = ImageDataLoader.load(stream, FileFormat.DEFAULT_ZOOM, currentDeviceZoom);
+	ImageData data = DPIUtil.scaleImageData(device, image, currentDeviceZoom);
 	init(data);
 	init();
 }
@@ -572,10 +573,9 @@ public Image(Device device, InputStream stream) {
 public Image(Device device, String filename) {
 	super(device);
 	if (filename == null) SWT.error(SWT.ERROR_NULL_ARGUMENT);
-
-	ImageData data = new ImageData(filename);
 	currentDeviceZoom = DPIUtil.getDeviceZoom();
-	data = DPIUtil.autoScaleUp (device, data);
+	ElementAtZoom<ImageData> image = ImageDataLoader.load(filename, FileFormat.DEFAULT_ZOOM, currentDeviceZoom);
+	ImageData data = DPIUtil.scaleImageData(device, image, currentDeviceZoom);
 	init(data);
 	init();
 }
@@ -775,9 +775,10 @@ private void initFromFileNameProvider(int zoom) {
 		initNative(fileForZoom.element());
 	}
 	if (this.surface == 0) {
-		ImageData imageData = new ImageData(fileForZoom.element());
-		if (fileForZoom.zoom() != zoom) {
-			imageData = DPIUtil.scaleImageData(device, imageData, zoom, fileForZoom.zoom());
+		ElementAtZoom<ImageData> imageDataAtZoom = ImageDataLoader.load(fileForZoom.element(), fileForZoom.zoom(), zoom);
+		ImageData imageData = imageDataAtZoom.element();
+		if (imageDataAtZoom.zoom() != zoom) {
+			imageData = DPIUtil.scaleImageData(device, imageDataAtZoom, zoom);
 		}
 		init(imageData);
 	}


### PR DESCRIPTION
This was originally part of and has been extracted out of https://github.com/eclipse-platform/eclipse.platform.swt/pull/1828 in order to separate preparatory work in the `FileFormat` and `ImageLoader` implementations for their adoption in the OS-specific image classes.

This adopts the zoom-aware `ImageLoader` methods added in https://github.com/eclipse-platform/eclipse.platform.swt/pull/1828 in the `Image` implementations.

<s>⚠️ This currently contains the commit of https://github.com/eclipse-platform/eclipse.platform.swt/pull/1828 and should thus be merged after that PR.</s>