### PR TITLE
[Win32] Ensure consistent image data returned for data-based images

### DIFF
--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_Image.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_Image.java
@@ -1033,6 +1033,31 @@ public void test_imageDataSameViaDifferentProviders() {
 	dataProviderImage.dispose();
 }
 
+@Test
+public void test_imageDataSameViaProviderAndSimpleData() {
+	assumeFalse("Cocoa generates inconsistent image data", SwtTestUtil.isCocoa);
+	String imagePath = getPath("collapseall.png");
+	ImageFileNameProvider imageFileNameProvider = __ -> {
+		return imagePath;
+	};
+	ImageDataProvider dataProvider = __ -> {
+		try (InputStream imageStream = Files.newInputStream(Path.of(imagePath))) {
+			return new ImageData(imageStream);
+		} catch (IOException e) {
+		}
+		return null;
+	};
+	Image fileNameProviderImage = new Image(display, imageFileNameProvider);
+	Image dataImage = new Image(display, dataProvider.getImageData(100));
+	ImageData dataFromFileNameProviderImage = fileNameProviderImage.getImageData(100);
+	ImageData dataFromImageWithSimpleData = dataImage.getImageData(100);
+	assertEquals(0, imageDataComparator().compare(dataFromFileNameProviderImage, dataFromImageWithSimpleData));
+
+	fileNameProviderImage.dispose();
+	dataImage.dispose();
+}
+
+
 private Comparator<ImageData> imageDataComparator() {
 	return Comparator.<ImageData>comparingInt(d -> d.width) //
 			.thenComparing(d -> d.height) //


### PR DESCRIPTION
Due to the on-demand creation of image handles, there is not necessarily a handles anymore from which image data is retrieved when requesting is via the getImageData(...) methods. This results in potentially different kinds of image data (including different anti-aliasing results) depending on whether a handle has already been created for an image at the given zoom or not.

This change adapts the implementation of Image based on static ImageData and streams to always use the image data retrieved from a native handle. To this end, it temporarily creates a handle if necessary. In order to avoid repeated loading and handle creation for the same source of image, a cache for the already retrieved image data is introduced.

<s>⚠️ This is based on and should thus be merged after https://github.com/eclipse-platform/eclipse.platform.swt/pull/2036</s>

Fixes https://github.com/eclipse-platform/eclipse.platform.swt/issues/2052

Supercedes and thus closes #2051