### PR TITLE
[win32] Allow disablement of autoscale per Widget

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Control.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Control.java
@@ -3257,7 +3257,8 @@ void setBoundsInPixels (int x, int y, int width, int height, int flags, boolean 
 public void setBounds (Rectangle rect) {
 	checkWidget ();
 	if (rect == null) error (SWT.ERROR_NULL_ARGUMENT);
-	setBoundsInPixels(DPIUtil.scaleUp(rect, getZoom()));
+	int zoom = autoScaleDisabled ? parent.getZoom() : getZoom();
+	setBoundsInPixels(DPIUtil.scaleUp(rect, zoom));
 }
 
 void setBoundsInPixels (Rectangle rect) {


### PR DESCRIPTION
This PR introduces the data attribute AUTOSCALE_DISABLED for the windows implementation for Widgets. This will disable autoscaling for this Widget and all of its children. This is a necessary requirement for complex usages utilizing GC. Without disabling autoscaling rendering artifacts will be introduced when only parts of the GC are redrawn on monitor specific scaling with some zoom value, e.g. 175%. This commit serves as starting point to harden this feature before considering extracting an API out of it.