### PR TITLE
Stop reexporting SWT spies from swt.tools bundle

### DIFF
--- a/bundles/org.eclipse.swt.tools/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.swt.tools/META-INF/MANIFEST.MF
@@ -12,7 +12,5 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="3.29.0",
  org.eclipse.core.resources;bundle-version="3.4.0",
  org.eclipse.jdt.core;bundle-version="3.4.0",
  org.eclipse.ui;bundle-version="3.4.0",
- org.eclipse.jface.text;bundle-version="3.4.0",
- org.eclipse.swt.tools.base;bundle-version="3.106.0";visibility:=reexport,
- org.eclipse.swt.tools.spies;bundle-version="3.106.0";visibility:=reexport
+ org.eclipse.jface.text;bundle-version="3.4.0"
 Automatic-Module-Name: org.eclipse.swt.tools


### PR DESCRIPTION
The o.e.swt.tools* bundles have 2 completely different roles. They used to live in the same bundle back in the days and these reexports were added to preserve backward compatibility.
If we want to progress with
https://github.com/eclipse-platform/eclipse.platform.swt/discussions/2068 we have to finally make the separation clearer. Note that the swt.tools feature still include both.