### PR TITLE
Add FreeBSD aarch64/x86_64 platforms' build.

### DIFF
--- a/binaries/org.eclipse.swt.gtk.freebsd.aarch64/.project
+++ b/binaries/org.eclipse.swt.gtk.freebsd.aarch64/.project
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>org.eclipse.swt.gtk.freebsd.aarch64</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ManifestBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.SchemaBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.api.tools.apiAnalysisBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>org.eclipse.pde.PluginNature</nature>
+		<nature>org.eclipse.pde.api.tools.apiAnalysisNature</nature>
+	</natures>
+	<linkedResources>
+		<link>
+			<name>.classpath</name>
+			<type>1</type>
+			<locationURI>PARENT-1-PROJECT_LOC/.classpath_gtk</locationURI>
+		</link>
+		<link>
+			<name>.settings/.api_filters</name>
+			<type>1</type>
+			<locationURI>PROJECT_LOC/.settings/.api_filters</locationURI>
+		</link>
+		<link>
+			<name>.settings</name>
+			<type>2</type>
+			<locationURI>PARENT-1-PROJECT_LOC/.settings</locationURI>
+		</link>
+		<link>
+			<name>Eclipse SWT</name>
+			<type>2</type>
+			<locationURI>SWT_HOST_PLUGIN/Eclipse%20SWT</locationURI>
+		</link>
+		<link>
+			<name>Eclipse SWT Accessibility</name>
+			<type>2</type>
+			<locationURI>SWT_HOST_PLUGIN/Eclipse%20SWT%20Accessibility</locationURI>
+		</link>
+		<link>
+			<name>Eclipse SWT AWT</name>
+			<type>2</type>
+			<locationURI>SWT_HOST_PLUGIN/Eclipse%20SWT%20AWT</locationURI>
+		</link>
+		<link>
+			<name>Eclipse SWT Browser</name>
+			<type>2</type>
+			<locationURI>SWT_HOST_PLUGIN/Eclipse%20SWT%20Browser</locationURI>
+		</link>
+		<link>
+			<name>Eclipse SWT Custom Widgets</name>
+			<type>2</type>
+			<locationURI>SWT_HOST_PLUGIN/Eclipse%20SWT%20Custom%20Widgets</locationURI>
+		</link>
+		<link>
+			<name>Eclipse SWT Drag and Drop</name>
+			<type>2</type>
+			<locationURI>SWT_HOST_PLUGIN/Eclipse%20SWT%20Drag%20and%20Drop</locationURI>
+		</link>
+		<link>
+			<name>Eclipse SWT OLE Win32</name>
+			<type>2</type>
+			<locationURI>SWT_HOST_PLUGIN/Eclipse%20SWT%20OLE%20Win32</locationURI>
+		</link>
+		<link>
+			<name>Eclipse SWT OpenGL</name>
+			<type>2</type>
+			<locationURI>SWT_HOST_PLUGIN/Eclipse%20SWT%20OpenGL</locationURI>
+		</link>
+		<link>
+			<name>Eclipse SWT PI</name>
+			<type>2</type>
+			<locationURI>SWT_HOST_PLUGIN/Eclipse%20SWT%20PI</locationURI>
+		</link>
+		<link>
+			<name>Eclipse SWT Printing</name>
+			<type>2</type>
+			<locationURI>SWT_HOST_PLUGIN/Eclipse%20SWT%20Printing</locationURI>
+		</link>
+		<link>
+			<name>Eclipse SWT Program</name>
+			<type>2</type>
+			<locationURI>SWT_HOST_PLUGIN/Eclipse%20SWT%20Program</locationURI>
+		</link>
+		<link>
+			<name>Eclipse SWT WebKit</name>
+			<type>2</type>
+			<locationURI>SWT_HOST_PLUGIN/Eclipse%20SWT%20WebKit</locationURI>
+		</link>
+	</linkedResources>
+	<variableList>
+		<variable>
+			<name>SWT_HOST_PLUGIN</name>
+			<value>$%7BPARENT-2-PROJECT_LOC%7D/bundles/org.eclipse.swt</value>
+		</variable>
+	</variableList>
+</projectDescription>

