### PR TITLE
Deprecate Image(Rectangle) constructor and replace usages

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/graphics/Image.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/graphics/Image.java
@@ -527,7 +527,10 @@ private void createRepFromSourceAndApplyFlag(NSBitmapImageRep srcRep, int srcWid
  * </ul>
  *
  * @see #dispose()
+ *
+ * @deprecated use {@link Image#Image(Device, int, int)} instead
  */
+@Deprecated(since = "2025-06", forRemoval = true)
 public Image(Device device, Rectangle bounds) {
 	super(device);
 	if (bounds == null) SWT.error(SWT.ERROR_NULL_ARGUMENT);

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/graphics/Image.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/graphics/Image.java
@@ -403,7 +403,10 @@ public Image(Device device, Image srcImage, int flag) {
  * </ul>
  *
  * @see #dispose()
+ *
+ * @deprecated use {@link Image#Image(Device, int, int)} instead
  */
+@Deprecated(since = "2025-06", forRemoval = true)
 public Image(Device device, Rectangle bounds) {
 	super(device);
 	if (bounds == null) SWT.error(SWT.ERROR_NULL_ARGUMENT);

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Image.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Image.java
@@ -335,7 +335,10 @@ public Image(Device device, Image srcImage, int flag) {
  * </ul>
  *
  * @see #dispose()
+ *
+ * @deprecated use {@link Image#Image(Device, int, int)} instead
  */
+@Deprecated(since = "2025-06", forRemoval = true)
 public Image(Device device, Rectangle bounds) {
 	super(device);
 	if (bounds == null) SWT.error(SWT.ERROR_NULL_ARGUMENT);

--- a/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet215.java
+++ b/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet215.java
@@ -38,7 +38,8 @@ public static void main(String[] args) {
 
 		/* Take the screen shot */
 		GC gc = new GC(display);
-		final Image image = new Image(display, display.getBounds());
+		Rectangle rect = display.getBounds();
+		final Image image = new Image(display, rect.width, rect.height);
 		gc.copyArea(image, 0, 0);
 		gc.dispose();
 

--- a/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet292.java
+++ b/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet292.java
@@ -55,7 +55,8 @@ public class Snippet292 {
 		button.addListener (SWT.Selection, e -> {
 			Image image = label.getImage ();
 			if (image != null) image.dispose ();
-			image = new Image (display, group.getBounds ());
+			Rectangle rect = group.getBounds();
+			image = new Image (display, rect.width, rect.height);
 			GC gc = new GC (image);
 			boolean success = group.print (gc);
 			gc.dispose ();

--- a/tests/org.eclipse.swt.tests.gtk/ManualTests/org/eclipse/swt/tests/gtk/snippets/Bug531667_CanvasPrint_does_not_work.java
+++ b/tests/org.eclipse.swt.tests.gtk/ManualTests/org/eclipse/swt/tests/gtk/snippets/Bug531667_CanvasPrint_does_not_work.java
@@ -81,7 +81,7 @@ public class Bug531667_CanvasPrint_does_not_work {
 
 	private static void snapshot(Display display, Composite composite, String filename) {
 		Rectangle bounds = composite.getBounds();
-		Image image = new Image(display, bounds);
+		Image image = new Image(display, bounds.width, bounds.height);
 		GC gc = new GC(image);
 		composite.print(gc);
 		gc.dispose();

--- a/tests/org.eclipse.swt.tests.gtk/ManualTests/org/eclipse/swt/tests/gtk/snippets/Bug547529_ControlPrintBroken.java
+++ b/tests/org.eclipse.swt.tests.gtk/ManualTests/org/eclipse/swt/tests/gtk/snippets/Bug547529_ControlPrintBroken.java
@@ -84,7 +84,7 @@ class Bug547529_ControlPrintBroken {
 
 	private static void snapshot(Display display, Composite composite, String filename) {
 		Rectangle bounds = composite.getBounds();
-		Image image = new Image(display, bounds);
+		Image image = new Image(display, bounds.width, bounds.height);
 		GC gc = new GC(image);
 		composite.print(gc);
 		gc.dispose();

--- a/tests/org.eclipse.swt.tests.gtk/ManualTests/org/eclipse/swt/tests/gtk/snippets/Bug547529_ImageLoaderStriping.java
+++ b/tests/org.eclipse.swt.tests.gtk/ManualTests/org/eclipse/swt/tests/gtk/snippets/Bug547529_ImageLoaderStriping.java
@@ -20,6 +20,7 @@ import org.eclipse.swt.graphics.GC;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.graphics.ImageData;
 import org.eclipse.swt.graphics.ImageLoader;
+import org.eclipse.swt.graphics.Rectangle;
 import org.eclipse.swt.layout.FillLayout;
 import org.eclipse.swt.layout.RowLayout;
 import org.eclipse.swt.widgets.Button;
@@ -72,7 +73,8 @@ public class Bug547529_ImageLoaderStriping {
 	}
 
 	private static void saveImage(Control control, String filename, int format) {
-		Image image = new Image(control.getDisplay(), control.getBounds());
+		Rectangle bounds = control.getBounds();
+		Image image = new Image(control.getDisplay(), bounds.width, bounds.height);
 		GC gc = new GC(image);
 		control.print(gc);
 		gc.dispose();

--- a/tests/org.eclipse.swt.tests.gtk/ManualTests/org/eclipse/swt/tests/gtk/snippets/Bug547557_ShellPrintGC.java
+++ b/tests/org.eclipse.swt.tests.gtk/ManualTests/org/eclipse/swt/tests/gtk/snippets/Bug547557_ShellPrintGC.java
@@ -66,7 +66,7 @@ public class Bug547557_ShellPrintGC {
 
 	private static void saveImage(Shell shell, String filename, int format) {
 		Rectangle bounds = shell.getBounds();
-		Image image = new Image(shell.getDisplay(), bounds);
+		Image image = new Image(shell.getDisplay(), bounds.width, bounds.height);
 		// Printing the client area will result in a warning and only the client area being printed
 //		Image image = new Image(shell.getDisplay(), shell.getClientArea());
 		GC gc = new GC(image);

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_Image.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_Image.java
@@ -119,6 +119,7 @@ public void test_ConstructorLorg_eclipse_swt_graphics_DeviceII() {
 	image.dispose();
 }
 
+@SuppressWarnings("removal")
 @Test
 public void test_ConstructorLorg_eclipse_swt_graphics_DeviceLorg_eclipse_swt_graphics_Rectangle() {
 	Image image;
@@ -153,6 +154,31 @@ public void test_ConstructorLorg_eclipse_swt_graphics_DeviceLorg_eclipse_swt_gra
 	image.dispose();
 
 	image = new Image(display, bounds);
+	image.dispose();
+}
+
+@Test
+public void test_ConstructorLorg_eclipse_swt_graphics_DeviceLorg_eclipse_swt_graphics_int_int() {
+	Image image;
+	IllegalArgumentException e;
+
+	e = assertThrows(IllegalArgumentException.class, () -> new Image(display, -1, 10));
+	assertSWTProblem("Incorrect exception thrown for width < 0", SWT.ERROR_INVALID_ARGUMENT, e);
+
+	e = assertThrows(IllegalArgumentException.class, () -> new Image(display, 0, 10));
+	assertSWTProblem("Incorrect exception thrown for width == 0", SWT.ERROR_INVALID_ARGUMENT, e);
+
+	e = assertThrows(IllegalArgumentException.class, () -> new Image(display, 10, -1));
+	assertSWTProblem("Incorrect exception thrown for height < 0", SWT.ERROR_INVALID_ARGUMENT, e);
+
+	e = assertThrows(IllegalArgumentException.class, () -> new Image(display, 10, 0));
+	assertSWTProblem("Incorrect exception thrown for height == 0", SWT.ERROR_INVALID_ARGUMENT, e);
+
+	// valid images
+	image = new Image(null, 10, 10);
+	image.dispose();
+
+	image = new Image(display, 10, 10);
 	image.dispose();
 }
 
@@ -521,7 +547,7 @@ public void test_getBounds() {
 	image.dispose();
 	assertEquals(bounds, bounds1);
 
-	image = new Image(display, bounds);
+	image = new Image(display, bounds.width, bounds.height);
 	bounds1 = image.getBounds();
 	image.dispose();
 	assertEquals(bounds, bounds1);
@@ -693,7 +719,7 @@ void getImageData_int(int zoom) {
 	assertEquals(":a: Size of ImageData returned from Image.getImageData(int) method doesn't return matches with bounds in Pixel values.", scaleBounds(bounds, zoom, 100), boundsAtZoom);
 
 	// creates second bitmap image and compare size of imageData
-	image = new Image(display, bounds);
+	image = new Image(display, bounds.width, bounds.height);
 	imageDataAtZoom = image.getImageData(zoom);
 	boundsAtZoom = new Rectangle(0, 0, imageDataAtZoom.width, imageDataAtZoom.height);
 	bounds = image.getBounds();

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_TextLayout.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_TextLayout.java
@@ -1009,7 +1009,8 @@ public void test_bug568740_multilineTextStyle() {
 private Image draw(TextLayout layout, int antialias) {
 	GC gc = null;
 	try {
-		Image image = new Image(display, layout.getBounds());
+		Rectangle rect = layout.getBounds();
+		Image image = new Image(display, rect.width, rect.height);
 		gc = new GC(image);
 		gc.setBackground(display.getSystemColor(SWT.COLOR_WHITE));
 		gc.fillRectangle(image.getBounds());

--- a/tests/org.eclipse.swt.tests/ManualTests/org/eclipse/swt/tests/manual/Bug529534_CTabFolder_topRight_wrapped.java
+++ b/tests/org.eclipse.swt.tests/ManualTests/org/eclipse/swt/tests/manual/Bug529534_CTabFolder_topRight_wrapped.java
@@ -96,7 +96,7 @@ public class Bug529534_CTabFolder_topRight_wrapped {
 
 	private static Image image(Display display, int shapeColor) {
 		Rectangle bounds = new Rectangle(0, 0, 16, 16);
-		Image image = new Image(display, bounds);
+		Image image = new Image(display, bounds.width, bounds.height);
 		GC gc = new GC(image);
 		gc.setBackground(display.getSystemColor(SWT.COLOR_WIDGET_BACKGROUND));
 		gc.fillRectangle(bounds);


### PR DESCRIPTION
Deprecate Image constructor that accepts Rectangle in favor of Image(display, width, height).