### PR TITLE
Ensure unique artifactIds for pomless aggregation modules

### DIFF
--- a/bundles/build.properties
+++ b/bundles/build.properties
@@ -13,3 +13,4 @@
 ###############################################################################
 
 tycho.pomless.parent = ../local-build/local-build-parent
+pom.model.artifactId = swt-bundles

--- a/tests/build.properties
+++ b/tests/build.properties
@@ -13,6 +13,7 @@
 ###############################################################################
 
 tycho.pomless.parent = ../local-build/local-build-parent
+pom.model.artifactId = swt-tests
 
 pom.model.property.code.ignoredWarnings = ${tests.ignoredWarnings}
 # Skip all tests on build servers, because it contains platform specific code (overriden to false on platform-specific build machines)


### PR DESCRIPTION
Fixes https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2950