### PR TITLE
 Removing getDeviceZoom from tests

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/graphics/GCWin32Tests.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/graphics/GCWin32Tests.java
@@ -54,12 +54,11 @@ class GCWin32Tests {
 	@Test
 	public void drawnElementsShouldScaleUpToTheRightZoomLevel() {
 		Shell shell = new Shell(Display.getDefault());
-
-		int zoom = DPIUtil.getDeviceZoom();
+		int zoom = shell.nativeZoom;
 		int scalingFactor = 2;
 		GC gc = GC.win32_new(shell, new GCData());
 		gc.getGCData().nativeZoom = zoom * scalingFactor;
 		gc.getGCData().lineWidth = 10;
-		assertEquals("DPIUtil calls with getDeviceZoom should scale to the right value", gc.getGCData().lineWidth, gc.getLineWidth() * scalingFactor, 0);
+		assertEquals("Drawn elements should scale to the right value", gc.getGCData().lineWidth, gc.getLineWidth() * scalingFactor, 0);
 	}
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/graphics/RegionWin32Tests.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/graphics/RegionWin32Tests.java
@@ -31,7 +31,7 @@ class RegionWin32Tests {
 	public void testRegionMustBeScaledOnHandleOfScaledZoomLevel() {
 		Display display = Display.getDefault();
 
-		int zoom = DPIUtil.getDeviceZoom();
+		int zoom = 100;
 		int scalingFactor = 2;
 
 		Region region = new Region(display);

--- a/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/graphics/TransformWin32Tests.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/graphics/TransformWin32Tests.java
@@ -29,7 +29,7 @@ class TransformWin32Tests {
 	@Test
 	public void testShouldHaveDifferentHandlesAtDifferentZoomLevels() {
 		Display display = Display.getDefault();
-		int zoom = DPIUtil.getDeviceZoom();
+		int zoom = 100;
 		Transform transform = new Transform(display);
 		long scaledHandle = transform.getHandle(zoom * 2);
 		assertNotEquals("There should be different handles for different zoom levels", scaledHandle, transform.getHandle(zoom));

--- a/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/widgets/ControlWin32Tests.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/widgets/ControlWin32Tests.java
@@ -80,7 +80,7 @@ class ControlWin32Tests {
 	private FontComparison updateFont(int scalingFactor) {
 		Shell shell = new Shell(Display.getDefault());
 		Control control = new Composite(shell, SWT.NONE);
-		int zoom = DPIUtil.getDeviceZoom();
+		int zoom = shell.getNativeZoom();
 		int newZoom = zoom * scalingFactor;
 
 		Font oldFont = control.getFont();

--- a/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/widgets/WidgetWin32Tests.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/widgets/WidgetWin32Tests.java
@@ -32,7 +32,7 @@ class WidgetWin32Tests {
 	public void testWidgetZoomShouldChangeOnZoomLevelChange() {
 		Display display = Display.getDefault();
 		Shell shell = new Shell(display);
-		int zoom = DPIUtil.getDeviceZoom();
+		int zoom = shell.getNativeZoom();
 		int scaledZoom = zoom * 2;
 
 		Button button = new Button(shell, SWT.PUSH);
@@ -49,10 +49,11 @@ class WidgetWin32Tests {
 	@Test
 	public void testButtonPointsAfterZooming() throws NoSuchMethodException, IllegalAccessException {
 		Display display = Display.getDefault();
-		int zoom = DPIUtil.getDeviceZoom();
+		Shell shell = new Shell(display);
+		int zoom = shell.getNativeZoom();
+
 		int scaledZoom = zoom * 2;
 
-		Shell shell = new Shell(display);
 		shell.setBounds(0, 0, 100, 160);
 		shell.setLayout(new FillLayout());
 		shell.pack();
@@ -73,7 +74,8 @@ class WidgetWin32Tests {
 	@Test
 	public void testImagePixelsWithDoubleZoomLevel() {
 		Display display = Display.getDefault();
-		int zoom = DPIUtil.getDeviceZoom();
+		Shell shell = new Shell(display);
+		int zoom = shell.getNativeZoom();
 		int scaledZoom = zoom * 2;
 
 		InputStream inputStream = WidgetWin32Tests.class.getResourceAsStream("folder.png");
@@ -99,10 +101,12 @@ class WidgetWin32Tests {
 	@Test
 	public void testButtonFontAfterZooming() {
 		Display display = Display.getDefault();
-		int zoom = DPIUtil.getDeviceZoom();
+		Shell shell = new Shell(display);
+		int zoom = shell.getNativeZoom();
+
 		int scaledZoom = zoom * 2;
 
-		Shell shell = new Shell(display);
+
 		shell.setBounds(0, 0, 100, 160);
 		shell.setLayout(new FillLayout());
 		shell.pack();
@@ -124,10 +128,11 @@ class WidgetWin32Tests {
 	@Test
 	public void testCoolItemAfterZooming() {
 		Display display = Display.getDefault();
-		int zoom = DPIUtil.getDeviceZoom();
+		Shell shell = new Shell(display);
+		int zoom = shell.getNativeZoom();
 		int scaledZoom = zoom * 2;
 
-		Shell shell = new Shell(display);
+
 		shell.setBounds(0, 0, 100, 160);
 		shell.setLayout(new FillLayout());
 		shell.pack();
@@ -163,10 +168,10 @@ class WidgetWin32Tests {
 	@Test
 	public void testExpandItemAfterZooming() {
 		Display display = Display.getDefault();
-		int zoom = DPIUtil.getDeviceZoom();
+		Shell shell = new Shell(display);
+		int zoom = shell.getNativeZoom();
 		int scaledZoom = zoom * 2;
 
-		Shell shell = new Shell(display);
 		shell.setBounds(0, 0, 100, 160);
 		shell.setLayout(new FillLayout());
 		shell.pack();
@@ -190,10 +195,10 @@ class WidgetWin32Tests {
 	@Test
 	public void testTabFolderSizeAfterZooming() {
 		Display display = Display.getDefault();
-		int zoom = DPIUtil.getDeviceZoom();
+		Shell shell = new Shell(display);
+		int zoom = shell.getNativeZoom();
 		int scaledZoom = zoom * 2;
 
-		Shell shell = new Shell(display);
 		shell.setBounds(0, 0, 100, 160);
 		shell.setLayout(new FillLayout());
 		shell.pack();
@@ -220,10 +225,10 @@ class WidgetWin32Tests {
 	@Test
 	public void testTableAfterZooming() {
 		Display display = Display.getDefault();
-		int zoom = DPIUtil.getDeviceZoom();
-		int scaledZoom = zoom * 2;
 
 		Shell shell = new Shell(display);
+		int zoom = shell.getNativeZoom();
+		int scaledZoom = zoom * 2;
 		shell.setBounds(0, 0, 100, 160);
 		shell.setLayout(new FillLayout());
 		shell.pack();
@@ -258,10 +263,10 @@ class WidgetWin32Tests {
 	@Test
 	public void testTreeAfterZooming() {
 		Display display = Display.getDefault();
-		int zoom = DPIUtil.getDeviceZoom();
+		Shell shell = new Shell(display);
+		int zoom =  shell.getNativeZoom();
 		int scaledZoom = zoom * 2;
 
-		Shell shell = new Shell(display);
 		shell.setBounds(0, 0, 100, 160);
 		shell.setLayout(new FillLayout());
 		shell.pack();
@@ -294,10 +299,10 @@ class WidgetWin32Tests {
 	@Test
 	public void testCaretInStyledTextAfterZooming() {
 		Display display = Display.getDefault();
-		int zoom = DPIUtil.getDeviceZoom();
+		Shell shell = new Shell(display);
+		int zoom = shell.getNativeZoom();
 		int scaledZoom = zoom * 2;
 
-		Shell shell = new Shell(display);
 		shell.setBounds(0, 0, 100, 160);
 		shell.setLayout(new FillLayout());
 		shell.pack();

--- a/tests/org.eclipse.swt.tests.win32/ManualTests/org/eclipse/swt/widgets/PatternWin32ManualTest.java
+++ b/tests/org.eclipse.swt.tests.win32/ManualTests/org/eclipse/swt/widgets/PatternWin32ManualTest.java
@@ -15,7 +15,6 @@ package org.eclipse.swt.widgets;
 
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.Pattern;
-import org.eclipse.swt.internal.DPIUtil;
 
 /*
  * This Snippet tests a pattern at multiple zoom levels.
@@ -33,8 +32,8 @@ public class PatternWin32ManualTest {
 	private static Display display = Display.getDefault();
 
 	public static void main (String [] args) {
-		@SuppressWarnings("restriction")
-		int zoom = DPIUtil.getDeviceZoom();
+		Shell shell = new Shell(display);
+		int zoom = shell.getNativeZoom();
 		int scalingFactor = 3;
 		int scaledZoom = zoom * scalingFactor;
 		int width = 400;

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/DPIUtilTests.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/DPIUtilTests.java
@@ -37,11 +37,12 @@ import org.junit.jupiter.api.condition.DisabledOnOs;
 public class DPIUtilTests {
 
 	private int deviceZoom;
+	private static final int ZOOM_200 = 200;
 
 	@BeforeEach
 	public void setup() {
 		deviceZoom = DPIUtil.getDeviceZoom();
-		DPIUtil.setDeviceZoom(200);
+		DPIUtil.setDeviceZoom(ZOOM_200);
 	}
 
 	@AfterEach
@@ -57,10 +58,10 @@ public class DPIUtilTests {
 
 		float[] scaledValue = DPIUtil.autoScaleDown(valueAt200);
 		assertArrayEquals(valueAt100, scaledValue, .001f, String.format("Scaling down float array from device zoom (%d) to 100 failed",
-				DPIUtil.getDeviceZoom()));
+				ZOOM_200));
 		scaledValue = DPIUtil.autoScaleDown((Device) null, valueAt200);
 		assertArrayEquals(valueAt100, scaledValue, .001f, String.format("Scaling down float array from device zoom (%d) to 100 with device failed",
-				DPIUtil.getDeviceZoom()));
+				ZOOM_200));
 
 		scaledValue = DPIUtil.scaleDown(valueAt200, 200);
 		assertArrayEquals(valueAt100, scaledValue, .001f, "Scaling down float array from 200 failed");
@@ -84,10 +85,10 @@ public class DPIUtilTests {
 
 		int scaledValue = DPIUtil.autoScaleDown(valueAt200);
 		assertEquals(
-				valueAt100, scaledValue, String.format("Scaling down integer from device zoom (%d) to 100 failed", DPIUtil.getDeviceZoom()));
+				valueAt100, scaledValue, String.format("Scaling down integer from device zoom (%d) to 100 failed", ZOOM_200));
 		scaledValue = DPIUtil.autoScaleDown((Device) null, valueAt200);
 		assertEquals(
-				 valueAt100, scaledValue, String.format("Scaling down integer from device zoom (%d) to 100 with device failed", DPIUtil.getDeviceZoom()));
+				 valueAt100, scaledValue, String.format("Scaling down integer from device zoom (%d) to 100 with device failed", ZOOM_200));
 
 		scaledValue = DPIUtil.scaleDown(valueAt200, 200);
 		assertEquals(valueAt100, scaledValue, "Scaling down integer from 200 failed");
@@ -111,10 +112,10 @@ public class DPIUtilTests {
 
 		float scaledValue = DPIUtil.autoScaleDown(valueAt200);
 		assertEquals(valueAt100, scaledValue, .001f,
-				String.format("Scaling down float from device zoom (%d) to 100 failed", DPIUtil.getDeviceZoom()));
+				String.format("Scaling down float from device zoom (%d) to 100 failed", ZOOM_200));
 		scaledValue = DPIUtil.autoScaleDown((Device) null, valueAt200);
 		assertEquals(valueAt100, scaledValue, .001f, String
-				.format("Scaling down float from device zoom (%d) to 100 with device failed", DPIUtil.getDeviceZoom()));
+				.format("Scaling down float from device zoom (%d) to 100 with device failed", ZOOM_200));
 
 		scaledValue = DPIUtil.scaleDown(valueAt200, 200);
 		assertEquals(valueAt100, scaledValue, .001f, "Scaling down float from 200 failed");
@@ -138,10 +139,10 @@ public class DPIUtilTests {
 
 		Point scaledValue = DPIUtil.autoScaleDown(valueAt200);
 		assertEquals(valueAt100, scaledValue,
-				String.format("Scaling down Point from device zoom (%d) to 100 failed", DPIUtil.getDeviceZoom()));
+				String.format("Scaling down Point from device zoom (%d) to 100 failed", ZOOM_200));
 		scaledValue = DPIUtil.autoScaleDown((Device) null, valueAt200);
 		assertEquals(valueAt100, scaledValue, String
-				.format("Scaling down Point from device zoom (%d) to 100 with device failed", DPIUtil.getDeviceZoom()));
+				.format("Scaling down Point from device zoom (%d) to 100 with device failed", ZOOM_200));
 
 		scaledValue = DPIUtil.scaleDown(valueAt200, 200);
 		assertEquals(valueAt100, scaledValue, "Scaling down Point from 200 failed");
@@ -165,10 +166,10 @@ public class DPIUtilTests {
 
 		Rectangle scaledValue = DPIUtil.autoScaleDown(valueAt200);
 		assertEquals(valueAt100, scaledValue,
-				String.format("Scaling down Rectangle from device zoom (%d) to 100 failed", DPIUtil.getDeviceZoom()));
+				String.format("Scaling down Rectangle from device zoom (%d) to 100 failed", ZOOM_200));
 		scaledValue = DPIUtil.autoScaleDown((Device) null, valueAt200);
 		assertEquals(valueAt100, scaledValue, String.format(
-				"Scaling down Rectangle from device zoom (%d) to 100 with device failed", DPIUtil.getDeviceZoom()));
+				"Scaling down Rectangle from device zoom (%d) to 100 with device failed", ZOOM_200));
 
 		scaledValue = DPIUtil.scaleDown(valueAt200, 200);
 		assertEquals(valueAt100, scaledValue, "Scaling down Rectangle from 200 failed");
@@ -192,10 +193,10 @@ public class DPIUtilTests {
 
 		int[] scaledValue = DPIUtil.autoScaleUp(valueAt100);
 		assertArrayEquals(valueAt200, scaledValue,
-				String.format("Scaling up int array to device zoom (%d) to 100 failed", DPIUtil.getDeviceZoom()));
+				String.format("Scaling up int array to device zoom (%d) to 100 failed", ZOOM_200));
 		scaledValue = DPIUtil.autoScaleUp((Device) null, valueAt100);
 		assertArrayEquals(valueAt200, scaledValue, String
-				.format("Scaling up int array to device zoom (%d) to 100 with device failed", DPIUtil.getDeviceZoom()));
+				.format("Scaling up int array to device zoom (%d) to 100 with device failed", ZOOM_200));
 
 		scaledValue = DPIUtil.scaleUp(valueAt100, 200);
 		assertArrayEquals(valueAt200, scaledValue, "Scaling up int array to 200 failed");
@@ -219,10 +220,10 @@ public class DPIUtilTests {
 
 		int scaledValue = DPIUtil.autoScaleUp(valueAt100);
 		assertEquals(valueAt200, scaledValue,
-				String.format("Scaling up integer to device zoom (%d) to 100 failed", DPIUtil.getDeviceZoom()));
+				String.format("Scaling up integer to device zoom (%d) to 100 failed", ZOOM_200));
 		scaledValue = DPIUtil.autoScaleUp((Device) null, valueAt100);
 		assertEquals(valueAt200, scaledValue, String
-				.format("Scaling up integer to device zoom (%d) to 100 with device failed", DPIUtil.getDeviceZoom()));
+				.format("Scaling up integer to device zoom (%d) to 100 with device failed", ZOOM_200));
 
 		scaledValue = DPIUtil.scaleUp(valueAt100, 200);
 		assertEquals(valueAt200, scaledValue, "Scaling up integer to 200 failed");
@@ -246,10 +247,10 @@ public class DPIUtilTests {
 
 		float scaledValue = DPIUtil.autoScaleUp(valueAt100);
 		assertEquals(valueAt200, scaledValue, 0.001f,
-				String.format("Scaling up integer to device zoom (%d) to 100 failed", DPIUtil.getDeviceZoom()));
+				String.format("Scaling up integer to device zoom (%d) to 100 failed", ZOOM_200));
 		scaledValue = DPIUtil.autoScaleUp((Device) null, valueAt100);
 		assertEquals(valueAt200, scaledValue, 0.001f, String
-				.format("Scaling up integer to device zoom (%d) to 100 with device failed", DPIUtil.getDeviceZoom()));
+				.format("Scaling up integer to device zoom (%d) to 100 with device failed", ZOOM_200));
 
 		scaledValue = DPIUtil.scaleUp(valueAt100, 200);
 		assertEquals(valueAt200, scaledValue, 0.001f, "Scaling up integer to 200 failed");
@@ -273,10 +274,10 @@ public class DPIUtilTests {
 
 		Point scaledValue = DPIUtil.autoScaleUp(valueAt100);
 		assertEquals(valueAt200, scaledValue,
-				String.format("Scaling up Point to device zoom (%d) to 100 failed", DPIUtil.getDeviceZoom()));
+				String.format("Scaling up Point to device zoom (%d) to 100 failed", ZOOM_200));
 		scaledValue = DPIUtil.autoScaleUp((Device) null, valueAt100);
 		assertEquals(valueAt200, scaledValue, String
-				.format("Scaling up Point to device zoom (%d) to 100 with device failed", DPIUtil.getDeviceZoom()));
+				.format("Scaling up Point to device zoom (%d) to 100 with device failed", ZOOM_200));
 
 		scaledValue = DPIUtil.scaleUp(valueAt100, 200);
 		assertEquals(valueAt200, scaledValue, "Scaling up Point to 200 failed");
@@ -300,10 +301,10 @@ public class DPIUtilTests {
 
 		Rectangle scaledValue = DPIUtil.autoScaleUp(valueAt100);
 		assertEquals(valueAt200, scaledValue,
-				String.format("Scaling up Rectangle to device zoom (%d) to 100 failed", DPIUtil.getDeviceZoom()));
+				String.format("Scaling up Rectangle to device zoom (%d) to 100 failed", ZOOM_200));
 		scaledValue = DPIUtil.autoScaleUp((Device) null, valueAt100);
 		assertEquals(valueAt200, scaledValue, String
-				.format("Scaling up Rectangle to device zoom (%d) to 100 with device failed", DPIUtil.getDeviceZoom()));
+				.format("Scaling up Rectangle to device zoom (%d) to 100 with device failed", ZOOM_200));
 
 		scaledValue = DPIUtil.scaleUp(valueAt100, 200);
 		assertEquals(valueAt200, scaledValue, "Scaling up Rectangle to 200 failed");

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_GC.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_GC.java
@@ -26,6 +26,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -154,13 +155,9 @@ public void test_copyAreaIIIIII() {
 	ImageData imageData = image.getImageData();
 	PaletteData palette = imageData.palette;
 
-	if (DPIUtil.getDeviceZoom() != 100) {
-		//TODO Fix non integer scaling factors.
-		if (SwtTestUtil.verbose) {
-			System.out.println("Excluded test_copyAreaIIIIII(org.eclipse.swt.tests.junit.Test_org_eclipse_swt_graphics_GC)");
-		}
-		return;
-	}
+	// This test verifies pixel-level color values after a copyArea() operation.
+	// Such pixel-accurate checks are only reliable at 100% zoom due to fractional scaling.
+	assumeTrue(DPIUtil.getDeviceZoom() == 100, "Skipping test due to non-100% zoom");
 
 	int pixel = imageData.getPixel(destX + 4, destY);
 	assertEquals(":a:", whiteRGB, palette.getRGB(pixel));
@@ -199,13 +196,9 @@ public void test_copyAreaIIIIII_overlapingSourceTarget() {
 	imageData = image.getImageData();
 	palette = imageData.palette;
 
-	if (DPIUtil.getDeviceZoom() != 100) {
-		//TODO Fix non integer scaling factors.
-		if (SwtTestUtil.verbose) {
-			System.out.println("Excluded test_copyAreaIIIIII(org.eclipse.swt.tests.junit.Test_org_eclipse_swt_graphics_GC)");
-		}
-		return;
-	}
+	// This test verifies pixel-level color values after a copyArea() operation.
+	// Such pixel-accurate checks are only reliable at 100% zoom due to fractional scaling.
+	assumeTrue(DPIUtil.getDeviceZoom() == 100, "Skipping test due to non-100% zoom");
 
 	pixel = imageData.getPixel(0, 105);
 	assertEquals(redRGB, palette.getRGB(pixel));
@@ -234,14 +227,9 @@ public void test_copyAreaLorg_eclipse_swt_graphics_ImageII() {
 	ImageData imageData = image.getImageData();
 	PaletteData palette = imageData.palette;
 
-	if (DPIUtil.getDeviceZoom() != 100) {
-		//TODO Fix non integer scaling factors.
-		if (SwtTestUtil.verbose) {
-			System.out.println("Excluded test_copyAreaLorg_eclipse_swt_graphics_ImageII(org.eclipse.swt.tests.junit.Test_org_eclipse_swt_graphics_GC)");
-		}
-		image.dispose();
-		return;
-	}
+	// This test verifies pixel-level color values after a copyArea() operation.
+	// Such pixel-accurate checks are only reliable at 100% zoom due to fractional scaling.
+	assumeTrue(DPIUtil.getDeviceZoom() == 100, "Skipping test due to non-100% zoom");
 
 	int pixel = imageData.getPixel(4, 0);
 	assertEquals(":a:", whiteRGB, palette.getRGB(pixel));

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_Image.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_Image.java
@@ -679,47 +679,24 @@ public void test_getImageData() {
 
 @Test
 public void test_getImageData_100() {
-	int zoom = DPIUtil.getDeviceZoom();
-	try {
-		DPIUtil.setDeviceZoom(100);
-		getImageData_int(100);
-	} finally {
-		DPIUtil.setDeviceZoom(zoom);
-	}
-}
+        getImageData_int(100);
+    }
 
 @Test
 public void test_getImageData_125() {
-	int zoom = DPIUtil.getDeviceZoom();
-	try {
-		DPIUtil.setDeviceZoom(125);
-		getImageData_int(125);
-	} finally {
-		DPIUtil.setDeviceZoom(zoom);
-	}
+    getImageData_int(125);
 }
 
 @Test
 public void test_getImageData_150() {
-	int zoom = DPIUtil.getDeviceZoom();
-	try {
-		DPIUtil.setDeviceZoom(150);
-		getImageData_int(150);
-	} finally {
-		DPIUtil.setDeviceZoom(zoom);
-	}
+    getImageData_int(150);
 }
 
 @Test
 public void test_getImageData_200() {
-	int zoom = DPIUtil.getDeviceZoom();
-	try {
-		DPIUtil.setDeviceZoom(200);
-		getImageData_int(200);
-	} finally {
-		DPIUtil.setDeviceZoom(zoom);
-	}
+    getImageData_int(200);
 }
+
 
 void getImageData_int(int zoom) {
 	Rectangle bounds = new Rectangle(0, 0, 10, 20);

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Display.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Display.java
@@ -37,7 +37,6 @@ import org.eclipse.swt.graphics.Font;
 import org.eclipse.swt.graphics.FontData;
 import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.graphics.Rectangle;
-import org.eclipse.swt.internal.DPIUtil;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Event;
@@ -55,7 +54,6 @@ import org.junit.jupiter.api.condition.DisabledOnOs;
  *
  * @see org.eclipse.swt.widgets.Display
  */
-@SuppressWarnings("restriction")
 public class Test_org_eclipse_swt_widgets_Display {
 
 private static boolean isRunningOnEclipseOrgHudson =
@@ -67,7 +65,6 @@ private static final boolean BUG_492569 = SwtTestUtil.isWindows && isRunningOnEc
 @Test
 public void test_Constructor() {
 	Display disp = new Display();
-	System.out.println("org.eclipse.swt.internal.DPIUtil.getDeviceZoom(): " + DPIUtil.getDeviceZoom());
 	disp.dispose();
 	if (SwtTestUtil.isGTK) {
 		System.out.println("org.eclipse.swt.internal.gtk.version=" + System.getProperty("org.eclipse.swt.internal.gtk.version"));


### PR DESCRIPTION
DPIUtil.get[Native]DeviceZoom() is no longer meaningful when monitor-specific scaling is used, so its usage has been removed from most tests. In some cases , these have been left unchanged for now.

Among the occurrences mentioned in [Eclipse Platform Issue #195](https://github.com/vi-eclipse/Eclipse-Platform/issues/195), most have been addressed. Still the following four cases remain unmodified:

```
1)org.eclipse.swt.tests.junit.Test_org_eclipse_swt_graphics_GC.executeWithNonDefaultDeviceZoom(Runnable)
2)org.eclipse.swt.tests.junit.DPIUtilTests.setup()
3)org.eclipse.swt.tests.junit.Test_org_eclipse_swt_graphics_Image.test_updateWidthHeightAfterDPIChange()
```
In these three tests, `getDeviceZoom()` is used to capture the zoom level before execution and restore it afterward. No suitable replacement has been identified yet.

```
4)org.eclipse.swt.snippets.Snippet373.main(String[])
```
The snippet description says it is used to to display/refresh Monitor DPI dynamically. However, it uses incorrect DPI access methods and presents a misleading example. It would be better to either remove or rewrite this snippet.