--- a/binaries/org.eclipse.swt.gtk.freebsd.aarch64/.settings/.api_filters
+++ b/binaries/org.eclipse.swt.gtk.freebsd.aarch64/.settings/.api_filters
@@ -1,0 +1,497 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<component id="org.eclipse.swt.gtk.linux.aarch64" version="2">
+    <resource path="Eclipse SWT Accessibility/common/org/eclipse/swt/accessibility/AccessibleActionListener.java" type="org.eclipse.swt.accessibility.AccessibleActionListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="AccessibleActionListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Accessibility/common/org/eclipse/swt/accessibility/AccessibleAttributeListener.java" type="org.eclipse.swt.accessibility.AccessibleAttributeListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="AccessibleAttributeListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Accessibility/common/org/eclipse/swt/accessibility/AccessibleControlListener.java" type="org.eclipse.swt.accessibility.AccessibleControlListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="AccessibleControlListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Accessibility/common/org/eclipse/swt/accessibility/AccessibleEditableTextListener.java" type="org.eclipse.swt.accessibility.AccessibleEditableTextListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="AccessibleEditableTextListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Accessibility/common/org/eclipse/swt/accessibility/AccessibleHyperlinkListener.java" type="org.eclipse.swt.accessibility.AccessibleHyperlinkListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="AccessibleHyperlinkListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Accessibility/common/org/eclipse/swt/accessibility/AccessibleListener.java" type="org.eclipse.swt.accessibility.AccessibleListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="AccessibleListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Accessibility/common/org/eclipse/swt/accessibility/AccessibleTableCellListener.java" type="org.eclipse.swt.accessibility.AccessibleTableCellListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="AccessibleTableCellListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Accessibility/common/org/eclipse/swt/accessibility/AccessibleTableListener.java" type="org.eclipse.swt.accessibility.AccessibleTableListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="AccessibleTableListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Accessibility/common/org/eclipse/swt/accessibility/AccessibleTextListener.java" type="org.eclipse.swt.accessibility.AccessibleTextListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="AccessibleTextListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Accessibility/common/org/eclipse/swt/accessibility/AccessibleValueListener.java" type="org.eclipse.swt.accessibility.AccessibleValueListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="AccessibleValueListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Browser/common/org/eclipse/swt/browser/AuthenticationListener.java" type="org.eclipse.swt.browser.AuthenticationListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="AuthenticationListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Browser/common/org/eclipse/swt/browser/CloseWindowListener.java" type="org.eclipse.swt.browser.CloseWindowListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="CloseWindowListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Browser/common/org/eclipse/swt/browser/LocationListener.java" type="org.eclipse.swt.browser.LocationListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="LocationListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Browser/common/org/eclipse/swt/browser/OpenWindowListener.java" type="org.eclipse.swt.browser.OpenWindowListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="OpenWindowListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Browser/common/org/eclipse/swt/browser/ProgressListener.java" type="org.eclipse.swt.browser.ProgressListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="ProgressListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Browser/common/org/eclipse/swt/browser/StatusTextListener.java" type="org.eclipse.swt.browser.StatusTextListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="StatusTextListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Browser/common/org/eclipse/swt/browser/TitleListener.java" type="org.eclipse.swt.browser.TitleListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="TitleListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Browser/common/org/eclipse/swt/browser/VisibilityWindowListener.java" type="org.eclipse.swt.browser.VisibilityWindowListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="VisibilityWindowListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/BidiSegmentListener.java" type="org.eclipse.swt.custom.BidiSegmentListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="BidiSegmentListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CTabFolder2Listener.java" type="org.eclipse.swt.custom.CTabFolder2Listener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="CTabFolder2Listener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CTabFolderListener.java" type="org.eclipse.swt.custom.CTabFolderListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="CTabFolderListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CaretListener.java" type="org.eclipse.swt.custom.CaretListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="CaretListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/ExtendedModifyListener.java" type="org.eclipse.swt.custom.ExtendedModifyListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="ExtendedModifyListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/LineBackgroundListener.java" type="org.eclipse.swt.custom.LineBackgroundListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="LineBackgroundListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/LineStyleListener.java" type="org.eclipse.swt.custom.LineStyleListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="LineStyleListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/MovementListener.java" type="org.eclipse.swt.custom.MovementListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="MovementListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/PaintObjectListener.java" type="org.eclipse.swt.custom.PaintObjectListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="PaintObjectListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/TextChangeListener.java" type="org.eclipse.swt.custom.TextChangeListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="TextChangeListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/VerifyKeyListener.java" type="org.eclipse.swt.custom.VerifyKeyListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="VerifyKeyListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+	<resource path="Eclipse SWT/common/org/eclipse/swt/graphics/ImageGcDrawer.java" type="org.eclipse.swt.graphics.ImageGcDrawer">
+        <filter id="404000815">
+            <message_arguments>
+                <message_argument value="org.eclipse.swt.graphics.ImageGcDrawer"/>
+                <message_argument value="getGcStyle()"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Drag and Drop/common/org/eclipse/swt/dnd/DragSourceListener.java" type="org.eclipse.swt.dnd.DragSourceListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="DragSourceListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Drag and Drop/common/org/eclipse/swt/dnd/DropTargetListener.java" type="org.eclipse.swt.dnd.DropTargetListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="DropTargetListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/ArmListener.java" type="org.eclipse.swt.events.ArmListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="ArmListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/ControlListener.java" type="org.eclipse.swt.events.ControlListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="ControlListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/DisposeListener.java" type="org.eclipse.swt.events.DisposeListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="DisposeListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/DragDetectListener.java" type="org.eclipse.swt.events.DragDetectListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="DragDetectListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/ExpandListener.java" type="org.eclipse.swt.events.ExpandListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="ExpandListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/FocusListener.java" type="org.eclipse.swt.events.FocusListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="FocusListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/GestureListener.java" type="org.eclipse.swt.events.GestureListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="GestureListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/HelpListener.java" type="org.eclipse.swt.events.HelpListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="HelpListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/KeyListener.java" type="org.eclipse.swt.events.KeyListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="KeyListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/MenuDetectListener.java" type="org.eclipse.swt.events.MenuDetectListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="MenuDetectListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/MenuListener.java" type="org.eclipse.swt.events.MenuListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="MenuListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/ModifyListener.java" type="org.eclipse.swt.events.ModifyListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="ModifyListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/MouseListener.java" type="org.eclipse.swt.events.MouseListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="MouseListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/MouseMoveListener.java" type="org.eclipse.swt.events.MouseMoveListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="MouseMoveListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/MouseTrackListener.java" type="org.eclipse.swt.events.MouseTrackListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="MouseTrackListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/MouseWheelListener.java" type="org.eclipse.swt.events.MouseWheelListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="MouseWheelListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/PaintListener.java" type="org.eclipse.swt.events.PaintListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="PaintListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/SegmentListener.java" type="org.eclipse.swt.events.SegmentListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="SegmentListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/SelectionListener.java" type="org.eclipse.swt.events.SelectionListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="SelectionListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/ShellListener.java" type="org.eclipse.swt.events.ShellListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="ShellListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/TouchListener.java" type="org.eclipse.swt.events.TouchListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="TouchListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/TraverseListener.java" type="org.eclipse.swt.events.TraverseListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="TraverseListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/TreeListener.java" type="org.eclipse.swt.events.TreeListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="TreeListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/VerifyListener.java" type="org.eclipse.swt.events.VerifyListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="VerifyListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/graphics/ImageLoaderListener.java" type="org.eclipse.swt.graphics.ImageLoaderListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="ImageLoaderListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/widgets/TypedListener.java" type="org.eclipse.swt.widgets.TypedListener">
+        <filter comment="Class declared as internal in its JavaDoc since ever." id="336744520">
+            <message_arguments>
+                <message_argument value="@noextend"/>
+                <message_argument value="org.eclipse.swt.widgets.TypedListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/gtk/org/eclipse/swt/widgets/Composite.java" type="org.eclipse.swt.widgets.Composite">
+        <filter id="576778288">
+            <message_arguments>
+                <message_argument value="Scrollable"/>
+                <message_argument value="Composite"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/SWT.java" type="org.eclipse.swt.SWT">
+        <filter id="336658481">
+            <message_arguments>
+                <message_argument value="org.eclipse.swt.SWT"/>
+                <message_argument value="IE"/>
+            </message_arguments>
+        </filter>
+        <filter id="336658481">
+            <message_arguments>
+                <message_argument value="org.eclipse.swt.SWT"/>
+                <message_argument value="NO_SEARCH"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="META-INF/MANIFEST.MF">
+        <filter id="926941240">
+            <message_arguments>
+                <message_argument value="3.130.0"/>
+                <message_argument value="3.129.0"/>
+            </message_arguments>
+        </filter>
+    </resource>
+</component>

