### PR TITLE
Allow to test for loading image at zoom and fix faulty Win32 image load

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/ImageDataLoader.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/ImageDataLoader.java
@@ -37,10 +37,18 @@ class ImageDataLoader {
 		return data[0];
 	}
 
+	public static boolean canLoadAtZoom(InputStream stream, int fileZoom, int targetZoom) {
+		return ImageLoader.canLoadAtZoom(stream, fileZoom, targetZoom);
+	}
+
 	public static ElementAtZoom<ImageData> load(InputStream stream, int fileZoom, int targetZoom) {
 		List<ElementAtZoom<ImageData>> data = new ImageLoader().load(stream, fileZoom, targetZoom);
 		if (data.isEmpty()) SWT.error(SWT.ERROR_INVALID_IMAGE);
 		return data.get(0);
+	}
+
+	public static boolean canLoadAtZoom(String filename, int fileZoom, int targetZoom) {
+		return ImageLoader.canLoadAtZoom(filename, fileZoom, targetZoom);
 	}
 
 	public static ElementAtZoom<ImageData> load(String filename, int fileZoom, int targetZoom) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/ImageLoader.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/ImageLoader.java
@@ -163,6 +163,11 @@ List<ElementAtZoom<ImageData>> load(InputStream stream, int fileZoom, int target
 	return images;
 }
 
+static boolean canLoadAtZoom(InputStream stream, int fileZoom, int targetZoom) {
+	if (stream == null) SWT.error(SWT.ERROR_NULL_ARGUMENT);
+	return FileFormat.canLoadAtZoom(new ElementAtZoom<>(stream, fileZoom), targetZoom);
+}
+
 /**
  * Loads an array of <code>ImageData</code> objects from the
  * file with the specified name. Throws an error if either
@@ -194,6 +199,16 @@ List<ElementAtZoom<ImageData>> load(String filename, int fileZoom, int targetZoo
 		SWT.error(SWT.ERROR_IO, e);
 	}
 	return null;
+}
+
+static boolean canLoadAtZoom(String filename, int fileZoom, int targetZoom) {
+	if (filename == null) SWT.error(SWT.ERROR_NULL_ARGUMENT);
+	try (InputStream stream = new FileInputStream(filename)) {
+		return canLoadAtZoom(stream, fileZoom, targetZoom);
+	} catch (IOException e) {
+		SWT.error(SWT.ERROR_IO, e);
+	}
+	return false;
 }
 
 /**

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/image/FileFormat.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/image/FileFormat.java
@@ -136,6 +136,10 @@ public static List<ElementAtZoom<ImageData>> load(ElementAtZoom<InputStream> is,
 	return fileFormat.loadFromStream(stream, is.zoom(), targetZoom);
 }
 
+public static boolean canLoadAtZoom(ElementAtZoom<InputStream> is, int targetZoom) {
+	return is.zoom() == targetZoom  || isDynamicallySizableFormat(is.element());
+}
+
 /**
  * Write the device independent image array stored in the specified loader
  * to the specified output stream using the specified file format.

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Image.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Image.java
@@ -2235,13 +2235,20 @@ private class ImageFileNameProviderWrapper extends BaseImageProviderWrapper<Imag
 	@Override
 	protected ElementAtZoom<ImageData> loadImageData(int zoom) {
 		ElementAtZoom<String> fileForZoom = DPIUtil.validateAndGetImagePathAtZoom(provider, zoom);
+
+		// Load at appropriate zoom via loader
+		if (fileForZoom.zoom() != zoom && ImageDataLoader.canLoadAtZoom(fileForZoom.element(), fileForZoom.zoom(), zoom)) {
+			ElementAtZoom<ImageData> imageDataAtZoom = ImageDataLoader.load(fileForZoom.element(), fileForZoom.zoom(), zoom);
+			return new ElementAtZoom<>(adaptImageDataIfDisabledOrGray(imageDataAtZoom.element()), zoom);
+		}
+
+		// Load at file zoom (native or via loader) and rescale
 		ImageHandle nativeInitializedImage;
 		if (zoomLevelToImageHandle.containsKey(fileForZoom.zoom())) {
 			nativeInitializedImage = zoomLevelToImageHandle.get(fileForZoom.zoom());
 		} else {
 			nativeInitializedImage = initNative(fileForZoom.element(), fileForZoom.zoom());
 		}
-
 		ElementAtZoom<ImageData> imageDataAtZoom;
 		if (nativeInitializedImage == null) {
 			imageDataAtZoom = ImageDataLoader.load(fileForZoom.element(), fileForZoom.zoom(), zoom);


### PR DESCRIPTION
The ImageLoader and FileFormat implementations currently combine the check whether an image can be provided at a specific scale value and the provision of an image in the scale itself. In case a consumer wants to test whether an image can be provided at a specific scale, it needs to request that image at that scale, even if it will not be used later one, e.g., because it cannot be provided in the required scale.

With this change, ImageLoader and FileFormat provide separate methods for validating whether an image can be retrieved at a specific zoom (such as from an SVG) and the retrieval of the image itself. This is employed by the Cocoa Image implementation to avoid unnecessary load operations and in the Win32 Image implementation to correct erroneous scaling from an already initialized handle instead of loading at proper zoom (such as for an SVG). In addition, this fixes a faulty reuse of the
same stream in the Cocoa Image implementation at the same place. See https://github.com/eclipse-platform/eclipse.platform/pull/1797#pullrequestreview-2740239609 and https://github.com/eclipse-platform/eclipse.platform.ui/pull/2643#pullrequestreview-2727866854.

This will specifically be useful for consumers that need to load images on their own (such as the URLImageFileNameProvider and URLImageDataProvider in JFace), as they would otherwise need to test for the ability to retrieve an image at a specific scale by actually retrieving the image without using the loaded image data later on.