### PR TITLE
Fix Edge::getWebViewWrapper deadlock threat #1466

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Browser/win32/org/eclipse/swt/browser/Edge.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Browser/win32/org/eclipse/swt/browser/Edge.java
@@ -405,13 +405,14 @@ class WebViewProvider {
 	}
 
 	private WebViewWrapper getWebViewWrapper(boolean waitForPendingWebviewTasksToFinish) {
+		WebViewWrapper webViewWrapper = getWebViewWrapper();
 		if(waitForPendingWebviewTasksToFinish) {
 			processOSMessagesUntil(lastWebViewTask::isDone, exception -> {
 				lastWebViewTask.completeExceptionally(exception);
 				throw exception;
 			}, browser.getDisplay());
 		}
-		return webViewWrapperFuture.join();
+		return webViewWrapper;
 	}
 
 	private WebViewWrapper getWebViewWrapper() {


### PR DESCRIPTION
This PR makes sure while calling `Edge::getWebViewWrapper` with `waitForPendingWebviewTasksToFinish` set to **true** that the method also checks for the completion of the `webViewWrapperFuture` before calling a `join()` on it, which can some time lead to deadlock as we allow forced exceptional completion of `lastWebViewTask` on timeout.

contributes to https://github.com/eclipse-platform/eclipse.platform.swt/issues/1466