### PR TITLE
Fix Browser.setCookie on WebkitGtk/Soup3

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/os.c
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/os.c
@@ -12648,6 +12648,33 @@ fail:
 }
 #endif
 
+#ifndef NO_g_1uri_1parse
+JNIEXPORT jlong JNICALL OS_NATIVE(g_1uri_1parse)
+	(JNIEnv *env, jclass that, jbyteArray arg0, jlong arg1, jlongArray arg2)
+{
+	jbyte *lparg0=NULL;
+	jlong *lparg2=NULL;
+	jlong rc = 0;
+	OS_NATIVE_ENTER(env, that, g_1uri_1parse_FUNC);
+	if (arg0) if ((lparg0 = (*env)->GetByteArrayElements(env, arg0, NULL)) == NULL) goto fail;
+	if (arg2) if ((lparg2 = (*env)->GetLongArrayElements(env, arg2, NULL)) == NULL) goto fail;
+/*
+	rc = (jlong)g_uri_parse((const gchar *)lparg0, arg1, (GError **)lparg2);
+*/
+	{
+		OS_LOAD_FUNCTION(fp, g_uri_parse)
+		if (fp) {
+			rc = (jlong)((jlong (CALLING_CONVENTION*)(const gchar *, jlong, GError **))fp)((const gchar *)lparg0, arg1, (GError **)lparg2);
+		}
+	}
+fail:
+	if (arg2 && lparg2) (*env)->ReleaseLongArrayElements(env, arg2, lparg2, 0);
+	if (arg0 && lparg0) (*env)->ReleaseByteArrayElements(env, arg0, lparg0, 0);
+	OS_NATIVE_EXIT(env, that, g_1uri_1parse_FUNC);
+	return rc;
+}
+#endif
+
 #ifndef NO_g_1utf16_1offset_1to_1pointer
 JNIEXPORT jlong JNICALL OS_NATIVE(g_1utf16_1offset_1to_1pointer)
 	(JNIEnv *env, jclass that, jlong arg0, jlong arg1)

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/os_custom.h
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/os_custom.h
@@ -59,6 +59,7 @@
 #define ubuntu_menu_proxy_get_LIB LIB_GTK
 #define FcConfigAppFontAddFile_LIB LIB_FONTCONFIG
 #define pango_attr_insert_hyphens_new_LIB LIB_PANGO
+#define g_uri_parse_LIB LIB_GLIB
 
 /* Field accessors */
 #define G_OBJECT_CLASS_CONSTRUCTOR(arg0) (arg0)->constructor

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/os_stats.h
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/os_stats.h
@@ -1021,6 +1021,7 @@ typedef enum {
 	g_1type_1parent_FUNC,
 	g_1type_1register_1static_FUNC,
 	g_1unsetenv_FUNC,
+	g_1uri_1parse_FUNC,
 	g_1utf16_1offset_1to_1pointer_FUNC,
 	g_1utf16_1offset_1to_1utf8_1offset_FUNC,
 	g_1utf16_1pointer_1to_1offset_FUNC,

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/org/eclipse/swt/internal/gtk/OS.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/org/eclipse/swt/internal/gtk/OS.java
@@ -1410,6 +1410,14 @@ public static final native long g_value_peek_pointer(long value);
  * @param variable cast=(const gchar *),flags=no_out
  */
 public static final native void g_unsetenv(byte [] variable);
+
+/**
+ * @method flags=dynamic
+ * @param uri_string cast=(const gchar *)
+ * @param flags
+ * @param error cast=(GError **)
+ */
+public static final native long g_uri_parse (byte[] uri_string,  long flags, long[] error);
 /** @method flags=const */
 public static final native int glib_major_version();
 /** @method flags=const */

--- a/bundles/org.eclipse.swt/Eclipse SWT WebKit/gtk/library/webkitgtk.c
+++ b/bundles/org.eclipse.swt/Eclipse SWT WebKit/gtk/library/webkitgtk.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2022 IBM Corporation and others. All rights reserved.
+ * Copyright (c) 2009, 2025 IBM Corporation and others. All rights reserved.
  * The contents of this file are made available under the terms
  * of the GNU Lesser General Public License (LGPL) Version 2.1 that
  * accompanies this distribution (lgpl-v21.txt).  The LGPL is also
@@ -303,6 +303,26 @@ JNIEXPORT jlong JNICALL WebKitGTK_NATIVE(soup_1cookie_1parse)
 fail:
 	if (arg0 && lparg0) (*env)->ReleaseByteArrayElements(env, arg0, lparg0, 0);
 	WebKitGTK_NATIVE_EXIT(env, that, soup_1cookie_1parse_FUNC);
+	return rc;
+}
+#endif
+
+#ifndef NO_soup_1get_1major_1version
+JNIEXPORT jint JNICALL WebKitGTK_NATIVE(soup_1get_1major_1version)
+	(JNIEnv *env, jclass that)
+{
+	jint rc = 0;
+	WebKitGTK_NATIVE_ENTER(env, that, soup_1get_1major_1version_FUNC);
+/*
+	rc = (jint)soup_get_major_version();
+*/
+	{
+		WebKitGTK_LOAD_FUNCTION(fp, soup_get_major_version)
+		if (fp) {
+			rc = (jint)((jint (CALLING_CONVENTION*)())fp)();
+		}
+	}
+	WebKitGTK_NATIVE_EXIT(env, that, soup_1get_1major_1version_FUNC);
 	return rc;
 }
 #endif

--- a/bundles/org.eclipse.swt/Eclipse SWT WebKit/gtk/library/webkitgtk_stats.h
+++ b/bundles/org.eclipse.swt/Eclipse SWT WebKit/gtk/library/webkitgtk_stats.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2023 IBM Corporation and others. All rights reserved.
+ * Copyright (c) 2009, 2025 IBM Corporation and others. All rights reserved.
  * The contents of this file are made available under the terms
  * of the GNU Lesser General Public License (LGPL) Version 2.1 that
  * accompanies this distribution (lgpl-v21.txt).  The LGPL is also
@@ -37,6 +37,7 @@ typedef enum {
 	soup_1cookie_1get_1name_FUNC,
 	soup_1cookie_1get_1value_FUNC,
 	soup_1cookie_1parse_FUNC,
+	soup_1get_1major_1version_FUNC,
 	soup_1message_1headers_1append_FUNC,
 	soup_1uri_1free_FUNC,
 	soup_1uri_1new_FUNC,

--- a/bundles/org.eclipse.swt/Eclipse SWT WebKit/gtk/org/eclipse/swt/internal/webkit/WebKitGTK.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT WebKit/gtk/org/eclipse/swt/internal/webkit/WebKitGTK.java
@@ -226,6 +226,9 @@ public static final native void soup_uri_free(long uri);
 /** @method flags=dynamic */
 public static final native long soup_uri_new(byte[] uri_string);
 
+/** @method flags=dynamic */
+public static final native int soup_get_major_version();
+
 /* --------------------- start WebKitGTK natives --------------------- */
 
 /** @method flags=dynamic */


### PR DESCRIPTION
Soup 3.x switched away from its own SoupURI to Glib's GUri (see https://libsoup.gnome.org/libsoup-3.0/migrating-from-libsoup-2.html#uri-type-changed ). Thus g_uri_parse have to be used instead of soup_uri_new.