--- a/binaries/org.eclipse.swt.gtk.freebsd.aarch64/META-INF/MANIFEST.MF
+++ b/binaries/org.eclipse.swt.gtk.freebsd.aarch64/META-INF/MANIFEST.MF
@@ -1,0 +1,35 @@
+Manifest-Version: 1.0
+Fragment-Host: org.eclipse.swt;bundle-version="[3.128.0,4.0.0)"
+Bundle-Name: %fragmentName
+Bundle-Vendor: %providerName
+Bundle-SymbolicName: org.eclipse.swt.gtk.freebsd.aarch64; singleton:=true
+Bundle-Version: 3.130.0.qualifier
+Bundle-ManifestVersion: 2
+Bundle-Localization: fragment
+Export-Package: 
+ org.eclipse.swt,
+ org.eclipse.swt.accessibility,
+ org.eclipse.swt.awt,
+ org.eclipse.swt.browser,
+ org.eclipse.swt.custom,
+ org.eclipse.swt.dnd,
+ org.eclipse.swt.events,
+ org.eclipse.swt.graphics,
+ org.eclipse.swt.layout,
+ org.eclipse.swt.opengl,
+ org.eclipse.swt.printing,
+ org.eclipse.swt.program,
+ org.eclipse.swt.widgets,
+ org.eclipse.swt.internal; x-friends:="org.eclipse.ui",
+ org.eclipse.swt.internal.image; x-internal:=true,
+ org.eclipse.swt.internal.accessibility.gtk; x-internal:=true,
+ org.eclipse.swt.internal.cairo; x-internal:=true,
+ org.eclipse.swt.internal.gtk; x-internal:=true,
+ org.eclipse.swt.internal.gtk3; x-internal:=true,
+ org.eclipse.swt.internal.gtk4; x-internal:=true,
+ org.eclipse.swt.internal.opengl.glx; x-internal:=true
+Eclipse-PlatformFilter: (& (osgi.ws=gtk) (osgi.os=freebsd) (osgi.arch=aarch64))
+SWT-WS: gtk
+SWT-OS: freebsd
+SWT-Arch: aarch64
+Automatic-Module-Name: org.eclipse.swt.gtk.freebsd.aarch64

--- a/binaries/org.eclipse.swt.gtk.freebsd.aarch64/build.properties
+++ b/binaries/org.eclipse.swt.gtk.freebsd.aarch64/build.properties
@@ -1,0 +1,48 @@
+###############################################################################
+# Copyright (c) 2015, 2025 Red Hat Inc. and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     Alexander Kurtakov, Red Hat, Inc.- initial API and implementation
+#     Hannes Wellmann - Leverage Tycho pomless
+#     Tue Ton - support for FreeBSD
+###############################################################################
+custom = true
+bin.includes = .,*.so,fragment.properties
+bin.excludes = library/
+source.. = \
+	../legal_files/gtk.linux,\
+	../../bundles/org.eclipse.swt/Eclipse SWT/gtk,\
+	../../bundles/org.eclipse.swt/Eclipse SWT/cairo,\
+	../../bundles/org.eclipse.swt/Eclipse SWT/emulated/bidi,\
+	../../bundles/org.eclipse.swt/Eclipse SWT/emulated/coolbar,\
+	../../bundles/org.eclipse.swt/Eclipse SWT/emulated/taskbar,\
+	../../bundles/org.eclipse.swt/Eclipse SWT/common,\
+	../../bundles/org.eclipse.swt/Eclipse SWT PI/gtk,\
+	../../bundles/org.eclipse.swt/Eclipse SWT PI/cairo,\
+	../../bundles/org.eclipse.swt/Eclipse SWT PI/common,\
+	../../bundles/org.eclipse.swt/Eclipse SWT Accessibility/gtk,\
+	../../bundles/org.eclipse.swt/Eclipse SWT Accessibility/common,\
+	../../bundles/org.eclipse.swt/Eclipse SWT AWT/gtk,\
+	../../bundles/org.eclipse.swt/Eclipse SWT AWT/common,\
+	../../bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/gtk,\
+	../../bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/common,\
+	../../bundles/org.eclipse.swt/Eclipse SWT Printing/gtk,\
+	../../bundles/org.eclipse.swt/Eclipse SWT Printing/common,\
+	../../bundles/org.eclipse.swt/Eclipse SWT Program/gtk,\
+	../../bundles/org.eclipse.swt/Eclipse SWT Program/common,\
+	../../bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common,\
+	../../bundles/org.eclipse.swt/Eclipse SWT Browser/common,\
+	../../bundles/org.eclipse.swt/Eclipse SWT Browser/gtk,\
+	../../bundles/org.eclipse.swt/Eclipse SWT OpenGL/gtk,\
+	../../bundles/org.eclipse.swt/Eclipse SWT OpenGL/glx,\
+	../../bundles/org.eclipse.swt/Eclipse SWT OpenGL/common,\
+	../../bundles/org.eclipse.swt/Eclipse SWT WebKit/gtk
+output.. = bin/
+
+pom.model.property.os=freebsd
+pom.model.property.ws=gtk
+pom.model.property.arch=aarch64

