### PR TITLE
Suppress warnings for getImageDataAtCurrentZoom()

### DIFF
--- a/examples/org.eclipse.swt.examples/src/org/eclipse/swt/examples/clipboard/ClipboardExample.java
+++ b/examples/org.eclipse.swt.examples/src/org/eclipse/swt/examples/clipboard/ClipboardExample.java
@@ -389,6 +389,7 @@ void createFileTransfer(Composite copyParent, Composite pasteParent){
 	}));
 }
 
+@SuppressWarnings("deprecation")
 void createImageTransfer(Composite copyParent, Composite pasteParent){
 	final Image[] copyImage = new Image[] {null};
 	Label l = new Label(copyParent, SWT.NONE);


### PR DESCRIPTION
This PR adds suppression for deprecation warnings related to getImageDataAtCurrentZoom() in the ClipboardExample code.