### PR TITLE
Adding a recommendation for the usage of setLocation in Control

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Control.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Control.java
@@ -3991,6 +3991,10 @@ public void setLayoutData (Object layoutData) {
  * @param x the new x coordinate for the receiver
  * @param y the new y coordinate for the receiver
  *
+ * <p><strong>Recommended Usage:</strong> If you plan to use {@link #setSize(int, int)},
+ * call it <em>before</em> calling this method. This ensures the control is sized
+ * correctly before positioning, which helps avoid layout issues when using absolute positioning.</p>
+ *
  * @exception SWTException <ul>
  *    <li>ERROR_WIDGET_DISPOSED - if the receiver has been disposed</li>
  *    <li>ERROR_THREAD_INVALID_ACCESS - if not called from the thread that created the receiver</li>
@@ -4012,6 +4016,10 @@ public void setLocation (int x, int y) {
  * shell when the environment uses the Wayland protocol, nothing will happen.
  *
  * @param location the new location for the receiver
+ *
+ * <p><strong>Recommended Usage:</strong> If you plan to use {@link #setSize(int, int)},
+ * call it <em>before</em> calling this method. This ensures the control is sized
+ * correctly before positioning, which helps avoid layout issues when using absolute positioning.</p>
  *
  * @exception SWTException <ul>
  *    <li>ERROR_WIDGET_DISPOSED - if the receiver has been disposed</li>

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Control.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Control.java
@@ -1260,6 +1260,10 @@ Point getLocationInPixels () {
  *
  * @param location the new location for the receiver
  *
+ * <p><strong>Recommended Usage:</strong> If you plan to use {@link #setSize(int, int)},
+ * call it <em>before</em> calling this method. This ensures the control is sized
+ * correctly before positioning, which helps avoid layout issues when using absolute positioning.</p>
+ *
  * @exception SWTException <ul>
  *    <li>ERROR_WIDGET_DISPOSED - if the receiver has been disposed</li>
  *    <li>ERROR_THREAD_INVALID_ACCESS - if not called from the thread that created the receiver</li>
@@ -1289,6 +1293,10 @@ void setLocationInPixels (Point location) {
  *
  * @param x the new x coordinate for the receiver
  * @param y the new y coordinate for the receiver
+ *
+ * <p><strong>Recommended Usage:</strong> If you plan to use {@link #setSize(int, int)},
+ * call it <em>before</em> calling this method. This ensures the control is sized
+ * correctly before positioning, which helps avoid layout issues when using absolute positioning.</p>
  *
  * @exception SWTException <ul>
  *    <li>ERROR_WIDGET_DISPOSED - if the receiver has been disposed</li>

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Control.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Control.java
@@ -3504,8 +3504,9 @@ public void setLayoutData (Object layoutData) {
  * intended effect on some platforms. For example, executing this operation on a
  * shell when the environment uses the Wayland protocol, nothing will happen.
  *
- * @param x the new x coordinate for the receiver
- * @param y the new y coordinate for the receiver
+ * <p><strong>Recommended Usage:</strong> If you plan to use {@link #setSize(int, int)},
+ * call it <em>before</em> calling this method. This ensures the control is sized
+ * correctly before positioning, which helps avoid layout issues when using absolute positioning.</p>
  *
  * @exception SWTException <ul>
  *    <li>ERROR_WIDGET_DISPOSED - if the receiver has been disposed</li>
@@ -3536,6 +3537,10 @@ void setLocationInPixels (int x, int y) {
  * shell when the environment uses the Wayland protocol, nothing will happen.
  *
  * @param location the new location for the receiver
+ *
+ * <p><strong>Recommended Usage:</strong> If you plan to use {@link #setSize(int, int)},
+ * call it <em>before</em> calling this method. This ensures the control is sized
+ * correctly before positioning, which helps avoid layout issues when using absolute positioning.</p>
  *
  * @exception SWTException <ul>
  *    <li>ERROR_WIDGET_DISPOSED - if the receiver has been disposed</li>


### PR DESCRIPTION
As mentioned in https://github.com/eclipse-platform/eclipse.platform.ui/pull/2948#pullrequestreview-2799170771, setting the location of the control before setting the size **could** cause problems with HiDpi settings. In order to prevent that we are adding  a recommendation in java doc for setLocation method of Control. 

Usages as per non-recommended way to be changed in Platform repositories in separate issue: https://github.com/vi-eclipse/Eclipse-Platform/issues/304