### PR TITLE
Unify and improve image disablement calculation algorithm

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/image/ImageColorTransformer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/image/ImageColorTransformer.java
@@ -1,0 +1,73 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Vector Informatik GmbH and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.swt.internal.image;
+
+import org.eclipse.swt.*;
+import org.eclipse.swt.graphics.*;
+
+public interface ImageColorTransformer {
+
+	public static final String IMAGE_DISABLEMENT_ALGORITHM_GRAYED = "grayed";
+	public static final String IMAGE_DISABLEMENT_ALGORITHM_GTK = "gtk";
+	public static final String IMAGE_DISABLEMENT_ALGORITHM_DESATURATED = "desaturated";
+	public static final String IMAGE_DISABLEMENT_ALGORITHM = System.getProperty("org.eclipse.swt.image.disablement",
+			IMAGE_DISABLEMENT_ALGORITHM_GRAYED).strip();
+
+	public static final ImageColorTransformer DEFAULT_DISABLED_IMAGE_TRANSFORMER = switch (IMAGE_DISABLEMENT_ALGORITHM) {
+	case IMAGE_DISABLEMENT_ALGORITHM_GTK -> ImageColorTransformer.forRGB(0.5f, 0.5f, 0.5f, 0.5f);
+	case IMAGE_DISABLEMENT_ALGORITHM_DESATURATED -> ImageColorTransformer.forHSB(1.0f, 0.2f, 0.9f, 0.5f);
+	default -> ImageColorTransformer.forGrayscaledContrastBrightness(0.2f, 2.9f);
+	};
+
+	RGBA adaptPixelValue(int red, int green, int blue, int alpha);
+
+	public static ImageColorTransformer forHSB(float hueFactor, float saturationFactor, float brightnessFactor,
+			float alphaFactor) {
+		return (red, green, blue, alpha) -> {
+			float[] hsba = new RGBA(red, green, blue, alpha).getHSBA();
+			float hue = Math.min(hueFactor * hsba[0], 1.0f);
+			float saturation = Math.min(saturationFactor * hsba[1], 1.0f);
+			float brightness = Math.min(brightnessFactor * hsba[2], 1.0f);
+			float alphaResult = Math.min(alphaFactor * hsba[3], 255.0f);
+			return new RGBA(hue, saturation, brightness, alphaResult);
+		};
+	}
+
+	public static ImageColorTransformer forRGB(float redFactor, float greenFactor, float blueFactor,
+			float alphaFactor) {
+		return (red, green, blue, alpha) -> {
+			int redResult = (int) Math.min(redFactor * red, 255.0f);
+			int greenResult = (int) Math.min(greenFactor * green, 255.0f);
+			int blueResult = (int) Math.min(blueFactor * blue, 255.0f);
+			int alphaResult = (int) Math.min(alphaFactor * alpha, 255.0f);
+			return new RGBA(redResult, greenResult, blueResult, alphaResult);
+		};
+	}
+
+	public static ImageColorTransformer forIntensityThreshold(Device device) {
+		RGBA lowIntensity = device.getSystemColor(SWT.COLOR_WIDGET_NORMAL_SHADOW).getRGBA();
+		RGBA highIntensity = device.getSystemColor(SWT.COLOR_WIDGET_BACKGROUND).getRGBA();
+		return (red, green, blue, alpha) -> {
+			int intensity = red * red + green * green + blue * blue;
+			RGBA usedGraytone = intensity < 98304 ? lowIntensity : highIntensity;
+			return new RGBA(usedGraytone.rgb.red, usedGraytone.rgb.green, usedGraytone.rgb.blue, alpha);
+		};
+	}
+
+	public static ImageColorTransformer forGrayscaledContrastBrightness(float contrast, float brightness) {
+		return (red, green, blue, alpha) -> {
+			int grayValue = Math.min((77 * red + 151 * green + 28 * blue) / 255, 255);
+			int resultValue = (int) Math.min(Math.max((contrast * (grayValue * brightness - 128) + 128), 0), 255);
+			return new RGBA(resultValue, resultValue, resultValue, alpha);
+		};
+	}
+
+}


### PR DESCRIPTION
Each OS-specific implementation of the Image class has its own implementation of an algorithm to calculate a disabled representation of a given image. In addition, the algorithm used on Windows and MacOS produces bad results, which is why usually pre-generated disabled icons are used.

This change centralizes the implementations of those algorithms in ImageColorTransformers. The implementations used for the pre-generated disabled icons is added as default algorithm with an enhanced and the existing GTK-conforming algorithms being provided as options. It is supposed to render the usage of pre-generated disabled version of icons obsolete in many cases.

This is based on the snippet for testing different algorithms proposed by @killingerm and the according discussion in https://github.com/eclipse-platform/eclipse.platform.swt/discussions/1741

### How to test
Most icons Eclipse are provided in a pre-generated, disabled version. To completely disable this and enforce all icons to be generated on-the-fly via the disablement algorithm, you can change the value of `IWorkbenchRegistryConstants#ATT_DISABLEDICON` so that the according attribute defining the disabled icon path does not match.

The following screenshot shows how the three version of icons look like:
- Top: pre-generated icons and icons generated by proposed on-the-fly algorithm
- Middle: icons with the proposed `enhanced` on-the-fly algorithm
- Bottom: icons with the current on-the-fly algorithm (to be removed)

![image](https://github.com/user-attachments/assets/388239e2-2b3d-4964-9df3-261663985eae)