### PR TITLE
Remove superfluous implementations of hashCode/equals

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/MonitorAwarePoint.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/MonitorAwarePoint.java
@@ -48,15 +48,4 @@ public final class MonitorAwarePoint extends Point {
 	public Monitor getMonitor() {
 		return monitor;
 	}
-
-	@Override
-	public boolean equals(Object object) {
-		return super.equals(object);
-	}
-
-	@Override
-	public int hashCode() {
-		return super.hashCode();
-	}
-
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/MonitorAwareRectangle.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/MonitorAwareRectangle.java
@@ -50,15 +50,4 @@ public final class MonitorAwareRectangle extends Rectangle {
 	public Monitor getMonitor() {
 		return monitor;
 	}
-
-	@Override
-	public boolean equals(Object object) {
-		return super.equals(object);
-	}
-
-	@Override
-	public int hashCode() {
-		return super.hashCode();
-	}
-
 }


### PR DESCRIPTION
The classes are marked `final` and the methods only call `super`. No need for them.