### PR TITLE
Consume SVG rasterizer via capability in SWT tests bundle

### DIFF
--- a/bundles/org.eclipse.swt.svg/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.swt.svg/META-INF/MANIFEST.MF
@@ -11,3 +11,4 @@ Import-Package: com.github.weisj.jsvg;version="[1.7.0,2.0.0)",
  com.github.weisj.jsvg.geometry.size;version="[1.7.0,2.0.0)",
  com.github.weisj.jsvg.parser;version="[1.7.0,2.0.0)"
 Export-Package: org.eclipse.swt.svg
+Provide-Capability: eclipse.swt;image.format="svg";version:Version="1.0"

--- a/tests/org.eclipse.swt.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.swt.tests/META-INF/MANIFEST.MF
@@ -20,3 +20,4 @@ Require-Bundle: org.junit;bundle-version="4.13.2",
 Eclipse-BundleShape: dir
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Automatic-Module-Name: org.eclipse.swt.tests
+Require-Capability: eclipse.swt;filter:="(image.format=svg)"

--- a/tests/org.eclipse.swt.tests/META-INF/p2.inf
+++ b/tests/org.eclipse.swt.tests/META-INF/p2.inf
@@ -1,4 +1,0 @@
-# pull in the applicable implementation fragment at build time (bug 461427)
-requires.0.namespace = org.eclipse.equinox.p2.iu
-requires.0.name = org.eclipse.swt.svg
-requires.0.range = 0.0.0


### PR DESCRIPTION
Currently, requiring an SVG rasterizer needs manual placement of an according fragment on the classpath. With this change, requiring SVG support can be defined explicitly via a required capability that is provided by the according SWT fragment.

Contributes to https://github.com/eclipse-platform/eclipse.platform.swt/issues/1944