### PR TITLE
Add getGcStyle() method to accommodate styling

### DIFF
--- a/binaries/org.eclipse.swt.cocoa.macosx.aarch64/.settings/.api_filters
+++ b/binaries/org.eclipse.swt.cocoa.macosx.aarch64/.settings/.api_filters
@@ -232,6 +232,14 @@
             </message_arguments>
         </filter>
     </resource>
+	<resource path="Eclipse SWT/common/org/eclipse/swt/graphics/ImageGcDrawer.java" type="org.eclipse.swt.graphics.ImageGcDrawer">
+        <filter id="404000815">
+            <message_arguments>
+                <message_argument value="org.eclipse.swt.graphics.ImageGcDrawer"/>
+                <message_argument value="getGcStyle()"/>
+            </message_arguments>
+        </filter>
+    </resource>
     <resource path="Eclipse SWT Drag and Drop/common/org/eclipse/swt/dnd/DragSourceListener.java" type="org.eclipse.swt.dnd.DragSourceListener">
         <filter id="576720909">
             <message_arguments>

--- a/binaries/org.eclipse.swt.cocoa.macosx.x86_64/.settings/.api_filters
+++ b/binaries/org.eclipse.swt.cocoa.macosx.x86_64/.settings/.api_filters
@@ -232,6 +232,14 @@
             </message_arguments>
         </filter>
     </resource>
+	<resource path="Eclipse SWT/common/org/eclipse/swt/graphics/ImageGcDrawer.java" type="org.eclipse.swt.graphics.ImageGcDrawer">
+        <filter id="404000815">
+            <message_arguments>
+                <message_argument value="org.eclipse.swt.graphics.ImageGcDrawer"/>
+                <message_argument value="getGcStyle()"/>
+            </message_arguments>
+        </filter>
+    </resource>
     <resource path="Eclipse SWT Drag and Drop/common/org/eclipse/swt/dnd/DragSourceListener.java" type="org.eclipse.swt.dnd.DragSourceListener">
         <filter id="576720909">
             <message_arguments>

--- a/binaries/org.eclipse.swt.gtk.linux.aarch64/.settings/.api_filters
+++ b/binaries/org.eclipse.swt.gtk.linux.aarch64/.settings/.api_filters
@@ -232,6 +232,14 @@
             </message_arguments>
         </filter>
     </resource>
+	<resource path="Eclipse SWT/common/org/eclipse/swt/graphics/ImageGcDrawer.java" type="org.eclipse.swt.graphics.ImageGcDrawer">
+        <filter id="404000815">
+            <message_arguments>
+                <message_argument value="org.eclipse.swt.graphics.ImageGcDrawer"/>
+                <message_argument value="getGcStyle()"/>
+            </message_arguments>
+        </filter>
+    </resource>
     <resource path="Eclipse SWT Drag and Drop/common/org/eclipse/swt/dnd/DragSourceListener.java" type="org.eclipse.swt.dnd.DragSourceListener">
         <filter id="576720909">
             <message_arguments>

--- a/binaries/org.eclipse.swt.gtk.linux.loongarch64/.settings/.api_filters
+++ b/binaries/org.eclipse.swt.gtk.linux.loongarch64/.settings/.api_filters
@@ -232,6 +232,14 @@
             </message_arguments>
         </filter>
     </resource>
+	<resource path="Eclipse SWT/common/org/eclipse/swt/graphics/ImageGcDrawer.java" type="org.eclipse.swt.graphics.ImageGcDrawer">
+        <filter id="404000815">
+            <message_arguments>
+                <message_argument value="org.eclipse.swt.graphics.ImageGcDrawer"/>
+                <message_argument value="getGcStyle()"/>
+            </message_arguments>
+        </filter>
+    </resource>
     <resource path="Eclipse SWT Drag and Drop/common/org/eclipse/swt/dnd/DragSourceListener.java" type="org.eclipse.swt.dnd.DragSourceListener">
         <filter id="576720909">
             <message_arguments>

--- a/binaries/org.eclipse.swt.gtk.linux.ppc64le/.settings/.api_filters
+++ b/binaries/org.eclipse.swt.gtk.linux.ppc64le/.settings/.api_filters
@@ -232,6 +232,14 @@
             </message_arguments>
         </filter>
     </resource>
+	<resource path="Eclipse SWT/common/org/eclipse/swt/graphics/ImageGcDrawer.java" type="org.eclipse.swt.graphics.ImageGcDrawer">
+        <filter id="404000815">
+            <message_arguments>
+                <message_argument value="org.eclipse.swt.graphics.ImageGcDrawer"/>
+                <message_argument value="getGcStyle()"/>
+            </message_arguments>
+        </filter>
+    </resource>
     <resource path="Eclipse SWT Drag and Drop/common/org/eclipse/swt/dnd/DragSourceListener.java" type="org.eclipse.swt.dnd.DragSourceListener">
         <filter id="576720909">
             <message_arguments>

--- a/binaries/org.eclipse.swt.gtk.linux.riscv64/.settings/.api_filters
+++ b/binaries/org.eclipse.swt.gtk.linux.riscv64/.settings/.api_filters
@@ -232,6 +232,14 @@
             </message_arguments>
         </filter>
     </resource>
+	<resource path="Eclipse SWT/common/org/eclipse/swt/graphics/ImageGcDrawer.java" type="org.eclipse.swt.graphics.ImageGcDrawer">
+        <filter id="404000815">
+            <message_arguments>
+                <message_argument value="org.eclipse.swt.graphics.ImageGcDrawer"/>
+                <message_argument value="getGcStyle()"/>
+            </message_arguments>
+        </filter>
+    </resource>
     <resource path="Eclipse SWT Drag and Drop/common/org/eclipse/swt/dnd/DragSourceListener.java" type="org.eclipse.swt.dnd.DragSourceListener">
         <filter id="576720909">
             <message_arguments>

