### PR TITLE
Create Font handles on demand

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Font.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Font.java
@@ -46,9 +46,8 @@ public final class Font extends Resource {
 	 * platforms and should never be accessed from application code.
 	 * </p>
 	 *
-	 * @noreference This field is not intended to be referenced by clients.
 	 */
-	public long handle;
+	private long handle;
 
 	/**
 	 * The zoom in % of the standard resolution used for conversion of point height to pixel height
@@ -172,7 +171,8 @@ public Font(Device device, String name, int height, int style) {
 	super(device);
 	if (name == null) SWT.error(SWT.ERROR_NULL_ARGUMENT);
 	this.zoom = DPIUtil.getNativeDeviceZoom();
-	init(new FontData (name, height, style));
+	FontData fd = new FontData (name, height, style);
+	init(fd);
 	this.fontHeight = height;
 	init();
 }
@@ -181,7 +181,8 @@ public Font(Device device, String name, int height, int style) {
 	super(device);
 	if (name == null) SWT.error(SWT.ERROR_NULL_ARGUMENT);
 	this.zoom = DPIUtil.getNativeDeviceZoom();
-	init(new FontData (name, height, style));
+	FontData fd = new FontData (name, height, style);
+	init(fd);
 	this.fontHeight = height;
 	init();
 }
@@ -283,6 +284,23 @@ public boolean isDisposed() {
 public String toString () {
 	if (isDisposed()) return "Font {*DISPOSED*}";
 	return "Font {" + handle + "}";
+}
+
+/**
+ * Creates or returns a handle for the requested font.
+ * <p>
+ * <b>IMPORTANT:</b> This method is not part of the public API for
+ * <code>Font</code>. It is marked public only so that it can be shared within
+ * the packages provided by SWT. It is not available on all platforms, and
+ * should never be called from application code.
+ *
+ * @param font the font to get the handle of
+ * @return handle of the font
+ *
+ * @noreference This method is not intended to be referenced by clients.
+ */
+public static long win32_getHandle(Font font) {
+	return font.handle;
 }
 
 /**

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/SWTFontProvider.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/SWTFontProvider.java
@@ -48,7 +48,7 @@ public class SWTFontProvider {
 	}
 
 	public static long getSystemFontHandle(Device device, int zoom) {
-		return getSystemFont(device, zoom).handle;
+		return Font.win32_getHandle(getSystemFont(device, zoom));
 	}
 
 	/**
@@ -67,14 +67,14 @@ public class SWTFontProvider {
 	}
 
 	public static long getFontHandle(Device device, FontData fontData, int zoom) {
-		return getFont(device, fontData, zoom).handle;
+		return Font.win32_getHandle(getFont(device, fontData, zoom));
 	}
 
 	public static long getFontHandle(Font font, int zoom) {
 		if (font == null) {
 			SWT.error(SWT.ERROR_NULL_ARGUMENT);
 		}
-		return getFont(font.getDevice(), font.getFontData()[0], zoom).handle;
+		return Font.win32_getHandle(getFont(font.getDevice(), font.getFontData()[0], zoom));
 	}
 
 	/**

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/ScalingSWTFontRegistry.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/ScalingSWTFontRegistry.java
@@ -44,7 +44,7 @@ final class ScalingSWTFontRegistry implements SWTFontRegistry {
 
 		private Font createAndCacheFont(int zoom) {
 			Font newFont = createFont(zoom);
-			customFontHandlesKeyMap.put(newFont.handle, this);
+			customFontHandlesKeyMap.put(Font.win32_getHandle(newFont), this);
 			scaledFonts.put(zoom, newFont);
 			return newFont;
 		}

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Control.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Control.java
@@ -3439,7 +3439,7 @@ public void setFont (Font font) {
 	long hFont = 0;
 	if (newFont != null) {
 		if (newFont.isDisposed()) error(SWT.ERROR_INVALID_ARGUMENT);
-		hFont = newFont.handle;
+		hFont = Font.win32_getHandle(newFont);
 	}
 	this.font = newFont;
 	if (hFont == 0) hFont = defaultFont ();


### PR DESCRIPTION
Creating a new static method to retrieve font handle. Handles will no longer be created during initialization. Also destroy condition is changed since handle being 0 doesn't mean that it was destroyed anymore.

### How to test

- Run the following snippet with following VM arguments:
```
-Dswt.autoScale=quarter
-Dswt.autoScale.updateOnRuntime=true
```
```java
import org.eclipse.swt.*;
import org.eclipse.swt.graphics.*;
import org.eclipse.swt.layout.*;
import org.eclipse.swt.widgets.*;

public class SWTFontExample {
    public static void main(String[] args) {
        Display display = new Display();
        Shell shell = new Shell(display);
        shell.setText("SWT Font Example");
        shell.setSize(400, 200);
        shell.setLayout(new FillLayout());

        Label label = new Label(shell, SWT.CENTER);
        label.setText("Hello, SWT with Custom Font!");

        FontData[] fontData = label.getFont().getFontData();
        for (FontData fd : fontData) {
            fd.setHeight(20); // Set font size to 20
            fd.setStyle(SWT.BOLD); // Make it bold
        }

        Font newFont = new Font(display, fontData);
        label.setFont(newFont);

        shell.open();
        while (!shell.isDisposed()) {
            if (!display.readAndDispatch()) {
                display.sleep();
            }
        }
        newFont.dispose();
        display.dispose();
    }
}
```

- The correct formatting should be applied on the text same as before this change was made.
- This change should not produce any regression and the handle will only be created on demand not during initialization of Font object. 