--- a/binaries/org.eclipse.swt.gtk.freebsd.aarch64/fragment.properties
+++ b/binaries/org.eclipse.swt.gtk.freebsd.aarch64/fragment.properties
@@ -1,0 +1,13 @@
+###############################################################################
+# Copyright (c) 2015, 2025 Red Hat Inc. and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     Alexander Kurtakov, Red Hat, Inc.- initial API and implementation
+#     Tue Ton - support for FreeBSD
+###############################################################################
+fragmentName = Standard Widget Toolkit for GTK on aarch64
+providerName = Eclipse.org

--- a/binaries/org.eclipse.swt.gtk.freebsd.x86_64/.project
+++ b/binaries/org.eclipse.swt.gtk.freebsd.x86_64/.project
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>org.eclipse.swt.gtk.freebsd.x86_64</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ManifestBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.SchemaBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.api.tools.apiAnalysisBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>org.eclipse.pde.PluginNature</nature>
+		<nature>org.eclipse.pde.api.tools.apiAnalysisNature</nature>
+	</natures>
+	<linkedResources>
+		<link>
+			<name>.classpath</name>
+			<type>1</type>
+			<locationURI>PARENT-1-PROJECT_LOC/.classpath_gtk</locationURI>
+		</link>
+		<link>
+			<name>.settings/.api_filters</name>
+			<type>1</type>
+			<locationURI>PROJECT_LOC/.settings/.api_filters</locationURI>
+		</link>
+		<link>
+			<name>.settings</name>
+			<type>2</type>
+			<locationURI>PARENT-1-PROJECT_LOC/.settings</locationURI>
+		</link>
+		<link>
+			<name>Eclipse SWT</name>
+			<type>2</type>
+			<locationURI>SWT_HOST_PLUGIN/Eclipse%20SWT</locationURI>
+		</link>
+		<link>
+			<name>Eclipse SWT Accessibility</name>
+			<type>2</type>
+			<locationURI>SWT_HOST_PLUGIN/Eclipse%20SWT%20Accessibility</locationURI>
+		</link>
+		<link>
+			<name>Eclipse SWT AWT</name>
+			<type>2</type>
+			<locationURI>SWT_HOST_PLUGIN/Eclipse%20SWT%20AWT</locationURI>
+		</link>
+		<link>
+			<name>Eclipse SWT Browser</name>
+			<type>2</type>
+			<locationURI>SWT_HOST_PLUGIN/Eclipse%20SWT%20Browser</locationURI>
+		</link>
+		<link>
+			<name>Eclipse SWT Custom Widgets</name>
+			<type>2</type>
+			<locationURI>SWT_HOST_PLUGIN/Eclipse%20SWT%20Custom%20Widgets</locationURI>
+		</link>
+		<link>
+			<name>Eclipse SWT Drag and Drop</name>
+			<type>2</type>
+			<locationURI>SWT_HOST_PLUGIN/Eclipse%20SWT%20Drag%20and%20Drop</locationURI>
+		</link>
+		<link>
+			<name>Eclipse SWT OLE Win32</name>
+			<type>2</type>
+			<locationURI>SWT_HOST_PLUGIN/Eclipse%20SWT%20OLE%20Win32</locationURI>
+		</link>
+		<link>
+			<name>Eclipse SWT OpenGL</name>
+			<type>2</type>
+			<locationURI>SWT_HOST_PLUGIN/Eclipse%20SWT%20OpenGL</locationURI>
+		</link>
+		<link>
+			<name>Eclipse SWT PI</name>
+			<type>2</type>
+			<locationURI>SWT_HOST_PLUGIN/Eclipse%20SWT%20PI</locationURI>
+		</link>
+		<link>
+			<name>Eclipse SWT Printing</name>
+			<type>2</type>
+			<locationURI>SWT_HOST_PLUGIN/Eclipse%20SWT%20Printing</locationURI>
+		</link>
+		<link>
+			<name>Eclipse SWT Program</name>
+			<type>2</type>
+			<locationURI>SWT_HOST_PLUGIN/Eclipse%20SWT%20Program</locationURI>
+		</link>
+		<link>
+			<name>Eclipse SWT WebKit</name>
+			<type>2</type>
+			<locationURI>SWT_HOST_PLUGIN/Eclipse%20SWT%20WebKit</locationURI>
+		</link>
+	</linkedResources>
+	<variableList>
+		<variable>
+			<name>SWT_HOST_PLUGIN</name>
+			<value>$%7BPARENT-2-PROJECT_LOC%7D/bundles/org.eclipse.swt</value>
+		</variable>
+	</variableList>
+</projectDescription>

