### PR TITLE
Introduce simple API to save ImageData to file and support '.jpg' extension

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/ImageData.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/ImageData.java
@@ -15,9 +15,11 @@ package org.eclipse.swt.graphics;
 
 
 import java.io.*;
+import java.nio.file.Path;
 
 import org.eclipse.swt.*;
 import org.eclipse.swt.internal.*;
+import org.eclipse.swt.internal.image.*;
 
 /**
  * Instances of this class are device-independent descriptions
@@ -1597,6 +1599,48 @@ public void setPixels(int x, int y, int putWidth, int[] pixels, int startIndex) 
 			return;
 	}
 	SWT.error(SWT.ERROR_UNSUPPORTED_DEPTH);
+}
+
+/**
+ * Saves this image to the specified file.
+ * The image format is derived from the file's extension and the following formats are supported:
+ * <dl>
+ * <dt>{@link SWT#IMAGE_BMP .bmp}</dt>
+ * <dd>Windows BMP file format, no compression</dd>
+ * <dt>{@link SWT#IMAGE_GIF .gif}</dt>
+ * <dd>GIF file format</dd>
+ * <dt>{@link SWT#IMAGE_ICO .ico}</dt>
+ * <dd>Windows ICO file format</dd>
+ * <dt>{@link SWT#IMAGE_JPEG .jpg or .jpeg}</dt>
+ * <dd>JPEG file format</dd>
+ * <dt>{@link SWT#IMAGE_PNG .png}</dt>
+ * <dd>PNG file format</dd>
+ * <dt>{@link SWT#IMAGE_TIFF .tiff}</dt>
+ * <dd>TIFF file format</dd>
+ * </dl>
+ *
+ * @param file the path to the file where this image is to be saved
+ *
+ * @exception IllegalArgumentException <ul>
+ *    <li>ERROR_NULL_ARGUMENT - if the file name is null</li>
+ * </ul>
+ * @exception SWTException <ul>
+ *    <li>ERROR_IO - if an IO error occurs while writing to the file</li>
+ *    <li>ERROR_INVALID_IMAGE - if this image data contains invalid data</li>
+ *    <li>ERROR_UNSUPPORTED_FORMAT - if the image data cannot be saved to the requested format</li>
+ * </ul>
+ * @since 3.130
+ */
+public void save(Path file) {
+	if (file == null) {
+		SWT.error(SWT.ERROR_NULL_ARGUMENT);
+	}
+	String filename = file.getFileName().toString();
+	String extension = filename.substring(filename.lastIndexOf('.') + 1);
+	int imageFormat = FileFormat.getImageFormatFromFileExtension(extension);
+	ImageLoader loader = new ImageLoader();
+	loader.data = new ImageData[] { this };
+	loader.save(file.toString(), imageFormat);
 }
 
 /**

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/image/FileFormat.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/image/FileFormat.java
@@ -58,6 +58,34 @@ public abstract class FileFormat {
 		} catch (NoClassDefFoundError e) { } // ignore format
 	}
 
+	public static int getImageFormatFromFileExtension(String extension) {
+		return switch (extension.toLowerCase(Locale.ROOT)) {
+		case "bmp" -> SWT.IMAGE_BMP;
+		case "gif" -> SWT.IMAGE_GIF;
+		case "ico" -> SWT.IMAGE_ICO;
+		case "jpg", "jpeg" -> SWT.IMAGE_JPEG;
+		case "png" -> SWT.IMAGE_PNG;
+		case "tiff" -> SWT.IMAGE_TIFF;
+		case "svg" -> SWT.IMAGE_SVG;
+		default -> SWT.IMAGE_UNDEFINED;
+		};
+	}
+
+	public static String getImageFileExtensionFromFormat(int format) {
+		String typeStr = switch (format) {
+		case SWT.IMAGE_BMP_RLE -> "bmp";
+		case SWT.IMAGE_BMP -> "bmp";
+		case SWT.IMAGE_GIF -> "gif";
+		case SWT.IMAGE_ICO -> "ico";
+		case SWT.IMAGE_JPEG -> "jpeg";
+		case SWT.IMAGE_PNG -> "png";
+		case SWT.IMAGE_TIFF -> "tiff";
+		case SWT.IMAGE_SVG -> "svg";
+		default -> "";
+		};
+		return typeStr;
+	}
+
 	public static final int DEFAULT_ZOOM = 100;
 
 	private static Optional<FileFormat> determineFileFormat(LEDataInputStream stream) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/internal/NativeImageLoader.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/internal/NativeImageLoader.java
@@ -180,16 +180,7 @@ public class NativeImageLoader {
 		long name = GDK.gdk_pixbuf_format_get_name(format);
 		String nameStr = Converter.cCharPtrToJavaString(name, false);
 		OS.g_free(name);
-		return switch (nameStr) {
-		case "bmp" -> SWT.IMAGE_BMP;
-		case "gif" -> SWT.IMAGE_GIF;
-		case "ico" -> SWT.IMAGE_ICO;
-		case "jpeg" -> SWT.IMAGE_JPEG;
-		case "png" -> SWT.IMAGE_PNG;
-		case "tiff" -> SWT.IMAGE_TIFF;
-		case "svg" -> SWT.IMAGE_SVG;
-		default -> SWT.IMAGE_UNDEFINED;
-		};
+		return FileFormat.getImageFormatFromFileExtension(nameStr);
 	}
 
 	/**
@@ -351,17 +342,7 @@ public class NativeImageLoader {
 		}
 
 		// Write pixbuf to byte array and then to OutputStream
-		String typeStr = switch (format) {
-		case SWT.IMAGE_BMP_RLE -> "bmp";
-		case SWT.IMAGE_BMP -> "bmp";
-		case SWT.IMAGE_GIF -> "gif";
-		case SWT.IMAGE_ICO -> "ico";
-		case SWT.IMAGE_JPEG -> "jpeg";
-		case SWT.IMAGE_PNG -> "png";
-		case SWT.IMAGE_TIFF -> "tiff";
-		case SWT.IMAGE_SVG -> "svg";
-		default -> "";
-		};
+		String typeStr = FileFormat.getImageFileExtensionFromFormat(format);
 		byte[] type = Converter.wcsToMbcs(typeStr, true);
 
 		long[] buffer = new long[1];

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TaskBar.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TaskBar.java
@@ -16,6 +16,7 @@ package org.eclipse.swt.widgets;
 
 
 import java.io.*;
+import java.nio.file.Path;
 
 import org.eclipse.swt.*;
 import org.eclipse.swt.graphics.*;
@@ -173,9 +174,7 @@ IShellLink createShellLink (MenuItem item) {
 				} else {
 					data = image.getImageData (DPIUtil.getDeviceZoom ());
 				}
-				ImageLoader loader = new ImageLoader ();
-				loader.data = new ImageData [] {data};
-				loader.save (icon, SWT.IMAGE_ICO);
+				data.save(Path.of(icon));
 			}
 		}
 		if (icon != null) {

--- a/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet246.java
+++ b/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet246.java
@@ -19,6 +19,8 @@ package org.eclipse.swt.snippets;
  * For a list of all SWT example snippets see
  * http://www.eclipse.org/swt/snippets/
  */