--- a/binaries/org.eclipse.swt.gtk.linux.x86_64/.settings/.api_filters
+++ b/binaries/org.eclipse.swt.gtk.linux.x86_64/.settings/.api_filters
@@ -16,6 +16,14 @@
             </message_arguments>
         </filter>
     </resource>
+	<resource path="Eclipse SWT/common/org/eclipse/swt/graphics/ImageGcDrawer.java" type="org.eclipse.swt.graphics.ImageGcDrawer">
+        <filter id="404000815">
+            <message_arguments>
+                <message_argument value="org.eclipse.swt.graphics.ImageGcDrawer"/>
+                <message_argument value="getGcStyle()"/>
+            </message_arguments>
+        </filter>
+    </resource>
     <resource path="META-INF/MANIFEST.MF">
         <filter id="926941240">
             <message_arguments>

--- a/binaries/org.eclipse.swt.win32.win32.aarch64/.settings/.api_filters
+++ b/binaries/org.eclipse.swt.win32.win32.aarch64/.settings/.api_filters
@@ -581,6 +581,14 @@
             </message_arguments>
         </filter>
     </resource>
+	<resource path="Eclipse SWT/common/org/eclipse/swt/graphics/ImageGcDrawer.java" type="org.eclipse.swt.graphics.ImageGcDrawer">
+        <filter id="404000815">
+            <message_arguments>
+                <message_argument value="org.eclipse.swt.graphics.ImageGcDrawer"/>
+                <message_argument value="getGcStyle()"/>
+            </message_arguments>
+        </filter>
+    </resource>
     <resource path="Eclipse SWT/common/org/eclipse/swt/graphics/ImageLoaderListener.java" type="org.eclipse.swt.graphics.ImageLoaderListener">
         <filter id="576720909">
             <message_arguments>

--- a/binaries/org.eclipse.swt.win32.win32.x86_64/.settings/.api_filters
+++ b/binaries/org.eclipse.swt.win32.win32.x86_64/.settings/.api_filters
@@ -581,6 +581,14 @@
             </message_arguments>
         </filter>
     </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/graphics/ImageGcDrawer.java" type="org.eclipse.swt.graphics.ImageGcDrawer">
+        <filter id="404000815">
+            <message_arguments>
+                <message_argument value="org.eclipse.swt.graphics.ImageGcDrawer"/>
+                <message_argument value="getGcStyle()"/>
+            </message_arguments>
+        </filter>
+    </resource>
     <resource path="Eclipse SWT/common/org/eclipse/swt/graphics/ImageLoaderListener.java" type="org.eclipse.swt.graphics.ImageLoaderListener">
         <filter id="576720909">
             <message_arguments>

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/ImageGcDrawer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/ImageGcDrawer.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.swt.graphics;
 
+import org.eclipse.swt.*;
+
 /**
  * Interface to provide a callback mechanism to draw on different GC instances
  * depending on the zoom the image will be used for. A common use case is when
@@ -45,4 +47,15 @@ public interface ImageGcDrawer {
 	default void postProcess(ImageData imageData) {
 	}
 
+	/**
+	 * Returns the GC style used when creating the GC instance. Default
+	 * implementation returns <code>SWT.NONE</code>.
+	 *
+	 * @return the GC style constant
+	 *
+	 * @since 3.130
+	 */
+	default int getGcStyle() {
+		return SWT.NONE;
+	}
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Image.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Image.java
@@ -2502,7 +2502,7 @@ private class ImageGcDrawerWrapper extends DynamicImageProviderWrapper {
 	ImageHandle getImageMetadata(int zoom) {
 		initialNativeZoom = zoom;
 		Image image = new Image(device, width, height, zoom);
-		GC gc = new GC(image);
+		GC gc = new GC(image, drawer.getGcStyle());
 		try {
 			gc.data.nativeZoom = zoom;
 			drawer.drawOn(gc, width, height);


### PR DESCRIPTION
GC can be initialize with `GC(drawable)` or `GC(drawable, style)`. Currently `Image(Device, ImageGcDrawer, height, width)` doesn't consider `style` attribute while initializing `GC`. We need to create a new constructor for `Image` _e.g._ `Image(Device, ImageGcDrawer, height, width, style)` for which later `GC` inside `ImageGcDrawer` is initialized considering the style provided to it.

Now from implementation side, you can override `getGcStyle()` to provide styling in `GC` _e.g._ `LEFT_TO_RIGHT`, etc


### Consumer usage

Before this change, there was no way for consumer to provide styling using `ImageGcDrawer`. 

```java
final ImageGcDrawer imageGcDrawer = (gc, width, height) -> {
  gc.fillRectangle(0, 0, 16, 16);
};
 Image = new Image(Display.getDefault(), imageGcDrawer, 1, 1);
}
```
Now with this change. Consumer can define the styling with which `GC` will be initialized later in `ImageGCDrawerWrapper`. 

```java
final ImageGcDrawer imageGcDrawer = new ImageGcDrawer() {
  @Override
  public void drawOn(GC gc, int iWidth, int iHeight) {
    gc.fillRectangle(0, 0, iWidth, iHeight);
 }

  @Override
  public int getGcStyle() {
    return SWT.LEFT_TO_RIGHT;
  }
};
 Image = new Image(Display.getDefault(), imageGcDrawer, 1, 1);
}
```

## Required by
- https://github.com/eclipse-jdt/eclipse.jdt.ui/pull/2116