### PR TITLE
[GTK] Stop using DPIUtil (take 2)

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Composite.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Composite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -266,7 +266,7 @@ Point computeSizeInPixels (int wHint, int hHint, boolean changed) {
 	if (layout != null) {
 		if (wHint == SWT.DEFAULT || hHint == SWT.DEFAULT) {
 			changed |= (state & LAYOUT_CHANGED) != 0;
-			size = DPIUtil.autoScaleUp(layout.computeSize (this, DPIUtil.autoScaleDown(wHint), DPIUtil.autoScaleDown(hHint), changed));
+			size = layout.computeSize (this, wHint, hHint, changed);
 			state &= ~LAYOUT_CHANGED;
 		} else {
 			size = new Point (wHint, hHint);
@@ -278,7 +278,7 @@ Point computeSizeInPixels (int wHint, int hHint, boolean changed) {
 	}
 	if (wHint != SWT.DEFAULT) size.x = wHint;
 	if (hHint != SWT.DEFAULT) size.y = hHint;
-	Rectangle trim = DPIUtil.autoScaleUp (computeTrim (0, 0, DPIUtil.autoScaleDown(size.x), DPIUtil.autoScaleDown(size.y)));
+	Rectangle trim = computeTrim (0, 0, size.x, size.y);
 	return new Point (trim.width, trim.height);
 }
 
@@ -550,9 +550,7 @@ void deregister () {
  */
 public void drawBackground (GC gc, int x, int y, int width, int height, int offsetX, int offsetY) {
 	checkWidget();
-	Rectangle rect = DPIUtil.autoScaleUp(new Rectangle (x, y, width, height));
-	offsetX = DPIUtil.autoScaleUp(offsetX);
-	offsetY = DPIUtil.autoScaleUp(offsetY);
+	Rectangle rect = new Rectangle (x, y, width, height);
 	drawBackgroundInPixels(gc, rect.x, rect.y, rect.width, rect.height, offsetX, offsetY);
 }
 
@@ -591,7 +589,7 @@ void drawBackgroundInPixels (GC gc, int x, int y, int width, int height, int off
 		Cairo.cairo_fill (cairo);
 		Cairo.cairo_restore (cairo);
 	} else {
-		gc.fillRectangle(DPIUtil.autoScaleDown(new Rectangle(x, y, width, height)));
+		gc.fillRectangle(new Rectangle(x, y, width, height));
 
 	}
 }
@@ -1427,10 +1425,10 @@ Point minimumSize (int wHint, int hHint, boolean changed) {
 	 * Since getClientArea can be overridden by subclasses, we cannot
 	 * call getClientAreaInPixels directly.
 	 */
-	Rectangle clientArea = DPIUtil.autoScaleUp(getClientArea ());
+	Rectangle clientArea = getClientArea ();
 	int width = 0, height = 0;
 	for (int i=0; i<children.length; i++) {
-		Rectangle rect = DPIUtil.autoScaleUp(children [i].getBounds ());
+		Rectangle rect = children [i].getBounds ();
 		width = Math.max (width, rect.x - clientArea.x + rect.width);
 		height = Math.max (height, rect.y - clientArea.y + rect.height);
 	}
@@ -1446,7 +1444,7 @@ long parentingHandle () {
 void printWidget (GC gc, long drawable, int depth, int x, int y) {
 	Region oldClip = new Region (gc.getDevice ());
 	Region newClip = new Region (gc.getDevice ());
-	Point loc = DPIUtil.autoScaleDown(new Point (x, y));
+	Point loc = new Point (x, y);
 	gc.getClipping (oldClip);
 	Rectangle rect = getBounds ();
 	newClip.add (oldClip);
@@ -1457,7 +1455,7 @@ void printWidget (GC gc, long drawable, int depth, int x, int y) {
 	Point pt = display.mapInPixels (this, parent, clientRect.x, clientRect.y);
 	clientRect.x = x + pt.x - rect.x;
 	clientRect.y = y + pt.y - rect.y;
-	newClip.intersect (DPIUtil.autoScaleDown(clientRect));
+	newClip.intersect (clientRect);
 	gc.setClipping (newClip);
 	Control [] children = _getChildren ();
 	for (int i=children.length-1; i>=0; --i) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Control.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Control.java
@@ -832,9 +832,7 @@ public Point computeSize (int wHint, int hHint, boolean changed) {
 	checkWidget();
 	if (wHint != SWT.DEFAULT && wHint < 0) wHint = 0;
 	if (hHint != SWT.DEFAULT && hHint < 0) hHint = 0;
-	wHint = DPIUtil.autoScaleUp(wHint);
-	hHint = DPIUtil.autoScaleUp(hHint);
-	return DPIUtil.autoScaleDown (computeSizeInPixels (wHint, hHint, changed));
+	return computeSizeInPixels (wHint, hHint, changed);
 }
 
 Point computeSizeInPixels (int wHint, int hHint, boolean changed) {
@@ -933,7 +931,7 @@ Accessible _getAccessible () {
  */
 public Rectangle getBounds () {
 	checkWidget();
-	return DPIUtil.autoScaleDown(getBoundsInPixels());
+	return getBoundsInPixels();
 }
 
 Rectangle getBoundsInPixels () {
@@ -975,7 +973,6 @@ Rectangle getBoundsInPixels () {
 public void setBounds (Rectangle rect) {
 	checkWidget ();
 	if (rect == null) error (SWT.ERROR_NULL_ARGUMENT);
-	rect = DPIUtil.autoScaleUp(rect);
 	setBounds (rect.x, rect.y, Math.max (0, rect.width), Math.max (0, rect.height), true, true);
 }
 
@@ -1015,7 +1012,7 @@ void setBoundsInPixels (Rectangle rect) {
  */
 public void setBounds (int x, int y, int width, int height) {
 	checkWidget();
-	Rectangle rect = DPIUtil.autoScaleUp(new Rectangle (x, y, width, height));
+	Rectangle rect = new Rectangle (x, y, width, height);
 	setBounds (rect.x, rect.y, Math.max (0, rect.width), Math.max (0, rect.height), true, true);
 }
 
@@ -1234,7 +1231,7 @@ int setBounds (int x, int y, int width, int height, boolean move, boolean resize
  */
 public Point getLocation () {
 	checkWidget();
-	return DPIUtil.autoScaleDown(getLocationInPixels());
+	return getLocationInPixels();
 }
 
 Point getLocationInPixels () {
@@ -1271,7 +1268,6 @@ Point getLocationInPixels () {
 public void setLocation (Point location) {
 	checkWidget ();
 	if (location == null) error (SWT.ERROR_NULL_ARGUMENT);
-	location = DPIUtil.autoScaleUp(location);
 	setBounds (location.x, location.y, 0, 0, true, false);
 }
 
@@ -1301,7 +1297,7 @@ void setLocationInPixels (Point location) {
  */
 public void setLocation(int x, int y) {
 	checkWidget();
-	Point loc = DPIUtil.autoScaleUp(new Point (x, y));
+	Point loc = new Point (x, y);
 	setBounds (loc.x, loc.y, 0, 0, true, false);
 }
 
@@ -1325,7 +1321,7 @@ void setLocationInPixels(int x, int y) {
  */
 public Point getSize () {
 	checkWidget();
-	return DPIUtil.autoScaleDown(getSizeInPixels());
+	return getSizeInPixels();
 }
 
 Point getSizeInPixels () {
@@ -1364,7 +1360,6 @@ Point getSizeInPixels () {
 public void setSize (Point size) {
 	checkWidget ();
 	if (size == null) error (SWT.ERROR_NULL_ARGUMENT);
-	size = DPIUtil.autoScaleUp(size);
 	setBounds (0, 0, Math.max (0, size.x), Math.max (0, size.y), false, true);
 }
 
@@ -1483,7 +1478,7 @@ void setRelations () {
  */
 public void setSize (int width, int height) {
 	checkWidget();
-	Point size = DPIUtil.autoScaleUp(new Point (width, height));
+	Point size = new Point (width, height);
 	setBounds (0, 0, Math.max (0, size.x), Math.max (0, size.y), false, true);
 }
 
@@ -1667,9 +1662,9 @@ public Point toControl(int x, int y) {
 		GDK.gdk_window_get_origin(window, origin_x, origin_y);
 	}
 
-	x -= DPIUtil.autoScaleDown(origin_x[0]);
-	y -= DPIUtil.autoScaleDown(origin_y[0]);
-	if ((style & SWT.MIRRORED) != 0) x = DPIUtil.autoScaleDown(getClientWidth()) - x;
+	x -= origin_x[0];
+	y -= origin_y[0];
+	if ((style & SWT.MIRRORED) != 0) x = getClientWidth() - x;
 
 	return new Point(x, y);
 }
@@ -1732,9 +1727,9 @@ public Point toDisplay(int x, int y) {
 		GDK.gdk_window_get_origin(window, origin_x, origin_y);
 	}
 
-	if ((style & SWT.MIRRORED) != 0) x = DPIUtil.autoScaleDown(getClientWidth()) - x;
-	x += DPIUtil.autoScaleDown(origin_x[0]);
-	y += DPIUtil.autoScaleDown(origin_y[0]);
+	if ((style & SWT.MIRRORED) != 0) x = getClientWidth() - x;
+	x += origin_x[0];
+	y += origin_y[0];
 
 	return new Point(x, y);
 }
@@ -3018,7 +3013,7 @@ GdkRGBA getBaseGdkRGBA () {
  * </ul>
  */
 public int getBorderWidth () {
-	return DPIUtil.autoScaleDown(getBorderWidthInPixels());
+	return getBorderWidthInPixels();
 }
 
 int getBorderWidthInPixels () {
@@ -3557,8 +3552,7 @@ long gtk_button_press_event (long widget, long event, boolean sendMouseDown) {
 		// See comment in #dragDetect()
 		if (OS.isX11()) {
 			if (dragging) {
-				Point scaledEvent = DPIUtil.autoScaleDown(new Point((int)eventX[0], (int) eventY[0]));
-				sendDragEvent (eventButton[0], eventState[0], scaledEvent.x, scaledEvent.y, false);
+				sendDragEvent (eventButton[0], eventState[0], (int)eventX[0], (int)eventY[0], false);
 				if (isDisposed ()) return 1;
 			}
 		}
@@ -3885,8 +3879,8 @@ long gtk_draw (long widget, long cairo) {
 	if (!hooksPaint ()) return 0;
 	Event event = new Event ();
 	event.count = 1;
-	Rectangle eventBounds = DPIUtil.autoScaleDown (new Rectangle (rect.x, rect.y, rect.width, rect.height));
-	if ((style & SWT.MIRRORED) != 0) eventBounds.x = DPIUtil.autoScaleDown (getClientWidth ()) - eventBounds.width - eventBounds.x;
+	Rectangle eventBounds = new Rectangle (rect.x, rect.y, rect.width, rect.height);
+	if ((style & SWT.MIRRORED) != 0) eventBounds.x = getClientWidth () - eventBounds.width - eventBounds.x;
 	event.setBounds (eventBounds);
 	GCData data = new GCData ();
 	/*
@@ -4175,7 +4169,7 @@ long gtk_motion_notify_event (long widget, long event) {
 			int eventType = GDK.gdk_event_get_event_type(event);
 			if (eventType == GDK.GDK_3BUTTON_PRESS) return 0;
 
-			Point scaledEvent = DPIUtil.autoScaleDown(new Point((int)eventX[0], (int) eventY[0]));
+			Point scaledEvent = new Point((int)eventX[0], (int) eventY[0]);
 
 			int [] eventButton = new int [1];
 			int [] eventState = new int [1];
@@ -4708,8 +4702,7 @@ void redraw (boolean all) {
  */
 public void redraw (int x, int y, int width, int height, boolean all) {
 	checkWidget();
-	Rectangle rect = DPIUtil.autoScaleUp(new Rectangle(x, y, width, height));
-	redrawInPixels(rect.x, rect.y, rect.width, rect.height, all);
+	redrawInPixels(x, y, width, height, all);
 }
 
 void redrawInPixels (int x, int y, int width, int height, boolean all) {
@@ -4894,7 +4887,7 @@ boolean sendDragEvent (int button, int stateMask, int x, int y, boolean isStateM
 	event.button = button;
 	Rectangle eventRect = new Rectangle (x, y, 0, 0);
 	event.setBounds (eventRect);
-	if ((style & SWT.MIRRORED) != 0) event.x = DPIUtil.autoScaleDown(getClientWidth ()) - event.x;
+	if ((style & SWT.MIRRORED) != 0) event.x = getClientWidth () - event.x;
 	if (isStateMask) {
 		event.stateMask = stateMask;
 	} else {
@@ -5062,7 +5055,7 @@ boolean sendMouseEvent (int type, int button, int count, int detail, boolean sen
 	if (is_hint) {
 		// coordinates are already window-relative, see #gtk_motion_notify_event(..) and bug 94502
 		Rectangle eventRect = new Rectangle ((int)x, (int)y, 0, 0);
-		event.setBounds (DPIUtil.autoScaleDown (eventRect));
+		event.setBounds (eventRect);
 	} else {
 		int [] origin_x = new int [1], origin_y = new int [1];
 		Rectangle eventRect;
@@ -5071,15 +5064,15 @@ boolean sendMouseEvent (int type, int button, int count, int detail, boolean sen
 //			GDK.gdk_surface_get_origin (surface, origin_x, origin_y);
 //			eventRect = new Rectangle ((int)x - origin_x [0], (int)y - origin_y [0], 0, 0);
 			eventRect = new Rectangle ((int)x, (int)y, 0, 0);
-			event.setBounds (DPIUtil.autoScaleDown (eventRect));
+			event.setBounds (eventRect);
 		} else {
 			long window = eventWindow ();
 			GDK.gdk_window_get_origin (window, origin_x, origin_y);
 			eventRect = new Rectangle ((int)x - origin_x [0], (int)y - origin_y [0], 0, 0);
-			event.setBounds (DPIUtil.autoScaleDown (eventRect));
+			event.setBounds (eventRect);
 		}
 	}
-	if ((style & SWT.MIRRORED) != 0) event.x = DPIUtil.autoScaleDown (getClientWidth ()) - event.x;
+	if ((style & SWT.MIRRORED) != 0) event.x = getClientWidth () - event.x;
 	setInputState (event, state);
 
 	/**
@@ -6309,7 +6302,7 @@ boolean showMenu (int x, int y) {
 boolean showMenu (int x, int y, int detail) {
 	Event event = new Event ();
 	Rectangle eventRect = new Rectangle (x, y, 0, 0);
-	event.setBounds (DPIUtil.autoScaleDown (eventRect));
+	event.setBounds (eventRect);
 	event.detail = detail;
 	sendEvent (SWT.MenuDetect, event);
 	//widget could be disposed at this point
@@ -6332,7 +6325,7 @@ boolean showMenu (int x, int y, int detail) {
 
 				return true;
 			} else {
-				Rectangle rect = DPIUtil.autoScaleUp (event.getBounds ());
+				Rectangle rect = event.getBounds ();
 				if (rect.x != x || rect.y != y) {
 					menu.setLocationInPixels (rect.x, rect.y);
 				}

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Display.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Display.java
@@ -1774,7 +1774,7 @@ public Shell getActiveShell () {
 @Override
 public Rectangle getBounds () {
 	checkDevice ();
-	return DPIUtil.autoScaleDown (getBoundsInPixels ());
+	return getBoundsInPixels ();
 }
 
 /**
@@ -1985,7 +1985,7 @@ boolean filters (int eventType) {
  * </ul>
  */
 public Point getCursorLocation() {
-	return DPIUtil.autoScaleDown(getCursorLocationInPixels());
+	return getCursorLocationInPixels();
 }
 
 Point getCursorLocationInPixels() {
@@ -2649,7 +2649,7 @@ Rectangle getWorkArea() {
 public Monitor[] getMonitors() {
 	checkDevice();
 	Monitor[] monitors = null;
-	Rectangle workArea = DPIUtil.autoScaleDown(getWorkArea ());
+	Rectangle workArea = getWorkArea ();
 	long display = GDK.gdk_display_get_default();
 	if (display != 0) {
 		int monitorCount;
@@ -2670,10 +2670,10 @@ public Monitor[] getMonitors() {
 
 				Monitor monitor = new Monitor();
 				monitor.handle = gdkMonitor;
-				monitor.x = DPIUtil.autoScaleDown(geometry.x);
-				monitor.y = DPIUtil.autoScaleDown(geometry.y);
-				monitor.width = DPIUtil.autoScaleDown(geometry.width);
-				monitor.height = DPIUtil.autoScaleDown(geometry.height);
+				monitor.x = geometry.x;
+				monitor.y = geometry.y;
+				monitor.width = geometry.width;
+				monitor.height = geometry.height;
 				if (!OS.isX11()) {
 					int scaleFactor = (int) GDK.gdk_monitor_get_scale_factor(gdkMonitor);
 					monitor.zoom = scaleFactor * 100;
@@ -2685,10 +2685,10 @@ public Monitor[] getMonitors() {
 				 * since it takes into account per-monitor trim. Not available in GTK4.
 				 */
 				if (!GTK.GTK4) GDK.gdk_monitor_get_workarea(gdkMonitor, geometry);
-				monitor.clientX = DPIUtil.autoScaleDown(geometry.x);
-				monitor.clientY = DPIUtil.autoScaleDown(geometry.y);
-				monitor.clientWidth = DPIUtil.autoScaleDown(geometry.width);
-				monitor.clientHeight = DPIUtil.autoScaleDown(geometry.height);
+				monitor.clientX = geometry.x;
+				monitor.clientY = geometry.y;
+				monitor.clientWidth = geometry.width;
+				monitor.clientHeight = geometry.height;
 
 				monitors[i] = monitor;
 			}
@@ -4016,16 +4016,16 @@ public Point map (Control from, Control to, int x, int y) {
 	Point point = new Point (x, y);
 	if (from == to) return point;
 	if (from != null) {
-		Point origin = DPIUtil.autoScaleDown (GTK.GTK4 ? from.getSurfaceOrigin() : from.getWindowOrigin ());
-		if ((from.style & SWT.MIRRORED) != 0) point.x = DPIUtil.autoScaleDown (from.getClientWidth ()) - point.x;
+		Point origin = GTK.GTK4 ? from.getSurfaceOrigin() : from.getWindowOrigin ();
+		if ((from.style & SWT.MIRRORED) != 0) point.x = from.getClientWidth () - point.x;
 		point.x += origin.x;
 		point.y += origin.y;
 	}
 	if (to != null) {
-		Point origin = DPIUtil.autoScaleDown (GTK.GTK4 ? to.getSurfaceOrigin() : to.getWindowOrigin ());
+		Point origin = GTK.GTK4 ? to.getSurfaceOrigin() : to.getWindowOrigin ();
 		point.x -= origin.x;
 		point.y -= origin.y;
-		if ((to.style & SWT.MIRRORED) != 0) point.x = DPIUtil.autoScaleDown (to.getClientWidth ()) - point.x;
+		if ((to.style & SWT.MIRRORED) != 0) point.x = to.getClientWidth () - point.x;
 	}
 	return point;
 }
@@ -4145,16 +4145,16 @@ public Rectangle map (Control from, Control to, int x, int y, int width, int hei
 	if (from == to) return rect;
 	boolean fromRTL = false, toRTL = false;
 	if (from != null) {
-		Point origin = DPIUtil.autoScaleDown (GTK.GTK4 ? from.getSurfaceOrigin () : from.getWindowOrigin ());
-		if (fromRTL = (from.style & SWT.MIRRORED) != 0) rect.x = DPIUtil.autoScaleDown (from.getClientWidth ()) - rect.x;
+		Point origin = GTK.GTK4 ? from.getSurfaceOrigin () : from.getWindowOrigin ();
+		if (fromRTL = (from.style & SWT.MIRRORED) != 0) rect.x = from.getClientWidth () - rect.x;
 		rect.x += origin.x;
 		rect.y += origin.y;
 	}
 	if (to != null) {
-		Point origin = DPIUtil.autoScaleDown (GTK.GTK4 ? to.getSurfaceOrigin() : to.getWindowOrigin ());
+		Point origin = GTK.GTK4 ? to.getSurfaceOrigin() : to.getWindowOrigin ();
 		rect.x -= origin.x;
 		rect.y -= origin.y;
-		if (toRTL = (to.style & SWT.MIRRORED) != 0) rect.x = DPIUtil.autoScaleDown (to.getClientWidth ()) - rect.x;
+		if (toRTL = (to.style & SWT.MIRRORED) != 0) rect.x = to.getClientWidth () - rect.x;
 	}
 
 	if (fromRTL != toRTL) rect.x -= rect.width;
@@ -4297,7 +4297,7 @@ public boolean post (Event event) {
 		int type = event.type;
 
 		if (type == SWT.MouseMove) {
-			Rectangle loc = DPIUtil.autoScaleUp(event.getBounds());
+			Rectangle loc = event.getBounds();
 			setCursorLocationInPixels(new Point(loc.x, loc.y));
 			return true;
 		}
@@ -5287,7 +5287,6 @@ void setCursorLocationInPixels (Point location) {
 public void setCursorLocation (Point point) {
 	checkDevice ();
 	if (point == null) error (SWT.ERROR_NULL_ARGUMENT);
-	point = DPIUtil.autoScaleUp(point);
 	setCursorLocationInPixels(point);
 }
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Link.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Link.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -18,7 +18,6 @@ import org.eclipse.swt.*;
 import org.eclipse.swt.accessibility.*;
 import org.eclipse.swt.events.*;
 import org.eclipse.swt.graphics.*;
-import org.eclipse.swt.internal.*;
 import org.eclipse.swt.internal.gtk.*;
 import org.eclipse.swt.internal.gtk3.*;
 import org.eclipse.swt.internal.gtk4.*;
@@ -130,12 +129,12 @@ Point computeSizeInPixels (int wHint, int hHint, boolean changed) {
 	//TEMPORARY CODE
 	if (wHint == 0) {
 		layout.setWidth (1);
-		Rectangle rect = DPIUtil.autoScaleUp(layout.getBounds ());
+		Rectangle rect = layout.getBounds ();
 		width = 0;
 		height = rect.height;
 	} else {
-		layout.setWidth (DPIUtil.autoScaleDown(wHint));
-		Rectangle rect = DPIUtil.autoScaleUp(layout.getBounds ());
+		layout.setWidth (wHint);
+		Rectangle rect = layout.getBounds ();
 		width = rect.width;
 		height = rect.height;
 	}
@@ -192,8 +191,7 @@ void drawWidget(GC gc) {
 	layout.draw (gc, 0, 0, selStart, selEnd, null, null);
 	if (hasFocus () && focusIndex != -1) {
 		Rectangle [] rects = getRectanglesInPixels (focusIndex);
-		for (int i = 0; i < rects.length; i++) {
-			Rectangle rect = DPIUtil.autoScaleDown(rects [i]);
+		for (Rectangle rect : rects) {
 			gc.drawFocus (rect.x, rect.y, rect.width, rect.height);
 		}
 	}
@@ -303,13 +301,13 @@ Rectangle [] getRectanglesInPixels (int linkIndex) {
 	while (point.y > lineOffsets [lineEnd]) lineEnd++;
 	int index = 0;
 	if (lineStart == lineEnd) {
-		rects [index++] = DPIUtil.autoScaleUp (layout.getBounds (point.x, point.y));
+		rects [index++] = layout.getBounds (point.x, point.y);
 	} else {
-		rects [index++] = DPIUtil.autoScaleUp (layout.getBounds (point.x, lineOffsets [lineStart]-1));
-		rects [index++] = DPIUtil.autoScaleUp (layout.getBounds (lineOffsets [lineEnd-1], point.y));
+		rects [index++] = layout.getBounds (point.x, lineOffsets [lineStart]-1);
+		rects [index++] = layout.getBounds (lineOffsets [lineEnd-1], point.y);
 		if (lineEnd - lineStart > 1) {
 			for (int i = lineStart; i < lineEnd - 1; i++) {
-				rects [index++] = DPIUtil.autoScaleUp (layout.getLineBounds (i));
+				rects [index++] = layout.getLineBounds (i);
 			}
 		}
 	}
@@ -365,7 +363,7 @@ long gtk_button_press_event (long widget, long event) {
 		int x = (int) eventX[0];
 		int y = (int) eventY[0];
 		if ((style & SWT.MIRRORED) != 0) x = getClientWidth () - x;
-		int offset = DPIUtil.autoScaleUp(layout.getOffset (x, y, null));
+		int offset = layout.getOffset (x, y, null);
 		int oldSelectionX = selection.x;
 		int oldSelectionY = selection.y;
 		selection.x = offset;
@@ -376,7 +374,7 @@ long gtk_button_press_event (long widget, long event) {
 				oldSelectionX = oldSelectionY;
 				oldSelectionY = temp;
 			}
-			Rectangle rect = DPIUtil.autoScaleUp(layout.getBounds (oldSelectionX, oldSelectionY));
+			Rectangle rect = layout.getBounds (oldSelectionX, oldSelectionY);
 			redrawInPixels (rect.x, rect.y, rect.width, rect.height, false);
 		}
 		for (int j = 0; j < offsets.length; j++) {
@@ -544,7 +542,7 @@ long gtk_motion_notify_event (long widget, long event) {
 	if ((style & SWT.MIRRORED) != 0) x = getClientWidth () - x;
 	if ((state[0] & GDK.GDK_BUTTON1_MASK) != 0) {
 		int oldSelection = selection.y;
-		selection.y = DPIUtil.autoScaleUp(layout.getOffset (x, y, null));
+		selection.y = layout.getOffset (x, y, null);
 		if (selection.y != oldSelection) {
 			int newSelection = selection.y;
 			if (oldSelection > newSelection) {
@@ -810,7 +808,7 @@ int parseMnemonics (char[] buffer, int start, int end, StringBuilder result) {
 int setBounds(int x, int y, int width, int height, boolean move, boolean resize) {
 	int result = super.setBounds (x, y, width,height, move, resize);
 	if ((result & RESIZED) != 0) {
-		layout.setWidth (DPIUtil.autoScaleDown((width > 0 ? width : -1)));
+		layout.setWidth ((width > 0 ? width : -1));
 		redraw ();
 	}
 	return result;

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Sash.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Sash.java
@@ -17,7 +17,6 @@ package org.eclipse.swt.widgets;
 import org.eclipse.swt.*;
 import org.eclipse.swt.events.*;
 import org.eclipse.swt.graphics.*;
-import org.eclipse.swt.internal.*;
 import org.eclipse.swt.internal.gtk.*;
 import org.eclipse.swt.internal.gtk3.*;
 import org.eclipse.swt.internal.gtk4.*;
@@ -191,11 +190,11 @@ int gtk_gesture_press_event(long gesture, int n_press, double x, double y, long 
 	Event jEvent = new Event();
 	jEvent.time = GDK.gdk_event_get_time(event);
 	Rectangle eventRect = new Rectangle(lastX, lastY, width, height);
-	jEvent.setBounds(DPIUtil.autoScaleDown(eventRect));
+	jEvent.setBounds(eventRect);
 	if ((style & SWT.SMOOTH) == 0) {
 		jEvent.detail = SWT.DRAG;
 	}
-	if ((parent.style & SWT.MIRRORED) != 0) jEvent.x = DPIUtil.autoScaleDown(parent.getClientWidth() - width) - jEvent.x;
+	if ((parent.style & SWT.MIRRORED) != 0) jEvent.x = parent.getClientWidth() - width - jEvent.x;
 	sendSelectionEvent(SWT.Selection, jEvent, true);
 	if (isDisposed()) return result;
 
@@ -245,15 +244,15 @@ void gtk4_motion_event(long controller, double x, double y, long event) {
 	Event jEvent = new Event();
 	jEvent.time = GDK.gdk_event_get_time(event);
 	Rectangle eventRect = new Rectangle(newX, newY, width, height);
-	jEvent.setBounds(DPIUtil.autoScaleDown(eventRect));
+	jEvent.setBounds(eventRect);
 	if ((style & SWT.SMOOTH) == 0) {
 		jEvent.detail = SWT.DRAG;
 	}
-	if ((parent.style & SWT.MIRRORED) != 0) jEvent.x = DPIUtil.autoScaleDown(parent.getClientWidth() - width) - jEvent.x;
+	if ((parent.style & SWT.MIRRORED) != 0) jEvent.x = parent.getClientWidth() - width - jEvent.x;
 	sendSelectionEvent(SWT.Selection, jEvent, true);
 	if (isDisposed()) return;
 
-	Rectangle rect = DPIUtil.autoScaleUp(jEvent.getBounds());
+	Rectangle rect = jEvent.getBounds();
 	if (jEvent.doit) {
 		lastX = rect.x;
 		lastY = rect.y;
@@ -311,13 +310,13 @@ boolean gtk4_key_press_event(long controller, int keyval, int keycode, int state
 			Event jEvent = new Event();
 			jEvent.time = GDK.gdk_event_get_time(event);
 			Rectangle eventRect = new Rectangle(newX, newY, width, height);
-			jEvent.setBounds(DPIUtil.autoScaleDown(eventRect));
-			if ((parent.style & SWT.MIRRORED) != 0) jEvent.x = DPIUtil.autoScaleDown(parent.getClientWidth() - width) - jEvent.x;
+			jEvent.setBounds(eventRect);
+			if ((parent.style & SWT.MIRRORED) != 0) jEvent.x = parent.getClientWidth() - width - jEvent.x;
 			sendSelectionEvent(SWT.Selection, jEvent, true);
 			if (isDisposed()) break;
 
 			if (jEvent.doit) {
-				Rectangle rect = DPIUtil.autoScaleUp(jEvent.getBounds());
+				Rectangle rect = jEvent.getBounds();
 				lastX = rect.x;
 				lastY = rect.y;
 				if ((parent.style & SWT.MIRRORED) != 0) lastX = parent.getClientWidth() - width  - lastX;
@@ -364,16 +363,16 @@ long gtk_button_press_event(long widget, long event) {
 	Event jEvent = new Event();
 	jEvent.time = GDK.gdk_event_get_time(event);
 	Rectangle eventRect = new Rectangle(lastX, lastY, width, height);
-	jEvent.setBounds(DPIUtil.autoScaleDown(eventRect));
+	jEvent.setBounds(eventRect);
 	if ((style & SWT.SMOOTH) == 0) {
 		jEvent.detail = SWT.DRAG;
 	}
-	if ((parent.style & SWT.MIRRORED) != 0) jEvent.x = DPIUtil.autoScaleDown(parent.getClientWidth() - width) - jEvent.x;
+	if ((parent.style & SWT.MIRRORED) != 0) jEvent.x = parent.getClientWidth() - width - jEvent.x;
 	sendSelectionEvent(SWT.Selection, jEvent, true);
 	if (isDisposed()) return 0;
 	if (jEvent.doit) {
 		dragging = true;
-		Rectangle rect = DPIUtil.autoScaleUp(jEvent.getBounds());
+		Rectangle rect = jEvent.getBounds();
 		lastX = rect.x;
 		lastY = rect.y;
 		if ((parent.style & SWT.MIRRORED) != 0) lastX = parent.getClientWidth() - width - lastX;
@@ -406,13 +405,13 @@ long gtk_button_release_event(long widget, long event) {
 	Event jEvent = new Event();
 	jEvent.time = GDK.gdk_event_get_time(event);
 	Rectangle eventRect = new Rectangle(lastX, lastY, width, height);
-	jEvent.setBounds(DPIUtil.autoScaleDown(eventRect));
-	if ((parent.style & SWT.MIRRORED) != 0) jEvent.x = DPIUtil.autoScaleDown(parent.getClientWidth() - width) - jEvent.x;
+	jEvent.setBounds(eventRect);
+	if ((parent.style & SWT.MIRRORED) != 0) jEvent.x = parent.getClientWidth() - width - jEvent.x;
 	sendSelectionEvent(SWT.Selection, jEvent, true);
 	if (isDisposed()) return result;
 	if (jEvent.doit) {
 		if ((style & SWT.SMOOTH) != 0) {
-			Rectangle rect = DPIUtil.autoScaleUp(jEvent.getBounds());
+			Rectangle rect = jEvent.getBounds();
 			setBoundsInPixels(rect.x, rect.y, width, height);
 			// widget could be disposed at this point
 		}
@@ -501,14 +500,14 @@ long gtk_key_press_event(long widget, long eventPtr) {
 			Event event = new Event();
 			event.time = GDK.gdk_event_get_time(eventPtr);
 			Rectangle eventRect = new Rectangle(newX, newY, width, height);
-			event.setBounds(DPIUtil.autoScaleDown(eventRect));
-			if ((parent.style & SWT.MIRRORED) != 0) event.x = DPIUtil.autoScaleDown(parent.getClientWidth() - width) - event.x;
+			event.setBounds(eventRect);
+			if ((parent.style & SWT.MIRRORED) != 0) event.x = parent.getClientWidth() - width - event.x;
 			sendSelectionEvent(SWT.Selection, event, true);
 			if (ptrGrabResult == GDK.GDK_GRAB_SUCCESS) gdk_pointer_ungrab(gdkResource, GDK.GDK_CURRENT_TIME);
 			if (isDisposed()) break;
 
 			if (event.doit) {
-				Rectangle rect = DPIUtil.autoScaleUp(event.getBounds());
+				Rectangle rect = event.getBounds();
 				lastX = rect.x;
 				lastY = rect.y;
 				if ((parent.style & SWT.MIRRORED) != 0) lastX = parent.getClientWidth() - width  - lastX;
@@ -590,15 +589,15 @@ long gtk_motion_notify_event(long widget, long eventPtr) {
 	Event event = new Event();
 	event.time = GDK.gdk_event_get_time(eventPtr);
 	Rectangle eventRect = new Rectangle(newX, newY, width, height);
-	event.setBounds(DPIUtil.autoScaleDown(eventRect));
+	event.setBounds(eventRect);
 	if ((style & SWT.SMOOTH) == 0) {
 		event.detail = SWT.DRAG;
 	}
-	if ((parent.style & SWT.MIRRORED) != 0) event.x = DPIUtil.autoScaleDown(parent.getClientWidth() - width) - event.x;
+	if ((parent.style & SWT.MIRRORED) != 0) event.x = parent.getClientWidth() - width - event.x;
 	sendSelectionEvent(SWT.Selection, event, true);
 	if (isDisposed()) return 0;
 
-	Rectangle rect = DPIUtil.autoScaleUp(event.getBounds());
+	Rectangle rect = event.getBounds();
 	if (event.doit) {
 		lastX = rect.x;
 		lastY = rect.y;

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Shell.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Shell.java
@@ -663,7 +663,7 @@ void center () {
 	Rectangle parentRect = display.mapInPixels (parent, null, parent.getClientAreaInPixels());
 	int x = Math.max (parentRect.x, parentRect.x + (parentRect.width - rect.width) / 2);
 	int y = Math.max (parentRect.y, parentRect.y + (parentRect.height - rect.height) / 2);
-	Rectangle monitorRect = DPIUtil.autoScaleUp(parent.getMonitor ().getClientArea());
+	Rectangle monitorRect = parent.getMonitor ().getClientArea();
 	if (x + rect.width > monitorRect.x + monitorRect.width) {
 		x = Math.max (monitorRect.x, monitorRect.x + monitorRect.width - rect.width);
 	} else {
@@ -1296,7 +1296,7 @@ public boolean getMaximized () {
  */
 public Point getMinimumSize () {
 	checkWidget ();
-	return DPIUtil.autoScaleDown (getMinimumSizeInPixels ());
+	return getMinimumSizeInPixels ();
 }
 
 Point getMinimumSizeInPixels () {
@@ -1323,7 +1323,7 @@ Point getMinimumSizeInPixels () {
  */
 public Point getMaximumSize () {
 	checkWidget ();
-	return DPIUtil.autoScaleDown (getMaximumSizeInPixels ());
+	return getMaximumSizeInPixels ();
 }
 
 Point getMaximumSizeInPixels () {
@@ -2701,7 +2701,7 @@ void setMinimumSizeInPixels (int width, int height) {
  */
 public void setMinimumSize (Point size) {
 	checkWidget ();
-	setMinimumSizeInPixels (DPIUtil.autoScaleUp (size));
+	setMinimumSizeInPixels (size);
 }
 
 void setMinimumSizeInPixels (Point size) {
@@ -2759,7 +2759,7 @@ public void setMaximumSize (int width, int height) {
  */
 public void setMaximumSize (Point size) {
 	checkWidget ();
-	setMaximumSizeInPixels (DPIUtil.autoScaleUp (size));
+	setMaximumSizeInPixels (size);
 }
 
 void setMaximumSizeInPixels (Point size) {
@@ -2860,7 +2860,7 @@ static Region mirrorRegion (Region region) {
 	int [] nRects = new int [1];
 	long [] rects = new long [1];
 	gdk_region_get_rectangles (rgn, rects, nRects);
-	Rectangle bounds = DPIUtil.autoScaleUp(region.getBounds ());
+	Rectangle bounds = region.getBounds ();
 	cairo_rectangle_int_t rect = new cairo_rectangle_int_t();
 	for (int i = 0; i < nRects [0]; i++) {
 		Cairo.memmove (rect, rects[0] + (i * GdkRectangle.sizeof), GdkRectangle.sizeof);

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Table.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Table.java
@@ -1434,7 +1434,7 @@ TableItem getFocusItem () {
  */
 public int getGridLineWidth () {
 	checkWidget ();
-	return DPIUtil.autoScaleDown (getGridLineWidthInPixels ());
+	return getGridLineWidthInPixels ();
 }
 
 int getGridLineWidthInPixels () {
@@ -1488,7 +1488,7 @@ public Color getHeaderForeground () {
  */
 public int getHeaderHeight () {
 	checkWidget ();
-	return DPIUtil.autoScaleDown (getHeaderHeightInPixels ());
+	return getHeaderHeightInPixels ();
 }
 
 int getHeaderHeightInPixels () {
@@ -1599,7 +1599,7 @@ public TableItem getItem (int index) {
  */
 public TableItem getItem (Point point) {
 	checkWidget();
-	return getItemInPixels(DPIUtil.autoScaleUp(point));
+	return getItemInPixels(point);
 }
 
 TableItem getItemInPixels (Point point) {
@@ -1657,7 +1657,7 @@ public int getItemCount () {
  */
 public int getItemHeight () {
 	checkWidget ();
-	return DPIUtil.autoScaleDown (getItemHeightInPixels ());
+	return getItemHeightInPixels ();
 }
 
 int getItemHeightInPixels () {
@@ -2890,11 +2890,11 @@ void sendMeasureEvent (long cell, long width, long height) {
 			event.index = columnIndex;
 			event.gc = gc;
 			Rectangle eventRect = new Rectangle (0, 0, contentWidth [0], contentHeight [0]);
-			event.setBounds (DPIUtil.autoScaleDown (eventRect));
+			event.setBounds (eventRect);
 			if (isSelected) event.detail = SWT.SELECTED;
 			sendEvent (SWT.MeasureItem, event);
 			gc.dispose ();
-			Rectangle rect = DPIUtil.autoScaleUp (event.getBounds ());
+			Rectangle rect = event.getBounds ();
 			contentWidth [0] = rect.width - imageWidth;
 			if (contentHeight [0] < rect.height) contentHeight [0] = rect.height;
 			if (width != 0) C.memmove (width, contentWidth, 4);
@@ -3044,13 +3044,9 @@ void rendererRender (long cell, long cr, long snapshot, long widget, long backgr
 				if (cr != 0) {
 					GdkRectangle r = new GdkRectangle();
 					GDK.gdk_cairo_get_clip_rectangle(cr, r);
-					Rectangle rect2 = DPIUtil.autoScaleDown(rect);
-					// Caveat: rect2 is necessary because GC#setClipping(Rectangle) got broken by bug 446075
-					gc.setClipping(rect2.x, rect2.y, rect2.width, rect2.height);
+					gc.setClipping(rect.x, rect.y, rect.width, rect.height);
 				} else {
-					Rectangle rect2 = DPIUtil.autoScaleDown(rect);
-					// Caveat: rect2 is necessary because GC#setClipping(Rectangle) got broken by bug 446075
-					gc.setClipping(rect2.x, rect2.y, rect2.width, rect2.height);
+					gc.setClipping(rect.x, rect.y, rect.width, rect.height);
 
 				}
 
@@ -3068,7 +3064,7 @@ void rendererRender (long cell, long cr, long snapshot, long widget, long backgr
 					event.index = columnIndex;
 					event.gc = gc;
 					event.detail = drawState;
-					event.setBounds (DPIUtil.autoScaleDown (eventRect));
+					event.setBounds (eventRect);
 					sendEvent (SWT.EraseItem, event);
 				} finally {
 					Cairo.cairo_translate (cr, 0, y_offset);
@@ -3102,7 +3098,7 @@ void rendererRender (long cell, long cr, long snapshot, long widget, long backgr
 	if ((drawState & SWT.BACKGROUND) != 0 && (drawState & SWT.SELECTED) == 0) {
 		GC gc = getGC(cr);
 		gc.setBackground (item.getBackground (columnIndex));
-		gc.fillRectangle (DPIUtil.autoScaleDown (rendererRect.toRectangle ()));
+		gc.fillRectangle (rendererRect.toRectangle ());
 		gc.dispose ();
 	}
 	if ((drawState & SWT.FOREGROUND) != 0 || GTK.GTK_IS_CELL_RENDERER_TOGGLE (cell)) {
@@ -3166,9 +3162,7 @@ void rendererRender (long cell, long cr, long snapshot, long widget, long backgr
 				gc.setFont (item.getFont (columnIndex));
 				if ((style & SWT.MIRRORED) != 0) rect.x = getClientWidth () - rect.width - rect.x;
 
-				Rectangle rect2 = DPIUtil.autoScaleDown(rect);
-				// Caveat: rect2 is necessary because GC#setClipping(Rectangle) got broken by bug 446075
-				gc.setClipping(rect2.x, rect2.y, rect2.width, rect2.height);
+				gc.setClipping(rect.x, rect.y, rect.width, rect.height);
 
 				// SWT.PaintItem/SWT.EraseItem often expect that event.y matches
 				// what 'event.item.getBounds()' returns. The workaround is to
@@ -3184,7 +3178,7 @@ void rendererRender (long cell, long cr, long snapshot, long widget, long backgr
 					event.index = columnIndex;
 					event.gc = gc;
 					event.detail = drawState;
-					event.setBounds (DPIUtil.autoScaleDown (eventRect));
+					event.setBounds (eventRect);
 					sendEvent (SWT.PaintItem, event);
 				} finally {
 					Cairo.cairo_translate (cr, 0, y_offset);

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Tree.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Tree.java
@@ -1602,7 +1602,7 @@ TreeItem getFocusItem () {
  */
 public int getGridLineWidth () {
 	checkWidget ();
-	return DPIUtil.autoScaleDown (getGridLineWidthInPixels ());
+	return getGridLineWidthInPixels ();
 }
 
 int getGridLineWidthInPixels () {
@@ -1656,7 +1656,7 @@ public Color getHeaderForeground () {
  */
 public int getHeaderHeight () {
 	checkWidget ();
-	return DPIUtil.autoScaleDown (getHeaderHeightInPixels ());
+	return getHeaderHeightInPixels ();
 }
 
 int getHeaderHeightInPixels () {
@@ -1771,7 +1771,7 @@ public TreeItem getItem (int index) {
  */
 public TreeItem getItem (Point point) {
 	checkWidget();
-	return getItemInPixels(DPIUtil.autoScaleUp(point));
+	return getItemInPixels(point);
 }
 
 TreeItem getItemInPixels (Point point) {
@@ -1846,7 +1846,7 @@ public int getItemCount () {
  */
 public int getItemHeight () {
 	checkWidget ();
-	return DPIUtil.autoScaleDown (getItemHeightInPixels ());
+	return getItemHeightInPixels ();
 }
 
 int getItemHeightInPixels () {
@@ -3089,7 +3089,7 @@ void sendMeasureEvent (long cell, long width, long height) {
 			event.index = columnIndex;
 			event.gc = gc;
 			Rectangle eventRect = new Rectangle (0, 0, contentWidth [0], contentHeight [0]);
-			event.setBounds (DPIUtil.autoScaleDown (eventRect));
+			event.setBounds (eventRect);
 			long path = GTK.gtk_tree_model_get_path (modelHandle, iter);
 			long selection = GTK.gtk_tree_view_get_selection (handle);
 			if (GTK.gtk_tree_selection_path_is_selected (selection, path)) {
@@ -3098,7 +3098,7 @@ void sendMeasureEvent (long cell, long width, long height) {
 			GTK.gtk_tree_path_free (path);
 			sendEvent (SWT.MeasureItem, event);
 			gc.dispose ();
-			Rectangle rect = DPIUtil.autoScaleUp (event.getBounds ());
+			Rectangle rect = event.getBounds ();
 			contentWidth [0] = rect.width - imageWidth;
 			if (contentHeight [0] < rect.height) contentHeight [0] = rect.height;
 			if (width != 0) C.memmove (width, contentWidth, 4);
@@ -3248,12 +3248,9 @@ void rendererRender (long cell, long cr, long snapshot, long widget, long backgr
 				if (cr != 0) {
 					// Use the original rectangle, not the Cairo clipping for the y, width, and height values.
 					// See bug 535124.
-					Rectangle rect2 = DPIUtil.autoScaleDown(rect);
-					gc.setClipping(rect2.x, rect2.y, rect2.width, rect2.height);
+					gc.setClipping(rect.x, rect.y, rect.width, rect.height);
 				} else {
-					Rectangle rect2 = DPIUtil.autoScaleDown(rect);
-					// Caveat: rect2 is necessary because GC#setClipping(Rectangle) got broken by bug 446075
-					gc.setClipping(rect2.x, rect2.y, rect2.width, rect2.height);
+					gc.setClipping(rect.x, rect.y, rect.width, rect.height);
 				}
 
 				// SWT.PaintItem/SWT.EraseItem often expect that event.y matches
@@ -3270,7 +3267,7 @@ void rendererRender (long cell, long cr, long snapshot, long widget, long backgr
 					event.index = columnIndex;
 					event.gc = gc;
 					event.detail = drawState;
-					event.setBounds (DPIUtil.autoScaleDown (eventRect));
+					event.setBounds (eventRect);
 					sendEvent (SWT.EraseItem, event);
 				} finally {
 					Cairo.cairo_translate (cr, 0, y_offset);
@@ -3295,7 +3292,7 @@ void rendererRender (long cell, long cr, long snapshot, long widget, long backgr
 	if ((drawState & SWT.BACKGROUND) != 0 && (drawState & SWT.SELECTED) == 0) {
 		GC gc = getGC(cr);
 		gc.setBackground (item.getBackground (columnIndex));
-		gc.fillRectangle (DPIUtil.autoScaleDown (rendererRect.toRectangle ()));
+		gc.fillRectangle (rendererRect.toRectangle ());
 		gc.dispose ();
 	}
 	if ((drawState & SWT.FOREGROUND) != 0 || GTK.GTK_IS_CELL_RENDERER_TOGGLE (cell)) {
@@ -3368,9 +3365,7 @@ void rendererRender (long cell, long cr, long snapshot, long widget, long backgr
 					rect.x = getClientWidth () - rect.width - rect.x;
 				}
 
-				Rectangle rect2 = DPIUtil.autoScaleDown(rect);
-				// Caveat: rect2 is necessary because GC#setClipping(Rectangle) got broken by bug 446075
-				gc.setClipping(rect2.x, rect2.y, rect2.width, rect2.height);
+				gc.setClipping(rect.x, rect.y, rect.width, rect.height);
 
 				// SWT.PaintItem/SWT.EraseItem often expect that event.y matches
 				// what 'event.item.getBounds()' returns. The workaround is to
@@ -3386,7 +3381,7 @@ void rendererRender (long cell, long cr, long snapshot, long widget, long backgr
 					event.index = columnIndex;
 					event.gc = gc;
 					event.detail = drawState;
-					event.setBounds (DPIUtil.autoScaleDown (eventRect));
+					event.setBounds (eventRect);
 					sendEvent (SWT.PaintItem, event);
 				} finally {
 					Cairo.cairo_translate (cr, 0, y_offset);


### PR DESCRIPTION
Handles remaining widgets code. Continuation of
https://github.com/eclipse-platform/eclipse.platform.swt/pull/2058 .
Part of https://github.com/eclipse-platform/eclipse.platform.swt/issues/1300