### PR TITLE
[GTK4] Implement Clipboard.getAvailableTypes()

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/gtk/org/eclipse/swt/dnd/TextTransfer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/gtk/org/eclipse/swt/dnd/TextTransfer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -141,22 +141,22 @@ public Object nativeToJava(TransferData transferData){
 
 @Override
 protected int[] getTypeIds() {
-	if (OS.isX11()) {
-		return new int[] {UTF8_STRING_ID, COMPOUND_TEXT_ID, STRING_ID};
-	}
 	if(GTK.GTK4) {
 		return new int[] {(int) OS.G_TYPE_STRING()};
+	}
+	if (OS.isX11()) {
+		return new int[] {UTF8_STRING_ID, COMPOUND_TEXT_ID, STRING_ID};
 	}
 	return new int[] {UTF8_STRING_ID, STRING_ID, TEXT_PLAIN_UTF8_ID};
 }
 
 @Override
 protected String[] getTypeNames() {
-	if (OS.isX11()) {
-		return new String[] {UTF8_STRING, COMPOUND_TEXT, STRING};
-	}
 	if(GTK.GTK4) {
 		return new String[] {"text/plain", STRING};
+	}
+	if (OS.isX11()) {
+		return new String[] {UTF8_STRING, COMPOUND_TEXT, STRING};
 	}
 
 	return new String[] {UTF8_STRING, STRING, TEXT_PLAIN_UTF8};

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/gtk4.c
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/gtk4.c
@@ -127,6 +127,22 @@ JNIEXPORT jlong JNICALL GTK4_NATIVE(gdk_1content_1formats_1builder_1new)
 }
 #endif
 
+#ifndef NO_gdk_1content_1formats_1get_1gtypes
+JNIEXPORT jlong JNICALL GTK4_NATIVE(gdk_1content_1formats_1get_1gtypes)
+	(JNIEnv *env, jclass that, jlong arg0, jlongArray arg1)
+{
+	jlong *lparg1=NULL;
+	jlong rc = 0;
+	GTK4_NATIVE_ENTER(env, that, gdk_1content_1formats_1get_1gtypes_FUNC);
+	if (arg1) if ((lparg1 = (*env)->GetLongArrayElements(env, arg1, NULL)) == NULL) goto fail;
+	rc = (jlong)gdk_content_formats_get_gtypes((GdkContentFormats *)arg0, (gsize *)lparg1);
+fail:
+	if (arg1 && lparg1) (*env)->ReleaseLongArrayElements(env, arg1, lparg1, 0);
+	GTK4_NATIVE_EXIT(env, that, gdk_1content_1formats_1get_1gtypes_FUNC);
+	return rc;
+}
+#endif
+
 #ifndef NO_gdk_1content_1formats_1to_1string
 JNIEXPORT jlong JNICALL GTK4_NATIVE(gdk_1content_1formats_1to_1string)
 	(JNIEnv *env, jclass that, jlong arg0)

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/gtk4_stats.h
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/gtk4_stats.h
@@ -31,6 +31,7 @@ typedef enum {
 	gdk_1content_1formats_1builder_1add_1mime_1type_FUNC,
 	gdk_1content_1formats_1builder_1free_1to_1formats_FUNC,
 	gdk_1content_1formats_1builder_1new_FUNC,
+	gdk_1content_1formats_1get_1gtypes_FUNC,
 	gdk_1content_1formats_1to_1string_FUNC,
 	gdk_1content_1provider_1get_1value_FUNC,
 	gdk_1content_1provider_1new_1for_1value_FUNC,

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/org/eclipse/swt/internal/gtk4/GTK4.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/org/eclipse/swt/internal/gtk4/GTK4.java
@@ -818,6 +818,11 @@ public class GTK4 {
 	public static final native long gdk_content_provider_new_union(long[] providers, int n_providers);
 	/** @param formats cast=(GdkContentFormats *) */
 	public static final native long gdk_content_formats_to_string(long formats);
+	/**
+	 * @param formats cast=(GdkContentFormats *)
+	 * @param n_gtypes cast=(gsize *)
+	 */
+	public static final native long gdk_content_formats_get_gtypes(long formats, long[] n_gtypes);
 
 	public static final native long gtk_gesture_rotate_new();
 


### PR DESCRIPTION
The list of available types is calculated using the GDK4 clipboard and
no longer falls back to the GTK3 bindings.

Note that UTF8_STRING, COMPOUND_TEXT and STRING_ID are not implemented
for GTK4, which is why those types must not be used in the TextTransfer,
regardless of whether X11 or Wayland is used.