### PR TITLE
Take `MonitorAware` out of the geometry hierarchy with as few other changes as possible

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/widgets/CoordinateSystemMapperTests.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/widgets/CoordinateSystemMapperTests.java
@@ -63,9 +63,9 @@ public class CoordinateSystemMapperTests {
 	@MethodSource("provideCoordinateSystemMappers")
 	void translatePointInNoMonitorBackAndForthShouldBeTheSame(CoordinateSystemMapper mapper) {
 		setupMonitors(mapper);
-		Point pt = createExpectedPoint(mapper, 5000, -400, monitors[0]);
+		MonitorAwarePoint pt = createExpectedPoint(mapper, 5000, -400, monitors[0]);
 		Point px = mapper.translateToDisplayCoordinates(pt, monitors[0].getZoom());
-		assertEquals(pt, mapper.translateFromDisplayCoordinates(px, monitors[0].getZoom()));
+		assertEquals(pt.getPoint(), mapper.translateFromDisplayCoordinates(px, monitors[0].getZoom()));
 	}
 
 	@Test
@@ -73,7 +73,7 @@ public class CoordinateSystemMapperTests {
 		SingleZoomCoordinateSystemMapper mapper = getSingleZoomCoordinateSystemMapper();
 		setupMonitors(mapper);
 		Point pt = new Point(1900, 400);
-		Point px = mapper.translateToDisplayCoordinates(pt, monitors[0].getZoom());
+		Point px = mapper.translateToDisplayCoordinates(new MonitorAwarePoint(pt), monitors[0].getZoom());
 		assertEquals(pt, mapper.translateFromDisplayCoordinates(px, monitors[0].getZoom()));
 	}
 
@@ -82,9 +82,9 @@ public class CoordinateSystemMapperTests {
 		MultiZoomCoordinateSystemMapper mapper = getMultiZoomCoordinateSystemMapper();
 		setupMonitors(mapper);
 		Point pt = new Point(1900, 400);
-		Point px = mapper.translateToDisplayCoordinates(pt, monitors[0].getZoom());
+		Point px = mapper.translateToDisplayCoordinates(new MonitorAwarePoint(pt), monitors[0].getZoom());
 		Point translatedPt = mapper.translateFromDisplayCoordinates(px, monitors[0].getZoom());
-		Point translatedPx = mapper.translateToDisplayCoordinates(translatedPt, monitors[0].getZoom());
+		Point translatedPx = mapper.translateToDisplayCoordinates(new MonitorAwarePoint(translatedPt), monitors[0].getZoom());
 		assertEquals(new Point(translatedPt.x, translatedPt.y), translatedPx);
 		assertEquals(translatedPx, px);
 	}
@@ -93,9 +93,9 @@ public class CoordinateSystemMapperTests {
 	@MethodSource("provideCoordinateSystemMappers")
 	void translateRectangleInNoMonitorBackAndForthShouldBeTheSame(CoordinateSystemMapper mapper) {
 		setupMonitors(mapper);
-		Rectangle rectInPts = createExpectedRectangle(mapper, 5000, -400, 200, 200, monitors[0]);
+		MonitorAwareRectangle rectInPts = createExpectedRectangle(mapper, 5000, -400, 200, 200, monitors[0]);
 		Rectangle rectInPxs = mapper.translateToDisplayCoordinates(rectInPts, monitors[0].getZoom());
-		assertEquals(rectInPts, mapper.translateFromDisplayCoordinates(rectInPxs, monitors[0].getZoom()));
+		assertEquals(rectInPts.getRectangle(), mapper.translateFromDisplayCoordinates(new MonitorAwareRectangle(rectInPxs), monitors[0].getZoom()));
 	}
 
 	@Test
@@ -103,8 +103,8 @@ public class CoordinateSystemMapperTests {
 		SingleZoomCoordinateSystemMapper mapper = getSingleZoomCoordinateSystemMapper();
 		setupMonitors(mapper);
 		Rectangle rectInPts = new Rectangle(1800, 400, 100, 100);
-		Rectangle rectInPxs = mapper.translateToDisplayCoordinates(rectInPts, monitors[0].getZoom());
-		assertEquals(rectInPts, mapper.translateFromDisplayCoordinates(rectInPxs, monitors[0].getZoom()));
+		Rectangle rectInPxs = mapper.translateToDisplayCoordinates(new MonitorAwareRectangle(rectInPts), monitors[0].getZoom());
+		assertEquals(rectInPts, mapper.translateFromDisplayCoordinates(new MonitorAwareRectangle(rectInPxs), monitors[0].getZoom()));
 	}
 
 	@Test
@@ -112,8 +112,8 @@ public class CoordinateSystemMapperTests {
 		MultiZoomCoordinateSystemMapper mapper = getMultiZoomCoordinateSystemMapper();
 		setupMonitors(mapper);
 		Rectangle rectInPts = new Rectangle(1800, 400, 100, 100);
-		Rectangle rectInPxs = mapper.translateToDisplayCoordinates(rectInPts, monitors[0].getZoom());
-		Rectangle rectInPtsTranslated = mapper.translateFromDisplayCoordinates(rectInPxs, monitors[0].getZoom());
+		Rectangle rectInPxs = mapper.translateToDisplayCoordinates(new MonitorAwareRectangle(rectInPts), monitors[0].getZoom());
+		Rectangle rectInPtsTranslated = mapper.translateFromDisplayCoordinates(new MonitorAwareRectangle(rectInPxs), monitors[0].getZoom());
 		boolean isInsideMonitor = false;
 		for (Monitor monitor : monitors) {
 			if (monitor.getClientArea().intersects(rectInPtsTranslated)) {
@@ -129,26 +129,26 @@ public class CoordinateSystemMapperTests {
 		SingleZoomCoordinateSystemMapper mapper = getSingleZoomCoordinateSystemMapper();
 		setupMonitors(mapper);
 		Rectangle rectInPts = new Rectangle(1950, 400, 150, 100);
-		Rectangle rectInPxs = mapper.translateToDisplayCoordinates(rectInPts, monitors[0].getZoom());
-		assertEquals(rectInPts, mapper.translateFromDisplayCoordinates(rectInPxs, monitors[0].getZoom()));
+		Rectangle rectInPxs = mapper.translateToDisplayCoordinates(new MonitorAwareRectangle(rectInPts), monitors[0].getZoom());
+		assertEquals(rectInPts, mapper.translateFromDisplayCoordinates(new MonitorAwareRectangle(rectInPxs), monitors[0].getZoom()));
 	}
 
 	@Test
 	void translateRectangleInGapPartiallyInRightBackAndForthInMultiZoomShouldBeInside() {
 		MultiZoomCoordinateSystemMapper mapper = getMultiZoomCoordinateSystemMapper();
 		setupMonitors(mapper);
-		Rectangle rectInPts = new MonitorAwareRectangle(1950, 400, 150, 100, monitors[1]);
+		MonitorAwareRectangle rectInPts = new MonitorAwareRectangle(1950, 400, 150, 100, monitors[1]);
 		Rectangle rectInPxs = mapper.translateToDisplayCoordinates(rectInPts, monitors[0].getZoom());
-		assertEquals(rectInPts, mapper.translateFromDisplayCoordinates(rectInPxs, monitors[0].getZoom()));
+		assertEquals(rectInPts.getRectangle(), mapper.translateFromDisplayCoordinates(new MonitorAwareRectangle(rectInPxs), monitors[0].getZoom()));
 	}
 
 	@ParameterizedTest
 	@MethodSource("provideCoordinateSystemMappers")
 	void translateRectangleInGapPartiallyInLeftBackAndForthShouldBeTheSame(CoordinateSystemMapper mapper) {
 		setupMonitors(mapper);
-		Rectangle rectInPts = createExpectedRectangle(mapper, 750, 400, 100, 100, monitors[0]);
+		MonitorAwareRectangle rectInPts = createExpectedRectangle(mapper, 750, 400, 100, 100, monitors[0]);
 		Rectangle rectInPxs = mapper.translateToDisplayCoordinates(rectInPts, monitors[0].getZoom());
-		assertEquals(rectInPts, mapper.translateFromDisplayCoordinates(rectInPxs, monitors[0].getZoom()));
+		assertEquals(rectInPts.getRectangle(), mapper.translateFromDisplayCoordinates(new MonitorAwareRectangle(rectInPxs), monitors[0].getZoom()));
 	}
 
 	@Test
@@ -156,8 +156,8 @@ public class CoordinateSystemMapperTests {
 		SingleZoomCoordinateSystemMapper mapper = getSingleZoomCoordinateSystemMapper();
 		setupMonitors(mapper);
 		Rectangle rectInPts = new Rectangle(950, 400, 1500, 100);
-		Rectangle rectInPxs = mapper.translateToDisplayCoordinates(rectInPts, monitors[0].getZoom());
-		assertEquals(rectInPts, mapper.translateFromDisplayCoordinates(rectInPxs, monitors[0].getZoom()));
+		Rectangle rectInPxs = mapper.translateToDisplayCoordinates(new MonitorAwareRectangle(rectInPts), monitors[0].getZoom());
+		assertEquals(rectInPts, mapper.translateFromDisplayCoordinates(new MonitorAwareRectangle(rectInPxs), monitors[0].getZoom()));
 	}
 
 	@Test
@@ -165,9 +165,9 @@ public class CoordinateSystemMapperTests {
 		MultiZoomCoordinateSystemMapper mapper = getMultiZoomCoordinateSystemMapper();
 		setupMonitors(mapper);
 		Rectangle rectInPts = new Rectangle(950, 400, 1500, 100);
-		Rectangle rectInPxs = mapper.translateToDisplayCoordinates(rectInPts, monitors[0].getZoom());
-		Rectangle rectInPtsTranslated = mapper.translateFromDisplayCoordinates(rectInPxs, monitors[0].getZoom());
-		Rectangle rectInPxsTranslated = mapper.translateToDisplayCoordinates(rectInPtsTranslated,
+		Rectangle rectInPxs = mapper.translateToDisplayCoordinates(new MonitorAwareRectangle(rectInPts), monitors[0].getZoom());
+		Rectangle rectInPtsTranslated = mapper.translateFromDisplayCoordinates(new MonitorAwareRectangle(rectInPxs), monitors[0].getZoom());
+		Rectangle rectInPxsTranslated = mapper.translateToDisplayCoordinates(new MonitorAwareRectangle(rectInPtsTranslated),
 				monitors[0].getZoom());
 		assertEquals(rectInPxs, rectInPxsTranslated);
 	}
@@ -182,13 +182,13 @@ public class CoordinateSystemMapperTests {
 		expectedSmallRectInPxs.y = rectInPxs.y + (rectInPxs.height / 2) - 200;
 		expectedSmallRectInPxs.width = 400;
 		expectedSmallRectInPxs.height = 400;
-		Rectangle rectInPts = mapper.translateFromDisplayCoordinates(rectInPxs, monitors[0].getZoom());
+		Rectangle rectInPts = mapper.translateFromDisplayCoordinates(new MonitorAwareRectangle(rectInPxs), monitors[0].getZoom());
 		Rectangle smallRectInPts = new Rectangle(0, 0, 0, monitors[0].getZoom());
 		smallRectInPts.x = rectInPts.x + (rectInPts.width / 2) - 200;
 		smallRectInPts.y = rectInPts.y + (rectInPts.height / 2) - 200;
 		smallRectInPts.width = 400;
 		smallRectInPts.height = 400;
-		Rectangle smallRectInPxs = mapper.translateToDisplayCoordinates(smallRectInPts, monitors[0].getZoom());
+		Rectangle smallRectInPxs = mapper.translateToDisplayCoordinates(new MonitorAwareRectangle(smallRectInPts), monitors[0].getZoom());
 		assertEquals(expectedSmallRectInPxs, smallRectInPxs);
 	}
 
@@ -197,8 +197,8 @@ public class CoordinateSystemMapperTests {
 	void translateRectangleInPixelsOutisdeMonitorsBackAndForthShouldBeTheSame(CoordinateSystemMapper mapper) {
 		setupMonitors(mapper);
 		Rectangle rectInPxs = new Rectangle(400, 2400, 1000, 1000);
-		Rectangle rectInPts = mapper.translateFromDisplayCoordinates(rectInPxs, monitors[0].getZoom());
-		assertEquals(rectInPxs, mapper.translateToDisplayCoordinates(rectInPts, monitors[0].getZoom()));
+		Rectangle rectInPts = mapper.translateFromDisplayCoordinates(new MonitorAwareRectangle(rectInPxs), monitors[0].getZoom());
+		assertEquals(rectInPxs, mapper.translateToDisplayCoordinates(new MonitorAwareRectangle(rectInPts), monitors[0].getZoom()));
 	}
 
 	@ParameterizedTest
@@ -206,21 +206,21 @@ public class CoordinateSystemMapperTests {
 	void translateRectangleInPixelsInBothMonitorsBackAndForthShouldBeTheSame(CoordinateSystemMapper mapper) {
 		setupMonitors(mapper);
 		Rectangle rectInPxs = new Rectangle(1500, 400, 502, 500);
-		Rectangle rectInPts = mapper.translateFromDisplayCoordinates(rectInPxs, monitors[0].getZoom());
-		assertEquals(rectInPxs, mapper.translateToDisplayCoordinates(rectInPts, monitors[0].getZoom()));
+		Rectangle rectInPts = mapper.translateFromDisplayCoordinates(new MonitorAwareRectangle(rectInPxs), monitors[0].getZoom());
+		assertEquals(rectInPxs, mapper.translateToDisplayCoordinates(new MonitorAwareRectangle(rectInPts), monitors[0].getZoom()));
 	}
 
-	private Point createExpectedPoint(CoordinateSystemMapper mapper, int x, int y, Monitor monitor) {
+	private MonitorAwarePoint createExpectedPoint(CoordinateSystemMapper mapper, int x, int y, Monitor monitor) {
 		if (mapper instanceof SingleZoomCoordinateSystemMapper) {
-			return new Point(x, y);
+			return new MonitorAwarePoint(new Point(x, y));
 		} else {
 			return new MonitorAwarePoint(x, y, monitor);
 		}
 	}
 
-	private Rectangle createExpectedRectangle(CoordinateSystemMapper mapper, int x, int y, int width, int height, Monitor monitor) {
+	private MonitorAwareRectangle createExpectedRectangle(CoordinateSystemMapper mapper, int x, int y, int width, int height, Monitor monitor) {
 		if (mapper instanceof SingleZoomCoordinateSystemMapper) {
-			return new Rectangle(x, y, width, height);
+			return new MonitorAwareRectangle(new Rectangle(x, y, width, height));
 		} else {
 			return new MonitorAwareRectangle(x, y, width, height, monitor);
 		}

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/MonitorAwarePoint.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/MonitorAwarePoint.java
@@ -13,8 +13,6 @@
  *******************************************************************************/
 package org.eclipse.swt.graphics;
 
-import java.util.*;
-
 import org.eclipse.swt.widgets.*;
 
 /**
@@ -26,10 +24,8 @@ import org.eclipse.swt.widgets.*;
  * @since 3.129
  * @noreference This class is not intended to be referenced by clients
  */
-public final class MonitorAwarePoint extends Point {
-
-	private static final long serialVersionUID = 6077427420686999194L;
-
+public final class MonitorAwarePoint {
+	private final Point point;
 	private final Monitor monitor;
 
 	/**
@@ -40,7 +36,7 @@ public final class MonitorAwarePoint extends Point {
 	 * @param monitor the monitor with whose context the point is created
 	 */
 	public MonitorAwarePoint(int x, int y, Monitor monitor) {
-		super(x, y);
+		this.point = new Point(x, y);
 		this.monitor = monitor;
 	}
 
@@ -51,21 +47,10 @@ public final class MonitorAwarePoint extends Point {
 		return monitor;
 	}
 
-	@Override
-	public boolean equals(Object object) {
-		if (this == object) {
-			return true;
-		}
-		if (!super.equals(object)) {
-			return false;
-		}
-		MonitorAwarePoint other = (MonitorAwarePoint) object;
-		return Objects.equals(this.monitor, other.monitor);
+	/**
+	 * {@return the monitor with whose context the instance is created}
+	 */
+	public Point getPoint() {
+		return point;
 	}
-
-	@Override
-	public int hashCode() {
-		return Objects.hash(super.hashCode(), monitor);
-	}
-
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/MonitorAwarePoint.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/MonitorAwarePoint.java
@@ -36,7 +36,15 @@ public final class MonitorAwarePoint {
 	 * @param monitor the monitor with whose context the point is created
 	 */
 	public MonitorAwarePoint(int x, int y, Monitor monitor) {
-		this.point = new Point(x, y);
+		this(new Point(x, y), monitor);
+	}
+
+	public MonitorAwarePoint(Point point) {
+		this(point, null);
+	}
+
+	public MonitorAwarePoint(Point point, Monitor monitor) {
+		this.point = point;
 		this.monitor = monitor;
 	}
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/MonitorAwareRectangle.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/MonitorAwareRectangle.java
@@ -38,7 +38,15 @@ public final class MonitorAwareRectangle {
 	 * @param monitor the monitor with whose context the rectangle is created
 	 */
 	public MonitorAwareRectangle(int x, int y, int width, int height, Monitor monitor) {
-		this.rect = new Rectangle(x, y, width, height);
+		this(new Rectangle(x, y, width, height), monitor);
+	}
+
+	public MonitorAwareRectangle(Rectangle rect) {
+		this(rect, null);
+	}
+
+	public MonitorAwareRectangle(Rectangle rect, Monitor monitor) {
+		this.rect = rect;
 		this.monitor = monitor;
 	}
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/MonitorAwareRectangle.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/MonitorAwareRectangle.java
@@ -13,8 +13,6 @@
  *******************************************************************************/
 package org.eclipse.swt.graphics;
 
-import java.util.*;
-
 import org.eclipse.swt.widgets.*;
 
 /**
@@ -26,10 +24,8 @@ import org.eclipse.swt.widgets.*;
  * @since 3.129
  * @noreference This class is not intended to be referenced by clients
  */
-public final class MonitorAwareRectangle extends Rectangle {
-
-	private static final long serialVersionUID = 5041911840525116925L;
-
+public final class MonitorAwareRectangle {
+	private final Rectangle rect;
 	private final Monitor monitor;
 
 	/**
@@ -42,8 +38,15 @@ public final class MonitorAwareRectangle extends Rectangle {
 	 * @param monitor the monitor with whose context the rectangle is created
 	 */
 	public MonitorAwareRectangle(int x, int y, int width, int height, Monitor monitor) {
-		super(x, y, width, height);
+		this.rect = new Rectangle(x, y, width, height);
 		this.monitor = monitor;
+	}
+
+	/**
+	 * {@return the monitor with whose context the instance is created}
+	 */
+	public Rectangle getRectangle() {
+		return rect;
 	}
 
 	/**
@@ -52,22 +55,4 @@ public final class MonitorAwareRectangle extends Rectangle {
 	public Monitor getMonitor() {
 		return monitor;
 	}
-
-	@Override
-	public boolean equals(Object object) {
-		if (this == object) {
-			return true;
-		}
-		if (!super.equals(object)) {
-			return false;
-		}
-		MonitorAwareRectangle other = (MonitorAwareRectangle) object;
-		return Objects.equals(this.monitor, other.monitor);
-	}
-
-	@Override
-	public int hashCode() {
-		return Objects.hash(super.hashCode(), monitor);
-	}
-
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/Point.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/Point.java
@@ -41,7 +41,7 @@ import java.io.*;
  * @see <a href="http://www.eclipse.org/swt/">Sample code and further information</a>
  */
 
-public sealed class Point implements Serializable permits MonitorAwarePoint {
+public final class Point implements Serializable {
 
 	/**
 	 * the x coordinate of the point

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/Rectangle.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/Rectangle.java
@@ -45,7 +45,7 @@ import org.eclipse.swt.*;
  * @see <a href="http://www.eclipse.org/swt/">Sample code and further information</a>
  */
 
-public sealed class Rectangle implements Serializable permits MonitorAwareRectangle {
+public final class Rectangle implements Serializable {
 
 	/**
 	 * the x coordinate of the rectangle

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Control.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Control.java
@@ -4009,7 +4009,7 @@ void subclass () {
 public Point toControl (int x, int y) {
 	checkWidget ();
 	int zoom = getZoom();
-	Point displayPointInPixels = getDisplay().translateToDisplayCoordinates(new Point(x, y), zoom);
+	Point displayPointInPixels = getDisplay().translateToDisplayCoordinates(new MonitorAwarePoint(new Point(x, y)), zoom);
 	final Point controlPointInPixels = toControlInPixels(displayPointInPixels.x, displayPointInPixels.y);
 	return DPIUtil.scaleDown(controlPointInPixels, zoom);
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/CoordinateSystemMapper.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/CoordinateSystemMapper.java
@@ -17,23 +17,23 @@ import org.eclipse.swt.graphics.*;
 
 interface CoordinateSystemMapper {
 
-	Rectangle map(Control from, Control to, Rectangle rectangle);
+	MonitorAwareRectangle map(Control from, Control to, Rectangle rectangle);
 
-	Rectangle map(Control from, Control to, int x, int y, int width, int height);
+	MonitorAwareRectangle map(Control from, Control to, int x, int y, int width, int height);
 
-	Point map(Control from, Control to, Point point);
+	MonitorAwarePoint map(Control from, Control to, Point point);
 
-	Point map(Control from, Control to, int x, int y);
+	MonitorAwarePoint map(Control from, Control to, int x, int y);
 
 	Rectangle mapMonitorBounds(Rectangle rectangle, int zoom);
 
 	Point translateFromDisplayCoordinates(Point point, int zoom);
 
-	Point translateToDisplayCoordinates(Point point, int zoom);
+	Point translateToDisplayCoordinates(MonitorAwarePoint point, int zoom);
 
-	Rectangle translateFromDisplayCoordinates(Rectangle rect, int zoom);
+	Rectangle translateFromDisplayCoordinates(MonitorAwareRectangle rect, int zoom);
 
-	Rectangle translateToDisplayCoordinates(Rectangle rect, int zoom);
+	Rectangle translateToDisplayCoordinates(MonitorAwareRectangle rect, int zoom);
 
 	void setCursorLocation(int x, int y);
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Display.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Display.java
@@ -2981,7 +2981,7 @@ boolean isValidThread () {
 public Point map (Control from, Control to, Point point) {
 	checkDevice ();
 	if (point == null) error (SWT.ERROR_NULL_ARGUMENT);
-	return coordinateSystemMapper.map(from, to, point);
+	return coordinateSystemMapper.map(from, to, point).getPoint();
 }
 
 Point mapInPixels (Control from, Control to, Point point) {
@@ -3026,7 +3026,7 @@ Point mapInPixels (Control from, Control to, Point point) {
  */
 public Point map (Control from, Control to, int x, int y) {
 	checkDevice ();
-	return coordinateSystemMapper.map(from, to, x, y);
+	return coordinateSystemMapper.map(from, to, x, y).getPoint();
 }
 
 Point mapInPixels (Control from, Control to, int x, int y) {
@@ -3081,7 +3081,7 @@ Point mapInPixels (Control from, Control to, int x, int y) {
 public Rectangle map (Control from, Control to, Rectangle rectangle) {
 	checkDevice ();
 	if (rectangle == null) error (SWT.ERROR_NULL_ARGUMENT);
-	return coordinateSystemMapper.map(from, to, rectangle);
+	return coordinateSystemMapper.map(from, to, rectangle).getRectangle();
 }
 
 Rectangle mapInPixels (Control from, Control to, Rectangle rectangle) {
@@ -3128,7 +3128,7 @@ Rectangle mapInPixels (Control from, Control to, Rectangle rectangle) {
  */
 public Rectangle map (Control from, Control to, int x, int y, int width, int height) {
 	checkDevice ();
-	return coordinateSystemMapper.map(from, to, x, y, width, height);
+	return coordinateSystemMapper.map(from, to, x, y, width, height).getRectangle();
 }
 
 Rectangle mapInPixels (Control from, Control to, int x, int y, int width, int height) {
@@ -3150,15 +3150,15 @@ Point translateFromDisplayCoordinates(Point point, int zoom) {
 	return coordinateSystemMapper.translateFromDisplayCoordinates(point, zoom);
 }
 
-Point translateToDisplayCoordinates(Point point, int zoom) {
+Point translateToDisplayCoordinates(MonitorAwarePoint point, int zoom) {
 	return coordinateSystemMapper.translateToDisplayCoordinates(point, zoom);
 }
 
-Rectangle translateFromDisplayCoordinates(Rectangle rect, int zoom) {
+Rectangle translateFromDisplayCoordinates(MonitorAwareRectangle rect, int zoom) {
 	return coordinateSystemMapper.translateFromDisplayCoordinates(rect, zoom);
 }
 
-Rectangle translateToDisplayCoordinates(Rectangle rect, int zoom) {
+Rectangle translateToDisplayCoordinates(MonitorAwareRectangle rect, int zoom) {
 	return coordinateSystemMapper.translateToDisplayCoordinates(rect, zoom);
 }
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Menu.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Menu.java
@@ -1225,7 +1225,7 @@ void setLocationInPixels (int x, int y) {
 public void setLocation (Point location) {
 	checkWidget ();
 	if (location == null) error (SWT.ERROR_NULL_ARGUMENT);
-	Point locationInPixels = getDisplay().translateToDisplayCoordinates(location, getZoom());
+	Point locationInPixels = getDisplay().translateToDisplayCoordinates(new MonitorAwarePoint(location), getZoom());
 	setLocationInPixels(locationInPixels.x, locationInPixels.y);
 }
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Shell.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Shell.java
@@ -1569,7 +1569,7 @@ public void setAlpha (int alpha) {
 @Override
 public Rectangle getBounds() {
 	checkWidget ();
-	return getDisplay().translateFromDisplayCoordinates(getBoundsInPixels(), getZoom());
+	return getDisplay().translateFromDisplayCoordinates(new MonitorAwareRectangle(getBoundsInPixels()), getZoom());
 }
 
 @Override
@@ -1582,7 +1582,7 @@ public Point getLocation() {
 public void setLocation(Point location) {
 	if (location == null) error (SWT.ERROR_NULL_ARGUMENT);
 	checkWidget ();
-	Point locationInPixels = getDisplay().translateToDisplayCoordinates(location, getZoom());
+	Point locationInPixels = getDisplay().translateToDisplayCoordinates(new MonitorAwarePoint(location), getZoom());
 	setLocationInPixels(locationInPixels.x, locationInPixels.y);
 }
 
@@ -1595,7 +1595,7 @@ public void setLocation(int x, int y) {
 public void setBounds(Rectangle rect) {
 	if (rect == null) error (SWT.ERROR_NULL_ARGUMENT);
 	checkWidget ();
-	Rectangle boundsInPixels = getDisplay().translateToDisplayCoordinates(rect, getZoom());
+	Rectangle boundsInPixels = getDisplay().translateToDisplayCoordinates(new MonitorAwareRectangle(rect), getZoom());
 	// The scaling of the width and height in case of a monitor change is handled by
 	// the WM_DPICHANGED event processing. So to avoid duplicate scaling, we always
 	// have to scale width and height with the zoom of the original monitor (still

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/SingleZoomCoordinateSystemMapper.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/SingleZoomCoordinateSystemMapper.java
@@ -39,35 +39,35 @@ class SingleZoomCoordinateSystemMapper implements CoordinateSystemMapper {
 	}
 
 	@Override
-	public Point map(Control from, Control to, Point point) {
+	public MonitorAwarePoint map(Control from, Control to, Point point) {
 		int zoom = getZoomLevelForMapping(from, to);
 		point = DPIUtil.scaleUp(point, zoom);
-		return DPIUtil.scaleDown(display.mapInPixels(from, to, point), zoom);
+		return new MonitorAwarePoint(DPIUtil.scaleDown(display.mapInPixels(from, to, point), zoom));
 	}
 
 	@Override
-	public Rectangle map(Control from, Control to, Rectangle rectangle) {
+	public MonitorAwareRectangle map(Control from, Control to, Rectangle rectangle) {
 		int zoom = getZoomLevelForMapping(from, to);
 		rectangle = DPIUtil.scaleUp(rectangle, zoom);
-		return DPIUtil.scaleDown(display.mapInPixels(from, to, rectangle), zoom);
+		return new MonitorAwareRectangle(DPIUtil.scaleDown(display.mapInPixels(from, to, rectangle), zoom));
 	}
 
 	@Override
-	public Point map(Control from, Control to, int x, int y) {
+	public MonitorAwarePoint map(Control from, Control to, int x, int y) {
 		int zoom = getZoomLevelForMapping(from, to);
 		x = DPIUtil.scaleUp(x, zoom);
 		y = DPIUtil.scaleUp(y, zoom);
-		return DPIUtil.scaleDown(display.mapInPixels(from, to, x, y), zoom);
+		return new MonitorAwarePoint(DPIUtil.scaleDown(display.mapInPixels(from, to, x, y), zoom));
 	}
 
 	@Override
-	public Rectangle map(Control from, Control to, int x, int y, int width, int height) {
+	public MonitorAwareRectangle map(Control from, Control to, int x, int y, int width, int height) {
 		int zoom = getZoomLevelForMapping(from, to);
 		x = DPIUtil.scaleUp(x, zoom);
 		y = DPIUtil.scaleUp(y, zoom);
 		width = DPIUtil.scaleUp(width, zoom);
 		height = DPIUtil.scaleUp(height, zoom);
-		return DPIUtil.scaleDown(display.mapInPixels(from, to, x, y, width, height), zoom);
+		return new MonitorAwareRectangle(DPIUtil.scaleDown(display.mapInPixels(from, to, x, y, width, height), zoom));
 	}
 
 	@Override
@@ -81,18 +81,18 @@ class SingleZoomCoordinateSystemMapper implements CoordinateSystemMapper {
 	}
 
 	@Override
-	public Point translateToDisplayCoordinates(Point point, int zoom) {
-		return DPIUtil.scaleUp(point, zoom);
+	public Point translateToDisplayCoordinates(MonitorAwarePoint point, int zoom) {
+		return DPIUtil.scaleUp(point.getPoint(), zoom);
 	}
 
 	@Override
-	public Rectangle translateFromDisplayCoordinates(Rectangle rect, int zoom) {
-		return DPIUtil.scaleDown(rect, zoom);
+	public Rectangle translateFromDisplayCoordinates(MonitorAwareRectangle rect, int zoom) {
+		return DPIUtil.scaleDown(rect.getRectangle(), zoom);
 	}
 
 	@Override
-	public Rectangle translateToDisplayCoordinates(Rectangle rect, int zoom) {
-		return DPIUtil.scaleUp(rect, zoom);
+	public Rectangle translateToDisplayCoordinates(MonitorAwareRectangle rect, int zoom) {
+		return DPIUtil.scaleUp(rect.getRectangle(), zoom);
 	}
 
 	@Override


### PR DESCRIPTION
This PR follows a very simple recipe

- make `Point` and `Rectangle` how they were before #1711
- make the `MonitorAware` classes not extend anything, and have no concept of equality
- change types to the internal APIs until the compile error go away

`CoordinateSystemMapperTests` are still passing.