### PR TITLE
Fix browser tests on Linux that open a new window + revert downgrade of WebKit for the Linux GH runner

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -48,7 +48,7 @@ jobs:
       if: ${{ matrix.config.native == 'gtk.linux.x86_64'}}
       run: |
         sudo apt-get update -qq 
-        WEBKIT_VERSION=2.44.0-2 && sudo apt-get install -qq -y libgtk-3-dev libgtk-4-dev freeglut3-dev webkit2gtk-driver=${WEBKIT_VERSION} libwebkit2gtk-4.1-0=${WEBKIT_VERSION} libjavascriptcoregtk-4.1-0=${WEBKIT_VERSION}
+        sudo apt-get install -qq -y libgtk-3-dev libgtk-4-dev freeglut3-dev webkit2gtk-driver
     - name: Pull large static Windows binaries
       if: ${{ matrix.config.native == 'win32.win32.x86_64'}}
       run: |


### PR DESCRIPTION
According to https://webkitgtk.org/reference/webkit2gtk/stable/signal.WebView.create.html

_The new WebKitWebView must be related to web_view, see WebKitWebView:related-view for more details._

To ensure this, org.eclipse.swt.browser.WebKit.create(Composite, int)
does the following:

```java
        Composite parentShell = parent.getParent();
        Browser parentBrowser = WebKit.parentBrowser;
        if (parentBrowser == null && parentShell != null) {
                Control[] children = parentShell.getChildren();
                for (int i = 0; i < children.length; i++) {
                        if (children[i] instanceof Browser) {
                                parentBrowser = (Browser) children[i];
                                break;
                        }
                }
        }

        if (parentBrowser == null) {
                webView = WebKitGTK.webkit_web_view_new();
        } else {
                webView = WebKitGTK.webkit_web_view_new_with_related_view(((WebKit)parentBrowser.webBrowser).webView);
        }
```

1) A static variable set to true inside NewWindowListeners:

```java
        /**
         * Stores the browser which is opening a new browser window,
         * during a WebKit {@code create} signal. This browser
         * must be passed to a newly created browser as "related".
         *
         * See bug 579257.
         */
        private static Browser parentBrowser;
```

2) A heuristic for when two browser instances share the parent

In the failing tests, we currently have neither.

To fix that, use the more 'correct' solution 1) by moving the instantiation of new Browser inside the OpenWindowListener.

Resolves #2014.
Resolves #1564.