### PR TITLE
[Edge] Add fallback when WebView2 runtime is not present #2000

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Browser/common/org/eclipse/swt/browser/Browser.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Browser/common/org/eclipse/swt/browser/Browser.java
@@ -13,7 +13,10 @@
  *******************************************************************************/
 package org.eclipse.swt.browser;
 
+import java.util.*;
+
 import org.eclipse.swt.*;
+import org.eclipse.swt.program.*;
 import org.eclipse.swt.widgets.*;
 
 /**
@@ -93,10 +96,7 @@ public Browser (Composite parent, int style) {
 	}
 
 	style = getStyle ();
-	webBrowser = new BrowserFactory ().createWebBrowser (style);
-	if (webBrowser != null) {
-		webBrowser.setBrowser (this);
-		webBrowser.create (parent, style);
+	if (createWebBrowser(parent, style)) {
 		return;
 	}
 	dispose ();
@@ -117,6 +117,72 @@ public Browser (Composite parent, int style) {
 		break;
 	}
 	SWT.error (SWT.ERROR_NO_HANDLES, null, errMsg);
+}
+
+private boolean createWebBrowser(Composite parent, int style) {
+	webBrowser = new BrowserFactory ().createWebBrowser (style);
+	if (webBrowser == null) {
+		return false;
+	}
+	webBrowser.setBrowser (this);
+	try {
+		webBrowser.create (parent, style);
+		return true;
+	} catch (SWTError error) {
+		boolean isEdge = "win32".equals(SWT.getPlatform()) && (style & SWT.IE) == 0;
+		if (isEdge && error.code == SWT.ERROR_NOT_IMPLEMENTED) {
+			WebViewUnavailableDialog.showAsync(getShell());
+		}
+		throw error;
+	}
+}
+
+private class WebViewUnavailableDialog {
+	private record DialogOption(int index, String message) {};
+	private static final DialogOption USE_IE_OPTION = new DialogOption(SWT.YES, "Use IE");
+	private static final DialogOption MORE_INFORMATION_OPTION = new DialogOption(SWT.NO, "Information");
+	private static final DialogOption CANCEL_OPTION = new DialogOption(SWT.CANCEL, "Cancel");
+
+	private static final String DIALOG_TITLE = "Default browser engine not available";
+	private static final String DIALOG_MESSAGE = "Microsoft Edge (WebView2) is not available. Do you want to use the legacy Internet Explorer?\n\nNote: It is necessary to reopen browsers for the change to take effect.";
+	private static final String FAQ_URL = "https://github.com/eclipse-platform/eclipse.platform/tree/master/docs/FAQ/FAQ_How_do_I_use_Edge-IE_as_the_Browser's_underlying_renderer.md";
+
+	private static final int DIALOG_OPTION_FLAGS = USE_IE_OPTION.index | MORE_INFORMATION_OPTION.index | CANCEL_OPTION.index;
+	private static final Map<Integer, String> DIALOG_OPTION_LABELS = Map.of( //
+			USE_IE_OPTION.index, USE_IE_OPTION.message, //
+			MORE_INFORMATION_OPTION.index, MORE_INFORMATION_OPTION.message, //
+			CANCEL_OPTION.index, CANCEL_OPTION.message);
+
+	private static boolean shownOnce;
+
+	static void showAsync(Shell parentShell) {
+		if (shownOnce) {
+			return;
+		}
+		shownOnce = true;
+		parentShell.getDisplay().asyncExec(() -> {
+			processDialog(parentShell);
+		});
+	}
+
+	static private void processDialog(Shell parentShell) {
+		MessageBox fallbackInfoBox = new MessageBox(parentShell, SWT.ICON_ERROR | DIALOG_OPTION_FLAGS);
+		fallbackInfoBox.setText(DIALOG_TITLE);
+		fallbackInfoBox.setMessage(DIALOG_MESSAGE);
+		fallbackInfoBox.setButtonLabels(DIALOG_OPTION_LABELS);
+		boolean completed;
+		do {
+			int result = fallbackInfoBox.open();
+			completed = true;
+			if (result == MORE_INFORMATION_OPTION.index) {
+				Program.launch(FAQ_URL);
+				completed = false;
+			} else if (result == USE_IE_OPTION.index) {
+				System.setProperty(PROPERTY_DEFAULTTYPE, "ie");
+				DefaultType = SWT.IE;
+			}
+		} while (!completed);
+	}
 }
 
 static Composite checkParent (Composite parent) {


### PR DESCRIPTION
When using WebView2 as browser engine in SWT without a WebView2 runtime being available on the system, browser initialization fails. In order to more gracefully handle the case that a system has no such runtime installed (like on some Windows 10 systems), this change introduces an automatic fallback to Internet Explorer in case no WebView2 runtime is found. In addition, once the first browser is instiantiated (either during application startup or when a view containing a browser is opened), it shows an error dialog informing about the missing runtime and the fallback to IE, and its point to the error log, to which an error is posted that also contains a link to FAQ. This makes it possible to easily copy the link, which is not possible from the message box (or maybe someone knows how to easily implement that).

Fixes https://github.com/eclipse-platform/eclipse.platform.swt/issues/2000

Supercedes and thus closes https://github.com/eclipse-platform/eclipse.platform.swt/pull/2038/files

This is supposed to raise an alternative for how to handle the situation that a WebView2 runtime is not present on the current system in addition to:
- https://github.com/eclipse-platform/eclipse.platform.swt/pull/2038

### Screenshots
The dialog popping up:
![image](https://github.com/user-attachments/assets/8776f723-9df9-4343-9416-196b31458109)

The event log entry:
![image](https://github.com/user-attachments/assets/3aabe9b2-0bcc-488d-9be1-99d8a47f34e5)

### How to test
If you want to test the change, it's easiest to force Edge to throw the error as if it was thrown when the runtime is missing.
To this end, you can add the following to the `Edge::create(Composite, int)` method:
```java
SWT.error(SWT.ERROR_NOT_IMPLEMENTED, null, "");
```