### PR TITLE
Rework new Image constructors accepting a ImageGcDrawer

### DIFF
--- a/binaries/org.eclipse.swt.win32.win32.x86_64/.settings/.api_filters
+++ b/binaries/org.eclipse.swt.win32.win32.x86_64/.settings/.api_filters
@@ -582,10 +582,11 @@
         </filter>
     </resource>
     <resource path="Eclipse SWT/common/org/eclipse/swt/graphics/ImageGcDrawer.java" type="org.eclipse.swt.graphics.ImageGcDrawer">
-        <filter id="404000815">
+        <filter id="403984517">
             <message_arguments>
                 <message_argument value="org.eclipse.swt.graphics.ImageGcDrawer"/>
-                <message_argument value="getGcStyle()"/>
+                <message_argument value="org.eclipse.swt.graphics.ImageDrawer"/>
+                <message_argument value="withGCStyle(int, ImageDrawer)"/>
             </message_arguments>
         </filter>
     </resource>

--- a/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CTabFolder.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CTabFolder.java
@@ -734,7 +734,7 @@ Image createButtonImage(Display display, int button) {
 	final Rectangle trim = renderer.computeTrim(button, SWT.NONE, 0, 0, 0, 0);
 	final Point imageSize = new Point(size.x - trim.width, size.y - trim.height);
 	Color transColor = renderer.parent.getBackground();
-	final ImageGcDrawer imageGcDrawer = new TransparencyColorImageGcDrawer(transColor) {
+	return new Image(display, imageSize.x, imageSize.y, new TransparencyColorImageGcDrawer(transColor) {
 		@Override
 		public void drawOn(GC gc, int imageWidth, int imageHeight) {
 			Rectangle imageBounds = new Rectangle(0, 0, imageWidth, imageHeight);
@@ -742,8 +742,7 @@ Image createButtonImage(Display display, int button) {
 			gc.fillRectangle(imageBounds);
 			renderer.draw(button, SWT.NONE, imageBounds, gc);
 		}
-	};
-	return new Image(display, imageGcDrawer, imageSize.x, imageSize.y);
+	});
 }
 
 private void notifyItemCountChange() {
@@ -4007,7 +4006,8 @@ void updateBkImages(boolean colorChanged) {
 						if (colorChanged || !bounds.equals(bkImageBounds[i])) {
 							bkImageBounds[i] = bounds;
 							if (controlBkImages[i] != null) controlBkImages[i].dispose();
-							controlBkImages[i] = new Image(control.getDisplay(), (gc, imageWidth, imageHeight) -> renderer.draw(CTabFolderRenderer.PART_BACKGROUND, 0, bounds, gc), bounds.width, bounds.height);
+							controlBkImages[i] = new Image(control.getDisplay(), bounds.width, bounds.height,
+									(gc, w, h) -> renderer.draw(CTabFolderRenderer.PART_BACKGROUND, 0, bounds, gc));
 							control.setBackground(null);
 							control.setBackgroundImage(controlBkImages[i]);
 						}

--- a/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/StyledText.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/StyledText.java
@@ -1593,15 +1593,14 @@ void createCaretBitmaps() {
 		leftCaretBitmap.dispose();
 	}
 	int lineHeight = renderer.getLineHeight();
-	final ImageGcDrawer leftCaretDrawer = (gc, width, height) -> {
+	leftCaretBitmap = new Image(display, caretWidth, lineHeight, (gc, width, height) -> {
 		gc.setBackground(display.getSystemColor(SWT.COLOR_BLACK));
 		gc.fillRectangle(0, 0, width, height);
 		gc.setForeground(display.getSystemColor(SWT.COLOR_WHITE));
 		gc.drawLine(0,0,0,height);
 		gc.drawLine(0,0,width-1,0);
 		gc.drawLine(0,1,1,1);
-	};
-	leftCaretBitmap = new Image(display, leftCaretDrawer, caretWidth, lineHeight);
+	});
 
 	if (rightCaretBitmap != null) {
 		if (defaultCaret != null && rightCaretBitmap.equals(defaultCaret.getImage())) {
@@ -1609,16 +1608,16 @@ void createCaretBitmaps() {
 		}
 		rightCaretBitmap.dispose();
 	}
-	final ImageGcDrawer rightCaretDrawer = (gc, width, height) -> {
+	rightCaretBitmap = new Image(display, caretWidth, lineHeight, (gc, width, height) -> {
 		gc.setBackground(display.getSystemColor(SWT.COLOR_BLACK));
 		gc.fillRectangle(0, 0, width, height);
 		gc.setForeground(display.getSystemColor(SWT.COLOR_WHITE));
 		gc.drawLine(width-1,0,width-1,height);
 		gc.drawLine(0,0,width-1,0);
 		gc.drawLine(width-1,1,1,1);
-	};
-	rightCaretBitmap = new Image(display, rightCaretDrawer, caretWidth, lineHeight);
+	});
 }
+
 /**
  * Moves the selected text to the clipboard.  The text will be put in the
  * clipboard in plain text, HTML, and RTF formats.

--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/graphics/Image.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/graphics/Image.java
@@ -878,9 +878,9 @@ public Image(Device device, ImageDataProvider imageDataProvider) {
  *    <li>ERROR_NULL_ARGUMENT - if device is null and there is no current device</li>
  *    <li>ERROR_NULL_ARGUMENT - if the ImageGcDrawer is null</li>
  * </ul>
- * @since 3.129
+ * @since 3.130
  */
-public Image(Device device, ImageGcDrawer imageGcDrawer, int width, int height) {
+public Image(Device device, int width, int height, ImageGcDrawer imageGcDrawer) {
 	super(device);
 	if (imageGcDrawer == null) SWT.error(SWT.ERROR_NULL_ARGUMENT);
 	this.imageGcDrawer = imageGcDrawer;
@@ -903,6 +903,15 @@ public Image(Device device, ImageGcDrawer imageGcDrawer, int width, int height) 
 	} finally {
 		if (pool != null) pool.release();
 	}
+}
+
+/**
+ * @since 3.129
+ * @deprecated Instead use {@link #Image(Device, int, int, ImageGcDrawer)}
+ */
+@Deprecated(forRemoval = true, since = "2025-06 (removal in 2027-06 or later)")
+public Image(Device device, ImageGcDrawer imageGcDrawer, int width, int height) {
+	this(device, width, height, imageGcDrawer);
 }
 
 private ImageData drawWithImageGcDrawer(ImageGcDrawer imageGcDrawer, int width, int height, int zoom) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/graphics/Image.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/graphics/Image.java
@@ -142,7 +142,7 @@ public final class Image extends Resource implements Drawable {
 	/**
 	 * ImageGcDrawer to provide a callback to draw on a GC for various zoom levels
 	 */
-	private ImageGcDrawer imageGcDrawer;
+	private ImageDrawer imageGcDrawer;
 
 	/**
 	 * Style flag used to differentiate normal, gray-scale and disabled images based
@@ -880,7 +880,7 @@ public Image(Device device, ImageDataProvider imageDataProvider) {
  * </ul>
  * @since 3.130
  */
-public Image(Device device, int width, int height, ImageGcDrawer imageGcDrawer) {
+public Image(Device device, int width, int height, ImageDrawer imageGcDrawer) {
 	super(device);
 	if (imageGcDrawer == null) SWT.error(SWT.ERROR_NULL_ARGUMENT);
 	this.imageGcDrawer = imageGcDrawer;
@@ -914,13 +914,13 @@ public Image(Device device, ImageGcDrawer imageGcDrawer, int width, int height) 
 	this(device, width, height, imageGcDrawer);
 }
 
-private ImageData drawWithImageGcDrawer(ImageGcDrawer imageGcDrawer, int width, int height, int zoom) {
+private ImageData drawWithImageGcDrawer(ImageDrawer imageGcDrawer, int width, int height, int zoom) {
 	Image image = new Image(device, width, height);
-	GC gc = new GC(image);
+	GC gc = new GC(image, ExtendedImageDrawer.getGCStyle(imageGcDrawer));
 	try {
 		imageGcDrawer.drawOn(gc, width, height);
 		ImageData imageData = image.getImageData(zoom);
-		imageGcDrawer.postProcess(imageData);
+		ExtendedImageDrawer.postProcess(imageGcDrawer, imageData);
 		return imageData;
 	} finally {
 		gc.dispose();

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/image/ExtendedImageDrawer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/image/ExtendedImageDrawer.java
@@ -1,0 +1,53 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Hannes Wellmann and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Hannes Wellmann - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.swt.internal.image;
+
+import java.util.*;
+import java.util.function.*;
+
+import org.eclipse.swt.*;
+import org.eclipse.swt.graphics.*;
+
+public record ExtendedImageDrawer(ImageDrawer original, Consumer<ImageData> postProcessor, int style)
+		implements ImageDrawer {
+
+	public ExtendedImageDrawer {
+		Objects.requireNonNull(original);
+	}
+
+	@Override
+	public void drawOn(GC gc, int imageWidth, int imageHeight) {
+		original.drawOn(gc, imageWidth, imageHeight);
+	}
+
+	public static int getGCStyle(ImageDrawer drawer) {
+		if (drawer instanceof ExtendedImageDrawer extendedDrawer) {
+			return extendedDrawer.style();
+		}
+		return SWT.NONE;
+	}
+
+	public static void postProcess(ImageDrawer drawer, ImageData data) {
+		if (drawer instanceof @SuppressWarnings("removal") ImageGcDrawer gcDrawer) {
+			gcDrawer.postProcess(data);
+		} else if (drawer instanceof ExtendedImageDrawer extendedDrawer) {
+			Consumer<ImageData> postProcessor2 = extendedDrawer.postProcessor();
+			if (postProcessor2 != null) {
+				postProcessor2.accept(data);
+			}
+		}
+	}
+
+}

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/graphics/Image.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/graphics/Image.java
@@ -670,9 +670,9 @@ public Image(Device device, ImageDataProvider imageDataProvider) {
  *    <li>ERROR_NULL_ARGUMENT - if device is null and there is no current device</li>
  *    <li>ERROR_NULL_ARGUMENT - if the ImageGcDrawer is null</li>
  * </ul>
- * @since 3.129
+ * @since 3.130
  */
-public Image(Device device, ImageGcDrawer imageGcDrawer, int width, int height) {
+public Image(Device device, int width, int height, ImageGcDrawer imageGcDrawer) {
 	super(device);
 	if (imageGcDrawer == null) {
 		SWT.error(SWT.ERROR_NULL_ARGUMENT);
@@ -682,6 +682,15 @@ public Image(Device device, ImageGcDrawer imageGcDrawer, int width, int height) 
 	ImageData imageData = drawWithImageGcDrawer(width, height, currentDeviceZoom);
 	init (imageData);
 	init ();
+}
+
+/**
+ * @since 3.129
+ * @deprecated Instead use {@link #Image(Device, int, int, ImageGcDrawer)}
+ */
+@Deprecated(forRemoval = true, since = "2025-06 (removal in 2027-06 or later)")
+public Image(Device device, ImageGcDrawer imageGcDrawer, int width, int height) {
+	this(device, width, height, imageGcDrawer);
 }
 
 /**

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/graphics/Image.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/graphics/Image.java
@@ -156,7 +156,7 @@ public final class Image extends Resource implements Drawable {
 	/**
 	 * ImageGcDrawer to provide a callback to draw on a GC for various zoom levels
 	 */
-	private ImageGcDrawer imageGcDrawer;
+	private ImageDrawer imageGcDrawer;
 
 	/**
 	 * Style flag used to differentiate normal, gray-scale and disabled images based
@@ -672,7 +672,7 @@ public Image(Device device, ImageDataProvider imageDataProvider) {
  * </ul>
  * @since 3.130
  */
-public Image(Device device, int width, int height, ImageGcDrawer imageGcDrawer) {
+public Image(Device device, int width, int height, ImageDrawer imageGcDrawer) {
 	super(device);
 	if (imageGcDrawer == null) {
 		SWT.error(SWT.ERROR_NULL_ARGUMENT);
@@ -1168,11 +1168,11 @@ public ImageData getImageData (int zoom) {
 
 private ImageData drawWithImageGcDrawer(int width, int height, int zoom) {
 	Image image = new Image(device, width, height);
-	GC gc = new GC(image);
+	GC gc = new GC(image, ExtendedImageDrawer.getGCStyle(imageGcDrawer));
 	try {
 		imageGcDrawer.drawOn(gc, width, height);
 		ImageData imageData = image.getImageData(zoom);
-		imageGcDrawer.postProcess(imageData);
+		ExtendedImageDrawer.postProcess(imageGcDrawer, imageData);
 		return imageData;
 	} finally {
 		gc.dispose();

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Image.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Image.java
@@ -631,7 +631,7 @@ public Image(Device device, ImageDataProvider imageDataProvider) {
  * </ul>
  * @since 3.130
  */
-public Image(Device device, int width, int height, ImageGcDrawer imageGcDrawer) {
+public Image(Device device, int width, int height, ImageDrawer imageGcDrawer) {
 	super(device);
 	this.imageProvider = new ImageGcDrawerWrapper(imageGcDrawer, width, height);
 	initialNativeZoom = DPIUtil.getNativeDeviceZoom();
@@ -2485,12 +2485,12 @@ private class ImageDataProviderWrapper extends BaseImageProviderWrapper<ImageDat
 }
 
 private class ImageGcDrawerWrapper extends DynamicImageProviderWrapper {
-	private ImageGcDrawer drawer;
+	private ImageDrawer drawer;
 	private int width;
 	private int height;
 
-	ImageGcDrawerWrapper(ImageGcDrawer imageGcDrawer, int width, int height) {
-		checkProvider(imageGcDrawer, ImageGcDrawer.class);
+	ImageGcDrawerWrapper(ImageDrawer imageGcDrawer, int width, int height) {
+		checkProvider(imageGcDrawer, ImageDrawer.class);
 		this.drawer = imageGcDrawer;
 		this.width = width;
 		this.height = height;
@@ -2511,12 +2511,12 @@ private class ImageGcDrawerWrapper extends DynamicImageProviderWrapper {
 	ImageHandle getImageMetadata(int zoom) {
 		initialNativeZoom = zoom;
 		Image image = new Image(device, width, height, zoom);
-		GC gc = new GC(image, drawer.getGcStyle());
+		GC gc = new GC(image, ExtendedImageDrawer.getGCStyle(drawer));
 		try {
 			gc.data.nativeZoom = zoom;
 			drawer.drawOn(gc, width, height);
 			ImageData imageData = image.getImageMetadata(zoom).getImageData();
-			drawer.postProcess(imageData);
+			ExtendedImageDrawer.postProcess(drawer, imageData);
 			ImageData newData = adaptImageDataIfDisabledOrGray(imageData);
 			init(newData, zoom);
 		} finally {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Image.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Image.java
@@ -629,13 +629,22 @@ public Image(Device device, ImageDataProvider imageDataProvider) {
  *    <li>ERROR_NULL_ARGUMENT - if device is null and there is no current device</li>
  *    <li>ERROR_NULL_ARGUMENT - if the ImageGcDrawer is null</li>
  * </ul>
- * @since 3.129
+ * @since 3.130
  */
-public Image(Device device, ImageGcDrawer imageGcDrawer, int width, int height) {
+public Image(Device device, int width, int height, ImageGcDrawer imageGcDrawer) {
 	super(device);
 	this.imageProvider = new ImageGcDrawerWrapper(imageGcDrawer, width, height);
 	initialNativeZoom = DPIUtil.getNativeDeviceZoom();
 	init();
+}
+
+/**
+ * @since 3.129
+ * @deprecated Instead use {@link #Image(Device, int, int, ImageGcDrawer)}
+ */
+@Deprecated(forRemoval = true, since = "2025-06 (removal in 2027-06 or later)")
+public Image(Device device, ImageGcDrawer imageGcDrawer, int width, int height) {
+	this(device, width, height, imageGcDrawer);
 }
 
 private ImageData adaptImageDataIfDisabledOrGray(ImageData data) {


### PR DESCRIPTION
When implementing the `ImageGCDrawer` as lambda, the resulting code is better to read if the `ImageGCDrawer` is passed as last argument:
```java
new Image(device, 16, 16, (gc, w, h) -> {
	gc.draw ...
})
```
For example at https://github.com/eclipse-platform/eclipse.platform.ui/pull/2869 or in the adapted parts within SWT one can see that the current order encourages to code in way that is more verbose.

Furthermore this way the argument order also better reflects the order in which the arguments are applied:
1. an image with the given size is created.
2. the GC draws on that image

I know that changing an API after it was released is not ideal, but since it's very new I assume there are not yet many users and existing users are very likely able to adapt especially as the change is trivial. Consequently we have a real chance to remove the first shot eventually. On the other hand if we stick with the existing API we might be annoyed by its imperfection forever.
If we have this, I can take care of adopting the existing callers in the SDK.

Follow-up on
- https://github.com/eclipse-platform/eclipse.platform.swt/pull/1734

@HeikoKlare, @fedejeanne or anybody else, what do you think?