### PR TITLE
[Win32] MultiZoomCoordinateSystemMapper: zero-sized rectangle handling

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/widgets/CoordinateSystemMapperTests.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/widgets/CoordinateSystemMapperTests.java
@@ -210,6 +210,15 @@ public class CoordinateSystemMapperTests {
 		assertEquals(rectInPxs, mapper.translateToDisplayCoordinates(rectInPts, monitors[0].getZoom()));
 	}
 
+	@ParameterizedTest
+	@MethodSource("provideCoordinateSystemMappers")
+	void translateRectangleInPixelsForZeroSize(CoordinateSystemMapper mapper) {
+		setupMonitors(mapper);
+		Rectangle rectInPts = createExpectedRectangle(mapper, 0, 0, 0, 0, monitors[0]);
+		Rectangle rectInPxs = mapper.translateToDisplayCoordinates(rectInPts, monitors[0].getZoom());
+		assertEquals(rectInPts, mapper.translateFromDisplayCoordinates(rectInPxs, monitors[0].getZoom()));
+	}
+
 	private Point createExpectedPoint(CoordinateSystemMapper mapper, int x, int y, Monitor monitor) {
 		if (mapper instanceof SingleZoomCoordinateSystemMapper) {
 			return new Point(x, y);

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/MultiZoomCoordinateSystemMapper.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/MultiZoomCoordinateSystemMapper.java
@@ -192,6 +192,9 @@ class MultiZoomCoordinateSystemMapper implements CoordinateSystemMapper {
 	}
 
 	private Monitor getContainingMonitorForPoints(int x, int y, int width, int height) {
+		if (width <= 0 || height <= 0) {
+			return getContainingMonitorForPoints(x, y);
+		}
 		Monitor[] monitors = monitorSupplier.get();
 		Monitor selectedMonitor = null;
 		int highestIntersectionRatio = 0;


### PR DESCRIPTION
The MultiZoomCoordinateSystemMapper currently produces a devide-by-zero error when transforming a rectangle of zero size. This can, for example, happen when a (dummy) shell with width=height=0 is created and its bounds are passed to the mapper.

This change ensures that the problematic calculation is avoided in case width or height are zero. In that case, no reasonable monitor can be identified anyway.