+import java.nio.file.Path;
+
 import org.eclipse.swt.*;
 import org.eclipse.swt.graphics.*;
 import org.eclipse.swt.layout.*;
@@ -62,9 +64,7 @@ public class Snippet246 {
 		gc.drawString("T", 124, 10);
 		gc.dispose();
 
-		ImageLoader loader = new ImageLoader();
-		loader.data = new ImageData[] { image.getImageData() };
-		loader.save("swt.png", SWT.IMAGE_PNG);
+		image.getImageData().save(Path.of("swt.png"));
 		image.dispose();
 		font.dispose();
 	}

--- a/tests/org.eclipse.swt.tests.gtk/ManualTests/org/eclipse/swt/tests/gtk/snippets/Bug547529_ControlPrintBroken.java
+++ b/tests/org.eclipse.swt.tests.gtk/ManualTests/org/eclipse/swt/tests/gtk/snippets/Bug547529_ControlPrintBroken.java
@@ -12,7 +12,7 @@
  *     Andrey Loskutov - initial API and implementation
  *******************************************************************************/
 package org.eclipse.swt.tests.gtk.snippets;
-import java.io.File;
+import java.nio.file.Path;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Color;
@@ -89,15 +89,11 @@ class Bug547529_ControlPrintBroken {
 		composite.print(gc);
 		gc.dispose();
 
+		Path file = Path.of(filename + ".png");
+		image.getImageData().save(file);
+
 		ImageLoader loader = new ImageLoader();
-		loader.data = new ImageData[] { image.getImageData() };
-		File file = new File(filename + ".png");
-		file.delete();
-		loader.save(filename + ".png", SWT.IMAGE_PNG);
-
-
-		loader = new ImageLoader();
-		ImageData[] loaded = loader.load(file.getAbsolutePath());
+		ImageData[] loaded = loader.load(file.toAbsolutePath().toString());
 		Shell shell = display.getShells()[0];
 		for (ImageData d : loaded) {
 			Label l = new Label(shell, SWT.NONE);

--- a/tests/org.eclipse.swt.tests.gtk/ManualTests/org/eclipse/swt/tests/gtk/snippets/Bug547529_ImageLoaderStriping.java
+++ b/tests/org.eclipse.swt.tests.gtk/ManualTests/org/eclipse/swt/tests/gtk/snippets/Bug547529_ImageLoaderStriping.java
@@ -13,13 +13,14 @@
  *******************************************************************************/
 package org.eclipse.swt.tests.gtk.snippets;
 
+import java.nio.file.Path;
+
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.SelectionAdapter;
 import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.graphics.GC;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.graphics.ImageData;
-import org.eclipse.swt.graphics.ImageLoader;
 import org.eclipse.swt.layout.FillLayout;
 import org.eclipse.swt.layout.RowLayout;
 import org.eclipse.swt.widgets.Button;
@@ -56,7 +57,7 @@ public class Bug547529_ImageLoaderStriping {
 				dialog.setFileName("Untitled.png");
 				String filename = dialog.open();
 				if ((filename != null) && !filename.isEmpty()) {
-					saveImage(composite, filename, SWT.IMAGE_PNG);
+					saveImage(composite, Path.of(filename));
 				}
 			}
 		});
