### PR TITLE
Extend ImageGcDrawer to support transparency

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/graphics/Image.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/graphics/Image.java
@@ -903,8 +903,16 @@ public Image(Device device, ImageGcDrawer imageGcDrawer, int width, int height) 
 }
 
 private ImageData drawWithImageGcDrawer(ImageGcDrawer imageGcDrawer, int width, int height, int zoom) {
-	Image image = new Image(device, width, height);
-	GC gc = new GC(image);
+	int gcStyle = imageGcDrawer.getGcStyle();
+	Image image;
+	if ((gcStyle & SWT.TRANSPARENT) != 0) {
+		final ImageData resultData = new ImageData (width, height, 24, new PaletteData (0xFF, 0xFF00, 0xFF0000));
+		resultData.alphaData = new byte [width * height];
+		image = new Image(device, resultData);
+	} else {
+		image = new Image(device, width, height);
+	}
+	GC gc = new GC(image, gcStyle);
 	try {
 		imageGcDrawer.drawOn(gc, width, height);
 		ImageData imageData = image.getImageData(zoom);

--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/graphics/Image.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/graphics/Image.java
@@ -906,6 +906,7 @@ private ImageData drawWithImageGcDrawer(ImageGcDrawer imageGcDrawer, int width, 
 	int gcStyle = imageGcDrawer.getGcStyle();
 	Image image;
 	if ((gcStyle & SWT.TRANSPARENT) != 0) {
+		/* Create a 24 bit image data with alpha channel */
 		final ImageData resultData = new ImageData (width, height, 24, new PaletteData (0xFF, 0xFF00, 0xFF0000));
 		resultData.alphaData = new byte [width * height];
 		image = new Image(device, resultData);

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/graphics/Image.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/graphics/Image.java
@@ -1168,6 +1168,7 @@ private ImageData drawWithImageGcDrawer(int width, int height, int zoom) {
 	int gcStyle = imageGcDrawer.getGcStyle();
 	Image image;
 	if ((gcStyle & SWT.TRANSPARENT) != 0) {
+		/* Create a 24 bit image data with alpha channel */
 		final ImageData resultData = new ImageData(width, height, 24, new PaletteData (0xFF, 0xFF00, 0xFF0000));
 		resultData.alphaData = new byte [width * height];
 		image = new Image(device, resultData, zoom);
@@ -1288,7 +1289,7 @@ void init(ImageData image) {
 	init(image, DPIUtil.getDeviceZoom());
 }
 
-void init(ImageData image, int zoom) {
+private void init(ImageData image, int zoom) {
 	if (image == null) SWT.error(SWT.ERROR_NULL_ARGUMENT);
 
 	PaletteData palette = image.palette;

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Image.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Image.java
@@ -1972,7 +1972,7 @@ private class PlainImageDataProviderWrapper extends ImageFromImageDataProviderWr
 		this(imageData, 100);
 	}
 
-	PlainImageDataProviderWrapper(ImageData imageData, int zoom) {
+	private PlainImageDataProviderWrapper(ImageData imageData, int zoom) {
 		this.imageDataAtBaseZoom = (ImageData) imageData.clone();
 		this.baseZoom = zoom;
 		initImage();
@@ -2499,6 +2499,7 @@ private class ImageGcDrawerWrapper extends DynamicImageProviderWrapper {
 		if ((gcStyle & SWT.TRANSPARENT) != 0) {
 			int scaledHeight = DPIUtil.scaleUp(height, zoom);
 			int scaledWidth = DPIUtil.scaleUp(width, zoom);
+			/* Create a 24 bit image data with alpha channel */
 			final ImageData resultData = new ImageData (scaledWidth, scaledHeight, 24, new PaletteData (0xFF, 0xFF00, 0xFF0000));
 			resultData.alphaData = new byte [scaledWidth * scaledHeight];
 			image = new Image(device, resultData, zoom);

--- a/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet367.java
+++ b/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet367.java
@@ -36,6 +36,8 @@ public class Snippet367 {
 	private static final String IMAGE_PATH_200 = IMAGES_ROOT + IMAGE_200;
 
 	public static void main (String [] args) {
+		final Display display = new Display ();
+
 		final ImageFileNameProvider filenameProvider = zoom -> {
 			switch (zoom) {
 			case 100:
@@ -65,7 +67,17 @@ public class Snippet367 {
 			gc.drawLine(3, 3, width - 3, height - 3);
 		};
 
-		final Display display = new Display ();
+		Image imageWithDataProvider = new Image (display, imageDataProvider);
+		final ImageGcDrawer transparentImageGcDrawer = new ImageGcDrawer() {
+			@Override
+			public void drawOn(GC gc, int width, int height) {
+				gc.drawImage(imageWithDataProvider, 0, 0);
+			}
+			@Override
+			public int getGcStyle() {
+				return SWT.TRANSPARENT;
+			}
+		};
 		final Shell shell = new Shell (display);
 		shell.setText("Snippet367");
 		shell.setLayout (new GridLayout (3, false));
@@ -99,12 +111,16 @@ public class Snippet367 {
 		new Button(shell, SWT.NONE).setImage (new Image (display, filenameProvider));
 
 		new Label (shell, SWT.NONE).setText ("ImageDataProvider:");
-		new Label (shell, SWT.NONE).setImage (new Image (display, imageDataProvider));
-		new Button(shell, SWT.NONE).setImage (new Image (display, imageDataProvider));
+		new Label (shell, SWT.NONE).setImage (imageWithDataProvider);
+		new Button(shell, SWT.NONE).setImage (imageWithDataProvider);
 
 		new Label (shell, SWT.NONE).setText ("ImageGcDrawer:");
 		new Label (shell, SWT.NONE).setImage (new Image (display, imageGcDrawer, 20, 20));
 		new Button(shell, SWT.NONE).setImage (new Image (display, imageGcDrawer, 20, 20));
+
+		new Label (shell, SWT.NONE).setText ("Transparent ImageGcDrawer:");
+		new Label (shell, SWT.NONE).setImage (new Image (display, transparentImageGcDrawer, 20, 20));
+		new Button(shell, SWT.NONE).setImage (new Image (display, transparentImageGcDrawer, 20, 20));
 
 		createSeparator(shell);
 

--- a/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet382.java
+++ b/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet382.java
@@ -64,12 +64,43 @@ public class Snippet382 {
 
 		final Display display = new Display ();
 
+		final Image imageWithFileNameProvider = new Image (display, filenameProvider);
+		final Image disabledImageWithFileNameProvider = new Image (display,imageWithFileNameProvider, SWT.IMAGE_DISABLE);
+		final Image greyImageWithFileNameProvider = new Image (display,imageWithFileNameProvider, SWT.IMAGE_GRAY);
+
+		final Image imageWithDataProvider = new Image (display, imageDataProvider);
+		final Image disabledImageWithDataProvider = new Image (display,imageWithDataProvider, SWT.IMAGE_DISABLE);
+		final Image greyImageWithDataProvider = new Image (display,imageWithDataProvider, SWT.IMAGE_GRAY);
+
+		final Image imageWithData = new Image (display, IMAGE_PATH_100);
+		final Image disabledImageWithData = new Image (display,imageWithData, SWT.IMAGE_DISABLE);
+		final Image greyImageWithData = new Image (display,imageWithData, SWT.IMAGE_GRAY);
+
 		final ImageGcDrawer imageGcDrawer = (gc, width, height) -> {
 			gc.setBackground(display.getSystemColor(SWT.COLOR_RED));
 			gc.fillRectangle(0, 0, width, height);
 			gc.setForeground(display.getSystemColor(SWT.COLOR_YELLOW));
 			gc.drawRectangle(4, 4, width - 8, height - 8);
 		};
+
+		final Image imageWithGcDrawer = new Image (display, imageGcDrawer, 16, 16);
+		final Image disabledImageWithGcDrawer = new Image (display, imageWithGcDrawer, SWT.IMAGE_DISABLE);
+		final Image greyImageWithGcDrawer = new Image (display, imageWithGcDrawer, SWT.IMAGE_GRAY);
+
+		final ImageGcDrawer transparentImageGcDrawer = new ImageGcDrawer() {
+			@Override
+			public void drawOn(GC gc, int width, int height) {
+				gc.drawImage(imageWithDataProvider, 0, 0);
+			}
+			@Override
+			public int getGcStyle() {
+				return SWT.TRANSPARENT;
+			}
+		};
+
+		final Image imageWithTransparentGcDrawer = new Image (display, transparentImageGcDrawer, 16, 16);
+		final Image disabledImageWithTransparentGcDrawer = new Image (display, imageWithTransparentGcDrawer, SWT.IMAGE_DISABLE);
+		final Image greyImageWithTransparentGcDrawer = new Image (display, imageWithTransparentGcDrawer, SWT.IMAGE_GRAY);
 
 		final Shell shell = new Shell (display);
 		shell.setText("Snippet382");
@@ -80,21 +111,7 @@ public class Snippet382 {
 				if (e.type == SWT.Paint) {
 					GC mainGC = e.gc;
 					GCData gcData = mainGC.getGCData();
-					final Image imageWithFileNameProvider = new Image (display, filenameProvider);
-					final Image disabledImageWithFileNameProvider = new Image (display,imageWithFileNameProvider, SWT.IMAGE_DISABLE);
-					final Image greyImageWithFileNameProvider = new Image (display,imageWithFileNameProvider, SWT.IMAGE_GRAY);
 
-					final Image imageWithDataProvider = new Image (display, imageDataProvider);
-					final Image disabledImageWithDataProvider = new Image (display,imageWithDataProvider, SWT.IMAGE_DISABLE);
-					final Image greyImageWithDataProvider = new Image (display,imageWithDataProvider, SWT.IMAGE_GRAY);
-
-					final Image imageWithData = new Image (display, IMAGE_PATH_100);
-					final Image disabledImageWithData = new Image (display,imageWithData, SWT.IMAGE_DISABLE);
-					final Image greyImageWithData = new Image (display,imageWithData, SWT.IMAGE_GRAY);
-
-					final Image imageWithGcDrawer = new Image (display, imageGcDrawer, 16, 16);
-					final Image disabledImageWithGcDrawer = new Image (display, imageWithGcDrawer, SWT.IMAGE_DISABLE);
-					final Image greyImageWithGcDrawer = new Image (display, imageWithGcDrawer, SWT.IMAGE_GRAY);
 
 					try {
 						drawImages(mainGC, gcData, "Normal",40, imageWithFileNameProvider);
@@ -112,6 +129,10 @@ public class Snippet382 {
 						drawImages(mainGC, gcData, "Normal", 400, imageWithGcDrawer);
 						drawImages(mainGC, gcData, "Disabled", 440, disabledImageWithGcDrawer);
 						drawImages(mainGC, gcData, "Greyed", 480, greyImageWithGcDrawer);
+
+						drawImages(mainGC, gcData, "Normal", 520, imageWithTransparentGcDrawer);
+						drawImages(mainGC, gcData, "Disabled", 560, disabledImageWithTransparentGcDrawer);
+						drawImages(mainGC, gcData, "Greyed", 600, greyImageWithTransparentGcDrawer);
 					} finally {
 						mainGC.dispose ();
 					}
@@ -130,7 +151,7 @@ public class Snippet382 {
 		};
 		shell.addListener(SWT.Paint, l);
 
-		shell.setSize(400, 550);
+		shell.setSize(400, 750);
 		shell.open ();
 		while (!shell.isDisposed ()) {
 			if (!display.readAndDispatch ()) display.sleep ();


### PR DESCRIPTION
This PR extends the usage of ImageGcDrawar to support SWT.Transparency as style that will initialize each GC with a proper transparent bitmap.

**Important:** 
Adaption for GTK and Cocoa will be added when we agree on the approach

I can extract to DPIUtil change into a separate PR