### PR TITLE
[win32] Fix for Image disablement

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Image.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Image.java
@@ -232,8 +232,8 @@ public Image(Device device, Image srcImage, int flag) {
 	if (srcImage == null) SWT.error(SWT.ERROR_NULL_ARGUMENT);
 	if (srcImage.isDisposed()) SWT.error(SWT.ERROR_INVALID_ARGUMENT);
 	this.type = srcImage.type;
-	this.imageProvider = srcImage.imageProvider.createCopy(this);
 	this.styleFlag = srcImage.styleFlag | flag;
+	this.imageProvider = srcImage.imageProvider.createCopy(this);
 	switch (flag) {
 		case SWT.IMAGE_COPY: {
 			switch (type) {


### PR DESCRIPTION
This PR adjusts the order in the Image copy constructor. As the call to ImageProviderWrapper#createCopy creates cached variants for some implementation. These created variants could be missing disablement/greyed state. Therfore this flag is set before that.