### PR TITLE
Use proper classloader for finding SVGRasterizer #1965 #2049

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/image/SVGFileFormat.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/image/SVGFileFormat.java
@@ -31,7 +31,8 @@ import org.eclipse.swt.internal.DPIUtil.*;
 public class SVGFileFormat extends FileFormat {
 
 	/** The instance of the registered {@link SVGRasterizer}. */
-	private static final SVGRasterizer RASTERIZER = ServiceLoader.load(SVGRasterizer.class).findFirst().orElse(null);
+	private static final SVGRasterizer RASTERIZER = ServiceLoader
+			.load(SVGRasterizer.class, SVGFileFormat.class.getClassLoader()).findFirst().orElse(null);
 
 	@Override
 	boolean isFileFormat(LEDataInputStream stream) throws IOException {


### PR DESCRIPTION
When initializing the SVGFileFormat class for loading SVGs, the current context classloader is used by the ServiceLoader to find an SVGRasterizer implementation. This classloader may be incorrect in some cases, i.e., it may not be the plain system classloader or an according OSGi classloader but, e.g., some specific classloader for test execution.

This change makes the ServiceLoader use the same classloader for finding an SVGRasterizer implementation than the classloader of the SVGRasterizer class itself.

Fixes https://github.com/eclipse-platform/eclipse.platform.swt/issues/1965

Fixes https://github.com/eclipse-platform/eclipse.platform.swt/issues/2049

## Remarks

I am not completely sure if this will always yield a "correct" classloader or whether the classloader of the `SVGRasterizer` may also be "wrong".

An alternative might be to force classloading of the `SVGFileFormat` class to happen easly in application lifecycle instead of at first usage where the current context classloader may vary.