### PR TITLE
Use custom variable for test folder path in win32 fragments

### DIFF
--- a/binaries/org.eclipse.swt.win32.win32.aarch64/.project
+++ b/binaries/org.eclipse.swt.win32.win32.aarch64/.project
@@ -110,8 +110,7 @@
 		<link>
 			<name>Eclipse SWT Tests</name>
 			<type>2</type>
-			<!-- Once Tycho supports custom variables, SWT_HOST_PLUGIN should be used here: https://github.com/eclipse-tycho/tycho/issues/3820 -->
-			<locationURI>PARENT-2-PROJECT_LOC/bundles/org.eclipse.swt/Eclipse%20SWT%20Tests</locationURI>
+			<locationURI>SWT_HOST_PLUGIN/Eclipse%20SWT%20Tests</locationURI>
 		</link>
 	</linkedResources>
 	<variableList>

--- a/binaries/org.eclipse.swt.win32.win32.x86_64/.project
+++ b/binaries/org.eclipse.swt.win32.win32.x86_64/.project
@@ -110,8 +110,7 @@
 		<link>
 			<name>Eclipse SWT Tests</name>
 			<type>2</type>
-			<!-- Once Tycho supports custom variables, SWT_HOST_PLUGIN should be used here: https://github.com/eclipse-tycho/tycho/issues/3820 -->
-			<locationURI>PARENT-2-PROJECT_LOC/bundles/org.eclipse.swt/Eclipse%20SWT%20Tests</locationURI>
+			<locationURI>SWT_HOST_PLUGIN/Eclipse%20SWT%20Tests</locationURI>
 		</link>
 	</linkedResources>
 	<variableList>


### PR DESCRIPTION
Tycho lacked support for resolving locations of linked resources whose path contained custom variables. For that reason, the linked folder path to the tests folder of the win32 fragments contain a repetition of an already existing custom variable to the host bundle. Since according Tycho support has been added recently , this change replaces the inlined custom variable with the actual custom variable.

This is a cleanup since
- https://github.com/eclipse-tycho/tycho/issues/3820 

has been resolved via
- https://github.com/eclipse-tycho/tycho/pull/4909