### PR TITLE
[win32] Delegate handle destruction to ImageHandle

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Image.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Image.java
@@ -2236,7 +2236,7 @@ private class ImageFileNameProviderWrapper extends BaseImageProviderWrapper<Imag
 			imageDataAtZoom = ImageDataLoader.load(fileForZoom.element(), fileForZoom.zoom(), zoom);
 		} else {
 			imageDataAtZoom = new ElementAtZoom<>(nativeInitializedImage.getImageData(), fileForZoom.zoom());
-			destroyHandleForZoom(zoom);
+			destroyHandleForZoom(fileForZoom.zoom());
 		}
 		return imageDataAtZoom;
 	}


### PR DESCRIPTION
This PR moves the cleanup of OS handle of images from Image to the subclass Image#ImageHandle.

Main reason to do this is Image#destroyHandleForZoom can easily be called with the wrong zoom. Calling destroy explicitly on ImageHandle reduces risk of too much or not deleted handles