--- a/binaries/org.eclipse.swt.gtk.freebsd.x86_64/.settings/.api_filters
+++ b/binaries/org.eclipse.swt.gtk.freebsd.x86_64/.settings/.api_filters
@@ -1,0 +1,497 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<component id="org.eclipse.swt.gtk.linux.x86_64" version="2">
+    <resource path="Eclipse SWT Accessibility/common/org/eclipse/swt/accessibility/AccessibleActionListener.java" type="org.eclipse.swt.accessibility.AccessibleActionListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="AccessibleActionListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Accessibility/common/org/eclipse/swt/accessibility/AccessibleAttributeListener.java" type="org.eclipse.swt.accessibility.AccessibleAttributeListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="AccessibleAttributeListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Accessibility/common/org/eclipse/swt/accessibility/AccessibleControlListener.java" type="org.eclipse.swt.accessibility.AccessibleControlListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="AccessibleControlListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Accessibility/common/org/eclipse/swt/accessibility/AccessibleEditableTextListener.java" type="org.eclipse.swt.accessibility.AccessibleEditableTextListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="AccessibleEditableTextListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Accessibility/common/org/eclipse/swt/accessibility/AccessibleHyperlinkListener.java" type="org.eclipse.swt.accessibility.AccessibleHyperlinkListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="AccessibleHyperlinkListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Accessibility/common/org/eclipse/swt/accessibility/AccessibleListener.java" type="org.eclipse.swt.accessibility.AccessibleListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="AccessibleListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Accessibility/common/org/eclipse/swt/accessibility/AccessibleTableCellListener.java" type="org.eclipse.swt.accessibility.AccessibleTableCellListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="AccessibleTableCellListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Accessibility/common/org/eclipse/swt/accessibility/AccessibleTableListener.java" type="org.eclipse.swt.accessibility.AccessibleTableListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="AccessibleTableListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Accessibility/common/org/eclipse/swt/accessibility/AccessibleTextListener.java" type="org.eclipse.swt.accessibility.AccessibleTextListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="AccessibleTextListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Accessibility/common/org/eclipse/swt/accessibility/AccessibleValueListener.java" type="org.eclipse.swt.accessibility.AccessibleValueListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="AccessibleValueListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Browser/common/org/eclipse/swt/browser/AuthenticationListener.java" type="org.eclipse.swt.browser.AuthenticationListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="AuthenticationListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Browser/common/org/eclipse/swt/browser/CloseWindowListener.java" type="org.eclipse.swt.browser.CloseWindowListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="CloseWindowListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Browser/common/org/eclipse/swt/browser/LocationListener.java" type="org.eclipse.swt.browser.LocationListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="LocationListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Browser/common/org/eclipse/swt/browser/OpenWindowListener.java" type="org.eclipse.swt.browser.OpenWindowListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="OpenWindowListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Browser/common/org/eclipse/swt/browser/ProgressListener.java" type="org.eclipse.swt.browser.ProgressListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="ProgressListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Browser/common/org/eclipse/swt/browser/StatusTextListener.java" type="org.eclipse.swt.browser.StatusTextListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="StatusTextListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Browser/common/org/eclipse/swt/browser/TitleListener.java" type="org.eclipse.swt.browser.TitleListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="TitleListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Browser/common/org/eclipse/swt/browser/VisibilityWindowListener.java" type="org.eclipse.swt.browser.VisibilityWindowListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="VisibilityWindowListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/BidiSegmentListener.java" type="org.eclipse.swt.custom.BidiSegmentListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="BidiSegmentListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CTabFolder2Listener.java" type="org.eclipse.swt.custom.CTabFolder2Listener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="CTabFolder2Listener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CTabFolderListener.java" type="org.eclipse.swt.custom.CTabFolderListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="CTabFolderListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CaretListener.java" type="org.eclipse.swt.custom.CaretListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="CaretListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/ExtendedModifyListener.java" type="org.eclipse.swt.custom.ExtendedModifyListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="ExtendedModifyListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/LineBackgroundListener.java" type="org.eclipse.swt.custom.LineBackgroundListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="LineBackgroundListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/LineStyleListener.java" type="org.eclipse.swt.custom.LineStyleListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="LineStyleListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/MovementListener.java" type="org.eclipse.swt.custom.MovementListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="MovementListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/PaintObjectListener.java" type="org.eclipse.swt.custom.PaintObjectListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="PaintObjectListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/TextChangeListener.java" type="org.eclipse.swt.custom.TextChangeListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="TextChangeListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/VerifyKeyListener.java" type="org.eclipse.swt.custom.VerifyKeyListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="VerifyKeyListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+	<resource path="Eclipse SWT/common/org/eclipse/swt/graphics/ImageGcDrawer.java" type="org.eclipse.swt.graphics.ImageGcDrawer">
+        <filter id="404000815">
+            <message_arguments>
+                <message_argument value="org.eclipse.swt.graphics.ImageGcDrawer"/>
+                <message_argument value="getGcStyle()"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Drag and Drop/common/org/eclipse/swt/dnd/DragSourceListener.java" type="org.eclipse.swt.dnd.DragSourceListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="DragSourceListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT Drag and Drop/common/org/eclipse/swt/dnd/DropTargetListener.java" type="org.eclipse.swt.dnd.DropTargetListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="DropTargetListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/ArmListener.java" type="org.eclipse.swt.events.ArmListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="ArmListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/ControlListener.java" type="org.eclipse.swt.events.ControlListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="ControlListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/DisposeListener.java" type="org.eclipse.swt.events.DisposeListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="DisposeListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/DragDetectListener.java" type="org.eclipse.swt.events.DragDetectListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="DragDetectListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/ExpandListener.java" type="org.eclipse.swt.events.ExpandListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="ExpandListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/FocusListener.java" type="org.eclipse.swt.events.FocusListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="FocusListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/GestureListener.java" type="org.eclipse.swt.events.GestureListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="GestureListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/HelpListener.java" type="org.eclipse.swt.events.HelpListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="HelpListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/KeyListener.java" type="org.eclipse.swt.events.KeyListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="KeyListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/MenuDetectListener.java" type="org.eclipse.swt.events.MenuDetectListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="MenuDetectListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/MenuListener.java" type="org.eclipse.swt.events.MenuListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="MenuListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/ModifyListener.java" type="org.eclipse.swt.events.ModifyListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="ModifyListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/MouseListener.java" type="org.eclipse.swt.events.MouseListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="MouseListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/MouseMoveListener.java" type="org.eclipse.swt.events.MouseMoveListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="MouseMoveListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/MouseTrackListener.java" type="org.eclipse.swt.events.MouseTrackListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="MouseTrackListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/MouseWheelListener.java" type="org.eclipse.swt.events.MouseWheelListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="MouseWheelListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/PaintListener.java" type="org.eclipse.swt.events.PaintListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="PaintListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/SegmentListener.java" type="org.eclipse.swt.events.SegmentListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="SegmentListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/SelectionListener.java" type="org.eclipse.swt.events.SelectionListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="SelectionListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/ShellListener.java" type="org.eclipse.swt.events.ShellListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="ShellListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/TouchListener.java" type="org.eclipse.swt.events.TouchListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="TouchListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/TraverseListener.java" type="org.eclipse.swt.events.TraverseListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="TraverseListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/TreeListener.java" type="org.eclipse.swt.events.TreeListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="TreeListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/events/VerifyListener.java" type="org.eclipse.swt.events.VerifyListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="VerifyListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/graphics/ImageLoaderListener.java" type="org.eclipse.swt.graphics.ImageLoaderListener">
+        <filter id="576720909">
+            <message_arguments>
+                <message_argument value="SWTEventListener"/>
+                <message_argument value="ImageLoaderListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/widgets/TypedListener.java" type="org.eclipse.swt.widgets.TypedListener">
+        <filter comment="Class declared as internal in its JavaDoc since ever." id="336744520">
+            <message_arguments>
+                <message_argument value="@noextend"/>
+                <message_argument value="org.eclipse.swt.widgets.TypedListener"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/gtk/org/eclipse/swt/widgets/Composite.java" type="org.eclipse.swt.widgets.Composite">
+        <filter id="576778288">
+            <message_arguments>
+                <message_argument value="Scrollable"/>
+                <message_argument value="Composite"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/SWT.java" type="org.eclipse.swt.SWT">
+        <filter id="336658481">
+            <message_arguments>
+                <message_argument value="org.eclipse.swt.SWT"/>
+                <message_argument value="IE"/>
+            </message_arguments>
+        </filter>
+        <filter id="336658481">
+            <message_arguments>
+                <message_argument value="org.eclipse.swt.SWT"/>
+                <message_argument value="NO_SEARCH"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="META-INF/MANIFEST.MF">
+        <filter id="926941240">
+            <message_arguments>
+                <message_argument value="3.130.0"/>
+                <message_argument value="3.129.0"/>
+            </message_arguments>
+        </filter>
+    </resource>
+</component>

