### PR TITLE
Move ImageData Scaling Impl to Image for all platforms

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/DPIUtil.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/DPIUtil.java
@@ -292,7 +292,7 @@ private static ImageData autoScaleImageData (Device device, final ImageData imag
 	int height = imageData.height;
 	int scaledWidth = Math.round (width * scaleFactor);
 	int scaledHeight = Math.round (height * scaleFactor);
-	boolean useSmoothScaling = isSmoothScalingEnabled() && imageData.getTransparencyType() != SWT.TRANSPARENCY_MASK;
+	boolean useSmoothScaling = autoScaleMethod == AutoScaleMethod.SMOOTH && imageData.getTransparencyType() != SWT.TRANSPARENCY_MASK;
 	if (useSmoothScaling) {
 		Image original = new Image (device, (ImageDataProvider) zoom -> imageData);
 		/* Create a 24 bit image data with alpha channel */
@@ -314,10 +314,6 @@ private static ImageData autoScaleImageData (Device device, final ImageData imag
 	} else {
 		return imageData.scaledTo (scaledWidth, scaledHeight);
 	}
-}
-
-public static boolean isSmoothScalingEnabled() {
-	return autoScaleMethod == AutoScaleMethod.SMOOTH;
 }
 
 /**
@@ -640,10 +636,6 @@ public static boolean useCairoAutoScale() {
 }
 
 public static int getZoomForAutoscaleProperty (int nativeDeviceZoom) {
-	return getZoomForAutoscaleProperty(nativeDeviceZoom, autoScaleValue);
-}
-
-private static int getZoomForAutoscaleProperty (int nativeDeviceZoom, String autoScaleValue) {
 	int zoom = 0;
 	if (autoScaleValue != null) {
 		if ("false".equalsIgnoreCase (autoScaleValue)) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Cursor.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Cursor.java
@@ -372,15 +372,21 @@ public static Long win32_getHandle (Cursor cursor, int zoom) {
 	if (cursor.source == null) {
 		cursor.setHandleForZoomLevel(cursor.handle, zoom);
 	} else {
-		ImageData source = DPIUtil.scaleImageData(cursor.device, cursor.source, zoom, DEFAULT_ZOOM);
+		Image image;
+		ImageData source, mask;
+		Cursor newCursor;
+		image = new Image(cursor.device, cursor.source);
+		source = image.getImageData(zoom);
+		image.dispose();
 		if (cursor.isIcon) {
-			Cursor newCursor = new Cursor(cursor.device, source, cursor.hotspotX, cursor.hotspotY);
-			cursor.setHandleForZoomLevel(newCursor.handle, zoom);
+			newCursor = new Cursor(cursor.device, source, cursor.hotspotX, cursor.hotspotY);
 		} else {
-			ImageData mask = DPIUtil.scaleImageData(cursor.device, cursor.mask, zoom, DEFAULT_ZOOM);
-			Cursor newCursor = new Cursor(cursor.device, source, mask, cursor.hotspotX, cursor.hotspotY);
-			cursor.setHandleForZoomLevel(newCursor.handle, zoom);
+			image = new Image(cursor.device, cursor.mask);
+			mask = image.getImageData(zoom);
+			image.dispose();
+			newCursor = new Cursor(cursor.device, source, mask, cursor.hotspotX, cursor.hotspotY);
 		}
+		cursor.setHandleForZoomLevel(newCursor.handle, zoom);
 	}
 	return cursor.zoomLevelToHandle.get(zoom);
 }


### PR DESCRIPTION
This PR contributes to fixing the implementation of Smooth scaling of the ImageData to get rid of the rounding errors because of multiple scale ups and downs with fractional scale factor. The commit moves and modifies the DPIUtil::autoScaleImageData method implementation in ImageData class to adapt the same.

contributes to
https://github.com/eclipse-platform/eclipse.platform.swt/issues/62 and https://github.com/eclipse-platform/eclipse.platform.swt/issues/127