### PR TITLE
Fix surefire warnings in build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -350,7 +350,7 @@ pipeline {
 					dir('eclipse.platform.swt') {
 						sh '''
 							mvn clean verify \
-								--batch-mode --threads 1C -V -U -e -DforkCount=0 \
+								--batch-mode --threads 1C -V -U -e \
 								-Pbree-libs -Papi-check -Pjavadoc \
 								-Dcompare-version-with-baselines.skip=false \
 								-Dorg.eclipse.swt.tests.junit.disable.test_isLocal=true \


### PR DESCRIPTION
Fixes following warnings in the build:
```
[WARNING] useSystemClassLoader setting has no effect when not forking
[WARNING] The parameter forkCount should likely not be 0. Forking a JVM
for tests improves test accuracy. Ensure to have a <forkCount> >= 1.
```