--- a/binaries/org.eclipse.swt.gtk.freebsd.x86_64/META-INF/MANIFEST.MF
+++ b/binaries/org.eclipse.swt.gtk.freebsd.x86_64/META-INF/MANIFEST.MF
@@ -1,0 +1,35 @@
+Manifest-Version: 1.0
+Fragment-Host: org.eclipse.swt;bundle-version="[3.128.0,4.0.0)"
+Bundle-Name: %fragmentName
+Bundle-Vendor: %providerName
+Bundle-SymbolicName: org.eclipse.swt.gtk.freebsd.x86_64; singleton:=true
+Bundle-Version: 3.130.0.qualifier
+Bundle-ManifestVersion: 2
+Bundle-Localization: fragment
+Export-Package: 
+ org.eclipse.swt,
+ org.eclipse.swt.accessibility,
+ org.eclipse.swt.awt,
+ org.eclipse.swt.browser,
+ org.eclipse.swt.custom,
+ org.eclipse.swt.dnd,
+ org.eclipse.swt.events,
+ org.eclipse.swt.graphics,
+ org.eclipse.swt.layout,
+ org.eclipse.swt.opengl,
+ org.eclipse.swt.printing,
+ org.eclipse.swt.program,
+ org.eclipse.swt.widgets,
+ org.eclipse.swt.internal; x-friends:="org.eclipse.ui",
+ org.eclipse.swt.internal.image; x-internal:=true,
+ org.eclipse.swt.internal.accessibility.gtk; x-internal:=true,
+ org.eclipse.swt.internal.cairo; x-internal:=true,
+ org.eclipse.swt.internal.gtk; x-internal:=true,
+ org.eclipse.swt.internal.gtk3; x-internal:=true,
+ org.eclipse.swt.internal.gtk4; x-internal:=true,
+ org.eclipse.swt.internal.opengl.glx; x-internal:=true
+Eclipse-PlatformFilter: (& (osgi.ws=gtk) (osgi.os=freebsd) (osgi.arch=x86_64))
+SWT-WS: gtk
+SWT-OS: freebsd
+SWT-Arch: x86_64
+Automatic-Module-Name: org.eclipse.swt.gtk.freebsd.x86_64

--- a/binaries/org.eclipse.swt.gtk.freebsd.x86_64/build.properties
+++ b/binaries/org.eclipse.swt.gtk.freebsd.x86_64/build.properties
@@ -1,0 +1,49 @@
+###############################################################################
+# Copyright (c) 2000, 2025 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+#     Krzysztof Daniel, Red Hat, Inc. - tycho enablement
+#     Hannes Wellmann - Leverage Tycho pomless
+#     Tue Ton - support for FreeBSD
+###############################################################################
+custom = true
+bin.includes = .,*.so,fragment.properties
+bin.excludes = library/
+source.. = \
+	../legal_files/gtk.linux,\
+	../../bundles/org.eclipse.swt/Eclipse SWT/gtk,\
+	../../bundles/org.eclipse.swt/Eclipse SWT/cairo,\
+	../../bundles/org.eclipse.swt/Eclipse SWT/emulated/bidi,\
+	../../bundles/org.eclipse.swt/Eclipse SWT/emulated/coolbar,\
+	../../bundles/org.eclipse.swt/Eclipse SWT/emulated/taskbar,\
+	../../bundles/org.eclipse.swt/Eclipse SWT/common,\
+	../../bundles/org.eclipse.swt/Eclipse SWT PI/gtk,\
+	../../bundles/org.eclipse.swt/Eclipse SWT PI/cairo,\
+	../../bundles/org.eclipse.swt/Eclipse SWT PI/common,\
+	../../bundles/org.eclipse.swt/Eclipse SWT Accessibility/gtk,\
+	../../bundles/org.eclipse.swt/Eclipse SWT Accessibility/common,\
+	../../bundles/org.eclipse.swt/Eclipse SWT AWT/gtk,\
+	../../bundles/org.eclipse.swt/Eclipse SWT AWT/common,\
+	../../bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/gtk,\
+	../../bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/common,\
+	../../bundles/org.eclipse.swt/Eclipse SWT Printing/gtk,\
+	../../bundles/org.eclipse.swt/Eclipse SWT Printing/common,\
+	../../bundles/org.eclipse.swt/Eclipse SWT Program/gtk,\
+	../../bundles/org.eclipse.swt/Eclipse SWT Program/common,\
+	../../bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common,\
+	../../bundles/org.eclipse.swt/Eclipse SWT Browser/common,\
+	../../bundles/org.eclipse.swt/Eclipse SWT Browser/gtk,\
+	../../bundles/org.eclipse.swt/Eclipse SWT OpenGL/gtk,\
+	../../bundles/org.eclipse.swt/Eclipse SWT OpenGL/glx,\
+	../../bundles/org.eclipse.swt/Eclipse SWT OpenGL/common,\
+	../../bundles/org.eclipse.swt/Eclipse SWT WebKit/gtk
+output.. = bin/
+
+pom.model.property.os=freebsd
+pom.model.property.ws=gtk
+pom.model.property.arch=x86_64

