### PR TITLE
[Win32] Do not initialize font when already disposed

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Font.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Font.java
@@ -312,7 +312,7 @@ public String toString () {
  * @noreference This method is not intended to be referenced by clients.
  */
 public static long win32_getHandle(Font font) {
-	if (font.handle == 0 && font.fontData != null) {
+	if (font.handle == 0 && font.fontData != null && !font.isDestroyed) {
 		font.init(font.fontData);
 	}
 	return font.handle;


### PR DESCRIPTION
The on-demand creation of Font handles does not consider that a font may already have been disposed when first retrieving it's handle, which triggers the on-demand initialization. To avoid that this initialization after disposal fails, this change adds a check for the font being destroyed when performing the initialization.

Fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/2960