### PR TITLE
CTabFolder: don't unset tooltip value on mouse enter

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CTabFolder.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CTabFolder.java
@@ -1813,10 +1813,6 @@ void onMouse(Event event) {
 	}
 	int x = event.x, y = event.y;
 	switch (event.type) {
-		case SWT.MouseEnter: {
-			_setToolTipText(event.x, event.y);
-			break;
-		}
 		case SWT.MouseExit: {
 			for (int i=0; i<items.length; i++) {
 				CTabItem item = items[i];
@@ -1910,6 +1906,10 @@ void onMouse(Event event) {
 				return;
 			}
 			break;
+		}
+		case SWT.MouseEnter: {
+			// fall through to the "move" case, see
+			// https://github.com/eclipse-platform/eclipse.platform.swt/issues/2017
 		}
 		case SWT.MouseMove: {
 			_setToolTipText(event.x, event.y);

--- a/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CTabFolder.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CTabFolder.java
@@ -1814,7 +1814,7 @@ void onMouse(Event event) {
 	int x = event.x, y = event.y;
 	switch (event.type) {
 		case SWT.MouseEnter: {
-			setToolTipText(null);
+			_setToolTipText(event.x, event.y);
 			break;
 		}
 		case SWT.MouseExit: {


### PR DESCRIPTION
Setting tooltip to null on mouse enter results in an unpredictable GTK tooltip behavior which in most cases simply doesn't show at all.

Fixes https://github.com/eclipse-platform/eclipse.platform.swt/issues/2017