### PR TITLE
[GTK3] Override gtk_im_module only if it was set to xim

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Display.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Display.java
@@ -1143,12 +1143,12 @@ void checkIMModule () {
 	if (module != null && module.equals("xim")) {
 		System.err.println("***WARNING: Detected: GTK_IM_MODULE=xim. This input method is unsupported and can cause graphical issues.");
 		System.err.println("***WARNING: Unset GTK_IM_MODULE or set GTK_IM_MODULE=ibus if flicking is experienced. ");
-	}
-	// Enforce ibus as the input module on GNOME
-	if (OS.isGNOME) {
-		long settings = GTK.gtk_settings_get_default ();
-		byte[] ibus = Converter.wcsToMbcs ("ibus", true);
-		if (settings != 0) OS.g_object_set (settings, GTK.gtk_im_module, ibus, 0);
+		// Enforce ibus as the input module on GNOME X11
+		if (OS.isGNOME && OS.isX11()) {
+			long settings = GTK.gtk_settings_get_default ();
+			byte[] ibus = Converter.wcsToMbcs ("ibus", true);
+			if (settings != 0) OS.g_object_set (settings, GTK.gtk_im_module, ibus, 0);
+		}
 	}
 }
 


### PR DESCRIPTION
From https://github.com/ibus/ibus/issues/2331#issuecomment-927110685 "There are two modes to communicate between IBus and GTK applications."
- GTK_IM_MODULE=wayland (composer mode - GNOME Wayland default) and GTK_IM_MODULE=ibus (no composer mode).

Note that "wayland" im module is another incarnation of ibus. The only thing that was broken for sure is "xim" so override only it under Gnome on X11 to prevent making SWT(and as a result Eclipse) use non-default IM modules and thus exposing different behaviour than other apps.