### PR TITLE
Add missing about.html to org.eclipse.swt.svg fragment #2009

### DIFF
--- a/bundles/org.eclipse.swt.svg/about.html
+++ b/bundles/org.eclipse.swt.svg/about.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1" />
+<title>About</title>
+</head>
+<body lang="EN-US">
+	<h2>About This Content</h2>
+
+	<p>November 30, 2017</p>
+	<h3>License</h3>
+
+	<p>
+		The Eclipse Foundation makes available all content in this plug-in
+		(&quot;Content&quot;). Unless otherwise indicated below, the Content
+		is provided to you under the terms and conditions of the Eclipse
+		Public License Version 2.0 (&quot;EPL&quot;). A copy of the EPL is
+		available at <a href="http://www.eclipse.org/legal/epl-2.0">http://www.eclipse.org/legal/epl-2.0</a>.
+		For purposes of the EPL, &quot;Program&quot; will mean the Content.
+	</p>
+
+	<p>
+		If you did not receive this Content directly from the Eclipse
+		Foundation, the Content is being redistributed by another party
+		(&quot;Redistributor&quot;) and different terms and conditions may
+		apply to your use of any object code in the Content. Check the
+		Redistributor's license that was provided with the Content. If no such
+		license exists, contact the Redistributor. Unless otherwise indicated
+		below, the terms and conditions of the EPL still apply to any source
+		code in the Content and such source code may be obtained at <a
+			href="http://www.eclipse.org/">http://www.eclipse.org</a>.
+	</p>
+
+</body>
+</html>

--- a/bundles/org.eclipse.swt.svg/build.properties
+++ b/bundles/org.eclipse.swt.svg/build.properties
@@ -15,7 +15,9 @@ source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\
                .,\
-               fragment.properties
+               fragment.properties,\
+               about.html
+src.includes = about.html
 
 jars.extra.classpath = platform:/plugin/org.eclipse.swt.cocoa.macosx.aarch64,\
                        platform:/plugin/org.eclipse.swt.cocoa.macosx.x86_64,\


### PR DESCRIPTION
The recently added org.eclipse.swt.svg fragment is lacking the required about.html file. This change adds the file to the generated source and binary artifacts bundles.

Fixes https://github.com/eclipse-platform/eclipse.platform.swt/issues/2009