### PR TITLE
[GTK] Set useCairoAutoScale to true and remove getter

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/DPIUtil.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/DPIUtil.java
@@ -47,7 +47,7 @@ public class DPIUtil {
 	private static AutoScaleMethod autoScaleMethod = AutoScaleMethod.NEAREST;
 
 	private static String autoScaleValue;
-	private static boolean useCairoAutoScale = false;
+	private static boolean useCairoAutoScale = true;
 
 	/**
 	 * System property that controls the autoScale functionality.
@@ -633,10 +633,6 @@ private static boolean sholdUseSmoothScaling() {
 
 public static void setUseCairoAutoScale (boolean cairoAutoScale) {
 	useCairoAutoScale = cairoAutoScale;
-}
-
-public static boolean useCairoAutoScale() {
-	return useCairoAutoScale;
 }
 
 public static int getZoomForAutoscaleProperty (int nativeDeviceZoom) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/graphics/Device.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/graphics/Device.java
@@ -698,8 +698,6 @@ protected void init () {
 	this.dpi = getDPI();
 	DPIUtil.setDeviceZoom (getDeviceZoom ());
 
-	DPIUtil.setUseCairoAutoScale(true);
-
 	/* Initialize the system font slot */
 	long [] defaultFontArray = new long [1];
 	long defaultFont = 0;

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/graphics/GC.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/graphics/GC.java
@@ -1621,18 +1621,16 @@ void fillGradientRectangleInPixels(int x, int y, int width, int height, boolean 
 	long cairo = data.cairo;
 	long pattern;
 
-	if (DPIUtil.useCairoAutoScale() ) {
-		/*
-		 * Here the co-ordinates passed are in points for GTK3.
-		 * That means the user is expecting surface to be at
-		 * device scale equal to current scale factor. So need
-		 * to set the device scale to current scale factor
-		 */
-		long surface = Cairo.cairo_get_target(cairo);
-		if (surface != 0) {
-			float scaleFactor = DPIUtil.getDeviceZoom() / 100f;
-			Cairo.cairo_surface_set_device_scale(surface, scaleFactor, scaleFactor);
-		}
+	/*
+	 * Here the co-ordinates passed are in points for GTK3.
+	 * That means the user is expecting surface to be at
+	 * device scale equal to current scale factor. So need
+	 * to set the device scale to current scale factor
+	 */
+	long surface = Cairo.cairo_get_target(cairo);
+	if (surface != 0) {
+		float scaleFactor = DPIUtil.getDeviceZoom() / 100f;
+		Cairo.cairo_surface_set_device_scale(surface, scaleFactor, scaleFactor);
 	}
 
 	if (fromRGB.equals(toRGB)) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/graphics/Image.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/graphics/Image.java
@@ -283,7 +283,7 @@ public Image(Device device, Image srcImage, int flag) {
 	boolean hasAlpha = format == Cairo.CAIRO_FORMAT_ARGB32;
 	surface = Cairo.cairo_image_surface_create(format, width, height);
 	if (surface == 0) SWT.error(SWT.ERROR_NO_HANDLES);
-	if (DPIUtil.getDeviceZoom() != currentDeviceZoom && DPIUtil.useCairoAutoScale()) {
+	if (DPIUtil.getDeviceZoom() != currentDeviceZoom) {
 		double scaleFactor = DPIUtil.getDeviceZoom() / 100f;
 		Cairo.cairo_surface_set_device_scale(surface, scaleFactor, scaleFactor);
 	}
@@ -738,19 +738,6 @@ boolean refreshImageForZoom () {
 			refreshed = true;
 			currentDeviceZoom = deviceZoomLevel;
 		}
-	} else {
-		if (!DPIUtil.useCairoAutoScale()) {
-			int deviceZoomLevel = deviceZoom;
-			if (deviceZoomLevel != currentDeviceZoom) {
-				ImageData data = getImageDataAtCurrentZoom();
-				destroy ();
-				ImageData resizedData = DPIUtil.scaleImageData(device, data, deviceZoomLevel, currentDeviceZoom);
-				init(resizedData);
-				init();
-				refreshed = true;
-				currentDeviceZoom = deviceZoomLevel;
-			}
-		}
 	}
 	return refreshed;
 }
@@ -809,7 +796,7 @@ void createFromPixbuf(int type, long pixbuf) {
 	// Initialize surface with dimensions received from the pixbuf and set device_scale appropriately
 	surface = Cairo.cairo_image_surface_create(format, pixbufWidth, pixbufHeight);
 	if (surface == 0) SWT.error(SWT.ERROR_NO_HANDLES);
-	if (DPIUtil.useCairoAutoScale()) Cairo.cairo_surface_set_device_scale(surface, scaleFactor, scaleFactor);
+	Cairo.cairo_surface_set_device_scale(surface, scaleFactor, scaleFactor);
 
 	long data = Cairo.cairo_image_surface_get_data(surface);
 	int cairoStride = Cairo.cairo_image_surface_get_stride(surface);
@@ -1257,12 +1244,8 @@ void init(int width, int height) {
 	if (surface == 0) SWT.error(SWT.ERROR_NO_HANDLES);
 	// When we create a blank image we need to set it to 100 in GTK3 as we draw using 100% scale.
 	// Cairo will take care of scaling for us when image needs to be scaled.
-	if (DPIUtil.useCairoAutoScale()) {
-		currentDeviceZoom = 100;
-		Cairo.cairo_surface_set_device_scale(surface, 1f, 1f);
-	} else {
-		currentDeviceZoom = DPIUtil.getDeviceZoom();
-	}
+	currentDeviceZoom = 100;
+	Cairo.cairo_surface_set_device_scale(surface, 1f, 1f);
 	long cairo = Cairo.cairo_create(surface);
 	if (cairo == 0) SWT.error(SWT.ERROR_NO_HANDLES);
 	Cairo.cairo_set_source_rgb(cairo, 1, 1, 1);
@@ -1296,7 +1279,7 @@ void init(ImageData image) {
 	// Initialize surface with dimensions received from the ImageData and set device_scale appropriately
 	surface = Cairo.cairo_image_surface_create(format, imageDataWidth, imageDataHeight);
 	if (surface == 0) SWT.error(SWT.ERROR_NO_HANDLES);
-	if (DPIUtil.useCairoAutoScale()) Cairo.cairo_surface_set_device_scale(surface, scaleFactor, scaleFactor);
+	Cairo.cairo_surface_set_device_scale(surface, scaleFactor, scaleFactor);
 
 	int stride = Cairo.cairo_image_surface_get_stride(surface);
 	long data = Cairo.cairo_image_surface_get_data(surface);

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Table.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Table.java
@@ -2880,13 +2880,7 @@ void sendMeasureEvent (long cell, long width, long height) {
 			Image image = item.getImage (columnIndex);
 			int imageWidth = 0;
 			if (image != null) {
-				Rectangle bounds;
-				if (DPIUtil.useCairoAutoScale()) {
-					bounds = image.getBounds ();
-				} else {
-					bounds = image.getBoundsInPixels();
-				}
-				imageWidth = bounds.width;
+				imageWidth = image.getBounds ().width;
 			}
 			contentWidth [0] += imageWidth;
 			GC gc = new GC (this);
@@ -3143,13 +3137,7 @@ void rendererRender (long cell, long cr, long snapshot, long widget, long backgr
 				Image image = item.getImage (columnIndex);
 				int imageWidth = 0;
 				if (image != null) {
-					Rectangle bounds;
-					if (DPIUtil.useCairoAutoScale()) {
-						bounds = image.getBounds ();
-					} else {
-						bounds = image.getBoundsInPixels ();
-					}
-					imageWidth = bounds.width;
+					imageWidth = image.getBounds ().width;
 				}
 				contentX [0] -= imageWidth;
 				contentWidth [0] += imageWidth;

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/TableItem.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/TableItem.java
@@ -807,12 +807,7 @@ Rectangle getTextBoundsInPixels (int index) {
 	Image image = _getImage(index);
 	int imageWidth = 0;
 	if (image != null) {
-		if (DPIUtil.useCairoAutoScale()) {
-			imageWidth = image.getBounds ().width;
-		} else {
-			imageWidth = image.getBoundsInPixels ().width;
-		}
-
+		imageWidth = image.getBounds ().width;
 	}
 	if (x [0] < imageWidth) {
 		rect.x += imageWidth;
@@ -1211,14 +1206,8 @@ public void setImage(int index, Image image) {
 	GTK.gtk_cell_renderer_get_fixed_size (pixbufRenderer, currentWidth, currentHeight);
 	if (!parent.pixbufSizeSet) {
 		if (image != null) {
-			int iWidth, iHeight;
-			if (DPIUtil.useCairoAutoScale()) {
-				iWidth = image.getBounds ().width;
-				iHeight = image.getBounds ().height;
-			} else {
-				iWidth = image.getBoundsInPixels ().width;
-				iHeight = image.getBoundsInPixels ().height;
-			}
+			int	iWidth = image.getBounds ().width;
+			int	iHeight = image.getBounds ().height;
 			if (iWidth > currentWidth [0] || iHeight > currentHeight [0]) {
 				GTK.gtk_cell_renderer_set_fixed_size (pixbufRenderer, iWidth, iHeight);
 				parent.pixbufHeight = iHeight;

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Tree.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Tree.java
@@ -3079,14 +3079,7 @@ void sendMeasureEvent (long cell, long width, long height) {
 			Image image = item.getImage (columnIndex);
 			int imageWidth = 0;
 			if (image != null && !image.isDisposed()) {
-				Rectangle bounds;
-				if (DPIUtil.useCairoAutoScale()) {
-					bounds = image.getBounds ();
-				} else {
-					bounds = image.getBoundsInPixels ();
-				}
-				bounds = image.getBounds ();
-				imageWidth = bounds.width;
+				imageWidth = image.getBounds ().width;
 			}
 			contentWidth [0] += imageWidth;
 			GC gc = new GC (this);
@@ -3337,13 +3330,7 @@ void rendererRender (long cell, long cr, long snapshot, long widget, long backgr
 				Image image = item.getImage (columnIndex);
 				int imageWidth = 0;
 				if (image != null) {
-					Rectangle bounds;
-					if(DPIUtil.useCairoAutoScale()) {
-						bounds = image.getBounds ();
-					} else {
-						bounds = image.getBoundsInPixels ();
-					}
-					imageWidth = bounds.width;
+					imageWidth = image.getBounds ().width;
 				}
 				// Account for the image width on GTK3, see bug 535124.
 				if (cr != 0) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/TreeItem.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/TreeItem.java
@@ -991,11 +991,7 @@ Rectangle getTextBoundsInPixels (int index) {
 	Image image = _getImage(index);
 	int imageWidth = 0;
 	if (image != null) {
-		if (DPIUtil.useCairoAutoScale()) {
-			imageWidth = image.getBounds ().width;
-		} else {
-			imageWidth = image.getBoundsInPixels ().width;
-		}
+		imageWidth = image.getBounds ().width;
 	}
 	if (x [0] < imageWidth) {
 		rect.x += imageWidth;
@@ -1528,14 +1524,8 @@ public void setImage(int index, Image image) {
 	GTK.gtk_cell_renderer_get_fixed_size (pixbufRenderer, currentWidth, currentHeight);
 	if (!parent.pixbufSizeSet) {
 		if (image != null) {
-			int iWidth, iHeight;
-			if (DPIUtil.useCairoAutoScale()) {
-				iWidth = image.getBounds ().width;
-				iHeight = image.getBounds ().height;
-			} else {
-				iWidth = image.getBoundsInPixels ().width;
-				iHeight = image.getBoundsInPixels ().height;
-			}
+			int	iWidth = image.getBounds ().width;
+			int	iHeight = image.getBounds ().height;
 			if (iWidth > currentWidth [0] || iHeight > currentHeight [0]) {
 				GTK.gtk_cell_renderer_set_fixed_size (pixbufRenderer, iWidth, iHeight);
 				parent.pixbufSizeSet = true;

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/DPIUtilTests.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/DPIUtilTests.java
@@ -34,19 +34,17 @@ import org.junit.Test;
 public class DPIUtilTests {
 
 	private int deviceZoom;
-	private boolean useCairoAutoScale;
 
 	@Before
 	public void setup() {
 		deviceZoom = DPIUtil.getDeviceZoom();
-		useCairoAutoScale = DPIUtil.useCairoAutoScale();
 		DPIUtil.setDeviceZoom(200);
 		DPIUtil.setUseCairoAutoScale(false);
 	}
 
 	@After
 	public void tearDown() {
-		DPIUtil.setUseCairoAutoScale(useCairoAutoScale);
+		DPIUtil.setUseCairoAutoScale(true);
 		DPIUtil.setDeviceZoom(deviceZoom);
 	}
 


### PR DESCRIPTION
Change all implementations to not check it but act assume it is always true. This was the case anyway as Device.init explicitly set it that way.