### PR TITLE
Edge: Implement mouse-related event listener support

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Browser/common/org/eclipse/swt/browser/Browser.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Browser/common/org/eclipse/swt/browser/Browser.java
@@ -16,6 +16,7 @@ package org.eclipse.swt.browser;
 import java.util.*;
 
 import org.eclipse.swt.*;
+import org.eclipse.swt.events.*;
 import org.eclipse.swt.program.*;
 import org.eclipse.swt.widgets.*;
 
@@ -1109,6 +1110,11 @@ public void removeVisibilityWindowListener (VisibilityWindowListener listener) {
  * Sets whether javascript will be allowed to run in pages subsequently
  * viewed in the receiver.  Note that setting this value does not affect
  * the running of javascript in the current page.
+ * <p>
+ * Note: When using the {@link SWT#EDGE} browser on Windows disabling javascript
+ * has certain side effects, e.g. proper support for {@link MouseEvent} depends
+ * on it and, when disabled, a limited timer-based fallback implementation is
+ * used.
  *
  * @param enabled the receiver's new javascript enabled state
  *

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/win32/org/eclipse/swt/internal/ole/win32/ICoreWebView2.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/win32/org/eclipse/swt/internal/ole/win32/ICoreWebView2.java
@@ -79,8 +79,8 @@ public int PostWebMessageAsJson(char[] webMessageAsJson) {
 	return COM.VtblCall(32, address, webMessageAsJson);
 }
 
-public int add_WebMessageReceived(long handler, long[] token) {
-	return COM.VtblCall(34, address, handler, token);
+public int add_WebMessageReceived(IUnknown eventHandler, long[] token) {
+	return COM.VtblCall(34, address, eventHandler.address, token);
 }
 
 public int get_CanGoBack(int[] canGoBack) {


### PR DESCRIPTION
- MouseListener
  - up
  - down
  - doubleClick

- MouseMoveListener
  - move

- MouseTrackListener
  - exit
  - enter

- MouseWheelListener
  - scroll

- DragDetectListener
  - dragDetected

The implementation is JavaScript-based by attaching listeners to the DOM for all relevant events and forwarding them to the WebView via `window.chrome.webview.postMessage()`.

The event handling is analogous to IE's
`IE#handleDOMEvent(org.eclipse.swt.ole.win32.OleEvent)`.

Note: Since the implementation is JavaScript-based, this requires JavaScript to be enabled on the Browser instance.

When JavaScript is disabled, we keep using the timer-based fallback implementation introduced in #1551.
As JavaScript is only truly enabled *after* navigation has finished, we also keep using this workaround when the Browser is first instantiated and before the first page has loaded.

This change also fixes the jsEnabled flag lifecycle by updating it in `handleNavigationCompleted()`, same as in IE.

This resolves #2164 as long as JavaScript is enabled.