### PR TITLE
Reenable wrongly disabled Browser tests

### DIFF
--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_browser_Browser.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_browser_Browser.java
@@ -131,8 +131,6 @@ public class Test_org_eclipse_swt_browser_Browser extends Test_org_eclipse_swt_w
 	Browser browser;
 	boolean isEdge = false;
 
-	static int[] webkitGtkVersionInts = new int[3];
-
 	/** Accumiliate logs, print only if test case fails. Cleared for each test case. */
 	StringBuilder testLog;
 	private void testLogAppend(String msg) {
@@ -438,9 +436,6 @@ public void test_evalute_Cookies () {
 
 @Test
 public void test_ClearAllSessionCookies () {
-	// clearSessions will only work for Webkit2 when >= 2.16
-	assumeTrue(webkitGtkVersionInts[1] >= 16);
-
 	final AtomicBoolean loaded = new AtomicBoolean(false);
 	browser.addProgressListener(ProgressListener.completedAdapter(event -> loaded.set(true)));
 
@@ -470,8 +465,6 @@ public void test_ClearAllSessionCookies () {
 
 @Test
 public void test_get_set_Cookies() {
-	// set/get cookies will only work for WebKit2.20+
-	assumeTrue(webkitGtkVersionInts[1] >= 20);
 	final AtomicBoolean loaded = new AtomicBoolean(false);
 	browser.addProgressListener(ProgressListener.completedAdapter(event -> loaded.set(true)));
 


### PR DESCRIPTION
In https://github.com/eclipse-platform/eclipse.platform.swt/commit/50da5ad8523b8c29ef79c494435c71f7e452d025 logic to disable tests was changed in a wrong way. Enable these tests unconditionally now that the prereqs are mandated.