### PR TITLE
Improve assertions for browser test #1843

### DIFF
--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_browser_Browser.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_browser_Browser.java
@@ -1176,9 +1176,10 @@ public void test_setTextContainingScript_applicationLayerProgressListenerMustSee
 				</body>
 			</html>
 			""");
-	waitForPassCondition(completed::get);
-	waitForPassCondition(() -> title.get() != null);
-	assertEquals("ProgressListener: Found 1 h1 tag(s)", title.get());
+	assertTrue("progress completion not reported", waitForPassCondition(completed::get));
+	assertTrue("title not set", waitForPassCondition(() -> title.get() != null));
+	assertTrue(
+			"unexpected title: " + title.get(), waitForPassCondition(() -> title.get().contains("ProgressListener: Found 1 h1 tag(s)")));
 }
 
 @Test


### PR DESCRIPTION
Improve assertions in browser test case `test_setTextContainingScript_applicationLayerProgressListenerMustSeeUpToDateDom` to avoid further test execution when expected conditions have not been fulfilled before.

Contributes to:
- https://github.com/eclipse-platform/eclipse.platform.swt/issues/1843