### PR TITLE
[win32] use fixed zoom for default system font

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/DefaultSWTFontRegistry.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/DefaultSWTFontRegistry.java
@@ -49,7 +49,7 @@ final class DefaultSWTFontRegistry implements SWTFontRegistry {
 		}
 		if (hFont == 0) hFont = OS.GetStockObject (OS.DEFAULT_GUI_FONT);
 		if (hFont == 0) hFont = OS.GetStockObject (OS.SYSTEM_FONT);
-		Font font = Font.win32_new(device, hFont);
+		Font font = Font.win32_new(device, hFont, zoom);
 		registerFont(KEY_SYSTEM_FONTS, font);
 		registerFont(font.getFontData()[0], font);
 		return font;


### PR DESCRIPTION
This commit addresses a regression that is caused by DPIUtil#getDeviceZoom not properly initialized yet, when created the first system font. Explicitly passing the target zoom to the Font prevent the issue.

### How to reproduce
Start a runtime on a zoom > 100 with default configuration (if not visible try a fresh workspace). The CTabFolder fonts will be bigger as expected