### PR TITLE
[GTK] Even more *InPixel method removal

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/cairo/org/eclipse/swt/graphics/Path.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cairo/org/eclipse/swt/graphics/Path.java
@@ -218,10 +218,6 @@ public Path (Device device, PathData data) {
 public void addArc(float x, float y, float width, float height, float startAngle, float arcAngle) {
 	if (isDisposed()) SWT.error(SWT.ERROR_GRAPHIC_DISPOSED);
 	if (width == 0 || height == 0 || arcAngle == 0) return;
-	addArcInPixels(x, y, width, height, startAngle, arcAngle);
-}
-
-void addArcInPixels(float x, float y, float width, float height, float startAngle, float arcAngle) {
 	moved = true;
 	if (width == height) {
 		float angle = -startAngle * (float)Math.PI / 180;
@@ -287,10 +283,6 @@ public void addPath(Path path) {
  */
 public void addRectangle(float x, float y, float width, float height) {
 	if (isDisposed()) SWT.error(SWT.ERROR_GRAPHIC_DISPOSED);
-	addRectangleInPixels(x, y, width, height);
-}
-
-void addRectangleInPixels(float x, float y, float width, float height) {
 	moved = false;
 	Cairo.cairo_rectangle(handle, x, y, width, height);
 	closed = true;
@@ -320,13 +312,10 @@ public void addString(String string, float x, float y, Font font) {
 	// Scale up the font
 	FontData fd = font.getFontData()[0];
 	Font scaledFont = new Font(font.getDevice(), fd);
-	addStringInPixels(string, x, y, scaledFont);
-	scaledFont.dispose(); // Dispose the scaled up font
-}
-void addStringInPixels(String string, float x, float y, Font font) {
 	moved = false;
-	GC.addCairoString(handle, string, x, y, font);
+	GC.addCairoString(handle, string, x, y, scaledFont);
 	closed = true;
+	scaledFont.dispose(); // Dispose the scaled up font
 }
 
 /**
@@ -372,9 +361,6 @@ public boolean contains(float x, float y, GC gc, boolean outline) {
 	if (isDisposed()) SWT.error(SWT.ERROR_GRAPHIC_DISPOSED);
 	if (gc == null) SWT.error(SWT.ERROR_NULL_ARGUMENT);
 	if (gc.isDisposed()) SWT.error(SWT.ERROR_INVALID_ARGUMENT);
-	return containsInPixels(x, y, gc, outline);
-}
-boolean containsInPixels(float x, float y, GC gc, boolean outline) {
 	//TODO - see Windows
 	gc.initCairo();
 	gc.checkGC(GC.LINE_CAP | GC.LINE_JOIN | GC.LINE_STYLE | GC.LINE_WIDTH);
@@ -409,9 +395,6 @@ boolean containsInPixels(float x, float y, GC gc, boolean outline) {
  */
 public void cubicTo(float cx1, float cy1, float cx2, float cy2, float x, float y) {
 	if (isDisposed()) SWT.error(SWT.ERROR_GRAPHIC_DISPOSED);
-	cubicToInPixels(cx1, cy1, cx2, cy2, x, y);
-}
-void cubicToInPixels(float cx1, float cy1, float cx2, float cy2, float x, float y) {
 	if (!moved) {
 		double[] currentX = new double[1], currentY = new double[1];
 		Cairo.cairo_get_current_point(handle, currentX, currentY);
@@ -441,9 +424,6 @@ public void getBounds(float[] bounds) {
 	if (isDisposed()) SWT.error(SWT.ERROR_GRAPHIC_DISPOSED);
 	if (bounds == null) SWT.error(SWT.ERROR_NULL_ARGUMENT);
 	if (bounds.length < 4) SWT.error(SWT.ERROR_INVALID_ARGUMENT);
-	getBoundsInPixels(bounds);
-}
-void getBoundsInPixels(float[] bounds) {
 	long copy = Cairo.cairo_copy_path(handle);
 	if (copy == 0) SWT.error(SWT.ERROR_NO_HANDLES);
 	cairo_path_t path = new cairo_path_t();
@@ -516,10 +496,6 @@ void getBoundsInPixels(float[] bounds) {
  */
 public void getCurrentPoint(float[] point) {
 	if (isDisposed()) SWT.error(SWT.ERROR_GRAPHIC_DISPOSED);
-	getCurrentPointInPixels(point);
-}
-
-void getCurrentPointInPixels(float[] point) {
 	if (point == null) SWT.error(SWT.ERROR_NULL_ARGUMENT);
 	if (point.length < 2) SWT.error(SWT.ERROR_INVALID_ARGUMENT);
 	double[] x = new double[1], y = new double[1];
@@ -541,10 +517,6 @@ void getCurrentPointInPixels(float[] point) {
  */
 public PathData getPathData() {
 	if (isDisposed()) SWT.error(SWT.ERROR_GRAPHIC_DISPOSED);
-	return getPathDataInPixels();
-}
-
-PathData getPathDataInPixels() {
 	long copy = Cairo.cairo_copy_path(handle);
 	if (copy == 0) SWT.error(SWT.ERROR_NO_HANDLES);
 	cairo_path_t path = new cairo_path_t();
@@ -619,9 +591,6 @@ PathData getPathDataInPixels() {
  */
 public void lineTo(float x, float y) {
 	if (isDisposed()) SWT.error(SWT.ERROR_GRAPHIC_DISPOSED);
-	lineToInPixels(x, y);
-}
-void lineToInPixels(float x, float y) {
 	if (!moved) {
 		double[] currentX = new double[1], currentY = new double[1];
 		Cairo.cairo_get_current_point(handle, currentX, currentY);
@@ -646,9 +615,6 @@ void lineToInPixels(float x, float y) {
  */
 public void moveTo(float x, float y) {
 	if (isDisposed()) SWT.error(SWT.ERROR_GRAPHIC_DISPOSED);
-	moveToInPixels(x, y);
-}
-void moveToInPixels(float x, float y) {
 	/*
 	* Bug in Cairo.  If cairo_move_to() is not called at the
 	* begining of a subpath, the first cairo_line_to() or
@@ -675,9 +641,6 @@ void moveToInPixels(float x, float y) {
  */
 public void quadTo(float cx, float cy, float x, float y) {
 	if (isDisposed()) SWT.error(SWT.ERROR_GRAPHIC_DISPOSED);
-	quadToInPixels(cx, cy, x, y);
-}
-void quadToInPixels(float cx, float cy, float x, float y) {
 	double[] currentX = new double[1], currentY = new double[1];
 	Cairo.cairo_get_current_point(handle, currentX, currentY);
 	if (!moved) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/graphics/Device.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/graphics/Device.java
@@ -367,10 +367,6 @@ protected void destroy () {
  */
 public Rectangle getBounds () {
 	checkDevice ();
-	return getBoundsInPixels ();
-}
-
-private Rectangle getBoundsInPixels () {
 	return new Rectangle(0, 0, 0, 0);
 }
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/graphics/Region.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/graphics/Region.java
@@ -155,9 +155,6 @@ static void cairo_region_get_rectangles(long region, long [] rectangles, int[] n
 public void add (int[] pointArray) {
 	if (isDisposed()) SWT.error(SWT.ERROR_GRAPHIC_DISPOSED);
 	if (pointArray == null) SWT.error(SWT.ERROR_NULL_ARGUMENT);
-	addInPixels(pointArray);
-}
-void addInPixels (int[] pointArray) {
 	/*
 	* Bug in GTK. If gdk_region_polygon() is called with one point,
 	* it segment faults. The fix is to make sure that it is called
@@ -186,10 +183,7 @@ void addInPixels (int[] pointArray) {
 public void add(Rectangle rect) {
 	if (isDisposed()) SWT.error(SWT.ERROR_GRAPHIC_DISPOSED);
 	if (rect == null) SWT.error(SWT.ERROR_NULL_ARGUMENT);
-	addInPixels(rect);
-}
-void addInPixels(Rectangle rect) {
-	addInPixels (rect.x, rect.y, rect.width, rect.height);
+	add (rect.x, rect.y, rect.width, rect.height);
 }
 
 /**
@@ -213,9 +207,6 @@ void addInPixels(Rectangle rect) {
 public void add(int x, int y, int width, int height) {
 	if (isDisposed()) SWT.error(SWT.ERROR_GRAPHIC_DISPOSED);
 	if (width < 0 || height < 0) SWT.error(SWT.ERROR_INVALID_ARGUMENT);
-	add(new Rectangle(x, y, width, height));
-}
-void addInPixels(int x, int y, int width, int height) {
 	cairo_rectangle_int_t rect = new cairo_rectangle_int_t();
 	rect.x = x;
 	rect.y = y;
@@ -261,9 +252,6 @@ public void add(Region region) {
  */
 public boolean contains(int x, int y) {
 	if (isDisposed()) SWT.error(SWT.ERROR_GRAPHIC_DISPOSED);
-	return contains(new Point(x, y));
-}
-boolean containsInPixels(int x, int y) {
 	return Cairo.cairo_region_contains_point(handle, x, y);
 }
 
@@ -284,11 +272,8 @@ boolean containsInPixels(int x, int y) {
  */
 public boolean contains(Point pt) {
 	if (isDisposed()) SWT.error(SWT.ERROR_GRAPHIC_DISPOSED);
-	return containsInPixels(pt);
-}
-boolean containsInPixels(Point pt) {
 	if (pt == null) SWT.error(SWT.ERROR_NULL_ARGUMENT);
-	return containsInPixels(pt.x, pt.y);
+	return contains(pt.x, pt.y);
 }
 
 @Override
@@ -327,9 +312,6 @@ public boolean equals(Object object) {
  */
 public Rectangle getBounds() {
 	if (isDisposed()) SWT.error(SWT.ERROR_GRAPHIC_DISPOSED);
-	return getBoundsInPixels();
-}
-Rectangle getBoundsInPixels() {
 	cairo_rectangle_int_t rect = new cairo_rectangle_int_t();
 	Cairo.cairo_region_get_extents(handle, rect);
 	return new Rectangle(rect.x, rect.y, rect.width, rect.height);
@@ -389,11 +371,7 @@ public int hashCode() {
 public void intersect(Rectangle rect) {
 	if (isDisposed()) SWT.error(SWT.ERROR_GRAPHIC_DISPOSED);
 	if (rect == null) SWT.error(SWT.ERROR_NULL_ARGUMENT);
-	intersectInPixels(rect);
-}
-
-void intersectInPixels(Rectangle rect) {
-	intersectInPixels (rect.x, rect.y, rect.width, rect.height);
+	intersect (rect.x, rect.y, rect.width, rect.height);
 }
 
 /**
@@ -417,10 +395,6 @@ void intersectInPixels(Rectangle rect) {
 public void intersect(int x, int y, int width, int height) {
 	if (isDisposed()) SWT.error(SWT.ERROR_GRAPHIC_DISPOSED);
 	if (width < 0 || height < 0) SWT.error(SWT.ERROR_INVALID_ARGUMENT);
-	intersect(new Rectangle(x, y, width, height));
-}
-
-void intersectInPixels(int x, int y, int width, int height) {
 	cairo_rectangle_int_t rect = new cairo_rectangle_int_t();
 	rect.x = x;
 	rect.y = y;
@@ -561,10 +535,6 @@ public boolean isEmpty() {
 public void subtract (int[] pointArray) {
 	if (isDisposed()) SWT.error(SWT.ERROR_GRAPHIC_DISPOSED);
 	if (pointArray == null) SWT.error(SWT.ERROR_NULL_ARGUMENT);
-	subtractInPixels(pointArray);
-}
-
-void subtractInPixels (int[] pointArray) {
 	/*
 	* Bug in GTK. If gdk_region_polygon() is called with one point,
 	* it segment faults. The fix is to make sure that it is called
@@ -594,11 +564,7 @@ void subtractInPixels (int[] pointArray) {
 public void subtract(Rectangle rect) {
 	if (isDisposed()) SWT.error(SWT.ERROR_GRAPHIC_DISPOSED);
 	if (rect == null) SWT.error(SWT.ERROR_NULL_ARGUMENT);
-	subtractInPixels(rect);
-}
-
-void subtractInPixels(Rectangle rect) {
-	subtractInPixels (rect.x, rect.y, rect.width, rect.height);
+	subtract (rect.x, rect.y, rect.width, rect.height);
 }
 
 /**
@@ -622,10 +588,6 @@ void subtractInPixels(Rectangle rect) {
 public void subtract(int x, int y, int width, int height) {
 	if (isDisposed()) SWT.error(SWT.ERROR_GRAPHIC_DISPOSED);
 	if (width < 0 || height < 0) SWT.error(SWT.ERROR_INVALID_ARGUMENT);
-	subtract(new Rectangle(x, y, width, height));
-}
-
-void subtractInPixels(int x, int y, int width, int height) {
 	cairo_rectangle_int_t rect = new cairo_rectangle_int_t ();
 	rect.x = x;
 	rect.y = y;
@@ -675,10 +637,6 @@ public void subtract(Region region) {
  */
 public void translate (int x, int y) {
 	if (isDisposed()) SWT.error(SWT.ERROR_GRAPHIC_DISPOSED);
-	translate(new Point(x, y));
-}
-
-void translateInPixels (int x, int y) {
 	Cairo.cairo_region_translate (handle, x, y);
 }
 
@@ -700,7 +658,7 @@ void translateInPixels (int x, int y) {
 public void translate (Point pt) {
 	if (isDisposed()) SWT.error(SWT.ERROR_GRAPHIC_DISPOSED);
 	if (pt == null) SWT.error(SWT.ERROR_NULL_ARGUMENT);
-	translateInPixels(pt.x, pt.y);
+	translate(pt.x, pt.y);
 }
 
 /**

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Composite.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Composite.java
@@ -550,12 +550,6 @@ void deregister () {
  */
 public void drawBackground (GC gc, int x, int y, int width, int height, int offsetX, int offsetY) {
 	checkWidget();
-	Rectangle rect = new Rectangle (x, y, width, height);
-	drawBackgroundInPixels(gc, rect.x, rect.y, rect.width, rect.height, offsetX, offsetY);
-}
-
-void drawBackgroundInPixels (GC gc, int x, int y, int width, int height, int offsetX, int offsetY) {
-	checkWidget ();
 	if (gc == null) error (SWT.ERROR_NULL_ARGUMENT);
 	if (gc.isDisposed ()) error (SWT.ERROR_INVALID_ARGUMENT);
 	Control control = findBackgroundControl ();

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Control.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Control.java
@@ -1780,12 +1780,6 @@ public Point toDisplay (Point point) {
 	return toDisplay (point.x, point.y);
 }
 
-Point toDisplayInPixels (Point point) {
-	checkWidget();
-	if (point == null) error (SWT.ERROR_NULL_ARGUMENT);
-	return toDisplayInPixels (point.x, point.y);
-}
-
 /**
  * GTK4 only function to replace gdk_surface_get_origin
  * @return the origin of the Control's SWTFixed container relative to the Shell
@@ -2693,7 +2687,7 @@ boolean dragDetect (int x, int y, boolean filter, boolean dragOnTimeout, boolean
 		//Note, input params x/y are relative, the two points below are absolute coords.
 		Point startPos = null;
 		Point currPos = null;
-		startPos = display.getCursorLocationInPixels();
+		startPos = display.getCursorLocation();
 
 		while (!quit) {
 			long eventPtr = 0;
@@ -2709,7 +2703,7 @@ boolean dragDetect (int x, int y, boolean filter, boolean dragOnTimeout, boolean
 				if (eventPtr != 0) {
 					break;
 				} else {
-					currPos = display.getCursorLocationInPixels();
+					currPos = display.getCursorLocation();
 					dragging = GTK3.gtk_drag_check_threshold (handle,
 								startPos.x, startPos.y, currPos.x, currPos.y);
 					if (dragging) break;
@@ -4701,11 +4695,6 @@ void redraw (boolean all) {
  * @see SWT#DOUBLE_BUFFERED
  */
 public void redraw (int x, int y, int width, int height, boolean all) {
-	checkWidget();
-	redrawInPixels(x, y, width, height, all);
-}
-
-void redrawInPixels (int x, int y, int width, int height, boolean all) {
 	checkWidget();
 	if (!GTK.gtk_widget_get_visible (topHandle ())) return;
 	if ((style & SWT.MIRRORED) != 0) x = getClientWidth () - width - x;

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Display.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Display.java
@@ -1985,10 +1985,6 @@ boolean filters (int eventType) {
  * </ul>
  */
 public Point getCursorLocation() {
-	return getCursorLocationInPixels();
-}
-
-Point getCursorLocationInPixels() {
 	checkDevice();
 
 	int[] x = new int[1], y = new int[1];
@@ -4298,7 +4294,7 @@ public boolean post (Event event) {
 
 		if (type == SWT.MouseMove) {
 			Rectangle loc = event.getBounds();
-			setCursorLocationInPixels(new Point(loc.x, loc.y));
+			setCursorLocation(new Point(loc.x, loc.y));
 			return true;
 		}
 
@@ -5258,17 +5254,6 @@ public void setCursorLocation (int x, int y) {
 	setCursorLocation(new Point (x, y));
 }
 
-void setCursorLocationInPixels (Point location) {
-	long gdkDisplay = GDK.gdk_display_get_default();
-	long gdkPointer = GDK.gdk_get_pointer(gdkDisplay);
-	if (GTK.GTK4) {
-		//TODO: GTK4 no gdk_device_warp
-	} else {
-		long gdkScreen = GDK.gdk_screen_get_default();
-		GDK.gdk_device_warp(gdkPointer, gdkScreen, location.x, location.y);
-	}
-}
-
 /**
  * Sets the location of the on-screen pointer relative to the top left corner
  * of the screen.  <b>Note: It is typically considered bad practice for a
@@ -5287,7 +5272,14 @@ void setCursorLocationInPixels (Point location) {
 public void setCursorLocation (Point point) {
 	checkDevice ();
 	if (point == null) error (SWT.ERROR_NULL_ARGUMENT);
-	setCursorLocationInPixels(point);
+	long gdkDisplay = GDK.gdk_display_get_default();
+	long gdkPointer = GDK.gdk_get_pointer(gdkDisplay);
+	if (GTK.GTK4) {
+		//TODO: GTK4 no gdk_device_warp
+	} else {
+		long gdkScreen = GDK.gdk_screen_get_default();
+		GDK.gdk_device_warp(gdkPointer, gdkScreen, point.x, point.y);
+	}
 }
 
 /**
@@ -5581,7 +5573,7 @@ void showIMWindow (Control control) {
 		OS.pango_font_description_free (fontDesc);
 		if (pangoAttrs [0] != 0) GTK.gtk_label_set_attributes (preeditLabel, pangoAttrs[0]);
 		GTK.gtk_label_set_text (preeditLabel, preeditString [0]);
-		Point point = control.toDisplayInPixels (control.getIMCaretPos ());
+		Point point = control.toDisplay (control.getIMCaretPos ());
 		GTK3.gtk_window_move (preeditWindow, point.x, point.y);
 		GtkRequisition requisition = new GtkRequisition ();
 		GTK.gtk_widget_get_preferred_size (preeditLabel, requisition, null);

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Link.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Link.java
@@ -375,7 +375,7 @@ long gtk_button_press_event (long widget, long event) {
 				oldSelectionY = temp;
 			}
 			Rectangle rect = layout.getBounds (oldSelectionX, oldSelectionY);
-			redrawInPixels (rect.x, rect.y, rect.width, rect.height, false);
+			redraw (rect.x, rect.y, rect.width, rect.height, false);
 		}
 		for (int j = 0; j < offsets.length; j++) {
 			Rectangle [] rects = getRectanglesInPixels (j);
@@ -551,7 +551,7 @@ long gtk_motion_notify_event (long widget, long event) {
 				newSelection = temp;
 			}
 			Rectangle rect = layout.getBounds (oldSelection, newSelection);
-			redrawInPixels (rect.x, rect.y, rect.width, rect.height, false);
+			redraw (rect.x, rect.y, rect.width, rect.height, false);
 		}
 	} else {
 		for (int j = 0; j < offsets.length; j++) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/ScrollBar.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/ScrollBar.java
@@ -327,11 +327,6 @@ public int getThumb () {
  */
 public Rectangle getThumbBounds() {
 	checkWidget();
-	return getThumbBoundsInPixels();
-}
-
-Rectangle getThumbBoundsInPixels() {
-	checkWidget();
 
 	int[] slider_start = new int[1], slider_end = new int[1];
 	long rangeHandle = GTK.GTK4 ? GTK4.gtk_widget_get_first_child(handle) : handle;
@@ -396,11 +391,6 @@ Rectangle getThumbBoundsInPixels() {
  */
 public Rectangle getThumbTrackBounds () {
 	checkWidget ();
-	return getThumbTrackBoundsInPixels();
-}
-
-Rectangle getThumbTrackBoundsInPixels () {
-	checkWidget();
 	int x = 0, y = 0, width, height;
 
 	/*


### PR DESCRIPTION
Remove nowadays useless extra methods that even has the bad side effect of duplicating checks.
Continuation of
https://github.com/eclipse-platform/eclipse.platform.swt/pull/2101