### PR TITLE
Support disabling the GTK SessionManagerDBus via environment variables

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/internal/SessionManagerDBus.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/internal/SessionManagerDBus.java
@@ -111,7 +111,8 @@ public class SessionManagerDBus {
 	public SessionManagerDBus() {
 		// Allow to disable session manager, for example in case it conflicts with
 		// session manager connection implemented in application itself.
-		boolean isDisabled = System.getProperty("org.eclipse.swt.internal.SessionManagerDBus.disable") != null;
+		boolean isDisabled = System.getProperty("org.eclipse.swt.internal.SessionManagerDBus.disable") != null
+				|| System.getenv("org.eclipse.swt.internal.SessionManagerDBus.disable") != null;
 		if (isDisabled) return;
 
 		start();


### PR DESCRIPTION
For example this simplifies disabling the `SessionManagerDBus` in CI environments where no bus is available.

At our CI-server, which formally doesn't have an X-Server installed and uses xvnc I see the following warnings:
```
SWT SessionManagerDBus: Failed to connect to org.gnome.SessionManager: Failed to execute child process “dbus-launch” (No such file or directory)
SWT SessionManagerDBus: Failed to connect to org.xfce.SessionManager: Failed to execute child process “dbus-launch” (No such file or directory)
```

Setting the system-property `org.eclipse.swt.internal.SessionManagerDBus.disable` disables the `SessionManagerDBus` right from the start and prevents these warnings. But I have to set that system-property in the Maven/Tycho pom.xml as well as in all headless eclipse executions we run in our build.
It would be more convenient, if I can just set an environment property for the entire pipeline that would be used as proposed here.

