### PR TITLE
Fix for runWithAutoScaleValue

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/DPIUtil.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/DPIUtil.java
@@ -667,10 +667,12 @@ private static int getZoomForAutoscaleProperty (int nativeDeviceZoom, String aut
 public static void runWithAutoScaleValue(String autoScaleValue, Runnable runnable) {
 	String initialAutoScaleValue = DPIUtil.autoScaleValue;
 	DPIUtil.autoScaleValue = autoScaleValue;
+	DPIUtil.deviceZoom = getZoomForAutoscaleProperty(nativeDeviceZoom);
 	try {
 		runnable.run();
 	} finally {
 		DPIUtil.autoScaleValue = initialAutoScaleValue;
+		DPIUtil.deviceZoom = getZoomForAutoscaleProperty(nativeDeviceZoom);
 	}
 }
 


### PR DESCRIPTION
This PR addresses and issue with DPIUtil#runWithAutoScaleValue. It only adapted DPIUtil#autoScaleValue temporarily. As DPIUtil#deviceZoom is directly affected by autoScaleValue, it is important to adjust it temporarily as well.
fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/2897