--- a/binaries/org.eclipse.swt.gtk.freebsd.x86_64/fragment.properties
+++ b/binaries/org.eclipse.swt.gtk.freebsd.x86_64/fragment.properties
@@ -1,0 +1,13 @@
+###############################################################################
+# Copyright (c) 2000, 2025 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+#     Tue Ton - support for FreeBSD
+###############################################################################
+fragmentName = Standard Widget Toolkit for GTK on x86_64
+providerName = Eclipse.org

--- a/binaries/pom.xml
+++ b/binaries/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
 ###############################################################################
-# Copyright (c) 2024, 2024 Hannes Wellmann and others.
+# Copyright (c) 2024, 2025 Hannes Wellmann and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -9,6 +9,7 @@
 #
 # Contributors:
 #     Hannes Wellmann - initial API and implementation
+#     Tue Ton - support for FreeBSD
 ###############################################################################
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
@@ -34,6 +35,8 @@
 	<modules>
 		<module>org.eclipse.swt.cocoa.macosx.x86_64</module>
 		<module>org.eclipse.swt.cocoa.macosx.aarch64</module>
+		<module>org.eclipse.swt.gtk.freebsd.aarch64</module>
+		<module>org.eclipse.swt.gtk.freebsd.x86_64</module>
 		<module>org.eclipse.swt.gtk.linux.aarch64</module>
 		<module>org.eclipse.swt.gtk.linux.ppc64le</module>
 		<module>org.eclipse.swt.gtk.linux.riscv64</module>

--- a/bundles/org.eclipse.swt.tools/Oomph/platformSwt.setup
+++ b/bundles/org.eclipse.swt.tools/Oomph/platformSwt.setup
@@ -74,7 +74,7 @@
                 xsi:type="predicates:OrPredicate">
               <operand
                   xsi:type="predicates:NamePredicate"
-                  pattern=".*(cocoa|gtk|win32)(\.(macosx|aix|hpux|linux|solaris|win32)(\.(x86_64|ppc64|ia64|aarch64|arm|ppc64|ppc64le|s390|s390x|x86|sparcv9))?)?"/>
+                  pattern=".*(cocoa|gtk|win32)(\.(freebsd|macosx|aix|hpux|linux|solaris|win32)(\.(x86_64|ia64|aarch64|arm|ppc64|ppc64le|s390|s390x|x86|sparcv9))?)?"/>
               <operand
                   xsi:type="predicates:NamePredicate"
                   pattern="org\.eclipse\.swt\.opengl\.examples">

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/common/org/eclipse/swt/internal/Library.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/common/org/eclipse/swt/internal/Library.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2022 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -10,6 +10,7 @@
  *
  * Contributors:
  *     IBM Corporation - initial API and implementation
+ *     Tue Ton - support for FreeBSD
  *******************************************************************************/
 package org.eclipse.swt.internal;
 
