### PR TITLE
Downgrade WebKit for the Linux GH runner

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -48,7 +48,7 @@ jobs:
       if: ${{ matrix.config.native == 'gtk.linux.x86_64'}}
       run: |
         sudo apt-get update -qq 
-        sudo apt-get install -qq -y libgtk-3-dev libgtk-4-dev freeglut3-dev webkit2gtk-driver
+        WEBKIT_VERSION=2.44.0-2 && sudo apt-get install -qq -y libgtk-3-dev libgtk-4-dev freeglut3-dev webkit2gtk-driver=${WEBKIT_VERSION} libwebkit2gtk-4.1-0=${WEBKIT_VERSION} libjavascriptcoregtk-4.1-0=${WEBKIT_VERSION}
     - name: Pull large static Windows binaries
       if: ${{ matrix.config.native == 'win32.win32.x86_64'}}
       run: |


### PR DESCRIPTION
Downgrade to `2.44.0-2` (from `2.48.0-0ubuntu0.24.04.1`). I would have liked to use the previously working version (`2.46.6-0ubuntu0.24.04.1`) but I wasn't able to provide the correct version string for it. If someone knows it, feel free to improve this solution.

This fixes the obscure errors thrown when running the Linux tests. I found this exception in the logs of the most recent GH Actions runs (all of which fail since 2 days ago):

```
2025-04-01T15:46:24.5810004Z Running Test_org_eclipse_swt_browser_Browser#test_OpenWindowListener_openHasValidEventDetails[browser flags: 0]
2025-04-01T15:46:24.5810524Z 
2025-04-01T15:46:24.5810839Z ### Descriptors opened BEFORE test_OpenWindowListener_openHasValidEventDetails[browser flags: 0]: 40
2025-04-01T15:46:24.6438504Z /usr/include/c++/13/optional:486: constexpr const _Tp& std::_Optional_base_impl<_Tp, _Dp>::_M_get() const [with _Tp = WebCore::WindowFeatures; _Dp = std::_Optional_base<WebCore::WindowFeatures, false, false>]: Assertion 'this->_M_is_engaged()' failed.
```

Which led me to believe that the problem was similar to what we already knew from https://github.com/eclipse-platform/eclipse.platform.swt/issues/1564 _i.e._ that **newer versions of WebKit don't work well with our current SWT tests**.

Downgrading to an older version of WebKit is just a temporary solution but the best I could come up with given my little knowledge of WebKit.