### PR TITLE
Do not treat warnings as errors in gtk4 port

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/make_linux.mak
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/make_linux.mak
@@ -111,7 +111,9 @@ LFLAGS = -shared -fPIC ${SWT_LFLAGS}
 
 # Treat all warnings as errors. If your new code produces a warning, please
 # take time to properly understand and fix/silence it as necessary.
+ifeq ($(GTK_VERSION), 3.0)
 CFLAGS += -Werror
+endif
 
 ifndef NO_STRIP
 	# -s = Remove all symbol table and relocation information from the executable.


### PR DESCRIPTION
The port is in early stages and there are still many deprecated usages that should be ported rather than silenced (as in the gtk3 port).