@@ -69,12 +70,14 @@ static {
 static String arch() {
 	String osArch = System.getProperty("os.arch"); //$NON-NLS-1$
 	if (osArch.equals ("amd64")) return "x86_64"; //$NON-NLS-1$ $NON-NLS-2$
+	if (osArch.equals ("arm64")) return "aarch64"; //$NON-NLS-1$ $NON-NLS-2$
 	return osArch;
 }
 
 static String os() {
 	String osName = System.getProperty("os.name"); //$NON-NLS-1$
 	if (osName.equals ("Linux")) return "linux"; //$NON-NLS-1$ $NON-NLS-2$
+	if (osName.equals ("FreeBSD")) return "freebsd"; //$NON-NLS-1$ $NON-NLS-2$
 	if (osName.equals ("Mac OS X")) return "macosx"; //$NON-NLS-1$ $NON-NLS-2$
 	if (osName.startsWith ("Win")) return "win32"; //$NON-NLS-1$ $NON-NLS-2$
 	return osName;

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/make_unix.mak
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/make_unix.mak
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2000, 2016 IBM Corporation and others.
+# Copyright (c) 2000, 2025 IBM Corporation and others.
 #
 # This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
@@ -10,9 +10,10 @@
 #
 # Contributors:
 #     IBM Corporation - initial API and implementation
+#     Tue Ton - support for FreeBSD
 #*******************************************************************************
 
-# Makefile for creating SWT libraries for Linux GTK
+# Makefile for creating SWT libraries for Linux & FreeBSD GTK
 
 # assumes these variables are set in the environment from which make is run
 #	SWT_JAVA_HOME
@@ -102,12 +103,30 @@ GLX_OBJECTS = swt.o glx.o glx_structs.o glx_stats.o
 CFLAGS := $(CFLAGS) \
 		$(SWT_DEBUG) \
 		$(SWT_WEBKIT_DEBUG) \
-		-DLINUX -DGTK \
+		-DGTK \
 		-I$(SWT_JAVA_HOME)/include \
-		-I$(SWT_JAVA_HOME)/include/linux \
 		-std=gnu17 \
 		${SWT_PTR_CFLAGS}
 LFLAGS = -shared -fPIC ${SWT_LFLAGS}
+
+ifdef FREEBSD_OS
+ifeq ($(GTK_VERSION), 4.0)
+freebsd_gtk_prefix = `pkg-config --variable=prefix gtk4`
+else
+freebsd_gtk_prefix = `pkg-config --variable=prefix gtk+-3.0`
+endif
+CFLAGS := $(CFLAGS) \
+		-DFREEBSD \
+		-Wno-deprecated-non-prototype \
+		-Wno-deprecated-declarations \
+		-I$(freebsd_gtk_prefix)/include \
+		-I$(SWT_JAVA_HOME)/include/freebsd
+LFLAGS := $(LFLAGS) -L$(freebsd_gtk_prefix)/lib
+else
+CFLAGS := $(CFLAGS) \
+		-DLINUX \
+		-I$(SWT_JAVA_HOME)/include/linux
+endif
 
 # Treat all warnings as errors. If your new code produces a warning, please
 # take time to properly understand and fix/silence it as necessary.

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/org/eclipse/swt/internal/gtk/OS.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/org/eclipse/swt/internal/gtk/OS.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2024 IBM Corporation and others. All rights reserved.
+ * Copyright (c) 2000, 2025 IBM Corporation and others. All rights reserved.
  * The contents of this file are made available under the terms
  * of the GNU Lesser General Public License (LGPL) Version 2.1 that
  * accompanies this distribution (lgpl-v21.txt).  The LGPL is also
@@ -11,6 +11,7 @@
  *
  * Contributors:
  *     IBM Corporation - initial API and implementation
+ *     Tue Ton - suport for FreeBSD
  *******************************************************************************/
 package org.eclipse.swt.internal.gtk;
 
@@ -60,15 +61,16 @@ import org.eclipse.swt.internal.*;
  */
 public class OS extends C {
 	/** OS Constants */
-	public static final boolean IsLinux, IsWin32, BIG_ENDIAN;
+	public static final boolean IsFreeBSD, IsLinux, IsWin32, BIG_ENDIAN;
 	static {
 
 		/* Initialize the OS flags and locale constants */
 		String osName = System.getProperty ("os.name");
-		boolean isLinux = false, isWin32 = false;
+		boolean isFreeBSD = false, isLinux = false, isWin32 = false;
+		if (osName.equals ("FreeBSD")) isFreeBSD = true;
 		if (osName.equals ("Linux")) isLinux = true;
 		if (osName.startsWith("Windows")) isWin32 = true;
-		IsLinux = isLinux;  IsWin32 = isWin32;
+		IsFreeBSD = isFreeBSD; IsLinux = isLinux;  IsWin32 = isWin32;
 
 		byte[] buffer = new byte[4];
 		long ptr = C.malloc(4);

--- a/bundles/org.eclipse.swt/META-INF/p2.inf
+++ b/bundles/org.eclipse.swt/META-INF/p2.inf
@@ -44,3 +44,13 @@ requires.9.namespace = org.eclipse.equinox.p2.iu
 requires.9.name = org.eclipse.swt.gtk.linux.riscv64
 requires.9.range = [$version$,$version$]
 requires.9.filter = (&(osgi.os=linux)(osgi.ws=gtk)(osgi.arch=riscv64)(!(org.eclipse.swt.buildtime=true)))
+
+requires.10.namespace = org.eclipse.equinox.p2.iu
+requires.10.name = org.eclipse.swt.gtk.freebsd.x86_64
+requires.10.range = [$version$,$version$]
+requires.10.filter = (&(osgi.os=freebsd)(osgi.ws=gtk)(osgi.arch=x86_64)(!(org.eclipse.swt.buildtime=true)))
+
+requires.11.namespace = org.eclipse.equinox.p2.iu
+requires.11.name = org.eclipse.swt.gtk.freebsd.aarch64
+requires.11.range = [$version$,$version$]
+requires.11.filter = (&(osgi.os=freebsd)(osgi.ws=gtk)(osgi.arch=aarch64)(!(org.eclipse.swt.buildtime=true)))

--- a/local-build/org.eclipse.swt.fragments.localbuild/META-INF/p2.inf
+++ b/local-build/org.eclipse.swt.fragments.localbuild/META-INF/p2.inf
@@ -38,3 +38,13 @@ requires.8.namespace = org.eclipse.equinox.p2.iu
 requires.8.name = org.eclipse.swt.gtk.linux.riscv64
 requires.8.range = 0.0.0
 requires.8.filter = (&(osgi.os=linux)(osgi.ws=gtk)(osgi.arch=riscv64))
+
+requires.9.namespace = org.eclipse.equinox.p2.iu
+requires.9.name = org.eclipse.swt.gtk.freebsd.x86_64
+requires.9.range = 0.0.0
+requires.9.filter = (&(osgi.os=freebsd)(osgi.ws=gtk)(osgi.arch=x86_64))
+
+requires.10.namespace = org.eclipse.equinox.p2.iu
+requires.10.name = org.eclipse.swt.gtk.freebsd.aarch64
+requires.10.range = 0.0.0
+requires.10.filter = (&(osgi.os=freebsd)(osgi.ws=gtk)(osgi.arch=aarch64))

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright (c) 2012,2024 Eclipse Foundation and others.
+  Copyright (c) 2012, 2025 Eclipse Foundation and others.
   All rights reserved. This program and the accompanying materials
   are made available under the terms of the Eclipse Distribution License v1.0
   which accompanies this distribution, and is available at
@@ -9,6 +9,7 @@
   Contributors:
      Igor Fedorenko - initial implementation
      Conrad Groth - add platform specific JUnit test bundles
+     Tue Ton - support for FreeBSD
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -117,7 +118,6 @@
       <activation>
         <os>
           <family>unix</family>
-          <name>Linux</name>
         </os>
       </activation>
       <modules>
@@ -139,6 +139,11 @@
                   <os>linux</os>
                   <ws>gtk</ws>
                   <arch>ppc64le</arch>
+                </environment>
+                <environment>
+                  <os>freebsd</os>
+                  <ws>gtk</ws>
+                  <arch>x86_64</arch>
                 </environment>
               </environments>
             </configuration>


### PR DESCRIPTION
- part of the overall issue eclipse-platform/eclipse.platform.releng.aggregator#2959
- add 2 SWT binary modules for FreeBSD: `org.eclipse.swt.gtk.freebsd.aarch64` and `org.eclipse.swt.gtk.freebsd.x86_64`
- changes made to the `build.sh` script and _make_linux.mak_ (renamed to `make_unix.mak`) to support compiling FreeBSD native binaries for SWT.

To support cross-compiling from Linux to FreeBSD, for the _same_ hardware architecture, a Docker container is made available in my fork with detailed instructions:
https://github.com/chirontt/eclipse.platform.releng.aggregator/tree/master/cje-production/dockerfiles/alpine/freebsd-cross 
which will be submitted to the official repo at later stage.