### PR TITLE
Fix NPE #1929

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/DirectoryDialog.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/DirectoryDialog.java
@@ -195,7 +195,7 @@ public Optional<String> openDialog () {
 	directoryPath = null;
 	panel = NSOpenPanel.openPanel();
 	if (panel == null) {
-		return null;
+		throw new SWTException(SWT.ERROR_INVALID_RETURN_VALUE);
 	}
 
 	callback_performKeyEquivalent = new Callback(this, "_performKeyEquivalent", 3);


### PR DESCRIPTION
This is a fixup for ab1d11972aab1c75149f271dca4b58ccfd7710a7.
The contract of `openDialog()` is to throw on error, and return an `Optional` on user action. Null return value is not expected.

This does not fix the issue #1929, but fixes the error reporting per #1026