### PR TITLE
Restore equality for all kinds of Point/Rectangle

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/MonitorAwarePoint.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/MonitorAwarePoint.java
@@ -13,8 +13,6 @@
  *******************************************************************************/
 package org.eclipse.swt.graphics;
 
-import java.util.*;
-
 import org.eclipse.swt.widgets.*;
 
 /**
@@ -53,19 +51,12 @@ public final class MonitorAwarePoint extends Point {
 
 	@Override
 	public boolean equals(Object object) {
-		if (this == object) {
-			return true;
-		}
-		if (!super.equals(object)) {
-			return false;
-		}
-		MonitorAwarePoint other = (MonitorAwarePoint) object;
-		return Objects.equals(this.monitor, other.monitor);
+		return super.equals(object);
 	}
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(super.hashCode(), monitor);
+		return super.hashCode();
 	}
 
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/MonitorAwareRectangle.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/MonitorAwareRectangle.java
@@ -13,8 +13,6 @@
  *******************************************************************************/
 package org.eclipse.swt.graphics;
 
-import java.util.*;
-
 import org.eclipse.swt.widgets.*;
 
 /**
@@ -55,19 +53,12 @@ public final class MonitorAwareRectangle extends Rectangle {
 
 	@Override
 	public boolean equals(Object object) {
-		if (this == object) {
-			return true;
-		}
-		if (!super.equals(object)) {
-			return false;
-		}
-		MonitorAwareRectangle other = (MonitorAwareRectangle) object;
-		return Objects.equals(this.monitor, other.monitor);
+		return super.equals(object);
 	}
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(super.hashCode(), monitor);
+		return super.hashCode();
 	}
 
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/Point.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/Point.java
@@ -84,10 +84,9 @@ public boolean equals (Object object) {
 	if (object == this) {
 		return true;
 	}
-	if (object.getClass() != this.getClass()) {
+	if (!(object instanceof Point other)) {
 		return false;
 	}
-	Point other = (Point) object;
 	return (other.x == this.x) && (other.y == this.y);
 }
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/Rectangle.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/Rectangle.java
@@ -162,10 +162,9 @@ public boolean equals(Object object) {
 	if (object == this) {
 		return true;
 	}
-	if (object.getClass() != this.getClass()) {
+	if (!(object instanceof Rectangle other)) {
 		return false;
 	}
-	Rectangle other = (Rectangle) object;
 	return (other.x == this.x) && (other.y == this.y) && (other.width == this.width) && (other.height == this.height);
 }
 


### PR DESCRIPTION
The MonitorAwarePoint and MonitorAwareRectangle classes have been introduced as specializations of the existing Point and Rectangle classes solely to support monitor-specific scaling and only used in the context of that feature. They are not supposed to be used outside of SWT but just an internal construct. However, instances of those classes reach consumers of SWT API, e.g., via the Shell class. This broke equality assumptions for consumers, as, e.g., a comparison between a Point and a MonitorAwarePoint (returned by methods of Shell) are never equal, even though the consumers is not supposed to even know that a MonitorAwarePoint can be returned here.

To restore equality, this change aligns equality of the monitor-aware implementations of point and rectangle with their original implementations. In consequence, a Point and a MonitorAwarePoint will be considered equal if their x/y coordinates match. The monitor stored in a MonitorAwarePoint will be ignored. This analogously applies to MonitorAwareRectangle. Since those classes are only used internally, no one may rely on any other kind of equality specification for the monitor-aware implementations of point and rectangle, but existing equality for Points and Rectangles in general is restored.

__Note:__ `MonitorAwarePoint`/`MonitorAwareRectangle` are not part of public API and are currently only used when monitor-specific scaling on Windows is active, which is marked as an experimental feature. This is why no one currently relies on specific equality handling of those added types, allowing to correct their equality relation.

See also https://github.com/eclipse-platform/eclipse.platform.swt/pull/1711#issuecomment-2722324061 and other comments in that PR.