### PR TITLE
[Build] Remove SWT library version information built into binaries

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT AWT/win32/library/swt_awt.rc
+++ b/bundles/org.eclipse.swt/Eclipse SWT AWT/win32/library/swt_awt.rc
@@ -15,7 +15,6 @@
 #include "windows.h"
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION SWT_COMMA_VERSION
  PRODUCTVERSION 0,0,0,0
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
@@ -33,9 +32,8 @@ BEGIN
         BEGIN
             VALUE "CompanyName", "Eclipse Foundation\0"
             VALUE "FileDescription", "SWT for Windows native library\0"
-            VALUE "FileVersion", SWT_FILE_VERSION
             VALUE "InternalName", "SWT\0"
-            VALUE "LegalCopyright", "Copyright (c) 2000, 2006 IBM Corp.  All Rights Reserved.\0"
+            VALUE "LegalCopyright", "Copyright (c) 2000, 2025 IBM Corp.  All Rights Reserved.\0"
             VALUE "OriginalFilename", SWT_ORG_FILENAME
             VALUE "ProductName", "Standard Widget Toolkit\0"
             VALUE "ProductVersion", "0,0,0,0\0"

--- a/bundles/org.eclipse.swt/Eclipse SWT OpenGL/win32/library/swt_wgl.rc
+++ b/bundles/org.eclipse.swt/Eclipse SWT OpenGL/win32/library/swt_wgl.rc
@@ -15,7 +15,6 @@
 #include "windows.h"
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION SWT_COMMA_VERSION
  PRODUCTVERSION 0,0,0,0
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
@@ -33,9 +32,8 @@ BEGIN
         BEGIN
             VALUE "CompanyName", "Eclipse Foundation\0"
             VALUE "FileDescription", "SWT for Windows native library\0"
-            VALUE "FileVersion", SWT_FILE_VERSION
             VALUE "InternalName", "SWT\0"
-            VALUE "LegalCopyright", "Copyright (c) 2000, 2006 IBM Corp.  All Rights Reserved.\0"
+            VALUE "LegalCopyright", "Copyright (c) 2000, 2025 IBM Corp.  All Rights Reserved.\0"
             VALUE "OriginalFilename", SWT_ORG_FILENAME
             VALUE "ProductName", "Standard Widget Toolkit\0"
             VALUE "ProductVersion", "0,0,0,0\0"

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/cocoa/library/make_macosx.mak
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/cocoa/library/make_macosx.mak
@@ -33,7 +33,7 @@ AWT_LIB    = lib$(AWT_PREFIX)-$(WS_PREFIX)-$(SWT_VERSION).jnilib
 AWT_OBJECTS   = swt_awt.o
 
 #SWT_DEBUG = -g
-CFLAGS = -c -xobjective-c -Wall $(ARCHS) -DSWT_VERSION=$(SWT_VERSION) $(SWT_DEBUG) -DUSE_ASSEMBLER -DCOCOA -DATOMIC \
+CFLAGS = -c -xobjective-c -Wall $(ARCHS) $(SWT_DEBUG) -DUSE_ASSEMBLER -DCOCOA -DATOMIC \
 	-I $(SWT_JAVA_HOME)/include \
 	-I $(SWT_JAVA_HOME)/include/darwin \
 	-I /System/Library/Frameworks/Cocoa.framework/Headers \

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/make_linux.mak
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/make_linux.mak
@@ -100,7 +100,6 @@ WEBKIT_OBJECTS = swt.o webkitgtk.o webkitgtk_structs.o webkitgtk_stats.o webkitg
 GLX_OBJECTS = swt.o glx.o glx_structs.o glx_stats.o
 
 CFLAGS := $(CFLAGS) \
-		-DSWT_VERSION=$(SWT_VERSION) \
 		$(SWT_DEBUG) \
 		$(SWT_WEBKIT_DEBUG) \
 		-DLINUX -DGTK \

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/win32/library/javaw.exe.manifest
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/win32/library/javaw.exe.manifest
@@ -16,10 +16,10 @@
          <!--<gdiScaling xmlns="http://schemas.microsoft.com/SMI/2017/WindowsSettings">true</gdiScaling>-->
       </windowsSettings>
    </application>
-   <!--Specifically targeting your application for Windows 8.1 or Windows 10: https://msdn.microsoft.com/en-us/library/windows/desktop/dn481241(v=vs.85).aspx -->
+   <!--Specifically targeting your application for Windows 8.1 or Windows 10: https://learn.microsoft.com/en-us/windows/win32/sysinfo/targeting-your-application-at-windows-8-1 -->
    <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
         <application>
