### PR TITLE
[win32] Prevent loop with fix swt.autoScale value

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/GC.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/GC.java
@@ -3909,7 +3909,7 @@ void init(Drawable drawable, GCData data, long hDC) {
 	}
 	Image image = data.image;
 	if (image != null) {
-		data.hNullBitmap = OS.SelectObject(hDC, Image.win32_getHandle(image, DPIUtil.getZoomForAutoscaleProperty(data.nativeZoom)));
+		data.hNullBitmap = OS.SelectObject(hDC, Image.win32_getHandle(image, data.nativeZoom));
 		image.memGC = this;
 	}
 	int layout = data.layout;


### PR DESCRIPTION
This PR adapts the extraction of the correct image handle in the windows implementation when using an Image with a GC. As the image will always pass the exact zoom it needs to the GC using the autoscaled zoom together with an Image can lead to unexpected results when fixed values for swt.autoScale are passed, e.g. scaling ImageData can result in endless loops.

This effect can be seen e.g. by executing Snippet119 with

```
-Dswt.autoScale=200
-Dswt.autoScale.updateOnRuntime=true
```