### PR TITLE
[win32] refactor Image::init with ImageData

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Cursor.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Cursor.java
@@ -325,7 +325,7 @@ public Cursor(Device device, ImageData source, int hotspotX, int hotspotY) {
 		if (hMask == 0) SWT.error(SWT.ERROR_NO_HANDLES);
 	} else {
 		ImageData mask = source.getTransparencyMask();
-		long [] result = Image.init(this.device, null, source, mask, null);	// Since the image is null, the device zoom can be null
+		long [] result = Image.initIcon(this.device, source, mask);
 		hBitmap = result[0];
 		hMask = result[1];
 	}


### PR DESCRIPTION
This PR refactors Image#init for ImageData in the win32 implementation. Currently this method serves two purposes: 

1. creating handles for the given ImageData 
2. Doing 1. but additionally initializing an image with those handles

These two use cases are made more explicit refactoring this logic out into concrete methods. This is a necessary refactoring to be able to create all OS handles on demand and create temporary OS handles if neede.