-            <!-- Windows 10 -->
+            <!-- Windows 10 and Windows 11 -->
             <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
             <!-- Windows 8.1 -->
             <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/win32/library/make_win32.mak
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/win32/library/make_win32.mak
@@ -48,10 +48,10 @@ WGL_OBJS   = wgl.obj wgl_structs.obj wgl_stats.obj
 
 #CFLAGS = $(cdebug) $(cflags) $(cvarsmt) $(CFLAGS) \
 CFLAGS = -O1 /WX /W4 -DNDEBUG -DUNICODE -D_UNICODE /c $(cflags) $(cvarsmt) $(CFLAGS) \
-	-DSWT_VERSION=$(maj_ver)$(min_ver) -DSWT_REVISION=$(rev) -DUSE_ASSEMBLER \
+	-DUSE_ASSEMBLER \
 	/I"$(SWT_JAVA_HOME)\include" /I"$(SWT_JAVA_HOME)\include\win32" /I.
 
-RCFLAGS = $(rcflags) $(rcvars) $(RCFLAGS) -DSWT_FILE_VERSION=\"$(maj_ver).$(min_ver).$(rev).0\" -DSWT_COMMA_VERSION=$(comma_ver)
+RCFLAGS = $(rcflags) $(rcvars) $(RCFLAGS)
 ldebug = /RELEASE  /INCREMENTAL:NO /NOLOGO
 dlllflags = -dll /WX
 guilibsmt = kernel32.lib  ws2_32.lib mswsock.lib advapi32.lib bufferoverflowu.lib user32.lib gdi32.lib comdlg32.lib winspool.lib

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/win32/library/os_custom.c
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/win32/library/os_custom.c
@@ -18,16 +18,6 @@
 
 #define OS_NATIVE(func) Java_org_eclipse_swt_internal_win32_OS_##func
 
-__declspec(dllexport) HRESULT DllGetVersion(DLLVERSIONINFO *dvi);
-HRESULT DllGetVersion(DLLVERSIONINFO *dvi)
-{
-	dvi->dwMajorVersion = SWT_VERSION / 1000;
-	dvi->dwMinorVersion = SWT_VERSION % 1000;
-	dvi->dwBuildNumber = SWT_REVISION;
-	dvi->dwPlatformID = DLLVER_PLATFORM_WINDOWS;
-	return 1;
-}
-
 HINSTANCE g_hInstance = NULL;
 BOOL WINAPI DllMain(HANDLE hInstDLL, DWORD dwReason, LPVOID lpvReserved)
 {

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/win32/library/swt.rc
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/win32/library/swt.rc
@@ -19,7 +19,6 @@
 MANIFEST_RESOURCE_ID RT_MANIFEST "javaw.exe.manifest"
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION SWT_COMMA_VERSION
  PRODUCTVERSION 0,0,0,0
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
@@ -37,9 +36,8 @@ BEGIN
         BEGIN
             VALUE "CompanyName", "Eclipse Foundation\0"
             VALUE "FileDescription", "SWT for Windows native library\0"
-            VALUE "FileVersion", SWT_FILE_VERSION
             VALUE "InternalName", "SWT\0"
-            VALUE "LegalCopyright", "Copyright (c) 2000, 2011 IBM Corp.  All Rights Reserved.\0"
+            VALUE "LegalCopyright", "Copyright (c) 2000, 2025 IBM Corp.  All Rights Reserved.\0"
             VALUE "OriginalFilename", SWT_ORG_FILENAME
             VALUE "ProductName", "Standard Widget Toolkit\0"
             VALUE "ProductVersion", "0,0,0,0\0"

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/win32/library/swt_gdip.rc
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/win32/library/swt_gdip.rc
@@ -15,7 +15,6 @@
 #include "windows.h"
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION SWT_COMMA_VERSION
  PRODUCTVERSION 0,0,0,0
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
@@ -33,9 +32,8 @@ BEGIN
         BEGIN
             VALUE "CompanyName", "Eclipse Foundation\0"
             VALUE "FileDescription", "SWT for Windows native library\0"
-            VALUE "FileVersion", SWT_FILE_VERSION
             VALUE "InternalName", "SWT\0"
-            VALUE "LegalCopyright", "Copyright (c) 2000, 2011 IBM Corp.  All Rights Reserved.\0"
+            VALUE "LegalCopyright", "Copyright (c) 2000, 2025 IBM Corp.  All Rights Reserved.\0"
             VALUE "OriginalFilename", SWT_ORG_FILENAME
             VALUE "ProductName", "Standard Widget Toolkit\0"
             VALUE "ProductVersion", "0,0,0,0\0"

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/library/make_common.mak
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/library/make_common.mak
@@ -15,4 +15,3 @@
 maj_ver=4
 min_ver=969
 rev=8
-comma_ver=4,969,8,0


### PR DESCRIPTION
This removes all native/library version information that is currently built into the native binaries of SWT.
Consequently the library-version information is only captured in the name of the native binary files and in the 'Library' java class.
The previously built-in information is not used anywhere in SWT.


This allows to just rename the binary files in case just the library version has changed without a change in the native sources. This happens for example if only the native sources for another platform are changed.