### PR TITLE
Preserved width/height on scaleUp/Down a Rectangle

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/DPIUtil.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/DPIUtil.java
@@ -257,6 +257,17 @@ public static Rectangle scaleDown(Rectangle rect, int zoom) {
 	scaledRect.y = scaledTopLeft.y;
 	scaledRect.width = scaledBottomRight.x - scaledTopLeft.x;
 	scaledRect.height = scaledBottomRight.y - scaledTopLeft.y;
+
+	int scaledDownWidth = DPIUtil.scaleDown(rect.width, zoom);
+	int scaledDownHeight = DPIUtil.scaleDown(rect.height, zoom);
+
+	// It must be ensured, that a scaled down width or height
+	// based on Rectangle x or y is not bigger than directly
+	// scaling down the width or height. Therefore the min
+	// value is used
+	scaledRect.width = Math.min(scaledRect.width, scaledDownWidth);
+	scaledRect.height = Math.min(scaledRect.height, scaledDownHeight);
+
 	return scaledRect;
 }
 /**
@@ -464,6 +475,16 @@ public static Rectangle scaleUp(Rectangle rect, int zoom) {
 	scaledRect.y = scaledTopLeft.y;
 	scaledRect.width = scaledBottomRight.x - scaledTopLeft.x;
 	scaledRect.height = scaledBottomRight.y - scaledTopLeft.y;
+
+	int scaledUpWidth = DPIUtil.scaleUp(rect.width, zoom);
+	int scaledUpHeight = DPIUtil.scaleUp(rect.height, zoom);
+
+	// It must be ensured, that a scaled up width or height
+	// based on Rectangle x or y is not smaller that directly
+	// scaling up the width or height. Therefore the max
+	// value is used
+	scaledRect.width = Math.max(scaledRect.width, scaledUpWidth);
+	scaledRect.height = Math.max(scaledRect.height, scaledUpHeight);
 	return scaledRect;
 }
 

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/DPIUtilTests.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/DPIUtilTests.java
@@ -160,7 +160,7 @@ public class DPIUtilTests {
 	@Test
 	public void scaleDownRectangle() {
 		Rectangle valueAt200 = new Rectangle(100, 150, 10, 14);
-		Rectangle valueAt150 = new Rectangle(75, 113, 7, 10);
+		Rectangle valueAt150 = new Rectangle(75, 113, 7, 11);
 		Rectangle valueAt100 = new Rectangle(50, 75, 5, 7);
 
 		Rectangle scaledValue = DPIUtil.autoScaleDown(valueAt200);
@@ -295,7 +295,7 @@ public class DPIUtilTests {
 	@Test
 	public void scaleUpRectangle() {
 		Rectangle valueAt200 = new Rectangle(100, 150, 10, 14);
-		Rectangle valueAt150 = new Rectangle(75, 113, 8, 10);
+		Rectangle valueAt150 = new Rectangle(75, 113, 8, 11);
 		Rectangle valueAt100 = new Rectangle(50, 75, 5, 7);
 
 		Rectangle scaledValue = DPIUtil.autoScaleUp(valueAt100);


### PR DESCRIPTION
This commit extends the logic when a Rectangle is scaled up/down from points to pixels regarding width and height.

Fixes https://github.com/eclipse-platform/eclipse.platform.swt/issues/2003