### PR TITLE
[win32] Fix GC font for composite

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Composite.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Composite.java
@@ -1525,6 +1525,7 @@ LRESULT WM_PAINT (long wParam, long lParam) {
 					Control control = findBackgroundControl ();
 					if (control == null) control = this;
 					data.background = control.getBackgroundPixel ();
+					data.font = SWTFontProvider.getFont(display, OS.SendMessage (handle, OS.WM_GETFONT, 0, 0), getNativeZoom());
 					data.uiState = (int)OS.SendMessage (handle, OS.WM_QUERYUISTATE, 0, 0);
 					if ((style & SWT.NO_BACKGROUND) != 0) {
 						/* This code is intentionally commented because it may be slow to copy bits from the screen */
@@ -1535,7 +1536,6 @@ LRESULT WM_PAINT (long wParam, long lParam) {
 						drawBackground (phdc [0], rect);
 					}
 					GC gc = createNewGC(phdc [0], data);
-					data.font = SWTFontProvider.getFont(display, OS.SendMessage (handle, OS.WM_GETFONT, 0, 0), data.nativeZoom);
 
 					Event event = new Event ();
 					event.gc = gc;


### PR DESCRIPTION
This commit reverts moving the initialization of GCData.font in Composite#WM_Paint in commit 033d733.

Fixes https://github.com/eclipse-platform/eclipse.platform.swt/issues/2066