### PR TITLE
Make FontData key in map immutable

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/DefaultSWTFontRegistry.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/DefaultSWTFontRegistry.java
@@ -72,7 +72,8 @@ final class DefaultSWTFontRegistry implements SWTFontRegistry {
 	}
 
 	private Font registerFont(FontData fontData, Font font) {
-		fontsMap.put(fontData, font);
+		FontData clonedFontData = new FontData(fontData.toString());
+		fontsMap.put(clonedFontData, font);
 		return font;
 	}
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/ScalingSWTFontRegistry.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/ScalingSWTFontRegistry.java
@@ -130,8 +130,9 @@ final class ScalingSWTFontRegistry implements SWTFontRegistry {
 		if (customFontsKeyMap.containsKey(fontData)) {
 			container = customFontsKeyMap.get(fontData);
 		} else {
-			container = new ScaledCustomFontContainer(fontData);
-			customFontsKeyMap.put(fontData, container);
+			FontData clonedFontData = new FontData(fontData.toString());
+			container = new ScaledCustomFontContainer(clonedFontData);
+			customFontsKeyMap.put(clonedFontData, container);
 		}
 		return container.getScaledFont(zoom);
 	}

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_FontData.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_FontData.java
@@ -45,6 +45,7 @@ public void test_ConstructorLjava_lang_String() {
 	FontData fd = new FontData(SwtTestUtil.testFontName, 10, SWT.NORMAL);
 	FontData reconstructedFontData = new FontData(fd.toString());
 	assertEquals(fd, reconstructedFontData);
+	assertEquals(fd.hashCode(), reconstructedFontData.hashCode());
 }
 
 @Test


### PR DESCRIPTION
Creating clone of FontData to be used as a key in map of ScalingSWTFontRegistry and DefaultSWTFontRegistry to make it immutable and inaccessible from outside of the class