### PR TITLE
[Edge] Add link to Edge FAQ with information on installing runtime #2000

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Browser/win32/org/eclipse/swt/browser/Edge.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Browser/win32/org/eclipse/swt/browser/Edge.java
@@ -599,7 +599,7 @@ WebViewEnvironment createEnvironment() {
 					pBrowserDir, pDataDir, options.getAddress(), completion.getAddress()));
 	options.Release();
 	if (hr == OS.HRESULT_FROM_WIN32(OS.ERROR_FILE_NOT_FOUND)) {
-		SWT.error(SWT.ERROR_NOT_IMPLEMENTED, null, " [WebView2 runtime not found]");
+		SWT.error(SWT.ERROR_NOT_IMPLEMENTED, null, " [WebView2 runtime not found. For details, see https://github.com/eclipse-platform/eclipse.platform/tree/master/docs/FAQ/FAQ_How_do_I_use_Edge-IE_as_the_Browser's_underlying_renderer.md]");
 	}
 	if (hr != COM.S_OK) error(SWT.ERROR_NO_HANDLES, hr);
 	ICoreWebView2Environment environment = new ICoreWebView2Environment(ppv[0]);


### PR DESCRIPTION
When the OS lacks a WebView2 runtime installation, an error is shown once a browser is initialized since Edge is used as the default browser on Windows. This change adds a link to the according FAQ page with information on how to install such a runtime to the error message.

Resolves https://github.com/eclipse-platform/eclipse.platform.swt/issues/2000