### PR TITLE
Do not use DPIUtil.getNativeDeviceZoom() to get the cursor handle #2057

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Cursor.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Cursor.java
@@ -355,13 +355,12 @@ public Cursor(Device device, ImageData source, int hotspotX, int hotspotY) {
  * Get the handle for a cursor given a zoom level.
  *
  * @param cursor the cursor
+ * @param zoom zoom level (in %) of the monitor the cursor is currently in.
  * @return The handle of the cursor.
  *
  * @noreference This method is not intended to be referenced by clients.
  */
-public static Long win32_getHandle (Cursor cursor) {
-	// The size of the cursor should match the zoom of the current monitor
-	int zoom = DPIUtil.getNativeDeviceZoom();
+public static Long win32_getHandle (Cursor cursor, int zoom) {
 	if (cursor.isDisposed()) {
 		return cursor.handle;
 	}

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Control.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Control.java
@@ -5475,7 +5475,7 @@ LRESULT WM_SETCURSOR (long wParam, long lParam) {
 		if (control == null) return null;
 		Cursor cursor = control.findCursor ();
 		if (cursor != null) {
-			OS.SetCursor (Cursor.win32_getHandle(cursor));
+			OS.SetCursor (Cursor.win32_getHandle(cursor, getNativeZoom()));
 			return LRESULT.ONE;
 		}
 	}

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Shell.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Shell.java
@@ -2659,7 +2659,7 @@ LRESULT WM_SETCURSOR (long wParam, long lParam) {
 				RECT rect = new RECT ();
 				OS.GetClientRect (handle, rect);
 				if (OS.PtInRect (rect, pt)) {
-					OS.SetCursor (Cursor.win32_getHandle(cursor));
+					OS.SetCursor (Cursor.win32_getHandle(cursor, getNativeZoom()));
 					switch (msg) {
 						case OS.WM_LBUTTONDOWN:
 						case OS.WM_RBUTTONDOWN:

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Tracker.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Tracker.java
@@ -823,7 +823,7 @@ public void setCursor(Cursor newCursor) {
 	checkWidget();
 	clientCursor = newCursor;
 	if (newCursor != null) {
-		if (inEvent) OS.SetCursor (Cursor.win32_getHandle(clientCursor));
+		if (inEvent) OS.SetCursor (Cursor.win32_getHandle(clientCursor, getNativeZoom()));
 	}
 }
 
@@ -892,7 +892,7 @@ long transparentProc (long hwnd, long msg, long wParam, long lParam) {
 			break;
 		case OS.WM_SETCURSOR:
 			if (clientCursor != null) {
-				OS.SetCursor (Cursor.win32_getHandle(clientCursor));
+				OS.SetCursor (Cursor.win32_getHandle(clientCursor, getNativeZoom()));
 				return 1;
 			}
 			if (resizeCursor != 0) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Tree.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Tree.java
@@ -4663,7 +4663,7 @@ void setCursor () {
 	* is IDC_ARROW.
 	*/
 	Cursor cursor = findCursor ();
-	long hCursor = cursor == null ? OS.LoadCursor (0, OS.IDC_ARROW) : Cursor.win32_getHandle(cursor);
+	long hCursor = cursor == null ? OS.LoadCursor (0, OS.IDC_ARROW) : Cursor.win32_getHandle(cursor, getNativeZoom());
 	OS.SetCursor (hCursor);
 }
 


### PR DESCRIPTION
Supersedes https://github.com/eclipse-platform/eclipse.platform.swt/pull/2071
 
Fixes https://github.com/eclipse-platform/eclipse.platform.swt/issues/2057

## Requires
- #2092 

# How to test
- Use 2 monitors with different zoom levels (none of them should match the zoom level passed to `-Dswt.autoScale` in the next step)
- Run `Snippet119` with the following JVM parameters: 
  - `-Dswt.autoScale=200` (or use another zoom level that doesn't match any of the zooms in your monitors)
  - `-Dswt.autoScale.updateOnRuntime=true`

Expected: the size of the cursor matches the size of the current monitor and **not** the one you provided for `-Dswt.autoScale`
 
- Move the window of the snippet to the monitor 

Expected: the size of the cursor still matches the size of the current monitor and **not** the one you provided for `-Dswt.autoScale`