### PR TITLE
Edge: Fix URI_FOR_CUSTOM_TEXT_PAGE in case of case mismatch

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Browser/win32/org/eclipse/swt/browser/Edge.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Browser/win32/org/eclipse/swt/browser/Edge.java
@@ -1534,8 +1534,10 @@ public void stop() {
 
 static boolean isLocationForCustomText(String location) {
 		try {
-			return URI_FOR_CUSTOM_TEXT_PAGE.equals(new URI(location));
-		} catch (URISyntaxException e) {
+			URI locationUri = new URI(location);
+			return "file".equals(locationUri.getScheme())
+					&& Path.of(URI_FOR_CUSTOM_TEXT_PAGE).equals(Path.of(locationUri));
+		} catch (URISyntaxException | IllegalArgumentException e) {
 			return false;
 		}
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/browser/EdgeTests.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/browser/EdgeTests.java
@@ -1,34 +1,81 @@
 package org.eclipse.swt.browser;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.*;
+import java.util.*;
 
 import org.eclipse.swt.internal.*;
-import org.junit.jupiter.api.*;
+import org.junit.*;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.*;
 
 @ExtendWith(PlatformSpecificExecutionExtension.class)
 class EdgeTests {
+
+	private String originalTempDir;
+
+	@Before
+	public void setup() throws Exception {
+		originalTempDir = System.getProperty("java.io.tmpdir");
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		setTempDirAndInitializeEdgeLocationForCustomTextPage(originalTempDir);
+	}
+
+	private static void setTempDirAndInitializeEdgeLocationForCustomTextPage(String dir) {
+		System.setProperty("java.io.tmpdir", dir);
+		Edge.setupLocationForCustomTextPage();
+	}
 
 	/**
 	 * https://github.com/eclipse-platform/eclipse.platform.swt/issues/1912
 	 */
 	@Test
 	public void handlingOfTempDirWithSpacesAndUnicodeCharacters() throws Exception {
-		String originalTempDir = System.getProperty("java.io.tmpdir");
-		String temporaryTempDirWithSpacesAndUnicode = Files.createTempDirectory("spaces and únîcòde").toString();
-		System.setProperty("java.io.tmpdir", temporaryTempDirWithSpacesAndUnicode);
-		try {
-			Edge.setupLocationForCustomTextPage();
+		setTempDirAndInitializeEdgeLocationForCustomTextPage(
+				Files.createTempDirectory("spaces and únîcòde").toString());
 
-			// URI_FOR_CUSTOM_TEXT_PAGE must already be encoded internally
-			assertTrue(Edge.URI_FOR_CUSTOM_TEXT_PAGE.toString().contains("spaces%20and%20%C3%BAn%C3%AEc%C3%B2de"));
-			assertTrue(Edge.isLocationForCustomText(Edge.URI_FOR_CUSTOM_TEXT_PAGE.toASCIIString()));
-
-		} finally {
-			System.setProperty("java.io.tmpdir", originalTempDir);
-			Edge.setupLocationForCustomTextPage(); // restore the original value
-		}
+		// URI_FOR_CUSTOM_TEXT_PAGE must already be encoded internally
+		// for correct handling of spaces and unicode characters
+		assertTrue(Edge.URI_FOR_CUSTOM_TEXT_PAGE.toString().contains("spaces%20and%20%C3%BAn%C3%AEc%C3%B2de"));
+		assertTrue(Edge.isLocationForCustomText(Edge.URI_FOR_CUSTOM_TEXT_PAGE.toASCIIString()));
 	}
+
+	/**
+	 * https://github.com/eclipse-platform/eclipse.platform.swt/issues/2061
+	 */
+	@Test
+	public void handlingOfUpperLowerCase() throws Exception {
+		setTempDirAndInitializeEdgeLocationForCustomTextPage(Files.createTempDirectory("FoObAr").toString());
+
+		String lowerCaseUri = Edge.URI_FOR_CUSTOM_TEXT_PAGE.toASCIIString().toLowerCase(Locale.ROOT);
+		String upperCaseUri = "file"
+				+ Edge.URI_FOR_CUSTOM_TEXT_PAGE.toASCIIString().toUpperCase(Locale.ROOT).substring(4);
+
+		assertTrue(Edge.isLocationForCustomText(lowerCaseUri));
+		assertTrue(Edge.isLocationForCustomText(upperCaseUri));
+	}
+
+	@Test
+	public void handlingOfNonFileURIs() throws Exception {
+		setTempDirAndInitializeEdgeLocationForCustomTextPage(Files.createTempDirectory("any").toString());
+
+		String httpsUri = "https://eclipse.org";
+
+		assertFalse(Edge.isLocationForCustomText(httpsUri));
+	}
+
+	@Test
+	public void handlingOfInvalidFileURIs() throws Exception {
+		setTempDirAndInitializeEdgeLocationForCustomTextPage(Files.createTempDirectory("any").toString());
+
+		String brokenFileUri = "file://--";
+
+		assertFalse(Edge.isLocationForCustomText(brokenFileUri));
+	}
+
 }


### PR DESCRIPTION
Use Path.equals() instead of URI.equals() to compare the URI paths.

This will will handle upper/lower-case differences correctly which can arise, e.g. when symlinks are involved.

Fixes #2061.