### PR TITLE
Introduce simple API to take a screenshot

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/SWT.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/SWT.java
@@ -15,6 +15,7 @@
 package org.eclipse.swt;
 
 
+import org.eclipse.swt.graphics.*;
 import org.eclipse.swt.internal.*;
 import org.eclipse.swt.widgets.*;
 
@@ -5010,4 +5011,39 @@ static {
 		MOD4 = 0;
 	}
 }
+
+/**
+ * Takes a screenshot of the given {@code display} and returns it as image.
+ *
+ * @param display the display to take a screenshot from
+ * @return the ImageData of the screenshot taken
+ * @since 3.130
+ */
+public static ImageData takeScreenShot(Display display) {
+	return takeScreenShot(display, display, display.getBounds());
+}
+
+/**
+ * Takes a screenshot of the given {@code control} and returns it as image.
+ *
+ * @param control the control to take a screenshot from
+ * @return the ImageData of the screenshot taken
+ * @since 3.130
+ */
+public static ImageData takeScreenShot(Control control) {
+	return takeScreenShot(control, control.getDisplay(), control.getBounds());
+}
+
+private static ImageData takeScreenShot(Drawable source, Display display, Rectangle bounds) {
+	Image image = new Image(display, bounds);
+	GC gc = new GC(source);
+	try {
+		gc.copyArea(image, 0, 0);
+		return image.getImageData();
+	} finally {
+		gc.dispose();
+		image.dispose();
+	}
+}
+
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Control.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Control.java
@@ -60,6 +60,7 @@ public abstract class Control extends Widget implements Drawable {
 	long firstFixedHandle = 0;
 	long keyController;
 	long redrawWindow, enableWindow, provider;
+	//TODO: derive alpha from color?
 	int drawCount, backgroundAlpha = 255;
 	long dragGesture, zoomGesture, rotateGesture, panGesture;
 	Composite parent;

--- a/tests/org.eclipse.swt.tests.gtk/ManualTests/org/eclipse/swt/tests/gtk/snippets/Bug531667_CanvasPrint_does_not_work.java
+++ b/tests/org.eclipse.swt.tests.gtk/ManualTests/org/eclipse/swt/tests/gtk/snippets/Bug531667_CanvasPrint_does_not_work.java
@@ -19,7 +19,6 @@ import java.io.File;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.GC;
-import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.graphics.ImageData;
 import org.eclipse.swt.graphics.ImageLoader;
 import org.eclipse.swt.graphics.Rectangle;
@@ -54,7 +53,7 @@ public class Bug531667_CanvasPrint_does_not_work {
 
 		shell.open();
 
-		snapshot(display, composite, filename);
+		snapshot(composite, filename);
 
 		while (!shell.isDisposed()) {
 			if (!display.readAndDispatch()) {
@@ -79,15 +78,11 @@ public class Bug531667_CanvasPrint_does_not_work {
 		return composite;
 	}
 
-	private static void snapshot(Display display, Composite composite, String filename) {
-		Rectangle bounds = composite.getBounds();
-		Image image = new Image(display, bounds);
-		GC gc = new GC(image);
-		composite.print(gc);
-		gc.dispose();
+	private static void snapshot(Composite composite, String filename) {
+		ImageData screenshot = SWT.takeScreenShot(composite);
 
 		ImageLoader loader = new ImageLoader();
-		loader.data = new ImageData[] { image.getImageData() };
+		loader.data = new ImageData[] { screenshot };
 		File output = new File(filename);
 		output.delete();
 		loader.save(filename, SWT.IMAGE_PNG);

--- a/tests/org.eclipse.swt.tests.gtk/ManualTests/org/eclipse/swt/tests/gtk/snippets/Bug547529_ImageLoaderStriping.java
+++ b/tests/org.eclipse.swt.tests.gtk/ManualTests/org/eclipse/swt/tests/gtk/snippets/Bug547529_ImageLoaderStriping.java
@@ -16,8 +16,6 @@ package org.eclipse.swt.tests.gtk.snippets;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.SelectionAdapter;
 import org.eclipse.swt.events.SelectionEvent;
-import org.eclipse.swt.graphics.GC;
-import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.graphics.ImageData;
 import org.eclipse.swt.graphics.ImageLoader;
 import org.eclipse.swt.layout.FillLayout;
@@ -72,14 +70,10 @@ public class Bug547529_ImageLoaderStriping {
 	}
 
 	private static void saveImage(Control control, String filename, int format) {
-		Image image = new Image(control.getDisplay(), control.getBounds());
-		GC gc = new GC(image);
-		control.print(gc);
-		gc.dispose();
-		ImageData data = image.getImageData();
+		ImageData screenshot = SWT.takeScreenShot(control);
+		ImageData data = screenshot;
 		ImageLoader loader = new ImageLoader();
 		loader.data = new ImageData[] { data };
 		loader.save(filename, format);
-		image.dispose();
 	}
 }


### PR DESCRIPTION
Currently it's quite cumbersome to take a screenshot from a `Control` or a `Display`. This proposes a convenience API to simplify this task.

When fully used within SWT it significantly reduces the calls to the to be deprecated Image constructor:
- https://github.com/eclipse-platform/eclipse.platform.swt/pull/2088

Together with https://github.com/eclipse-platform/eclipse.platform.swt/pull/2103, it becomes very simple to take and save a screenshot.

I'm not yet sure where such a method is added best. Currently it's a new static method in the general `SWT` class. Alternativly it could be a static 'factory' like method in the `Image`/`ImageData` class or it could be in a new utility class or somewhere else? 

