### PR TITLE
[Build] Extend list of kept builds but reduce artifacts kept

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -89,7 +89,7 @@ pipeline {
 		skipDefaultCheckout() // Specialiced checkout is performed below
 		timestamps()
 		timeout(time: 180, unit: 'MINUTES')
-		buildDiscarder(logRotator(numToKeepStr:'5'))
+		buildDiscarder(logRotator(numToKeepStr: 'master'.equals(env.BRANCH_NAME) ? '20' : '5', artifactNumToKeepStr: 'master'.equals(env.BRANCH_NAME) ? '3' : '1' ))
 		disableConcurrentBuilds(abortPrevious: true)
 	}
 	agent {


### PR DESCRIPTION
Keep the metadata of more builds but reduce the number of builds for which artifacts are kept. This reduces the overall storage occupation but lengths the trend lists.