### PR TITLE
Correct Cairo autoscaling setting in DPIUtil and remove setter #2031

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/DPIUtil.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/DPIUtil.java
@@ -47,7 +47,7 @@ public class DPIUtil {
 	private static AutoScaleMethod autoScaleMethod = AutoScaleMethod.NEAREST;
 
 	private static String autoScaleValue;
-	private static boolean useCairoAutoScale = true;
+	private static final boolean USE_CAIRO_AUTOSCALE = SWT.getPlatform().equals("gtk");
 
 	/**
 	 * System property that controls the autoScale functionality.
@@ -484,7 +484,7 @@ public static Rectangle scaleUp(Drawable drawable, Rectangle rect, int zoom) {
  * @return float scaling factor
  */
 private static float getScalingFactor(int zoom) {
-	if (useCairoAutoScale) {
+	if (USE_CAIRO_AUTOSCALE) {
 		return 1;
 	}
 	if (zoom <= 0) {
@@ -629,10 +629,6 @@ private static boolean sholdUseSmoothScaling() {
 	case "win32" -> isMonitorSpecificScalingActive();
 	default -> false;
 	};
-}
-
-public static void setUseCairoAutoScale (boolean cairoAutoScale) {
-	useCairoAutoScale = cairoAutoScale;
 }
 
 public static int getZoomForAutoscaleProperty (int nativeDeviceZoom) {

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/DPIUtilTests.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/DPIUtilTests.java
@@ -16,6 +16,7 @@ package org.eclipse.swt.tests.junit;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
+import static org.junit.Assume.assumeFalse;
 
 import org.eclipse.swt.graphics.Device;
 import org.eclipse.swt.graphics.Point;
@@ -37,14 +38,13 @@ public class DPIUtilTests {
 
 	@Before
 	public void setup() {
+		assumeFalse("Linux uses Cairo auto scaling, thus DPIUtil scaling is disabled", SwtTestUtil.isLinux);
 		deviceZoom = DPIUtil.getDeviceZoom();
 		DPIUtil.setDeviceZoom(200);
-		DPIUtil.setUseCairoAutoScale(false);
 	}
 
 	@After
 	public void tearDown() {
-		DPIUtil.setUseCairoAutoScale(true);
 		DPIUtil.setDeviceZoom(deviceZoom);
 	}
 


### PR DESCRIPTION
Cairo auto-scaling was enabled in DPIUtil for every OS in a recent commit. This corrects the setting to be only applied on Linux/GTK and thus also issues arising from it. In addition, it removes the unnecessary setter for the auto-scaling and disables the tests that previously required it as they are meaningless without productive use of disabled Cairo auto-scale on Linux anyway.

Fixes https://github.com/eclipse-platform/eclipse.platform.swt/issues/2031