### PR TITLE
Use auto-scale "nearest" by default in Windows #2910

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/DPIUtil.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/DPIUtil.java
@@ -626,7 +626,10 @@ public static void setDeviceZoom (int nativeDeviceZoom) {
 private static boolean sholdUseSmoothScaling() {
 	return switch (SWT.getPlatform()) {
 	case "gtk" -> deviceZoom / 100 * 100 != deviceZoom;
-	case "win32" -> isMonitorSpecificScalingActive();
+	// FIXME the "win32" case should be uncommented as soon as the issue
+	// https://github.com/eclipse-platform/eclipse.platform.ui/issues/2910
+	// is properly fixed
+	//	case "win32" -> isMonitorSpecificScalingActive();
 	default -> false;
 	};
 }


### PR DESCRIPTION
Defaulting to "smooth" creates blurry images when first displaying the image in a monitor with a high zoom level (e.g. 200%).

This is a temporary workaround until https://github.com/eclipse-platform/eclipse.platform.swt/issues/2052 is properly fixed.

The auto-scale method can still be manually set to "smooth" by setting this VM argument: `-Dswt.autoScale.method=smooth`

## FIXME
This PR is just a workaround and I am only keeping it here in store in case there is no proper fix in time for M2. **I'll keep it drafted until noon but feel free to review now**.

## Screenshots
When starting the workbench in a monitor at 200% zoom level and with _monitor-specific UI scaling_ enabled. (original [screenshots.zip](https://github.com/user-attachments/files/19862188/screenshots.zip))

In green you can see which images look better using the **nearest** scale method (and in rot, the same images when using **smooth** scaling, for comparison).

Auto-scale method **nearest** (the new default when applying this PR)
![image](https://github.com/user-attachments/assets/c334a6d0-c9cb-42e6-b694-c5c06df1f579)

Auto-scale method **smooth** (the previous default)
![image](https://github.com/user-attachments/assets/d2010b5a-6851-4a31-8cc2-a35fe9465ed7)