@@ -71,15 +72,13 @@ public class Bug547529_ImageLoaderStriping {
 		display.dispose();
 	}
 
-	private static void saveImage(Control control, String filename, int format) {
+	private static void saveImage(Control control, Path file) {
 		Image image = new Image(control.getDisplay(), control.getBounds());
 		GC gc = new GC(image);
 		control.print(gc);
 		gc.dispose();
 		ImageData data = image.getImageData();
-		ImageLoader loader = new ImageLoader();
-		loader.data = new ImageData[] { data };
-		loader.save(filename, format);
+		data.save(file);
 		image.dispose();
 	}
 }

--- a/tests/org.eclipse.swt.tests.gtk/ManualTests/org/eclipse/swt/tests/gtk/snippets/Bug547557_ShellPrintGC.java
+++ b/tests/org.eclipse.swt.tests.gtk/ManualTests/org/eclipse/swt/tests/gtk/snippets/Bug547557_ShellPrintGC.java
@@ -14,13 +14,13 @@
 package org.eclipse.swt.tests.gtk.snippets;
 
 
+import java.nio.file.Path;
+
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.SelectionAdapter;
 import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.graphics.GC;
 import org.eclipse.swt.graphics.Image;
-import org.eclipse.swt.graphics.ImageData;
-import org.eclipse.swt.graphics.ImageLoader;
 import org.eclipse.swt.graphics.Rectangle;
 import org.eclipse.swt.layout.RowLayout;
 import org.eclipse.swt.widgets.Button;
@@ -50,7 +50,7 @@ public class Bug547557_ShellPrintGC {
 				// String filename = "/home/<user>/shell_test.png";
 				String filename = "";
 				if ((filename != null) && !filename.isEmpty()) {
-					saveImage(shell, filename, SWT.IMAGE_PNG);
+					saveImage(shell, Path.of(filename));
 				}
 			}
 		});
@@ -64,7 +64,7 @@ public class Bug547557_ShellPrintGC {
 		display.dispose();
 	}
 
-	private static void saveImage(Shell shell, String filename, int format) {
+	private static void saveImage(Shell shell, Path file) {
 		Rectangle bounds = shell.getBounds();
 		Image image = new Image(shell.getDisplay(), bounds);
 		// Printing the client area will result in a warning and only the client area being printed
@@ -72,10 +72,7 @@ public class Bug547557_ShellPrintGC {
 		GC gc = new GC(image);
 		shell.print(gc);
 		gc.dispose();
-		ImageData data = image.getImageData();
-		ImageLoader loader = new ImageLoader();
-		loader.data = new ImageData[] { data };
-		loader.save(filename, format);
+		image.getImageData().save(file);
 		image.dispose();
 	}
 }

--- a/tests/org.eclipse.swt.tests.gtk/ManualTests/org/eclipse/swt/tests/gtk/snippets/Bug553240_ImageLoaderSavingStriped.java
+++ b/tests/org.eclipse.swt.tests.gtk/ManualTests/org/eclipse/swt/tests/gtk/snippets/Bug553240_ImageLoaderSavingStriped.java
@@ -56,13 +56,8 @@ public class Bug553240_ImageLoaderSavingStriped {
 		ImageLoader loader = new ImageLoader();
 		final ImageData[] loadedImageData = loader.load("./images/map.png");
 		final ImageData tileImageData = loadedImageData[0];
-		final ImageLoader imageLoader = new ImageLoader();
-		imageLoader.data = new ImageData[] { tileImageData };
-
-		final int imageType = tileImageData.type;
 		file.delete();
-		final String imageFilePath = file.getAbsolutePath();
-		imageLoader.save(imageFilePath, imageType);
+		tileImageData.save(file.toPath());
 		text.setText(file.getAbsolutePath());
 
 		Composite composite = new Composite(shell, SWT.NONE);


### PR DESCRIPTION
Currently it's quite cumbersome to save ImageData into a file. screenshot from a `Control` or a `Display`. This proposes a convenience API to simplify this task.

This also complements the ImageData.load(Path) method introduced in
- https://github.com/eclipse-platform/eclipse.platform.swt/pull/1767

It becomes also very simple to take and save a screenshot together with 
- https://github.com/eclipse-platform/eclipse.platform.swt/pull/2104, .
