### PR TITLE
Make `MonitorAwarePoint` a windows-specific implementation detail

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/Point.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/Point.java
@@ -41,7 +41,7 @@ import java.io.*;
  * @see <a href="http://www.eclipse.org/swt/">Sample code and further information</a>
  */
 
-public sealed class Point implements Serializable permits MonitorAwarePoint {
+public class Point implements Serializable {
 
 	/**
 	 * the x coordinate of the point

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/Rectangle.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/Rectangle.java
@@ -45,7 +45,7 @@ import org.eclipse.swt.*;
  * @see <a href="http://www.eclipse.org/swt/">Sample code and further information</a>
  */
 
-public sealed class Rectangle implements Serializable permits MonitorAwareRectangle {
+public class Rectangle implements Serializable {
 
 	/**
 	 * the x coordinate of the rectangle

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/MonitorAwarePoint.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/MonitorAwarePoint.java
@@ -26,7 +26,7 @@ import org.eclipse.swt.widgets.*;
  * @since 3.129
  * @noreference This class is not intended to be referenced by clients
  */
-public final class MonitorAwarePoint extends Point {
+final class MonitorAwarePoint extends Point {
 
 	private static final long serialVersionUID = 6077427420686999194L;
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/MonitorAwareRectangle.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/MonitorAwareRectangle.java
@@ -26,7 +26,7 @@ import org.eclipse.swt.widgets.*;
  * @since 3.129
  * @noreference This class is not intended to be referenced by clients
  */
-public final class MonitorAwareRectangle extends Rectangle {
+final class MonitorAwareRectangle extends Rectangle {
 
 	private static final long serialVersionUID = 5041911840525116925L;
 


### PR DESCRIPTION
- #1711 made `Point` and `Rectangle` part of a sealed class hierarchy which added `MonitorAware` variants
- this new hierarchy causes two problems
  - users cannot instantiate `Point` or `Rectangle` from Kotlin, because Kotlin does not allow the base of a sealed hierarchy to be one of the elements
  - even for Java users, equality is now muddled. Two points can have the same `x, y` values, but not be equal. For example, take a point, map it to a control, map it back, you'll get the same coordinates you started with, but `.equals` will be false now because one of the points will be a `MonitorAware`. This behavior only happens on Windows.

I'm proposing two PRs. This, the first one, doesn't fix the muddled equality bug, but it makes `MonitorAware` a package-private implementation detail that only affects the win32 platform.

The second one (#1904) removes `MonitorAware` and replaces it with logic that is contained within the `MultiZoomCoordinateMapper`. As of SWT in the release 4.35, these new `MonitorAware` variants are created in exactly two places.

  - https://github.com/eclipse-platform/eclipse.platform.swt/blob/e1f11c985538793b9ae512ddedba1fa3a2108fff/bundles/org.eclipse.swt/Eclipse%20SWT/win32/org/eclipse/swt/widgets/MultiZoomCoordinateSystemMapper.java#L155
  - https://github.com/eclipse-platform/eclipse.platform.swt/blob/e1f11c985538793b9ae512ddedba1fa3a2108fff/bundles/org.eclipse.swt/Eclipse%20SWT/win32/org/eclipse/swt/widgets/MultiZoomCoordinateSystemMapper.java#L264
