### PR TITLE
[GTK] Fix webkit download on GTK 4

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT WebKit/gtk/library/webkitgtk.c
+++ b/bundles/org.eclipse.swt/Eclipse SWT WebKit/gtk/library/webkitgtk.c
@@ -1163,6 +1163,26 @@ JNIEXPORT jlong JNICALL WebKitGTK_NATIVE(webkit_1navigation_1policy_1decision_1g
 }
 #endif
 
+#ifndef NO_webkit_1network_1session_1get_1default
+JNIEXPORT jlong JNICALL WebKitGTK_NATIVE(webkit_1network_1session_1get_1default)
+	(JNIEnv *env, jclass that)
+{
+	jlong rc = 0;
+	WebKitGTK_NATIVE_ENTER(env, that, webkit_1network_1session_1get_1default_FUNC);
+/*
+	rc = (jlong)webkit_network_session_get_default();
+*/
+	{
+		WebKitGTK_LOAD_FUNCTION(fp, webkit_network_session_get_default)
+		if (fp) {
+			rc = (jlong)((jlong (CALLING_CONVENTION*)())fp)();
+		}
+	}
+	WebKitGTK_NATIVE_EXIT(env, that, webkit_1network_1session_1get_1default_FUNC);
+	return rc;
+}
+#endif
+
 #ifndef NO_webkit_1policy_1decision_1download
 JNIEXPORT void JNICALL WebKitGTK_NATIVE(webkit_1policy_1decision_1download)
 	(JNIEnv *env, jclass that, jlong arg0)

--- a/bundles/org.eclipse.swt/Eclipse SWT WebKit/gtk/library/webkitgtk_stats.h
+++ b/bundles/org.eclipse.swt/Eclipse SWT WebKit/gtk/library/webkitgtk_stats.h
@@ -79,6 +79,7 @@ typedef enum {
 	webkit_1javascript_1result_1get_1value_FUNC,
 	webkit_1javascript_1result_1unref_FUNC,
 	webkit_1navigation_1policy_1decision_1get_1request_FUNC,
+	webkit_1network_1session_1get_1default_FUNC,
 	webkit_1policy_1decision_1download_FUNC,
 	webkit_1policy_1decision_1ignore_FUNC,
 	webkit_1response_1policy_1decision_1get_1request_FUNC,

--- a/bundles/org.eclipse.swt/Eclipse SWT WebKit/gtk/org/eclipse/swt/browser/WebKit.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT WebKit/gtk/org/eclipse/swt/browser/WebKit.java
@@ -703,7 +703,11 @@ public void create (Composite parent, int style) {
 
 	// (!) Note this one's a 'webContext' signal, not webview. See:
 	// https://webkitgtk.org/reference/webkit2gtk/stable/WebKitWebContext.html#WebKitWebContext-download-started
-	OS.g_signal_connect (WebKitGTK.webkit_web_context_get_default(), WebKitGTK.download_started, Proc3.getAddress (), DOWNLOAD_STARTED);
+	if (GTK.GTK4) {
+		OS.g_signal_connect (WebKitGTK.webkit_network_session_get_default(), WebKitGTK.download_started, Proc3.getAddress (), DOWNLOAD_STARTED);
+	} else {
+		OS.g_signal_connect (WebKitGTK.webkit_web_context_get_default(), WebKitGTK.download_started, Proc3.getAddress (), DOWNLOAD_STARTED);
+	}
 
 	GTK.gtk_widget_show (webView);
 	GTK.gtk_widget_show (browser.handle);

--- a/bundles/org.eclipse.swt/Eclipse SWT WebKit/gtk/org/eclipse/swt/internal/webkit/WebKitGTK.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT WebKit/gtk/org/eclipse/swt/internal/webkit/WebKitGTK.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corporation and others. All rights reserved.
+ * Copyright (c) 2000, 2025 IBM Corporation and others. All rights reserved.
  * The contents of this file are made available under the terms
  * of the GNU Lesser General Public License (LGPL) Version 2.1 that
  * accompanies this distribution (lgpl-v21.txt).  The LGPL is also
@@ -358,6 +358,9 @@ public static final native void webkit_policy_decision_ignore(long decision);
 
 /** @method flags=dynamic */
 public static final native long webkit_web_context_get_default();
+
+/** @method flags=dynamic */
+public static final native long webkit_network_session_get_default();
 
 /** @method flags=dynamic */
 public static final native long webkit_web_context_get_cookie_manager(long context);


### PR DESCRIPTION
Webkitgtk on GTK 4 changed the component which handles the download-started signal. This PR adjusts SWT accordingly.