### PR TITLE
Use consistent versions for surefire plug-ins

### DIFF
--- a/binaries/pom.xml
+++ b/binaries/pom.xml
@@ -51,7 +51,7 @@
 					<dependency>
 						<groupId>org.apache.maven.surefire</groupId>
 						<artifactId>surefire-junit-platform</artifactId>
-						<version>3.2.5</version>
+						<version>${surefire.version}</version>
 					</dependency>
 				</dependencies>
 				<executions>


### PR DESCRIPTION
This PR replaces the hardcoded version of surefire-junit-platform with the commonly used ${surefire.version} property. The hardcoded version led to class loading issues with the latest surefire release, 3.5.3.