### PR TITLE
[GTK] Disable WindowListener-related test for WebKit #2014

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -47,8 +47,7 @@ jobs:
     - name: Install Linux requirements
       if: ${{ matrix.config.native == 'gtk.linux.x86_64'}}
       run: |
-        sudo apt-get update -qq 
-        WEBKIT_VERSION=2.44.0-2 && sudo apt-get install -qq -y libgtk-3-dev libgtk-4-dev freeglut3-dev webkit2gtk-driver=${WEBKIT_VERSION} libwebkit2gtk-4.1-0=${WEBKIT_VERSION} libjavascriptcoregtk-4.1-0=${WEBKIT_VERSION}
+        sudo apt-get install -qq -y libgtk-3-dev libgtk-4-dev freeglut3-dev webkit2gtk-driver
     - name: Pull large static Windows binaries
       if: ${{ matrix.config.native == 'win32.win32.x86_64'}}
       run: |

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_browser_Browser.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_browser_Browser.java
@@ -823,6 +823,8 @@ public void test_OpenWindowListener_addAndRemove() {
 
 @Test
 public void test_OpenWindowListener_openHasValidEventDetails() {
+	assumeFalse("Stopped working with WebKit 2.48, see https://github.com/eclipse-platform/eclipse.platform.swt/issues/2014", SwtTestUtil.isGTK);
+
 	AtomicBoolean openFiredCorrectly = new AtomicBoolean(false);
 	final Browser browserChild = createBrowser(shell, swtBrowserSettings);
 	browser.addOpenWindowListener(event -> {
@@ -845,7 +847,7 @@ public void test_OpenWindowListener_openHasValidEventDetails() {
 /** Test that a script 'window.open()' opens a child popup shell. */
 @Test
 public void test_OpenWindowListener_open_ChildPopup() {
-	assumeFalse("Not currently working on Linux, see https://github.com/eclipse-platform/eclipse.platform.swt/issues/1564", SwtTestUtil.isGTK);
+	assumeFalse("Stopped working with WebKit 2.46, see https://github.com/eclipse-platform/eclipse.platform.swt/issues/1564", SwtTestUtil.isGTK);
 	AtomicBoolean childCompleted = new AtomicBoolean(false);
 
 	Shell childShell = new Shell(shell, SWT.None);
@@ -883,7 +885,7 @@ public void test_OpenWindowListener_open_ChildPopup() {
 /** Validate event order : Child's visibility should come before progress completed event */
 @Test
 public void test_OpenWindow_Progress_Listener_ValidateEventOrder() {
-	assumeFalse("Not currently working on Linux, see https://github.com/eclipse-platform/eclipse.platform.swt/issues/1564", SwtTestUtil.isGTK);
+	assumeFalse("Stopped working with WebKit 2.46, see https://github.com/eclipse-platform/eclipse.platform.swt/issues/1564", SwtTestUtil.isGTK);
 
 	AtomicBoolean windowOpenFired = new AtomicBoolean(false);
 	AtomicBoolean childCompleted = new AtomicBoolean(false);
@@ -1384,7 +1386,7 @@ public void test_VisibilityWindowListener_multiple_shells() {
  */
 @Test
 public void test_VisibilityWindowListener_eventSize() {
-	assumeFalse("Not currently working on Linux, see https://github.com/eclipse-platform/eclipse.platform.swt/issues/1564", SwtTestUtil.isGTK);
+	assumeFalse("Stopped working with WebKit 2.46, see https://github.com/eclipse-platform/eclipse.platform.swt/issues/1564", SwtTestUtil.isGTK);
 
 	shell.setSize(200,300);
 	AtomicBoolean childCompleted = new AtomicBoolean(false);


### PR DESCRIPTION
With the update to WebKit 2.48, the browser test case test_OpenWindowListener_openHasValidEventDetails leads to runtime crashed. This disables the test to allow test executions and builds to complete until the root cause is found and fixed. It also reverts the downgrade of the WebKit version in GitHub actions runners.

Contributes to https://github.com/eclipse-platform/eclipse.platform.swt/issues/2014