### PR TITLE
Remove unused constructors in Color

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/graphics/Color.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/graphics/Color.java
@@ -48,10 +48,6 @@ public final class Color extends Resource {
 	 */
 	public double [] handle;
 
-Color() {
-	super();
-}
-
 Color(Device device) {
 	super(device);
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/graphics/Color.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/graphics/Color.java
@@ -50,10 +50,6 @@ public final class Color extends Resource {
 	public GdkRGBA handle;
 	int alpha = 0;
 
-Color() {
-	super();
-}
-
 Color(Device device) {
 	super(device);
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Color.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Color.java
@@ -53,13 +53,6 @@ public final class Color extends Resource {
 /**
  * Prevents uninitialized instances from being created outside the package.
  */
-Color() {
-	super();
-}
-
-/**
- * Prevents uninitialized instances from being created outside the package.
- */
 Color(Device device) {
 	super(device);
 }


### PR DESCRIPTION
They were added a while ago but they are not used and their visibility makes them unusable outside the same package.

What confuses me is the comment (JavaDoc) saying `Prevents uninitialized instances from being created outside the package`. Maybe @jonahgraham / @akurtakov remember why they were needed or what the JavaDoc means? 

## Additional info
- Introduced in 6f25fa51112fbf1670baee56c085ab60273daf47
- Fix for https://bugs.eclipse.org/bugs/show_bug.cgi?id=563560
- Related to https://bugs.eclipse.org/bugs/show_bug.cgi?id=563018

