### PR TITLE
Add DPIUtil method to get device zoom for original autoscale value

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/DPIUtil.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/DPIUtil.java
@@ -597,6 +597,10 @@ public static int getDeviceZoom() {
 	return deviceZoom;
 }
 
+public static int getDeviceZoom(String autoScaleProperty) {
+	return getZoomForAutoscaleProperty(nativeDeviceZoom, autoScaleProperty);
+}
+
 public static void setDeviceZoom (int nativeDeviceZoom) {
 	DPIUtil.nativeDeviceZoom = nativeDeviceZoom;
 	int deviceZoom = getZoomForAutoscaleProperty (nativeDeviceZoom);


### PR DESCRIPTION
The autoscale value may be adapted during runtime, either via explicit methods in DPIUtil or by rewriting the system property. In order to be able to calculate the device zooom for a different autoscale value, such as the initial one, this change adds an according method.

Needed for https://github.com/eclipse-platform/eclipse.platform.ui/pull/2858