### PR TITLE
Clean-up Test_org_eclipse_swt_graphics_Image

### DIFF
--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_Image.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_Image.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -22,8 +22,8 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeFalse;
 import static org.junit.Assume.assumeTrue;
 
@@ -58,51 +58,30 @@ import org.junit.Test;
  */
 @SuppressWarnings("restriction")
 public class Test_org_eclipse_swt_graphics_Image {
-ImageFileNameProvider imageFileNameProvider = zoom -> {
-	String fileName;
-	switch (zoom) {
-	case 100:
-		fileName = "collapseall.png";
-		break;
-	case 150:
-		fileName = "collapseall@1.5x.png";
-		break;
-	case 200:
-		fileName = "collapseall@2x.png";
-		break;
-	default:
+	ImageFileNameProvider imageFileNameProvider = zoom -> {
+		String fileName = switch (zoom) {
+		case 100 -> "collapseall.png";
+		case 150 -> "collapseall@1.5x.png";
+		case 200 -> "collapseall@2x.png";
+		default -> null;
+		};
+		return fileName != null ? getPath(fileName) : null;
+	};
+	ImageDataProvider imageDataProvider = zoom -> {
+		String fileName = switch (zoom) {
+		case 100 -> "collapseall.png";
+		case 150 -> "collapseall@1.5x.png";
+		case 200 -> "collapseall@2x.png";
+		default -> null;
+		};
+		return fileName != null ? new ImageData(getPath(fileName)) : null;
+	};
+	ImageDataProvider imageDataProvider1xOnly = zoom -> {
+		if (zoom == 100) {
+			return new ImageData(getPath("collapseall.png"));
+		}
 		return null;
-	}
-	return getPath(fileName);
-};
-ImageDataProvider imageDataProvider = zoom -> {
-	String fileName;
-	switch (zoom) {
-	case 100:
-		fileName = "collapseall.png";
-		break;
-	case 150:
-		fileName = "collapseall@1.5x.png";
-		break;
-	case 200:
-		fileName = "collapseall@2x.png";
-		break;
-	default:
-		return null;
-	}
-	return new ImageData(getPath(fileName));
-};
-ImageDataProvider imageDataProvider1xOnly = zoom -> {
-	String fileName;
-	switch (zoom) {
-	case 100:
-		fileName = "collapseall.png";
-		break;
-	default:
-		return null;
-	}
-	return new ImageData(getPath(fileName));
-};
+	};
 ImageGcDrawer imageGcDrawer = (gc, width, height) -> {};
 
 @Before
@@ -112,98 +91,51 @@ public void setUp() {
 
 @Test
 public void test_ConstructorLorg_eclipse_swt_graphics_DeviceII() {
-	Image image;
-	try {
-		image = new Image(display, -1, 10);
-		image.dispose();
-		fail("No exception thrown for width <= 0");
-	} catch (IllegalArgumentException e) {
-		assertSWTProblem("Incorrect exception thrown for width <= 0", SWT.ERROR_INVALID_ARGUMENT, e);
-	}
+	IllegalArgumentException e1 = assertThrows(IllegalArgumentException.class, () -> new Image(display, -1, 10));
+	assertSWTProblem("Incorrect exception thrown for width < 0", SWT.ERROR_INVALID_ARGUMENT, e1);
 
-	try {
-		image = new Image(display, 0, 10);
-		image.dispose();
-		fail("No exception thrown for width <= 0");
-	} catch (IllegalArgumentException e) {
-		assertSWTProblem("Incorrect exception thrown for width <= 0", SWT.ERROR_INVALID_ARGUMENT, e);
-	}
+	IllegalArgumentException e2 = assertThrows(IllegalArgumentException.class, () -> new Image(display, 0, 10));
+	assertSWTProblem("Incorrect exception thrown for width == 0", SWT.ERROR_INVALID_ARGUMENT, e2);
 
-	try {
-		image = new Image(display, 10, -20);
-		image.dispose();
-		fail("No exception thrown for height <= 0");
-	} catch (IllegalArgumentException e) {
-		assertSWTProblem("Incorrect exception thrown for height <= 0", SWT.ERROR_INVALID_ARGUMENT, e);
-	}
+	IllegalArgumentException e3 = assertThrows(IllegalArgumentException.class, () -> new Image(display, 10, -20));
+	assertSWTProblem("Incorrect exception thrown for height < 0", SWT.ERROR_INVALID_ARGUMENT, e3);
 
-	try {
-		image = new Image(display, 10, 0);
-		image.dispose();
-		fail("No exception thrown for height <= 0");
-	} catch (IllegalArgumentException e) {
-		assertSWTProblem("Incorrect exception thrown for height <= 0", SWT.ERROR_INVALID_ARGUMENT, e);
-	}
+	IllegalArgumentException e4 = assertThrows(IllegalArgumentException.class, () -> new Image(display, 10, 0));
+	assertSWTProblem("Incorrect exception thrown for height == 0", SWT.ERROR_INVALID_ARGUMENT, e4);
 
-	image = new Image(null, 10, 10);
+	Image image = new Image(null, 10, 10);
 	image.dispose();
 
 	image = new Image(display, 10, 10);
 	image.dispose();
-
 }
 
 @Test
 public void test_ConstructorLorg_eclipse_swt_graphics_DeviceLorg_eclipse_swt_graphics_Rectangle() {
 	Image image;
-	Rectangle bounds = null;
+	IllegalArgumentException e;
+	Rectangle bounds1 = null;
+	e = assertThrows(IllegalArgumentException.class, () -> new Image(display, bounds1));
+	assertSWTProblem("Incorrect exception thrown for rectangle == null", SWT.ERROR_NULL_ARGUMENT, e);
 
-	try {
-		image = new Image(display, bounds);
-		image.dispose();
-		fail("No exception thrown for rectangle == null");
-	} catch (IllegalArgumentException e) {
-		assertSWTProblem("Incorrect exception thrown for rectangle == null", SWT.ERROR_NULL_ARGUMENT, e);
-	}
+	Rectangle bounds2 = new Rectangle(0, 0, -1, 10);
+	e = assertThrows(IllegalArgumentException.class, () -> new Image(display, bounds2));
+	assertSWTProblem("Incorrect exception thrown for width < 0", SWT.ERROR_INVALID_ARGUMENT, e);
 
-	bounds = new Rectangle(0, 0, -1, 10);
-	try {
-		image = new Image(display, bounds);
-		image.dispose();
-		fail("No exception thrown for width < 0");
-	} catch (IllegalArgumentException e) {
-		assertSWTProblem("Incorrect exception thrown for width < 0", SWT.ERROR_INVALID_ARGUMENT, e);
-	}
+	Rectangle bounds3 = new Rectangle(0, 0, 0, 10);
+	e = assertThrows(IllegalArgumentException.class, () -> new Image(display, bounds3));
+	assertSWTProblem("Incorrect exception thrown for width == 0", SWT.ERROR_INVALID_ARGUMENT, e);
 
-	bounds = new Rectangle(0, 0, 0, 10);
-	try {
-		image = new Image(display, bounds);
-		image.dispose();
-		fail("No exception thrown for width == 0");
-	} catch (IllegalArgumentException e) {
-		assertSWTProblem("Incorrect exception thrown for width == 0", SWT.ERROR_INVALID_ARGUMENT, e);
-	}
+	Rectangle bounds4 = new Rectangle(0, 0, 10, -1);
+	e = assertThrows(IllegalArgumentException.class, () -> new Image(display, bounds4));
+	assertSWTProblem("Incorrect exception thrown for height < 0", SWT.ERROR_INVALID_ARGUMENT, e);
 
-	bounds = new Rectangle(0, 0, 10, -1);
-	try {
-		image = new Image(display, bounds);
-		image.dispose();
-		fail("No exception thrown for height < 0");
-	} catch (IllegalArgumentException e) {
-		assertSWTProblem("Incorrect exception thrown for height < 0", SWT.ERROR_INVALID_ARGUMENT, e);
-	}
-
-	bounds = new Rectangle(0, 0, 10, 0);
-	try {
-		image = new Image(display, bounds);
-		image.dispose();
-		fail("No exception thrown for height == 0");
-	} catch (IllegalArgumentException e) {
-		assertSWTProblem("Incorrect exception thrown for height == 0", SWT.ERROR_INVALID_ARGUMENT, e);
-	}
+	Rectangle bounds5 = new Rectangle(0, 0, 10, 0);
+	e = assertThrows(IllegalArgumentException.class, () -> new Image(display, bounds5));
+	assertSWTProblem("Incorrect exception thrown for height == 0", SWT.ERROR_INVALID_ARGUMENT, e);
 
 	// valid images
-	bounds = new Rectangle(-1, -10, 10, 10);
+	Rectangle bounds = new Rectangle(-1, -10, 10, 10);
 	image = new Image(display, bounds);
 	image.dispose();
 
@@ -217,26 +149,18 @@ public void test_ConstructorLorg_eclipse_swt_graphics_DeviceLorg_eclipse_swt_gra
 
 @Test
 public void test_ConstructorLorg_eclipse_swt_graphics_DeviceLorg_eclipse_swt_graphics_ImageData() {
-	ImageData data = null;
-	Image image = null;
+	IllegalArgumentException e;
 
-	try {
-		image = new Image(display, data);
-		image.dispose();
-		fail("No exception thrown for ImageData == null");
-	} catch (IllegalArgumentException e) {
-		assertSWTProblem("Incorrect exception thrown for ImageData == null", SWT.ERROR_NULL_ARGUMENT, e);
-	}
+	ImageData data1 = null;
+	e = assertThrows(IllegalArgumentException.class, () -> new Image(display, data1));
+	assertSWTProblem("Incorrect exception thrown for ImageData == null", SWT.ERROR_NULL_ARGUMENT, e);
 
 //	Platform-specific test.
-//	data = new ImageData(10, 10, 1, new PaletteData(0xff0000, 0x00ff00, 0x0000ff));
-//	try {
-//		image = new Image(display, data);
-//		image.dispose();
-//		fail("Unsupported color depth");
-//	} catch (SWTException e) {
-//	}
+//	ImageData data2 = new ImageData(10, 10, 1, new PaletteData(0xff0000, 0x00ff00, 0x0000ff));
+//	e = assertThrows(IllegalArgumentException.class, () -> new Image(display, data2));
 
+	ImageData data;
+	Image image;
 	data = new ImageData(10, 10, 1, new PaletteData(new RGB(0, 0, 0)));
 	image = new Image(null, data);
 	image.dispose();
@@ -254,7 +178,7 @@ public void test_ConstructorLorg_eclipse_swt_graphics_DeviceLorg_eclipse_swt_gra
 	gc.drawImage(image, 0, 0);
 	ImageData gcImageData = gcImage.getImageData();
 	int redPixel = gcImageData.getPixel(9, 9);
-	assertEquals(":a:", getRealRGB(display.getSystemColor(SWT.COLOR_RED)), gcImageData.palette.getRGB(redPixel));
+	assertEquals(getRealRGB(display.getSystemColor(SWT.COLOR_RED)), gcImageData.palette.getRGB(redPixel));
 	gc.dispose();
 	gcImage.dispose();
 	image.dispose();
@@ -262,59 +186,36 @@ public void test_ConstructorLorg_eclipse_swt_graphics_DeviceLorg_eclipse_swt_gra
 
 @Test
 public void test_ConstructorLorg_eclipse_swt_graphics_DeviceLorg_eclipse_swt_graphics_ImageDataLorg_eclipse_swt_graphics_ImageData() {
-	ImageData data = null;
+	IllegalArgumentException e;
+
 	ImageData data1 = new ImageData(10, 10, 1, new PaletteData(new RGB(0, 0, 0)));
-	Image image = null;
+	e = assertThrows(IllegalArgumentException.class, () -> new Image(display, null, data1));
+	assertSWTProblem("Incorrect exception thrown for ImageData source == null", SWT.ERROR_NULL_ARGUMENT, e);
 
-	try {
-		image = new Image(display, data, data1);
-		image.dispose();
-		fail("No exception thrown for ImageData source == null");
-	} catch (IllegalArgumentException e) {
-		assertSWTProblem("Incorrect exception thrown for ImageData source == null", SWT.ERROR_NULL_ARGUMENT, e);
-	}
+	e = assertThrows(IllegalArgumentException.class, () -> new Image(display, data1, null));
+	assertSWTProblem("Incorrect exception thrown for ImageData mask == null", SWT.ERROR_NULL_ARGUMENT, e);
 
-	data = new ImageData(10, 10, 1, new PaletteData(new RGB(0, 0, 0)));
-	data1 = null;
-	try {
-		image = new Image(display, data, data1);
-		image.dispose();
-		fail("No exception thrown for ImageData mask == null");
-	} catch (IllegalArgumentException e) {
-		assertSWTProblem("Incorrect exception thrown for ImageData mask == null", SWT.ERROR_NULL_ARGUMENT, e);
-	}
+	ImageData data2 = new ImageData(10, 10, 1, new PaletteData(new RGB(0, 0, 0)));
+	ImageData data3 = new ImageData(1, 10, 1, new PaletteData(new RGB(0, 0, 0)));
+	e = assertThrows(IllegalArgumentException.class, () -> new Image(display, data2, data3));
+	assertSWTProblem("Incorrect exception thrown for ImageData source width != ImageData mask width", SWT.ERROR_INVALID_ARGUMENT, e);
 
-	data = new ImageData(10, 10, 1, new PaletteData(new RGB(0, 0, 0)));
-	data1 = new ImageData(1, 10, 1, new PaletteData(new RGB(0, 0, 0)));
-	try {
-		image = new Image(display, data, data1);
-		image.dispose();
-		fail("No exception thrown for ImageData source width != ImageData mask width");
-	} catch (IllegalArgumentException e) {
-		assertSWTProblem("Incorrect exception thrown for ImageData source width != ImageData mask width", SWT.ERROR_INVALID_ARGUMENT, e);
-	}
+	ImageData data4 = new ImageData(10, 1, 1, new PaletteData(new RGB(0, 0, 0)));
+	ImageData data5 = new ImageData(10, 10, 1, new PaletteData(new RGB(0, 0, 0)));
+	e = assertThrows(IllegalArgumentException.class, () -> new Image(display, data4, data5));
+	assertSWTProblem("Incorrect exception thrown for ImageData source height != ImageData mask height", SWT.ERROR_INVALID_ARGUMENT, e);
 
-	data = new ImageData(10, 1, 1, new PaletteData(new RGB(0, 0, 0)));
-	data1 = new ImageData(10, 10, 1, new PaletteData(new RGB(0, 0, 0)));
-	try {
-		image = new Image(display, data, data1);
-		image.dispose();
-		fail("No exception thrown for ImageData source height != ImageData mask height");
-	} catch (IllegalArgumentException e) {
-		assertSWTProblem("Incorrect exception thrown for ImageData source height != ImageData mask height", SWT.ERROR_INVALID_ARGUMENT, e);
-	}
-
-	data = new ImageData(10, 10, 8, new PaletteData(new RGB(0, 0, 0)));
-	data1 = new ImageData(10, 10, 8, new PaletteData(new RGB(0, 0, 0)));
-	image = new Image(display, data, data1); // Image now accepts masks where depth != 1
+	ImageData data6 = new ImageData(10, 10, 8, new PaletteData(new RGB(0, 0, 0)));
+	ImageData data7 = new ImageData(10, 10, 8, new PaletteData(new RGB(0, 0, 0)));
+	Image image = new Image(display, data6, data7); // Image now accepts masks where depth != 1
 	image.dispose();
 
-	data = new ImageData(10, 10, 8, new PaletteData(0x30, 0x0C, 0x03));
+	data6 = new ImageData(10, 10, 8, new PaletteData(0x30, 0x0C, 0x03));
 	// set opaque red pixel at x=9, y=9
-	data.setPixel(9, 9, 0x30);
-	data1 = new ImageData(10, 10, 1, new PaletteData(new RGB(0, 0, 0), new RGB(255, 255, 255)));
-	data1.setPixel(9, 9, 1);
-	image = new Image(display, data, data1);
+	data6.setPixel(9, 9, 0x30);
+	data7 = new ImageData(10, 10, 1, new PaletteData(new RGB(0, 0, 0), new RGB(255, 255, 255)));
+	data7.setPixel(9, 9, 1);
+	image = new Image(display, data6, data7);
 	Image gcImage = new Image(display, 10, 10);
 	GC gc = new GC(gcImage);
 	Color backgroundColor = display.getSystemColor(SWT.COLOR_BLUE);
@@ -323,294 +224,170 @@ public void test_ConstructorLorg_eclipse_swt_graphics_DeviceLorg_eclipse_swt_gra
 	gc.drawImage(image, 0, 0);
 	ImageData gcImageData = gcImage.getImageData();
 	int redPixel = gcImageData.getPixel(9, 9);
-	assertEquals(":a:", getRealRGB(display.getSystemColor(SWT.COLOR_RED)), gcImageData.palette.getRGB(redPixel));
+	assertEquals(getRealRGB(display.getSystemColor(SWT.COLOR_RED)), gcImageData.palette.getRGB(redPixel));
 	int bluePixel = gcImageData.getPixel(0, 0);
-	assertEquals(":b:", getRealRGB(backgroundColor), gcImageData.palette.getRGB(bluePixel));
+	assertEquals(getRealRGB(backgroundColor), gcImageData.palette.getRGB(bluePixel));
 	gc.dispose();
 	gcImage.dispose();
 	image.dispose();
 }
 
 @Test
-public void test_ConstructorLorg_eclipse_swt_graphics_DeviceLjava_io_InputStream() {
-	InputStream stream = null;
-	Image image = null;
-	try {
-		try {
-			image = new Image(display, stream);
-			image.dispose();
-			fail("No exception thrown for InputStream == null");
-		} catch (IllegalArgumentException e) {
-			assertSWTProblem("Incorrect exception thrown for InputStream == null", SWT.ERROR_NULL_ARGUMENT, e);
-		}
+public void test_ConstructorLorg_eclipse_swt_graphics_DeviceLjava_io_InputStream() throws IOException {
+	Exception e;
 
-		stream = SwtTestUtil.class.getResourceAsStream("empty.txt");
-		try {
-			image = new Image(display, stream);
-			image.dispose();
-			try {
-				stream.close();
-			} catch (IOException e) {}
-			fail("No exception thrown for invalid InputStream");
-		} catch (SWTException e) {
-			assertSWTProblem("Incorrect exception thrown for invalid InputStream", SWT.ERROR_UNSUPPORTED_FORMAT, e);
-		}
+	InputStream stream1 = null;
+	e = assertThrows(IllegalArgumentException.class, () -> new Image(display, stream1));
+	assertSWTProblem("Incorrect exception thrown for InputStream == null", SWT.ERROR_NULL_ARGUMENT, e);
 
-		int numFormats = SwtTestUtil.imageFormats.length;
-		String fileName = SwtTestUtil.invalidImageFilenames[0];
-		Display[] displays = {display, null};
-		for (int j = 0; j < displays.length; j++) {
-			for (int i=0; i<numFormats; i++) {
-				String format = SwtTestUtil.imageFormats[i];
-				stream = SwtTestUtil.class.getResourceAsStream(fileName + "." + format);
+	try (InputStream stream2 = SwtTestUtil.class.getResourceAsStream("empty.txt")) {
+		e = assertThrows(SWTException.class, () -> new Image(display, stream2));
+	}
+	assertSWTProblem("Incorrect exception thrown for invalid InputStream", SWT.ERROR_UNSUPPORTED_FORMAT, e);
 
-				try {
-					image = new Image(display, stream);
-					image.dispose();
-					try {
-						stream.close();
-					} catch (IOException e) {}
-					fail("No exception thrown for invalid InputStream");
-				} catch (SWTException e) {
-// Bug 70167 - Image(Device, InputStream) throws incorrect exception for bad PNG
-// remove comment when bug is fixed.
-// Bug appears fixed on Bugzilla, however, removing the comment below still results in a failed test as of June 2021
-//					assertEquals("Incorrect exception thrown for invalid image InputStream", SWT.ERROR_INVALID_IMAGE, e);
-				}
+	String firstFile = SwtTestUtil.invalidImageFilenames[0];
+	Display[] displays = { display, null };
+	for (int j = 0; j < displays.length; j++) {
+		for (String format : SwtTestUtil.imageFormats) {
+			try (InputStream stream = SwtTestUtil.class.getResourceAsStream(firstFile + "." + format)) {
+				e = assertThrows(SWTException.class, () -> new Image(display, stream));
 			}
-		}
-
-		stream = SwtTestUtil.class.getResourceAsStream(SwtTestUtil.invalidImageFilenames[1]);
-		try {
-			image = new Image(display, stream);
-			image.dispose();
-			try {
-				stream.close();
-			} catch (IOException e) {}
-			fail("No exception thrown for invalid InputStream");
-		} catch (SWTException e) {
 			assertSWTProblem("Incorrect exception thrown for invalid image InputStream", SWT.ERROR_INVALID_IMAGE, e);
 		}
+	}
 
-		// create valid images
-		for (Display tempDisplay : displays) {
-			int numFileNames = SwtTestUtil.imageFilenames.length;
-			for (int k=0; k<numFileNames; k++) {
-				fileName = SwtTestUtil.imageFilenames[k];
-				for (int i=0; i<numFormats; i++) {
-					String format = SwtTestUtil.imageFormats[i];
-					stream = SwtTestUtil.class.getResourceAsStream(fileName + "." + format);
-					image = new Image(tempDisplay, stream);
+	try (InputStream stream = SwtTestUtil.class.getResourceAsStream(SwtTestUtil.invalidImageFilenames[1])) {
+		e = assertThrows(SWTException.class, () -> new Image(display, stream));
+	}
+	assertSWTProblem("Incorrect exception thrown for invalid image InputStream", SWT.ERROR_INVALID_IMAGE, e);
+
+	// create valid images
+	for (Display tempDisplay : displays) {
+		for (String fileName : SwtTestUtil.imageFilenames) {
+			for (String format : SwtTestUtil.imageFormats) {
+				try (InputStream stream = SwtTestUtil.class.getResourceAsStream(fileName + "." + format);) {
+					Image image = new Image(tempDisplay, stream);
 					image.dispose();
-					try {
-						stream.close();
-					} catch (IOException e) {}
 				}
 			}
-		}
-	} finally {
-		try {
-			stream.close();
-		} catch (Exception e) {
 		}
 	}
 }
 
 @Test
 public void test_ConstructorLorg_eclipse_swt_graphics_DeviceLjava_lang_String() {
-	String fileName = null;
-	try {
-		Image image = new Image(display, fileName);
-		image.dispose();
-		fail("No exception thrown for file name == null");
-	} catch (IllegalArgumentException e) {
-		assertSWTProblem("Incorrect exception thrown for file name == null", SWT.ERROR_NULL_ARGUMENT, e);
-	}
-	try {
-		String pathName = "nonexistent.txt";
-		Image image = new Image(display, pathName);
-		image.dispose();
-		fail("No exception thrown for non-existent file name");
-	} catch (SWTException e) {
-		assertSWTProblem("Incorrect exception thrown for non-existent file name", SWT.ERROR_IO, e);
-	}
-		try {
-			String pathName = getPath("empty.txt");
-			Image image = new Image(display, pathName);
-			image.dispose();
-			fail("No exception thrown for invalid file name");
-		} catch (SWTException e) {
-			assertSWTProblem("Incorrect exception thrown for invalid file name", SWT.ERROR_UNSUPPORTED_FORMAT, e);
-		}
+	Exception e;
 
-		int numFormats = SwtTestUtil.imageFormats.length;
-		fileName = SwtTestUtil.invalidImageFilenames[0];
-		Display[] displays = {display, null};
-		for (int j = 0; j < displays.length; j++) {
-			for (int i=0; i<numFormats; i++) {
-				String format = SwtTestUtil.imageFormats[i];
+	String fileName1 = null;
+	e = assertThrows(IllegalArgumentException.class, () -> new Image(display, fileName1));
+	assertSWTProblem("Incorrect exception thrown for file name == null", SWT.ERROR_NULL_ARGUMENT, e);
 
-				try {
-					String pathName = getPath(fileName + "." + format);
-					Image image = new Image(display, pathName);
-					image.dispose();
-					fail("No exception thrown for invalid file name");
-				} catch (SWTException e) {
-//					 Bug 70167 - Image(Device, InputStream) throws incorrect exception for bad PNG
-//					 remove comment when bug is fixed.
-//					 Bug is fixed yet still results in a failed test as of June 2021.
-//					assertEquals("Incorrect exception thrown for invalid image file name", SWT.ERROR_INVALID_IMAGE, e);
-				}
-			}
-		}
+	String pathName2 = "nonexistent.txt";
+	e = assertThrows(SWTException.class, () -> new Image(display, pathName2));
+	assertSWTProblem("Incorrect exception thrown for non-existent file name", SWT.ERROR_IO, e);
 
-		try {
-			String pathName = getPath(SwtTestUtil.invalidImageFilenames[1]);
-			Image image = new Image(display, pathName);
-			image.dispose();
-			fail("No exception thrown for invalid file name");
-		} catch (SWTException e) {
+	String pathName3 = getPath("empty.txt").toString();
+	e = assertThrows(SWTException.class, () -> new Image(display, pathName3));
+	assertSWTProblem("Incorrect exception thrown for invalid file name", SWT.ERROR_UNSUPPORTED_FORMAT, e);
+
+	String firstFile = SwtTestUtil.invalidImageFilenames[0];
+	Display[] displays = { display, null };
+	for (Display display : displays) {
+		for (String format : SwtTestUtil.imageFormats) {
+			String pathName = getPath(firstFile + "." + format).toString();
+			e = assertThrows(SWTException.class, () -> new Image(display, pathName));
 			assertSWTProblem("Incorrect exception thrown for invalid image file name", SWT.ERROR_INVALID_IMAGE, e);
 		}
+	}
 
-		// create valid images
-		for (int j = 0; j < displays.length; j++) {
-			int numFileNames = SwtTestUtil.imageFilenames.length;
-			for (int k=0; k<numFileNames; k++) {
-				fileName = SwtTestUtil.imageFilenames[k];
-				for (int i=0; i<numFormats; i++) {
-					String format = SwtTestUtil.imageFormats[i];
-					String pathName = getPath(fileName + "." + format);
-					Image image = new Image(display, pathName);
-					image.dispose();
-				}
+	String pathName4 = getPath(SwtTestUtil.invalidImageFilenames[1]).toString();
+	e = assertThrows(SWTException.class, () -> new Image(display, pathName4));
+	assertSWTProblem("Incorrect exception thrown for invalid image file name", SWT.ERROR_INVALID_IMAGE, e);
+
+	// create valid images
+	for (Display display : displays) {
+		for (String fileName : SwtTestUtil.imageFilenames) {
+			for (int i = 0; i < SwtTestUtil.imageFormats.length; i++) {
+				String format = SwtTestUtil.imageFormats[i];
+				String pathName = getPath(fileName + "." + format).toString();
+				Image image = new Image(display, pathName);
+				image.dispose();
 			}
 		}
+	}
 }
 
 @Test
 public void test_ConstructorLorg_eclipse_swt_graphics_Device_ImageFileNameProvider() {
+	 Exception e;
+
 	// Null provider
-	ImageFileNameProvider provider = null;
-	try {
-		Image image = new Image(display, provider);
-		image.dispose();
-		fail("No exception thrown for file name == null");
-	} catch (IllegalArgumentException e) {
-		assertSWTProblem("Incorrect exception thrown for provider == null", SWT.ERROR_NULL_ARGUMENT, e);
-	}
+	ImageFileNameProvider provider1 = null;
+	  e = assertThrows(IllegalArgumentException.class, ()->new Image(display, provider1));
+	assertSWTProblem("Incorrect exception thrown for provider == null", SWT.ERROR_NULL_ARGUMENT, e);
+
 	// Invalid provider
-	provider = zoom -> null;
-	try {
-		Image image = new Image(display, provider);
-		image.dispose();
-		fail("No exception thrown for non-existent file name");
-	} catch (IllegalArgumentException e) {
-		assertSWTProblem("Incorrect exception thrown for provider == null", SWT.ERROR_INVALID_ARGUMENT, e);
-	}
+	ImageFileNameProvider	provider2 = zoom -> null;
+	e = assertThrows(IllegalArgumentException.class, ()->new Image(display, provider2));
+	assertSWTProblem("Incorrect exception thrown for provider == null", SWT.ERROR_INVALID_ARGUMENT, e);
+
 	// Valid provider
 	Image image = new Image(display, imageFileNameProvider);
 	image.dispose();
 	// Corrupt Image provider
-	provider = zoom -> {
-		String fileName;
-		switch (zoom) {
-		case 100:
-			fileName = "corrupt.png"; break;
-		case 150:
-			fileName = "corrupt.png"; break;
-		case 200:
-			fileName = "corrupt.png"; break;
-		default:
-			return null;
-		}
-		return getPath(fileName);
+	ImageFileNameProvider provider3 = zoom -> {
+		String fileName = switch (zoom) {
+		case 100, 150, 200 -> "corrupt.png";
+		default -> null;
+		};
+		return fileName != null ? getPath(fileName) : null;
 	};
-	try {
-		image = new Image(display, provider);
-		image.dispose();
-		fail("No exception thrown for corrupt image file.");
-	} catch (SWTException e) {
-		assertSWTProblem("Incorrect exception thrown for provider with corrupt images", SWT.ERROR_INVALID_IMAGE, e);
-	}
+	e = assertThrows(SWTException.class, ()->new Image(display, provider3));
+	assertSWTProblem("Incorrect exception thrown for provider with corrupt images", SWT.ERROR_INVALID_IMAGE, e);
+
 	// Valid provider only 100% zoom
-	provider = zoom -> {
-		String fileName;
-		switch (zoom) {
-		case 100:
-			fileName = "collapseall.png";
-			break;
-		case 150:
-		case 200:
-		default:
-			return null;
+	ImageFileNameProvider provider4 = zoom -> {
+		if (zoom == 100) {
+			return getPath("collapseall.png");
 		}
-		return getPath(fileName);
+		return null;
 	};
-	image = new Image(display, provider);
+	image = new Image(display, provider4);
 	image.dispose();
 }
 
 @Test
 public void test_ConstructorLorg_eclipse_swt_graphics_Device_ImageDataProvider() {
+	Exception e;
 	// Null provider
-	ImageDataProvider provider = null;
-	try {
-		Image image = new Image(display, provider);
-		image.dispose();
-		fail("No exception thrown for file name == null");
-	} catch (IllegalArgumentException e) {
-		assertSWTProblem("Incorrect exception thrown for provider == null", SWT.ERROR_NULL_ARGUMENT, e);
-	}
+	ImageDataProvider provider1 = null;
+	e = assertThrows(IllegalArgumentException.class, () -> new Image(display, provider1));
+	assertSWTProblem("Incorrect exception thrown for provider == null", SWT.ERROR_NULL_ARGUMENT, e);
+
 	// Invalid provider
-	provider = zoom -> null;
-	try {
-		Image image = new Image(display, provider);
-		image.dispose();
-		fail("No exception thrown for non-existent file name");
-	} catch (IllegalArgumentException e) {
-		assertSWTProblem("Incorrect exception thrown for provider == null", SWT.ERROR_INVALID_ARGUMENT, e);
-	}
+	ImageDataProvider provider2 = zoom -> null;
+	e = assertThrows(IllegalArgumentException.class, () -> new Image(display, provider2));
+	assertSWTProblem("Incorrect exception thrown for provider == null", SWT.ERROR_INVALID_ARGUMENT, e);
 	// Valid provider
 	Image image = new Image(display, imageDataProvider);
 	image.dispose();
 	// Corrupt Image provider
-	provider = zoom -> {
-		String fileName;
-		switch (zoom) {
-		case 100:
-			fileName = "corrupt.png"; break;
-		case 150:
-			fileName = "corrupt.png"; break;
-		case 200:
-			fileName = "corrupt.png"; break;
-		default:
-			return null;
-		}
-		return new ImageData(getPath(fileName));
+	ImageDataProvider provider3 = zoom -> {
+		return switch (zoom) {
+		case 100, 150, 200 -> new ImageData(getPath("corrupt.png"));
+		default -> null;
+		};
 	};
-	try {
-		image = new Image(display, provider);
-		image.dispose();
-		fail("No exception thrown for corrupt image file.");
-	} catch (SWTException e) {
-		assertSWTProblem("Incorrect exception thrown for provider with corrupt images", SWT.ERROR_INVALID_IMAGE, e);
-	}
+	e = assertThrows(SWTException.class, () -> new Image(display, provider3));
+	assertSWTProblem("Incorrect exception thrown for provider with corrupt images", SWT.ERROR_INVALID_IMAGE, e);
 	// Valid provider only 100% zoom
-	provider = zoom -> {
-		String fileName;
-		switch (zoom) {
-		case 100:
-			fileName = "collapseall.png";
-			break;
-		case 150:
-		case 200:
-		default:
-			return null;
+	ImageDataProvider provider4 = zoom -> {
+		if (zoom == 100) {
+			return new ImageData(getPath("collapseall.png"));
 		}
-		return new ImageData(getPath(fileName));
+		return null;
 	};
-	image = new Image(display, provider);
+	image = new Image(display, provider4);
 	image.dispose();
 }
 
@@ -618,13 +395,8 @@ public void test_ConstructorLorg_eclipse_swt_graphics_Device_ImageDataProvider()
 public void test_ConstructorLorg_eclipse_swt_graphics_Device_ImageGcDrawer() {
 	// Null provider
 	ImageGcDrawer drawer = null;
-	try {
-		Image image = new Image(display, drawer, 20, 20);
-		image.dispose();
-		fail("No exception thrown for ImageGcDrawer == null");
-	} catch (IllegalArgumentException e) {
-		assertSWTProblem("Incorrect exception thrown for ImageGcDrawer == null", SWT.ERROR_NULL_ARGUMENT, e);
-	}
+	IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> new Image(display, drawer, 20, 20));
+	assertSWTProblem("Incorrect exception thrown for ImageGcDrawer == null", SWT.ERROR_NULL_ARGUMENT, e);
 
 	// Valid provider
 	Image image = new Image(display, imageGcDrawer, 20, 20);
@@ -640,15 +412,15 @@ public void test_equalsLjava_lang_Object() {
 		image = new Image(display, 10, 10);
 		image1 = image;
 
-		assertFalse(":a:", image.equals(null));
+		assertFalse(image.equals(null));
 
-		assertTrue(":b:", image.equals(image1));
+		assertTrue(image.equals(image1));
 
 		ImageData imageData = new ImageData(10, 10, 1, new PaletteData(new RGB(0, 0, 0)));
 		image.dispose();
 		image = new Image(display, imageData);
 		image1 = new Image(display, imageData);
-		assertFalse(":c:", image.equals(image1));
+		assertFalse(image.equals(image1));
 	} finally {
 		image.dispose();
 		image1.dispose();
@@ -659,12 +431,12 @@ public void test_equalsLjava_lang_Object() {
 		image = new Image(display, imageFileNameProvider);
 		image1 = image;
 
-		assertFalse(":d:", image.equals(null));
+		assertFalse(image.equals(null));
 
-		assertTrue(":e:", image.equals(image1));
+		assertTrue(image.equals(image1));
 
 		image1 = new Image(display, imageFileNameProvider);
-		assertTrue(":f:", image.equals(image1));
+		assertTrue(image.equals(image1));
 	} finally {
 		image.dispose();
 		image1.dispose();
@@ -673,12 +445,12 @@ public void test_equalsLjava_lang_Object() {
 		image = new Image(display, imageFileNameProvider);
 		image1 = image;
 
-		assertFalse(":d:", image.equals(null));
+		assertFalse(image.equals(null));
 
-		assertTrue(":e:", image.equals(image1));
+		assertTrue(image.equals(image1));
 
 		image1 = new Image(display, imageFileNameProvider);
-		assertTrue(":f:", image.equals(image1));
+		assertTrue(image.equals(image1));
 	} finally {
 		image.dispose();
 		image1.dispose();
@@ -689,12 +461,12 @@ public void test_equalsLjava_lang_Object() {
 		image = new Image(display, imageDataProvider);
 		image1 = image;
 
-		assertFalse(":g:", image.equals(null));
+		assertFalse(image.equals(null));
 
-		assertTrue(":h:", image.equals(image1));
+		assertTrue(image.equals(image1));
 
 		image1 = new Image(display, imageDataProvider);
-		assertTrue(":i:", image.equals(image1));
+		assertTrue(image.equals(image1));
 	} finally {
 		image.dispose();
 		image1.dispose();
@@ -721,59 +493,49 @@ public void test_equalsLjava_lang_Object() {
 public void test_getBackground() {
 	Image image = new Image(display, 10, 10);
 	image.dispose();
-	try {
-		image.getBackground();
-		fail("No exception thrown for disposed image");
-	} catch (SWTException e) {
-		assertSWTProblem("Incorrect exception thrown for disposed image", SWT.ERROR_GRAPHIC_DISPOSED, e);
-	}
+	SWTException e = assertThrows(SWTException.class, () -> image.getBackground());
+	assertSWTProblem("Incorrect exception thrown for disposed image", SWT.ERROR_GRAPHIC_DISPOSED, e);
 	// remainder tested in setBackground method
 }
 
 @Test
 public void test_getBounds() {
 	Rectangle bounds = new Rectangle(0, 0, 10, 20);
-	Image image = new Image(display, bounds.width, bounds.height);
-	image.dispose();
-	try {
-		image.getBounds();
-		fail("No exception thrown for disposed image");
-	} catch (SWTException e) {
-		assertSWTProblem("Incorrect exception thrown for disposed image", SWT.ERROR_GRAPHIC_DISPOSED, e);
-	}
+	Image image1 = new Image(display, bounds.width, bounds.height);
+	image1.dispose();
+	SWTException e = assertThrows(SWTException.class, () -> image1.getBounds());
+	assertSWTProblem("Incorrect exception thrown for disposed image", SWT.ERROR_GRAPHIC_DISPOSED, e);
 
+	Image image;
 	// creates bitmap image
 	image = new Image(display, bounds.width, bounds.height);
 	Rectangle bounds1 = image.getBounds();
 	image.dispose();
-	assertEquals(":a:", bounds, bounds1);
+	assertEquals(bounds, bounds1);
 
 	image = new Image(display, bounds);
 	bounds1 = image.getBounds();
 	image.dispose();
-	assertEquals(":b:", bounds, bounds1);
+	assertEquals(bounds, bounds1);
 
 	// create icon image
 	ImageData imageData = new ImageData(bounds.width, bounds.height, 1, new PaletteData(new RGB(0, 0, 0)));
 	image = new Image(display, imageData);
 	bounds1 = image.getBounds();
 	image.dispose();
-	assertEquals(":c:", bounds, bounds1);
+	assertEquals(bounds, bounds1);
 }
 
 @SuppressWarnings("deprecation")
 @Test
 public void test_getBoundsInPixels() {
 	Rectangle initialBounds = new Rectangle(0, 0, 10, 20);
-	Image image = new Image(display, initialBounds.width, initialBounds.height);
-	image.dispose();
-	try {
-		image.getBoundsInPixels();
-		fail("No exception thrown for disposed image");
-	} catch (SWTException e) {
-		assertSWTProblem("Incorrect exception thrown for disposed image", SWT.ERROR_GRAPHIC_DISPOSED, e);
-	}
+	Image image1 = new Image(display, initialBounds.width, initialBounds.height);
+	image1.dispose();
+	SWTException e = assertThrows(SWTException.class, () -> image1.getBoundsInPixels());
+	assertSWTProblem("Incorrect exception thrown for disposed image", SWT.ERROR_GRAPHIC_DISPOSED, e);
 
+	Image image;
 	// creates bitmap image
 	image = new Image(display, initialBounds.width, initialBounds.height);
 	Rectangle boundsInPixels = image.getBoundsInPixels();
@@ -818,15 +580,12 @@ public void test_getBoundsInPixels() {
 @Test
 public void test_getImageDataCurrentZoom() {
 	Rectangle bounds = new Rectangle(0, 0, 10, 20);
-	Image image = new Image(display, bounds.width, bounds.height);
-	image.dispose();
-	try {
-		image.getImageDataAtCurrentZoom();
-		fail("No exception thrown for disposed image");
-	} catch (SWTException e) {
-		assertSWTProblem("Incorrect exception thrown for disposed image", SWT.ERROR_GRAPHIC_DISPOSED, e);
-	}
+	Image image1 = new Image(display, bounds.width, bounds.height);
+	image1.dispose();
+	SWTException e = assertThrows(SWTException.class, () -> image1.getImageDataAtCurrentZoom());
+	assertSWTProblem("Incorrect exception thrown for disposed image", SWT.ERROR_GRAPHIC_DISPOSED, e);
 
+	Image image;
 	// creates bitmap image and compare size of imageData
 	image = new Image(display, bounds.width, bounds.height);
 	ImageData imageDataAtCurrentZoom = image.getImageDataAtCurrentZoom();
@@ -912,15 +671,12 @@ public void test_getImageData_200() {
 
 void getImageData_int(int zoom) {
 	Rectangle bounds = new Rectangle(0, 0, 10, 20);
-	Image image = new Image(display, bounds.width, bounds.height);
-	image.dispose();
-	try {
-		image.getImageData(zoom);
-		fail("No exception thrown for disposed image");
-	} catch (SWTException e) {
-		assertSWTProblem("Incorrect exception thrown for disposed image", SWT.ERROR_GRAPHIC_DISPOSED, e);
-	}
+	Image image1 = new Image(display, bounds.width, bounds.height);
+	image1.dispose();
+	SWTException e = assertThrows(SWTException.class, () -> image1.getImageData(zoom));
+	assertSWTProblem("Incorrect exception thrown for disposed image", SWT.ERROR_GRAPHIC_DISPOSED, e);
 
+	Image image;
 	// creates bitmap image and compare size of imageData
 	image = new Image(display, bounds.width, bounds.height);
 	ImageData imageDataAtZoom = image.getImageData(zoom);
@@ -988,14 +744,14 @@ public void test_hashCode() {
 		image = new Image(display, 10, 10);
 		image1 = image;
 
-		assertEquals(":a:", image1.hashCode(), image.hashCode());
+		assertEquals(image1.hashCode(), image.hashCode());
 
 		ImageData imageData = new ImageData(10, 10, 1, new PaletteData(new RGB(0, 0, 0)));
 		image.dispose();
 		image = new Image(display, imageData);
 		image1 = new Image(display, imageData);
 		boolean equals = (image1.hashCode() == image.hashCode());
-		assertFalse(":b:", equals);
+		assertFalse(equals);
 	} finally {
 		image.dispose();
 		image1.dispose();
@@ -1005,7 +761,7 @@ public void test_hashCode() {
 	try {
 		image = new Image(display, imageFileNameProvider);
 		image1 = new Image(display, imageFileNameProvider);
-		assertEquals(":c:", image1.hashCode(), image.hashCode());
+		assertEquals(image1.hashCode(), image.hashCode());
 	} finally {
 		image.dispose();
 		image1.dispose();
@@ -1015,7 +771,7 @@ public void test_hashCode() {
 	try {
 		image = new Image(display, imageDataProvider);
 		image1 = new Image(display, imageDataProvider);
-		assertEquals(":d:", image1.hashCode(), image.hashCode());
+		assertEquals(image1.hashCode(), image.hashCode());
 	} finally {
 		image.dispose();
 		image1.dispose();
@@ -1035,71 +791,55 @@ public void test_hashCode() {
 @Test
 public void test_isDisposed() {
 	Image image = new Image(display, 10, 10);
-	assertFalse(":a:", image.isDisposed());
+	assertFalse(image.isDisposed());
 	image.dispose();
-	assertTrue(":b:", image.isDisposed());
+	assertTrue(image.isDisposed());
 }
 
 @Test
 public void test_setBackgroundLorg_eclipse_swt_graphics_Color() {
-	if (SwtTestUtil.isGTK) {
-		//TODO Fix GTK failure.
-		if (SwtTestUtil.verbose) {
-			System.out.println("Excluded test_setBackgroundLorg_eclipse_swt_graphics_Color(org.eclipse.swt.tests.junit.Test_org_eclipse_swt_graphics_Image)");
-		}
-		return;
-	}
-
-	Image image = new Image(display, 10, 10);
-
+	assumeFalse(
+			"Excluded test_setBackgroundLorg_eclipse_swt_graphics_Color(org.eclipse.swt.tests.junit.Test_org_eclipse_swt_graphics_Image)",
+			SwtTestUtil.isGTK);
+	// TODO Fix GTK failure.
+	Image image1 = new Image(display, 10, 10);
 	try {
-		image.setBackground(null);
-		fail("No exception thrown for color == null");
-	} catch (IllegalArgumentException e) {
+		IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> image1.setBackground(null));
 		assertSWTProblem("Incorrect exception thrown for color == null", SWT.ERROR_NULL_ARGUMENT, e);
 	} finally {
-		image.dispose();
+		image1.dispose();
 	}
-
-	image = new Image(display, 10, 10);
-	Color color = new Color(255, 255, 255);
-	color.dispose();
+	Image image2 = new Image(display, 10, 10);
+	Color color2 = new Color(255, 255, 255);
+	color2.dispose();
 	try {
-		image.setBackground(color);
-		fail("No exception thrown for disposed color");
-	} catch (IllegalArgumentException e) {
+		IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> image2.setBackground(color2));
 		assertSWTProblem("Incorrect exception thrown for disposed color", SWT.ERROR_INVALID_ARGUMENT, e);
 	} finally {
-		image.dispose();
+		image2.dispose();
 	}
-
-	image = new Image(display, 10, 10);
-	image.dispose();
-	color = new Color(255, 255, 255);
-	try {
-		image.setBackground(color);
-		fail("No exception thrown for disposed image");
-	} catch (SWTException e) {
-		assertSWTProblem("Incorrect exception thrown for disposed image", SWT.ERROR_GRAPHIC_DISPOSED, e);
-	} finally {
-		color.dispose();
-	}
+	Image image3 = new Image(display, 10, 10);
+	image3.dispose();
+	Color color3 = new Color(255, 255, 255);
+	SWTException e = assertThrows(SWTException.class, () -> image3.setBackground(color3));
+	assertSWTProblem("Incorrect exception thrown for disposed image", SWT.ERROR_GRAPHIC_DISPOSED, e);
 
 	// this image does not have a transparent pixel by default so setBackground has no effect
-	image = new Image(display, 10, 10);
-	image.setBackground(display.getSystemColor(SWT.COLOR_GREEN));
-	color = image.getBackground();
-	assertNull("background color should be null for non-transparent image", color);
-	image.dispose();
+	Image image4 = new Image(display, 10, 10);
+	image4.setBackground(display.getSystemColor(SWT.COLOR_GREEN));
+	Color color4 = image4.getBackground();
+	assertNull("background color should be null for non-transparent image", color4);
+	image4.dispose();
 
 	// create an image with transparency and then set the background color
-	ImageData imageData = new ImageData(10, 10, 2, new PaletteData(new RGB(0, 0, 0), new RGB(255, 255, 255), new RGB(50, 100, 150)));
+	ImageData imageData = new ImageData(10, 10, 2,
+			new PaletteData(new RGB(0, 0, 0), new RGB(255, 255, 255), new RGB(50, 100, 150)));
 	imageData.transparentPixel = 0; // transparent pixel is currently black
-	image = new Image(display, imageData);
-	image.setBackground(display.getSystemColor(SWT.COLOR_GREEN));
-	color = image.getBackground();
-	assertEquals("background color should have been set to green", display.getSystemColor(SWT.COLOR_GREEN), color);
-	image.dispose();
+	Image image5 = new Image(display, imageData);
+	image5.setBackground(display.getSystemColor(SWT.COLOR_GREEN));
+	Color color5 = image5.getBackground();
+	assertEquals("background color should have been set to green", display.getSystemColor(SWT.COLOR_GREEN), color5);
+	image5.dispose();
 }
 
 @Test


### PR DESCRIPTION
- Leverage assertThrows()
- Remove marker messages
- general code clean-ups