### PR TITLE
[GTK] Revert unification of blank Image initialization #1891

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/graphics/Image.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/graphics/Image.java
@@ -1249,7 +1249,11 @@ void init(int width, int height) {
 	this.type = SWT.BITMAP;
 
 	/* Create the pixmap */
-	surface = Cairo.cairo_image_surface_create(Cairo.CAIRO_FORMAT_ARGB32, width, height);
+	if (GTK.GTK4) {
+		surface = Cairo.cairo_image_surface_create(Cairo.CAIRO_FORMAT_RGB24, width, height);
+	} else {
+		surface = GDK.gdk_window_create_similar_surface(GDK.gdk_get_default_root_window(), Cairo.CAIRO_CONTENT_COLOR, width, height);
+	}
 	if (surface == 0) SWT.error(SWT.ERROR_NO_HANDLES);
 	// When we create a blank image we need to set it to 100 in GTK3 as we draw using 100% scale.
 	// Cairo will take care of scaling for us when image needs to be scaled.


### PR DESCRIPTION
A previous change unified the Image surface initialization for blank Image instances just based on height and width. Because of the change, screen capturing using a GC on the display does only work properly when executed the first time in an application lifecycle and in specific situation, the initial properties of a GC changed (such as the text anti-aliasing behavior). Due to a lack of a better solution for now, this change reverts the unification of the Image surface initialization to the previous state.

Fixes https://github.com/eclipse-platform/eclipse.platform.swt/issues/1891

This partially reverts commit 5c2611d677f45fe2c19cd84d4274ab7ca6dd1350.

Supercedes and thus closes #1835
Supercedes and thus closes #1839