### PR TITLE
MenuItem Image Half Scaling #62

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/DPIUtil.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/DPIUtil.java
@@ -631,7 +631,19 @@ public static boolean useCairoAutoScale() {
 	return useCairoAutoScale;
 }
 
+public static int getZoomForMenuItemImage(int nativeDeviceZoom) {
+	String autoScaleValueForMenuItemImage = DPIUtil.autoScaleValue;
+	if(autoScaleValueForMenuItemImage.equals("quarter") || autoScaleValueForMenuItemImage.equals("exact")) {
+		autoScaleValueForMenuItemImage = "half";
+	}
+	return getZoomForAutoscaleProperty(nativeDeviceZoom, autoScaleValueForMenuItemImage);
+}
+
 public static int getZoomForAutoscaleProperty (int nativeDeviceZoom) {
+	return getZoomForAutoscaleProperty(nativeDeviceZoom, autoScaleValue);
+}
+
+private static int getZoomForAutoscaleProperty (int nativeDeviceZoom, String autoScaleValue) {
 	int zoom = 0;
 	if (autoScaleValue != null) {
 		if ("false".equalsIgnoreCase (autoScaleValue)) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/MenuItem.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/MenuItem.java
@@ -782,7 +782,15 @@ public void setImage (Image image) {
 	} else {
 		if (OS.IsAppThemed ()) {
 			if (hBitmap != 0) OS.DeleteObject (hBitmap);
-			info.hbmpItem = hBitmap = image != null ? Display.create32bitDIB (image, getZoom()) : 0;
+			int desiredSize = getSystemMetrics(72);
+			int zoom = (int) (((double) desiredSize / image.getBounds().height) * 100);
+			int currentSize = image.getImageData(zoom).height;
+			while(currentSize == desiredSize) {
+				zoom--;
+				currentSize = image.getImageData(zoom).height;
+			}
+			zoom++;
+			info.hbmpItem = hBitmap = image != null ? Display.create32bitDIB (image, zoom) : 0;
 		} else {
 			info.hbmpItem = image != null ? OS.HBMMENU_CALLBACK : 0;
 		}


### PR DESCRIPTION
This commit contributes to enforcing half scaling on the MenuItem Image. On Win32, the OS is responsible for painting the Image of a MenuItem and it expects images to be in standard sizes i.e. 16px, 24 px, 32 px, etc. If the images are not provided within these sizes, Windows tries to rescale them, leading to unexpected sizes and masking. Since, half scaling yields the images in standard sizes, MenuItems are scaled accordingly.

contributes to
https://github.com/eclipse-platform/eclipse.platform.swt/issues/62 and https://github.com/eclipse-platform/eclipse.platform.swt/issues/127