### PR TITLE
Remove hue from ImageColorTransformer#forHSB #2060

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/image/ImageColorTransformer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/image/ImageColorTransformer.java
@@ -23,17 +23,17 @@ public interface ImageColorTransformer {
 
 	public static final ImageColorTransformer DEFAULT_DISABLED_IMAGE_TRANSFORMER = switch (IMAGE_DISABLEMENT_ALGORITHM) {
 	case IMAGE_DISABLEMENT_ALGORITHM_GTK -> ImageColorTransformer.forRGB(0.5f, 0.5f, 0.5f, 0.5f);
-	case IMAGE_DISABLEMENT_ALGORITHM_DESATURATED -> ImageColorTransformer.forHSB(1.0f, 0.2f, 0.9f, 0.5f);
+	case IMAGE_DISABLEMENT_ALGORITHM_DESATURATED -> ImageColorTransformer.forSaturationBrightness(0.2f, 0.9f, 0.5f);
 	default -> ImageColorTransformer.forGrayscaledContrastBrightness(0.2f, 2.9f);
 	};
 
 	RGBA adaptPixelValue(int red, int green, int blue, int alpha);
 
-	public static ImageColorTransformer forHSB(float hueFactor, float saturationFactor, float brightnessFactor,
+	public static ImageColorTransformer forSaturationBrightness(float saturationFactor, float brightnessFactor,
 			float alphaFactor) {
 		return (red, green, blue, alpha) -> {
 			float[] hsba = new RGBA(red, green, blue, alpha).getHSBA();
-			float hue = Math.min(hueFactor * hsba[0], 1.0f);
+			float hue = hsba[0];
 			float saturation = Math.min(saturationFactor * hsba[1], 1.0f);
 			float brightness = Math.min(brightnessFactor * hsba[2], 1.0f);
 			float alphaResult = Math.min(alphaFactor * hsba[3], 255.0f);


### PR DESCRIPTION
The ImageColorTransformer introduced for disabled icon calculation has a default implementation taking hue, saturation, brightness and alpha factors for transformation. The hue factor was by accident limited to 1, even though it is a value between 0 and 360. In addition, a multiplication of a hue value with a factor is not reasonable at all.

This change removes the ability to change the hue of a color value, as the existing usage of that method does not change the hue anyway. It renames the method accordingly.

Fixes https://github.com/eclipse-platform/eclipse.platform.swt/issues/2060