### PR TITLE
Improve signature of methods in InternalImageLoader

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/internal/NativeImageLoader.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/internal/NativeImageLoader.java
@@ -11,21 +11,22 @@
  * Contributors:
  *     Hannes Wellmann - initial API and implementation
  *******************************************************************************/
-package org.eclipse.swt.graphics;
+package org.eclipse.swt.internal;
 
 import java.io.*;
 import java.util.*;
 
+import org.eclipse.swt.graphics.*;
 import org.eclipse.swt.internal.DPIUtil.*;
 import org.eclipse.swt.internal.image.*;
 
-class InternalImageLoader {
+public class NativeImageLoader {
 
-	static List<ElementAtZoom<ImageData>> load(InputStream stream, ImageLoader imageLoader, int fileZoom, int targetZoom) {
-		return FileFormat.load(stream, imageLoader, fileZoom, targetZoom);
+	public static List<ElementAtZoom<ImageData>> load(ElementAtZoom<InputStream> streamAtZoom, ImageLoader imageLoader, int targetZoom) {
+		return FileFormat.load(streamAtZoom, imageLoader, targetZoom);
 	}
 
-	static void save(OutputStream stream, int format, ImageLoader imageLoader) {
+	public static void save(OutputStream stream, int format, ImageLoader imageLoader) {
 		FileFormat.save(stream, format, imageLoader);
 	}
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/ImageLoader.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/ImageLoader.java
@@ -18,6 +18,7 @@ import java.io.*;
 import java.util.*;
 
 import org.eclipse.swt.*;
+import org.eclipse.swt.internal.*;
 import org.eclipse.swt.internal.DPIUtil.*;
 import org.eclipse.swt.internal.image.*;
 
@@ -157,7 +158,7 @@ public ImageData[] load(InputStream stream) {
 List<ElementAtZoom<ImageData>> load(InputStream stream, int fileZoom, int targetZoom) {
 	if (stream == null) SWT.error(SWT.ERROR_NULL_ARGUMENT);
 	reset();
-	List<ElementAtZoom<ImageData>> images = InternalImageLoader.load(stream, this, fileZoom, targetZoom);
+	List<ElementAtZoom<ImageData>> images = NativeImageLoader.load(new ElementAtZoom<>(stream, fileZoom), this, targetZoom);
 	data = images.stream().map(ElementAtZoom::element).toArray(ImageData[]::new);
 	return images;
 }
@@ -229,7 +230,7 @@ List<ElementAtZoom<ImageData>> load(String filename, int fileZoom, int targetZoo
  */
 public void save(OutputStream stream, int format) {
 	if (stream == null) SWT.error(SWT.ERROR_NULL_ARGUMENT);
-	InternalImageLoader.save(stream, format, this);
+	NativeImageLoader.save(stream, format, this);
 }
 
 /**

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/DPIUtil.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/DPIUtil.java
@@ -521,6 +521,14 @@ public static int mapZoomToDPI (int zoom) {
  * @param <T> type of the element to be presented, e.g., {@link ImageData}
  */
 public record ElementAtZoom<T>(T element, int zoom) {
+	public ElementAtZoom {
+		if (element == null) {
+			SWT.error(SWT.ERROR_NULL_ARGUMENT);
+		}
+		if (zoom <= 0) {
+			SWT.error(SWT.ERROR_INVALID_ARGUMENT);
+		}
+	}
 }
 
 /**

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/image/FileFormat.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/image/FileFormat.java
@@ -126,14 +126,14 @@ public List<ElementAtZoom<ImageData>> loadFromStream(LEDataInputStream stream, i
  * Read the specified input stream using the specified loader, and
  * return the device independent image array represented by the stream.
  */
-public static List<ElementAtZoom<ImageData>> load(InputStream is, ImageLoader loader, int fileZoom, int targetZoom) {
-	LEDataInputStream stream = new LEDataInputStream(is);
+public static List<ElementAtZoom<ImageData>> load(ElementAtZoom<InputStream> is, ImageLoader loader, int targetZoom) {
+	LEDataInputStream stream = new LEDataInputStream(is.element());
 	FileFormat fileFormat = determineFileFormat(stream).orElseGet(() -> {
 		SWT.error(SWT.ERROR_UNSUPPORTED_FORMAT);
 		return null;
 	});
 	fileFormat.loader = loader;
-	return fileFormat.loadFromStream(stream, fileZoom, targetZoom);
+	return fileFormat.loadFromStream(stream, is.zoom(), targetZoom);
 }
 
 /**

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/NativeImageLoader.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/NativeImageLoader.java
@@ -11,21 +11,22 @@
  * Contributors:
  *     Hannes Wellmann - initial API and implementation
  *******************************************************************************/
-package org.eclipse.swt.graphics;
+package org.eclipse.swt.internal;
 
 import java.io.*;
 import java.util.*;
 
+import org.eclipse.swt.graphics.*;
 import org.eclipse.swt.internal.DPIUtil.*;
 import org.eclipse.swt.internal.image.*;
 
-class InternalImageLoader {
+public class NativeImageLoader {
 
-	static List<ElementAtZoom<ImageData>> load(InputStream stream, ImageLoader imageLoader, int fileZoom, int targetZoom) {
-		return FileFormat.load(stream, imageLoader, fileZoom, targetZoom);
+	public static List<ElementAtZoom<ImageData>> load(ElementAtZoom<InputStream> streamAtZoom, ImageLoader imageLoader, int targetZoom) {
+		return FileFormat.load(streamAtZoom, imageLoader, targetZoom);
 	}
 
-	static void save(OutputStream stream, int format, ImageLoader imageLoader) {
+	public static void save(OutputStream stream, int format, ImageLoader imageLoader) {
 		FileFormat.save(stream, format, imageLoader);
 	}
 }


### PR DESCRIPTION
The InternalImageLoader is currently placed in the graphics package and marked as package internal. This change moves it to the internal package improves its name to NativeImageLoader. It also adapts its method's signatures to properly combine element and zoom information if appropriate.