### PR TITLE
[GTK] Remove more *InPixels method

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Canvas.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Canvas.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -317,12 +317,6 @@ public void scroll (int destX, int destY, int x, int y, int width, int height, b
 	 * as to why it's unneeded is left as a TODO. See bug 546274.
 	 */
 	if (GTK.GTK4) return;
-	Point destination = new Point (destX, destY);
-	Rectangle srcRect = new Rectangle (x, y, width, height);
-	scrollInPixels(destination.x, destination.y, srcRect.x, srcRect.y, srcRect.width, srcRect.height, all);
-}
-
-void scrollInPixels (int destX, int destY, int x, int y, int width, int height, boolean all) {
 	if ((style & SWT.MIRRORED) != 0) {
 		int clientWidth = getClientWidth ();
 		x = clientWidth - width - x;

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Caret.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Caret.java
@@ -142,11 +142,6 @@ private void drawInCellEditor(long window) {
  */
 public Rectangle getBounds () {
 	checkWidget();
-	return getBoundsInPixels();
-}
-
-Rectangle getBoundsInPixels () {
-	checkWidget();
 	if (image != null) {
 		Rectangle rect = image.getBoundsInPixels ();
 		return new Rectangle (x, y, rect.width, rect.height);
@@ -202,11 +197,6 @@ public Image getImage () {
  */
 public Point getLocation () {
 	checkWidget();
-	return getLocationInPixels();
-}
-
-Point getLocationInPixels () {
-	checkWidget();
 	return new Point (x, y);
 }
 
@@ -236,11 +226,6 @@ public Canvas getParent () {
  * </ul>
  */
 public Point getSize () {
-	checkWidget();
-	return getSizeInPixels();
-}
-
-Point getSizeInPixels () {
 	checkWidget();
 	if (image != null) {
 		Rectangle rect = image.getBoundsInPixels ();
@@ -349,11 +334,6 @@ void releaseWidget () {
  */
 public void setBounds (int x, int y, int width, int height) {
 	checkWidget();
-	setBounds (new Rectangle (x, y, width, height));
-}
-
-void setBoundsInPixels (int x, int y, int width, int height) {
-	checkWidget();
 	if (this.x == x && this.y == y && this.width == width && this.height == height) return;
 	boolean isFocus = isFocusCaret ();
 	if (isFocus && isVisible) hideCaret ();
@@ -378,13 +358,8 @@ void setBoundsInPixels (int x, int y, int width, int height) {
  */
 public void setBounds (Rectangle rect) {
 	checkWidget();
-	setBoundsInPixels(rect);
-}
-
-void setBoundsInPixels (Rectangle rect) {
-	checkWidget();
 	if (rect == null) error (SWT.ERROR_NULL_ARGUMENT);
-	setBoundsInPixels (rect.x, rect.y, rect.width, rect.height);
+	setBounds (rect.x, rect.y, rect.width, rect.height);
 }
 
 void setFocus () {
@@ -457,12 +432,7 @@ public void setImage (Image image) {
  */
 public void setLocation (int x, int y) {
 	checkWidget();
-	setLocation (new Point (x, y));
-}
-
-void setLocationInPixels (int x, int y) {
-	checkWidget();
-	setBoundsInPixels (x, y, width, height);
+	setBounds (x, y, width, height);
 }
 
 /**
@@ -479,13 +449,8 @@ void setLocationInPixels (int x, int y) {
  */
 public void setLocation (Point location) {
 	checkWidget();
-	setLocationInPixels (location);
-}
-
-void setLocationInPixels (Point location) {
-	checkWidget();
 	if (location == null) error (SWT.ERROR_NULL_ARGUMENT);
-	setLocationInPixels (location.x, location.y);
+	setLocation (location.x, location.y);
 }
 
 /**
@@ -501,12 +466,7 @@ void setLocationInPixels (Point location) {
  */
 public void setSize (int width, int height) {
 	checkWidget();
-	setSize (new Point (width,height));
-}
-
-void setSizeInPixels (int width, int height) {
-	checkWidget();
-	setBoundsInPixels (x, y, width, height);
+	setBounds (x, y, width, height);
 }
 
 /**
@@ -524,13 +484,8 @@ void setSizeInPixels (int width, int height) {
  */
 public void setSize (Point size) {
 	checkWidget();
-	setSizeInPixels(size);
-}
-
-void setSizeInPixels (Point size) {
-	checkWidget();
 	if (size == null) error (SWT.ERROR_NULL_ARGUMENT);
-	setSizeInPixels (size.x, size.y);
+	setSize (size.x, size.y);
 }
 
 /**

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Combo.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Combo.java
@@ -1081,12 +1081,6 @@ long eventSurface () {
  */
 public Point getCaretLocation () {
 	checkWidget ();
-	return getCaretLocationInPixels();
-}
-
-
-Point getCaretLocationInPixels () {
-	checkWidget ();
 	if ((style & SWT.READ_ONLY) != 0) {
 		return new Point (0, 0);
 	}
@@ -1389,12 +1383,6 @@ String getText (int start, int stop) {
  * </ul>
  */
 public int getTextHeight () {
-	checkWidget();
-	return getTextHeightInPixels();
-}
-
-
-int getTextHeightInPixels () {
 	checkWidget();
 	GtkRequisition requisition = new GtkRequisition ();
 	gtk_widget_get_preferred_size (handle, requisition);
@@ -2275,7 +2263,7 @@ void setBackgroundGdkRGBA (long context, long handle, GdkRGBA rgba) {
 @Override
 int setBounds (int x, int y, int width, int height, boolean move, boolean resize) {
 	int newHeight = height;
-	if (resize) newHeight = Math.max (getTextHeightInPixels (), height);
+	if (resize) newHeight = Math.max (getTextHeight (), height);
 	return super.setBounds (x, y, width, newHeight, move, resize);
 }
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Control.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Control.java
@@ -6320,14 +6320,14 @@ boolean showMenu (int x, int y, int detail) {
 				if (temp != 0) OS.g_object_unref(temp);
 
 
-				menu.setLocationInPixels(x, y);
+				menu.setLocation(x, y);
 				menu.setVisible(true);
 
 				return true;
 			} else {
 				Rectangle rect = event.getBounds ();
 				if (rect.x != x || rect.y != y) {
-					menu.setLocationInPixels (rect.x, rect.y);
+					menu.setLocation (rect.x, rect.y);
 				}
 				menu.setVisible (true);
 				return true;

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/ExpandBar.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/ExpandBar.java
@@ -484,11 +484,6 @@ void setOrientation (boolean create) {
  */
 public void setSpacing (int spacing) {
 	checkWidget ();
-	setSpacingInPixels(spacing);
-}
-
-void setSpacingInPixels (int spacing) {
-	checkWidget ();
 	if (spacing < 0) return;
 	if (spacing == this.spacing) return;
 	this.spacing = spacing;

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/ExpandItem.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/ExpandItem.java
@@ -232,11 +232,6 @@ public boolean getExpanded() {
  */
 public int getHeaderHeight () {
 	checkWidget ();
-	return getHeaderHeightInPixels ();
-}
-
-int getHeaderHeightInPixels() {
-	checkWidget();
 
 	GtkAllocation allocation = new GtkAllocation();
 	GTK.gtk_widget_get_allocation(GTK.gtk_expander_get_label_widget(handle), allocation);
@@ -506,11 +501,6 @@ void setForegroundRGBA (GdkRGBA rgba) {
  * </ul>
  */
 public void setHeight (int height) {
-	checkWidget ();
-	setHeightInPixels(height);
-}
-
-void setHeightInPixels (int height) {
 	checkWidget ();
 	if (height < 0) return;
 	this.height = height;

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/List.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/List.java
@@ -275,7 +275,7 @@ Point computeSizeInPixels (int wHint, int hHint, boolean changed) {
 	 * based on the number of items in the table
 	 */
 	if (size.y == 0 && hHint == SWT.DEFAULT) {
-		size.y = getItemCount() * getItemHeightInPixels();
+		size.y = getItemCount() * getItemHeight();
 	}
 
 	/*
@@ -535,11 +535,6 @@ public int getItemCount () {
  * </ul>
  */
 public int getItemHeight () {
-	checkWidget();
-	return getItemHeightInPixels();
-}
-
-int getItemHeightInPixels() {
 	checkWidget();
 
 	final int BASE_ITEM_PADDING = 1;

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Menu.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Menu.java
@@ -1198,11 +1198,6 @@ public void setEnabled(boolean enabled) {
  */
 public void setLocation (int x, int y) {
 	checkWidget ();
-	setLocation (new Point (x, y));
-}
-
-void setLocationInPixels (int x, int y) {
-	checkWidget();
 	if ((style & (SWT.BAR | SWT.DROP_DOWN)) != 0) return;
 	this.x = x;
 	this.y = y;
@@ -1235,13 +1230,8 @@ void setLocationInPixels (int x, int y) {
  */
 public void setLocation (Point location) {
 	checkWidget ();
-	setLocationInPixels (location);
-}
-
-void setLocationInPixels (Point location) {
-	checkWidget();
 	if (location == null) error (SWT.ERROR_NULL_ARGUMENT);
-	setLocationInPixels (location.x, location.y);
+	setLocation (location.x, location.y);
 }
 
 /**

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/ScrollBar.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/ScrollBar.java
@@ -289,11 +289,6 @@ public int getSelection () {
  */
 public Point getSize () {
 	checkWidget ();
-	return getSizeInPixels ();
-}
-
-Point getSizeInPixels () {
-	checkWidget ();
 	if (handle == 0) return new Point (0,0);
 	GtkRequisition requisition = new GtkRequisition ();
 	gtk_widget_get_preferred_size (handle, requisition);

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Shell.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Shell.java
@@ -1296,11 +1296,6 @@ public boolean getMaximized () {
  */
 public Point getMinimumSize () {
 	checkWidget ();
-	return getMinimumSizeInPixels ();
-}
-
-Point getMinimumSizeInPixels () {
-	checkWidget ();
 	int width = Math.max (1, geometry.getMinWidth() + trimWidth ());
 	int height = Math.max (1, geometry.getMinHeight() + trimHeight ());
 	return new Point (width, height);
@@ -1323,12 +1318,6 @@ Point getMinimumSizeInPixels () {
  */
 public Point getMaximumSize () {
 	checkWidget ();
-	return getMaximumSizeInPixels ();
-}
-
-Point getMaximumSizeInPixels () {
-	checkWidget ();
-
 	int width = Math.min (Integer.MAX_VALUE, geometry.getMaxWidth() + trimWidth ());
 	int height = Math.min (Integer.MAX_VALUE, geometry.getMaxHeight() + trimHeight ());
 	return new Point (width, height);
@@ -2662,11 +2651,6 @@ public void setMinimized (boolean minimized) {
  */
 public void setMinimumSize (int width, int height) {
 	checkWidget ();
-	setMinimumSize (new Point (width, height));
-}
-
-void setMinimumSizeInPixels (int width, int height) {
-	checkWidget ();
 	geometry.setMinWidth(Math.max (width, trimWidth ()) - trimWidth ());
 	geometry.setMinHeight(Math.max (height, trimHeight ()) - trimHeight ());
 
@@ -2701,13 +2685,8 @@ void setMinimumSizeInPixels (int width, int height) {
  */
 public void setMinimumSize (Point size) {
 	checkWidget ();
-	setMinimumSizeInPixels (size);
-}
-
-void setMinimumSizeInPixels (Point size) {
-	checkWidget ();
 	if (size == null) error (SWT.ERROR_NULL_ARGUMENT);
-	setMinimumSizeInPixels (size.x, size.y);
+	setMinimumSize (size.x, size.y);
 }
 
 /**
@@ -2732,7 +2711,13 @@ void setMinimumSizeInPixels (Point size) {
  */
 public void setMaximumSize (int width, int height) {
 	checkWidget ();
-	setMaximumSize (new Point (width, height));
+	geometry.setMaxWidth(Math.max (width, trimWidth ()) - trimWidth ());
+	geometry.setMaxHeight(Math.max (height, trimHeight ()) - trimHeight ());
+	int hint = GDK.GDK_HINT_MAX_SIZE;
+	if (geometry.getMinWidth() > 0 || geometry.getMinHeight() > 0) {
+		hint = hint | GDK.GDK_HINT_MIN_SIZE;
+	}
+	GTK3.gtk_window_set_geometry_hints (shellHandle, 0, (GdkGeometry) geometry, hint);
 }
 
 /**
@@ -2759,24 +2744,8 @@ public void setMaximumSize (int width, int height) {
  */
 public void setMaximumSize (Point size) {
 	checkWidget ();
-	setMaximumSizeInPixels (size);
-}
-
-void setMaximumSizeInPixels (Point size) {
-	checkWidget ();
 	if (size == null) error (SWT.ERROR_NULL_ARGUMENT);
-	setMaximumSizeInPixels (size.x, size.y);
-}
-
-void setMaximumSizeInPixels (int width, int height) {
-	checkWidget ();
-	geometry.setMaxWidth(Math.max (width, trimWidth ()) - trimWidth ());
-	geometry.setMaxHeight(Math.max (height, trimHeight ()) - trimHeight ());
-	int hint = GDK.GDK_HINT_MAX_SIZE;
-	if (geometry.getMinWidth() > 0 || geometry.getMinHeight() > 0) {
-		hint = hint | GDK.GDK_HINT_MIN_SIZE;
-	}
-	GTK3.gtk_window_set_geometry_hints (shellHandle, 0, (GdkGeometry) geometry, hint);
+	setMaximumSize (size.x, size.y);
 }
 
 /**

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/TabItem.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/TabItem.java
@@ -160,11 +160,6 @@ void destroyWidget () {
  */
 public Rectangle getBounds () {
 	checkWidget ();
-	return getBoundsInPixels ();
-}
-
-Rectangle getBoundsInPixels () {
-	checkWidget();
 	GtkAllocation allocation = new GtkAllocation ();
 	GTK.gtk_widget_get_allocation (handle, allocation);
 	int x = allocation.x;

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Text.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Text.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -949,11 +949,6 @@ public int getCaretLineNumber () {
  */
 public Point getCaretLocation () {
 	checkWidget ();
-	return getCaretLocationInPixels();
-}
-
-Point getCaretLocationInPixels () {
-	checkWidget ();
 	if ((style & SWT.SINGLE) != 0) {
 		int index = GTK.gtk_editable_get_position (handle);
 		index = GTK3.gtk_entry_text_index_to_layout_index (handle, index);
@@ -1532,11 +1527,6 @@ public int getTopIndex () {
  * </ul>
  */
 public int getTopPixel () {
-	checkWidget ();
-	return getTopPixelInPixels();
-}
-
-int getTopPixelInPixels () {
 	checkWidget ();
 	if ((style & SWT.SINGLE) != 0) return 0;
 	byte [] position = new byte [ITER_SIZEOF];

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/ToolBar.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/ToolBar.java
@@ -302,15 +302,10 @@ public ToolItem getItem (int index) {
  */
 public ToolItem getItem (Point point) {
 	checkWidget();
-	return getItemInPixels(point);
-}
-
-
-ToolItem getItemInPixels (Point point) {
 	if (point == null) error (SWT.ERROR_NULL_ARGUMENT);
 	ToolItem[] items = getItems();
 	for (int i=0; i<items.length; i++) {
-		if (items[i].getBoundsInPixels().contains(point)) return items[i];
+		if (items[i].getBounds().contains(point)) return items[i];
 	}
 	return null;
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/ToolItem.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/ToolItem.java
@@ -407,11 +407,6 @@ public Color getBackground () {
  */
 public Rectangle getBounds () {
 	checkWidget ();
-	return getBoundsInPixels ();
-}
-
-Rectangle getBoundsInPixels () {
-	checkWidget();
 	parent.forceResize ();
 	long topHandle = topHandle ();
 	GtkAllocation allocation = new GtkAllocation ();
@@ -607,11 +602,6 @@ public String getToolTipText () {
  */
 public int getWidth () {
 	checkWidget ();
-	return getWidthInPixels ();
-}
-
-int getWidthInPixels () {
-	checkWidget();
 	parent.forceResize ();
 	long topHandle = topHandle ();
 	GtkAllocation allocation = new GtkAllocation();
@@ -1534,11 +1524,6 @@ public void setToolTipText(String string) {
  */
 public void setWidth (int width) {
 	checkWidget ();
-	setWidthInPixels(width);
-}
-
-void setWidthInPixels (int width) {
-	checkWidget();
 	if ((style & SWT.SEPARATOR) == 0) return;
 	if (width < 0) return;
 	resizeHandle(width, (parent.style & SWT.VERTICAL) != 0 ? 6 : 15);

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/ToolTip.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/ToolTip.java
@@ -711,11 +711,6 @@ public void setAutoHide (boolean autoHide) {
  */
 public void setLocation (int x, int y) {
 	checkWidget ();
-	setLocation (new Point (x, y));
-}
-
-void setLocationInPixels (int x, int y) {
-	checkWidget ();
 	this.x = x;
 	this.y = y;
 	if ((style & SWT.BALLOON) != 0) {
@@ -746,13 +741,8 @@ void setLocationInPixels (int x, int y) {
  */
 public void setLocation (Point location) {
 	checkWidget ();
-	setLocationInPixels(location);
-}
-
-void setLocationInPixels (Point location) {
-	checkWidget ();
 	if (location == null) error (SWT.ERROR_NULL_ARGUMENT);
-	setLocationInPixels (location.x, location.y);
+	setLocation (location.x, location.y);
 }
 
 /**

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Tracker.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Tracker.java
@@ -445,16 +445,6 @@ public Rectangle [] getRectangles () {
 	return result;
 }
 
-Rectangle [] getRectanglesInPixels () {
-	checkWidget();
-	Rectangle [] result = new Rectangle [rectangles.length];
-	for (int i = 0; i < rectangles.length; i++) {
-		Rectangle current = rectangles [i];
-		result [i] = new Rectangle (current.x, current.y, current.width, current.height);
-	}
-	return result;
-}
-
 /**
  * Returns <code>true</code> if the rectangles are drawn with a stippled line, <code>false</code> otherwise.
  *
@@ -1154,12 +1144,6 @@ public void setCursor (Cursor newCursor) {
  * </ul>
  */
 public void setRectangles (Rectangle [] rectangles) {
-	checkWidget();
-	if (rectangles == null) error (SWT.ERROR_NULL_ARGUMENT);
-	setRectanglesInPixels (rectangles);
-}
-
-void setRectanglesInPixels (Rectangle [] rectangles) {
 	checkWidget();
 	if (rectangles == null) error (SWT.ERROR_NULL_ARGUMENT);
 	int length = rectangles.length;


### PR DESCRIPTION
They are not needed at all, double some calls (like checkWidget()), and overall complicate debugging and understanding the codebase. Continuation of
https://github.com/eclipse-platform/eclipse.platform.swt/pull/2100