### PR TITLE
Revert "Fix Jenkinsfile to not ust strip but trim"

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -71,7 +71,7 @@ def getNativeJdkUrl(String os, String arch) { // To update the used JDK version 
 }
 
 def getLatestGitTag() {
-	return sh(script: 'git describe --abbrev=0 --tags --match v[0-9][0-9][0-9][0-9]*', returnStdout: true).trim()
+	return sh(script: 'git describe --abbrev=0 --tags --match v[0-9][0-9][0-9][0-9]*', returnStdout: true).strip()
 }
 
 def getSWTVersions() { // must be called from the repository root
@@ -159,7 +159,7 @@ pipeline {
 							def sources = sourceFoldersProps.collectEntries{ k, src -> [ k, src.split(',').collect{ f -> '\'' + f + '\''}.join(' ') ] }
 							for(ws in allWS) {
 								def diff = sh(script: "git diff HEAD ${swtTag} ${sources.src_common} ${sources['src_' + ws]}", returnStdout: true)
-								if (!diff.trim().isEmpty()) {
+								if (!diff.strip().isEmpty()) {
 									NATIVES_CHANGED += ws
 								}
 							}


### PR DESCRIPTION
Using `String.strip()` is now permitted: https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/2936#note_3785062

This reverts commit 788ba23c9f17dcdf515c5f08f5d4679b3e0f1904 from
- https://github.com/eclipse-platform/eclipse.platform.swt/pull/2077


