### PR TITLE
Compile as C17 code

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/make_linux.mak
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/make_linux.mak
@@ -106,6 +106,7 @@ CFLAGS := $(CFLAGS) \
 		-DLINUX -DGTK \
 		-I$(SWT_JAVA_HOME)/include \
 		-I$(SWT_JAVA_HOME)/include/linux \
+		-std=gnu17 \
 		${SWT_PTR_CFLAGS}
 LFLAGS = -shared -fPIC ${SWT_LFLAGS}
 


### PR DESCRIPTION
GCC 15 defaults to C23 standard but it's not feasible to use it as even Xlib.h is not compatible yet e.g.
```
/usr/include/X11/Xlib.h:2105:5: note: expected ‘int (*)(Display *,
XEvent *, char *)’ but argument is of type ‘int (*)(void)’
 2105 |     Bool (*) (
```
Fixes https://github.com/eclipse-platform/eclipse.platform.swt/issues/1865 .