### PR TITLE
MenuItem Image Scaling with DPI aware metrics #62

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT PI/win32/org/eclipse/swt/internal/win32/OS.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/win32/org/eclipse/swt/internal/win32/OS.java
@@ -1248,6 +1248,7 @@ public class OS extends C {
 	public static final int SM_CYFOCUSBORDER = 84;
 	public static final int SM_CYHSCROLL = 0x3;
 	public static final int SM_CYMENU = 0xf;
+	public static final int SM_CYMENUCHECK = 72;
 	public static final int SM_CXMINTRACK = 34;
 	public static final int SM_CYMINTRACK = 35;
 	public static final int SM_CXMAXTRACK = 59;


### PR DESCRIPTION
On Win32, the OS is responsible for painting the Image of a MenuItem and it expects images to be in metrics specific size specified by SM_CYMENUCHECK or SM_CXMENUCHECK. If the images are not provided within these sizes, Windows tries to rescale them, leading to unexpected sizes and masking.
This PR contributes to scaling of the MenuItem::hBitmap with the DPI Aware System Metrics for the size of the SM_CYMENUCHECK since the expected size of the Context menu images can differ from the size specific to the zoom level of the monitor.
This PR also addresses the internal rounding error in the size obtained by the systemMetrics while scaling across different zooms (in case of fractional scaling factor) - The reasoning to that has been added as a comment block in the code.

contributes to
https://github.com/eclipse-platform/eclipse.platform.swt/issues/62 and
https://github.com/eclipse-platform/eclipse.platform.swt/issues/127

Depends on: https://github.com/eclipse-platform/eclipse.platform.swt/pull/1933

## Bug Description
- Start the IDE at a 125% zoom monitor (175, 225, 275, etc also work)
- Create a context menu with a right-click
- The disabled images have a dark gray/black background
- The images might appear too small or too big.
![image](https://github.com/user-attachments/assets/4b375f03-f8ab-4196-bdc8-e2a0e224f75b)

## How to test
- Follow the same steps as described above
- The images should be of the metrics specific size.
- There should not be any black background on disabled images and the image must be scaled to exepected sizes.
![image](https://github.com/user-attachments/assets/79c8f1d4-a7df-48cf-ae85-fae0cba87e99)

contributes to
https://github.com/eclipse-platform/eclipse.platform.swt/issues/62 and https://github.com/eclipse-platform/eclipse.platform.swt/issues/127