### PR TITLE
[win32] Handle all scaled font via SWTFontProvider

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/GC.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/GC.java
@@ -3898,14 +3898,14 @@ void init(Drawable drawable, GCData data, long hDC) {
 		data.background = OS.GetBkColor(hDC);
 	}
 	data.state &= ~(NULL_BRUSH | NULL_PEN);
+	if (data.nativeZoom == 0) {
+		data.nativeZoom = extractZoom(hDC);
+	}
 	Font font = data.font;
 	if (font != null) {
 		data.state &= ~FONT;
 	} else {
-		data.font = Font.win32_new(device, OS.GetCurrentObject(hDC, OS.OBJ_FONT));
-	}
-	if (data.nativeZoom == 0) {
-		data.nativeZoom = extractZoom(hDC);
+		data.font = SWTFontProvider.getFont(device, OS.GetCurrentObject(hDC, OS.OBJ_FONT), data.nativeZoom);
 	}
 	Image image = data.image;
 	if (image != null) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/DefaultSWTFontRegistry.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/DefaultSWTFontRegistry.java
@@ -71,6 +71,11 @@ final class DefaultSWTFontRegistry implements SWTFontRegistry {
 		return font;
 	}
 
+	@Override
+	public Font getFont(long fontHandle, int zoom) {
+		return Font.win32_new(device, fontHandle, zoom);
+	}
+
 	private Font registerFont(FontData fontData, Font font) {
 		fontsMap.put(fontData, font);
 		return font;

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/SWTFontProvider.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/SWTFontProvider.java
@@ -62,6 +62,21 @@ public class SWTFontProvider {
 	}
 
 	/**
+	 * Returns the font with the given fontHandle for the given device at the
+	 * specified zoom.
+	 *
+	 * <b>Note:</b> This operation is not thread-safe. It must thus always be called
+	 * from the same thread for the same device, such as the display's UI thread.
+	 *
+	 * @param device     the device to retrieve the font for, must not be {@code null}
+	 * @param fontHandle the handle to an existing font
+	 * @param zoom       the zoom for which the font shall be scaled
+	 */
+	public static Font getFont(Device device, long fontHandle, int zoom) {
+		return getFontRegistry(device).getFont(fontHandle, zoom);
+	}
+
+	/**
 	 * Disposes the font registry for the given device, if one exists.
 	 *
 	 * @param device the device to dispose the font registry for, must not be

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/SWTFontRegistry.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/SWTFontRegistry.java
@@ -46,6 +46,18 @@ public interface SWTFontRegistry {
 	 */
 	Font getFont(FontData fontData, int zoom);
 
+
+	/**
+	 * Provides a font optimally suited for the specified zoom. If the handle is yet unknown to
+	 * the registry, the font will not be managed by the font registry. Only Fonts created in the
+	 * font registry are managed by it and should not be disposed of externally.
+	 *
+	 * @param fontHandle the handle to an existing font
+	 * @param zoom zoom in % of the standard resolution to determine the appropriate font
+	 * @return the font best suited for the specified zoom
+	 */
+	Font getFont(long fontHandle, int zoom);
+
 	/**
 	 * Disposes all fonts managed by the font registry.
 	 */

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/ScalingSWTFontRegistry.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/ScalingSWTFontRegistry.java
@@ -44,6 +44,7 @@ final class ScalingSWTFontRegistry implements SWTFontRegistry {
 
 		private Font createAndCacheFont(int zoom) {
 			Font newFont = createFont(zoom);
+			customFontHandlesKeyMap.put(newFont.handle, this);
 			scaledFonts.put(zoom, newFont);
 			return newFont;
 		}
@@ -112,6 +113,7 @@ final class ScalingSWTFontRegistry implements SWTFontRegistry {
 
 	private ScaledFontContainer systemFontContainer;
 	private Map<FontData, ScaledFontContainer> customFontsKeyMap = new HashMap<>();
+	private Map<Long, ScaledFontContainer> customFontHandlesKeyMap = new HashMap<>();
 	private Device device;
 
 	ScalingSWTFontRegistry(Device device) {
@@ -134,6 +136,14 @@ final class ScalingSWTFontRegistry implements SWTFontRegistry {
 			customFontsKeyMap.put(fontData, container);
 		}
 		return container.getScaledFont(zoom);
+	}
+
+	@Override
+	public Font getFont(long fontHandle, int zoom) {
+		if (customFontHandlesKeyMap.containsKey(fontHandle)) {
+			return customFontHandlesKeyMap.get(fontHandle).getScaledFont(zoom);
+		}
+		return Font.win32_new(device, fontHandle, zoom);
 	}
 
 	@Override

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Composite.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Composite.java
@@ -1525,7 +1525,7 @@ LRESULT WM_PAINT (long wParam, long lParam) {
 					Control control = findBackgroundControl ();
 					if (control == null) control = this;
 					data.background = control.getBackgroundPixel ();
-					data.font = Font.win32_new(display, OS.SendMessage (handle, OS.WM_GETFONT, 0, 0), nativeZoom);
+
 					data.uiState = (int)OS.SendMessage (handle, OS.WM_QUERYUISTATE, 0, 0);
 					if ((style & SWT.NO_BACKGROUND) != 0) {
 						/* This code is intentionally commented because it may be slow to copy bits from the screen */
@@ -1536,6 +1536,8 @@ LRESULT WM_PAINT (long wParam, long lParam) {
 						drawBackground (phdc [0], rect);
 					}
 					GC gc = createNewGC(phdc [0], data);
+					data.font = SWTFontProvider.getFont(display, OS.SendMessage (handle, OS.WM_GETFONT, 0, 0), data.nativeZoom);
+
 					Event event = new Event ();
 					event.gc = gc;
 					event.setBounds(DPIUtil.scaleDown(new Rectangle(ps.left, ps.top, width, height), getZoom()));

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Control.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Control.java
@@ -1315,7 +1315,7 @@ public Font getFont () {
 	if (font != null) return font;
 	long hFont = OS.SendMessage (handle, OS.WM_GETFONT, 0, 0);
 	if (hFont == 0) hFont = defaultFont ();
-	return Font.win32_new (display, hFont, getShell().nativeZoom);
+	return SWTFontProvider.getFont(display, hFont, getFontZoom());
 }
 
 /**
@@ -1755,7 +1755,11 @@ public long internal_new_GC (GCData data) {
 		if (control == null) control = this;
 		int background = control.getBackgroundPixel ();
 		if (background != OS.GetBkColor (hDC)) data.background = background;
-		data.font = font != null ? font : Font.win32_new (display, OS.SendMessage (hwnd, OS.WM_GETFONT, 0, 0));
+		if (font != null) {
+			data.font = font;
+		} else {
+			data.font = SWTFontProvider.getFont(display, OS.SendMessage (hwnd, OS.WM_GETFONT, 0, 0), data.nativeZoom);
+		}
 		data.uiState = (int)OS.SendMessage (hwnd, OS.WM_QUERYUISTATE, 0, 0);
 	}
 	return hDC;

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Widget.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Widget.java
@@ -2690,6 +2690,10 @@ GC createNewGC(long hDC, GCData data) {
 	return GC.win32_new(hDC, data);
 }
 
+int getFontZoom() {
+	return nativeZoom;
+}
+
 int getZoom() {
 	return DPIUtil.getZoomForAutoscaleProperty(nativeZoom);
 }


### PR DESCRIPTION
This PR extends the SWTFontProvider and the SWTFontRegistry to receive scaled variants of a font where only the handle is available. Common use case for this is OS.SendMessage (hwnd, OS.WM_GETFONT, 0, 0) to receive the handle of the current SWT font of an OS handle. As at this point the correct zoom the handle was created is not known with 100%, it is better to retrieve and manage those fonts via the SWTFontRegistry, expecially when monitor specific scaling is used. When the passed font handle is not already managed via the SWTFontRegistry it will create the SWT Font as it was create previously.