### PR TITLE
New FontData Constructor to create a deep copy

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/graphics/FontData.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/graphics/FontData.java
@@ -187,6 +187,31 @@ public FontData(String string) {
 }
 
 /**
+ * Constructs a deep copy of the given font data object.
+ *
+ * @param fontData the FontData object to copy
+ *
+ * @exception IllegalArgumentException
+ * <ul>
+ *    <li>ERROR_NULL_ARGUMENT - if the argument is null</li>
+ * </ul>
+ * @since 3.131
+ */
+public FontData(FontData fontData) {
+	if (fontData == null) {
+		SWT.error(SWT.ERROR_NULL_ARGUMENT);
+	}
+
+	this.name = fontData.name;
+	this.height = fontData.height;
+	this.style = fontData.style;
+	this.nsName = fontData.nsName;
+	this.lang = fontData.lang;
+	this.country = fontData.country;
+	this.variant = fontData.variant;
+}
+
+/**
  * Constructs a new font data given a font name,
  * the height of the desired font in points,
  * and a font style.

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/graphics/FontData.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/graphics/FontData.java
@@ -185,6 +185,35 @@ public FontData(String string) {
 }
 
 /**
+ * Constructs a deep copy of the given font data object.
+ *
+ * @param fontData the FontData object to copy
+ *
+ * @exception IllegalArgumentException
+ * <ul>
+ *    <li>ERROR_NULL_ARGUMENT - if the argument is null</li>
+ * </ul>
+ * @since 3.131
+ */
+public FontData(FontData fontData) {
+	if (fontData == null) {
+		SWT.error(SWT.ERROR_NULL_ARGUMENT);
+	}
+
+	this.name = fontData.name;
+	this.height = fontData.height;
+	this.style = fontData.style;
+	this.lang = fontData.lang;
+	this.country = fontData.country;
+	this.variant = fontData.variant;
+
+	if (fontData.string != null) {
+		this.string = new byte[fontData.string.length];
+		System.arraycopy(fontData.string, 0, this.string, 0, fontData.string.length);
+	}
+}
+
+/**
  * Constructs a new font data given a font name,
  * the height of the desired font in points,
  * and a font style.

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Font.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Font.java
@@ -103,7 +103,7 @@ public Font(Device device, FontData fd) {
 	super(device);
 	if (fd == null) SWT.error(SWT.ERROR_NULL_ARGUMENT);
 	this.zoom = DPIUtil.getNativeDeviceZoom();
-	this.fontData = new FontData(fd.toString());
+	this.fontData = new FontData(fd);
 	this.fontHeight = fd.height;
 	init();
 }
@@ -112,7 +112,7 @@ private Font(Device device, FontData fd, int zoom) {
 	super(device);
 	if (fd == null) SWT.error(SWT.ERROR_NULL_ARGUMENT);
 	this.zoom = zoom;
-	this.fontData = new FontData(fd.toString());
+	this.fontData = new FontData(fd);
 	this.fontHeight = fd.height;
 	init();
 }
@@ -151,7 +151,7 @@ public Font(Device device, FontData[] fds) {
 	}
 	this.zoom = DPIUtil.getNativeDeviceZoom();
 	FontData fd = fds[0];
-	this.fontData = new FontData(fd.toString());
+	this.fontData = new FontData(fd);
 	this.fontHeight = fd.height;
 	init();
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/FontData.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/FontData.java
@@ -240,6 +240,59 @@ public FontData(String string) {
 	}
 }
 
+
+/**
+ * Constructs a deep copy of the given font data object.
+ *
+ * @param fontData the FontData object to copy
+ *
+ * @exception IllegalArgumentException
+ * <ul>
+ *    <li>ERROR_NULL_ARGUMENT - if the argument is null</li>
+ * </ul>
+ * @since 3.131
+ */
+public FontData(FontData fontData) {
+	if (fontData == null) {
+		SWT.error(SWT.ERROR_NULL_ARGUMENT);
+	}
+	this.height = fontData.height;
+	this.lang = fontData.lang;
+	this.country = fontData.country;
+	this.variant = fontData.variant;
+	this.data = cloneLogFont(fontData);
+}
+
+private static LOGFONT cloneLogFont(FontData fontData) {
+	if (fontData.data == null) {
+		return null;
+	}
+
+	LOGFONT existingData = fontData.data;
+	LOGFONT newData = new LOGFONT();
+	newData.lfHeight = existingData.lfHeight;
+	newData.lfWidth = existingData.lfWidth;
+	newData.lfEscapement = existingData.lfEscapement;
+	newData.lfOrientation = existingData.lfOrientation;
+	newData.lfWeight = existingData.lfWeight;
+	newData.lfItalic = existingData.lfItalic;
+	newData.lfUnderline = existingData.lfUnderline;
+	newData.lfStrikeOut = existingData.lfStrikeOut;
+	newData.lfCharSet = existingData.lfCharSet;
+	newData.lfOutPrecision = existingData.lfOutPrecision;
+	newData.lfClipPrecision = existingData.lfClipPrecision;
+	newData.lfQuality = existingData.lfQuality;
+	newData.lfPitchAndFamily = existingData.lfPitchAndFamily;
+
+	// Deep copy of the char array lfFaceName
+	if (existingData.lfFaceName != null) {
+		newData.lfFaceName = new char[existingData.lfFaceName.length];
+		System.arraycopy(existingData.lfFaceName, 0, newData.lfFaceName, 0, existingData.lfFaceName.length);
+	}
+	return newData;
+}
+
+
 /**
  * Constructs a new font data given a font name,
  * the height of the desired font in points,

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/DefaultSWTFontRegistry.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/DefaultSWTFontRegistry.java
@@ -77,7 +77,7 @@ final class DefaultSWTFontRegistry implements SWTFontRegistry {
 	}
 
 	private Font registerFont(FontData fontData, Font font) {
-		FontData clonedFontData = new FontData(fontData.toString());
+		FontData clonedFontData = new FontData(fontData);
 		fontsMap.put(clonedFontData, font);
 		return font;
 	}

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/ScalingSWTFontRegistry.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/ScalingSWTFontRegistry.java
@@ -128,7 +128,7 @@ final class ScalingSWTFontRegistry implements SWTFontRegistry {
 		if (customFontsKeyMap.containsKey(fontData)) {
 			container = customFontsKeyMap.get(fontData);
 		} else {
-			FontData clonedFontData = new FontData(fontData.toString());
+			FontData clonedFontData = new FontData(fontData);
 			container = new ScaledCustomFontContainer(clonedFontData);
 			customFontsKeyMap.put(clonedFontData, container);
 		}

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_FontData.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_FontData.java
@@ -91,6 +91,15 @@ public void test_ConstructorLjava_lang_StringII() {
 }
 
 @Test
+public void test_ConstructorLjava_lang_FontData() {
+	// Test new FontData(FontData fontData)
+	FontData fd = new FontData(SwtTestUtil.testFontName, 30, SWT.ITALIC);
+	FontData reconstructedFontDataFromCopyConstructor = new FontData(fd);
+	assertEquals(fd, reconstructedFontDataFromCopyConstructor);
+	assertEquals(fd.hashCode(), reconstructedFontDataFromCopyConstructor.hashCode());
+}
+
+@Test
 public void test_equalsLjava_lang_Object() {
 	FontData fd1 = new FontData(SwtTestUtil.testFontName, 10, SWT.NORMAL);
 	FontData fd2 = new FontData(SwtTestUtil.testFontName, 10, SWT.NORMAL);


### PR DESCRIPTION
This change will give us a chance to use proper channel to create a deep copy of FontData object instead of using FontData(fd.toString)