### PR TITLE
[win32] Use consistent font zoom retrieval

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Caret.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Caret.java
@@ -152,7 +152,7 @@ public Font getFont () {
 	checkWidget();
 	if (font == null) {
 		long hFont = defaultFont ();
-		return Font.win32_new (display, hFont, getZoom());
+		return Font.win32_new (display, hFont, getNativeZoom());
 	}
 	return font;
 }
@@ -478,8 +478,7 @@ public void setFont (Font font) {
 	if (font != null && font.isDisposed ()) {
 		error (SWT.ERROR_INVALID_ARGUMENT);
 	}
-	Shell shell = parent.getShell();
-	this.font = font == null ? null : Font.win32_new(font, shell.nativeZoom);
+	this.font = font == null ? null : Font.win32_new(font, getNativeZoom());
 	if (hasFocus ()) setIMEFont ();
 }
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Composite.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Composite.java
@@ -1525,7 +1525,7 @@ LRESULT WM_PAINT (long wParam, long lParam) {
 					Control control = findBackgroundControl ();
 					if (control == null) control = this;
 					data.background = control.getBackgroundPixel ();
-					data.font = Font.win32_new(display, OS.SendMessage (handle, OS.WM_GETFONT, 0, 0), nativeZoom);
+					data.font = Font.win32_new(display, OS.SendMessage (handle, OS.WM_GETFONT, 0, 0), getNativeZoom());
 					data.uiState = (int)OS.SendMessage (handle, OS.WM_QUERYUISTATE, 0, 0);
 					if ((style & SWT.NO_BACKGROUND) != 0) {
 						/* This code is intentionally commented because it may be slow to copy bits from the screen */

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Control.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Control.java
@@ -721,7 +721,7 @@ int defaultBackground () {
 }
 
 long defaultFont() {
-	return display.getSystemFont(getShell().nativeZoom).handle;
+	return display.getSystemFont(getNativeZoom()).handle;
 }
 
 int defaultForeground () {
@@ -1315,7 +1315,7 @@ public Font getFont () {
 	if (font != null) return font;
 	long hFont = OS.SendMessage (handle, OS.WM_GETFONT, 0, 0);
 	if (hFont == 0) hFont = defaultFont ();
-	return Font.win32_new (display, hFont, getShell().nativeZoom);
+	return Font.win32_new (display, hFont, getNativeZoom());
 }
 
 /**
@@ -3330,7 +3330,7 @@ public void setCursor (Cursor cursor) {
 }
 
 void setDefaultFont () {
-	long hFont = display.getSystemFont (getShell().nativeZoom).handle;
+	long hFont = display.getSystemFont (getNativeZoom()).handle;
 	OS.SendMessage (handle, OS.WM_SETFONT, hFont, 0);
 }
 
@@ -3432,7 +3432,7 @@ public void setFont (Font font) {
 	Font newFont = font;
 	if (newFont != null) {
 		if (newFont.isDisposed()) error(SWT.ERROR_INVALID_ARGUMENT);
-		newFont = Font.win32_new(newFont, getShell().nativeZoom);
+		newFont = Font.win32_new(newFont, getNativeZoom());
 	}
 	long hFont = 0;
 	if (newFont != null) {
@@ -5869,7 +5869,7 @@ private static void handleDPIChange(Widget widget, int newZoom, float scalingFac
 	if (!(widget instanceof Control control)) {
 		return;
 	}
-	resizeFont(control, control.getShell().nativeZoom);
+	resizeFont(control, control.getNativeZoom());
 
 	Image image = control.backgroundImage;
 	if (image != null) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TableItem.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TableItem.java
@@ -870,8 +870,7 @@ public void setFont (Font font){
 		error (SWT.ERROR_INVALID_ARGUMENT);
 	}
 	Font oldFont = this.font;
-	Shell shell = parent.getShell();
-	Font newFont = (font == null ? font : Font.win32_new(font, shell.nativeZoom));
+	Font newFont = (font == null ? font : Font.win32_new(font, getNativeZoom()));
 	if (oldFont == newFont) return;
 	this.font = newFont;
 	if (oldFont != null && oldFont.equals (newFont)) return;
@@ -936,7 +935,7 @@ public void setFont (int index, Font font) {
 	}
 	Font oldFont = cellFont [index];
 	if (oldFont == font) return;
-	cellFont [index] = font == null ? font : Font.win32_new(font, nativeZoom);
+	cellFont [index] = font == null ? font : Font.win32_new(font, getNativeZoom());
 	if (oldFont != null && oldFont.equals (font)) return;
 	if (font != null) parent.setCustomDraw (true);
 	if ((parent.style & SWT.VIRTUAL) != 0) cached = true;
@@ -1282,10 +1281,9 @@ private static void handleDPIChange(Widget widget, int newZoom, float scalingFac
 	}
 	Font[] cellFonts = tableItem.cellFont;
 	if (cellFonts != null) {
-		Shell shell = tableItem.parent.getShell();
 		for (int index = 0; index < cellFonts.length; index++) {
 			Font cellFont = cellFonts[index];
-			cellFonts[index] = cellFont == null ? null : Font.win32_new(cellFont, shell.nativeZoom);
+			cellFonts[index] = cellFont == null ? null : Font.win32_new(cellFont, tableItem.getNativeZoom());
 		}
 	}
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TreeItem.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TreeItem.java
@@ -1388,8 +1388,7 @@ public void setFont (Font font){
 		error (SWT.ERROR_INVALID_ARGUMENT);
 	}
 	Font oldFont = this.font;
-	Shell shell = parent.getShell();
-	Font newFont = (font == null ? font : Font.win32_new(font, shell.nativeZoom));
+	Font newFont = (font == null ? font : Font.win32_new(font, getNativeZoom()));
 	if (oldFont == newFont) return;
 	this.font = newFont;
 	if (oldFont != null && oldFont.equals (font)) return;
@@ -1445,8 +1444,7 @@ public void setFont (int index, Font font) {
 	}
 	Font oldFont = cellFont [index];
 	if (oldFont == font) return;
-	Shell shell = parent.getShell();
-	cellFont [index] = font == null ? font : Font.win32_new(font, shell.nativeZoom);
+	cellFont [index] = font == null ? font : Font.win32_new(font, getNativeZoom());
 	if (oldFont != null && oldFont.equals (font)) return;
 	if (font != null) parent.customDraw = true;
 	if ((parent.style & SWT.VIRTUAL) != 0) cached = true;
@@ -1828,10 +1826,9 @@ private static void handleDPIChange(Widget widget, int newZoom, float scalingFac
 	}
 	Font[] cellFonts = treeItem.cellFont;
 	if (cellFonts != null) {
-		Shell shell = treeItem.parent.getShell();
 		for (int index = 0; index < cellFonts.length; index++) {
 			Font cellFont = cellFonts[index];
-			cellFonts[index] = cellFont == null ? null : Font.win32_new(cellFont, shell.nativeZoom);
+			cellFonts[index] = cellFont == null ? null : Font.win32_new(cellFont, treeItem.getNativeZoom());
 		}
 	}
 	for (TreeItem item : treeItem.getItems()) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Widget.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Widget.java
@@ -2690,6 +2690,10 @@ GC createNewGC(long hDC, GCData data) {
 	return GC.win32_new(hDC, data);
 }
 
+int getNativeZoom() {
+	return nativeZoom;
+}
+
 int getZoom() {
 	return DPIUtil.getZoomForAutoscaleProperty(nativeZoom);
 }


### PR DESCRIPTION
This PR unifies the extraction of the target zoom of a font to be
affected by the zoom context of the underlying Widget. Before there
were different strategies like getting it from the Shell.