### PR TITLE
Remove DPIUtil.getDeviceZoom() in test which just prints to console

### DIFF
--- a/tests/org.eclipse.swt.tests/ManualTests/org/eclipse/swt/tests/manual/Issue0445_HiDPISmoothScaling.java
+++ b/tests/org.eclipse.swt.tests/ManualTests/org/eclipse/swt/tests/manual/Issue0445_HiDPISmoothScaling.java
@@ -20,7 +20,6 @@ import org.eclipse.swt.SWTException;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.graphics.ImageData;
 import org.eclipse.swt.graphics.ImageDataProvider;
-import org.eclipse.swt.internal.DPIUtil;
 import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Label;
@@ -58,7 +57,6 @@ public class Issue0445_HiDPISmoothScaling {
 		shell.setSize(100, 100);
 		shell.setLayout(new GridLayout(1, true));
 
-		System.out.println("Device Zoom: " + DPIUtil.getDeviceZoom());
 
 		ImageDataProvider provider1x = zoom -> {
 			if (zoom == 100) {


### PR DESCRIPTION
This pull request removes the call to DPIUtil.getDeviceZoom() from a test. The commit is intended as a test to ensure that the subsequent refactoring commits will trigger the GitHub workflow.