### PR TITLE
Fix zoom issue during copy paste in clipboard example

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/win32/org/eclipse/swt/dnd/ImageTransfer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/win32/org/eclipse/swt/dnd/ImageTransfer.java
@@ -15,7 +15,6 @@ package org.eclipse.swt.dnd;
 
 import org.eclipse.swt.*;
 import org.eclipse.swt.graphics.*;
-import org.eclipse.swt.internal.*;
 import org.eclipse.swt.internal.ole.win32.*;
 import org.eclipse.swt.internal.win32.*;
 
@@ -184,8 +183,9 @@ public Object nativeToJava(TransferData transferData) {
 					pSourceBits -= scanline;
 				}
 			}
-			Image image = Image.win32_new(null, SWT.BITMAP, memDib, DPIUtil.getNativeDeviceZoom());
-			ImageData data = image.getImageData (DPIUtil.getDeviceZoom ());
+			final int DEFAULT_IMAGE_STORAGE_ZOOM = 100;
+			Image image = Image.win32_new(null, SWT.BITMAP, memDib, DEFAULT_IMAGE_STORAGE_ZOOM);
+			ImageData data = image.getImageData ();
 			OS.DeleteObject(memDib);
 			image.dispose();
 			return data;

--- a/examples/org.eclipse.swt.examples/META-INF/MANIFEST.MF
+++ b/examples/org.eclipse.swt.examples/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %plugin.SWTStandaloneExampleSet.name
 Bundle-SymbolicName: org.eclipse.swt.examples; singleton:=true
-Bundle-Version: 3.108.800.qualifier
+Bundle-Version: 3.108.900.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/examples/org.eclipse.swt.examples/src/org/eclipse/swt/examples/clipboard/ClipboardExample.java
+++ b/examples/org.eclipse.swt.examples/src/org/eclipse/swt/examples/clipboard/ClipboardExample.java
@@ -30,7 +30,6 @@ import org.eclipse.swt.dnd.Transfer;
 import org.eclipse.swt.graphics.GC;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.graphics.ImageData;
-import org.eclipse.swt.graphics.ImageDataProvider;
 import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.graphics.Rectangle;
 import org.eclipse.swt.layout.FillLayout;
@@ -62,38 +61,6 @@ public class ClipboardExample {
 	Label status;
 	static final int HSIZE = 100, VSIZE = 60;
 
-static final class AutoScaleImageDataProvider implements ImageDataProvider {
-	ImageData imageData;
-	int currentZoom;
-	public AutoScaleImageDataProvider (ImageData data) {
-		this.imageData = data;
-		this.currentZoom = getDeviceZoom ();
-	}
-
-	@Override
-	public ImageData getImageData (int zoom) {
-		return autoScaleImageData(imageData, zoom, currentZoom);
-	}
-
-	static ImageData autoScaleImageData (ImageData imageData, int targetZoom, int currentZoom) {
-		if (imageData == null || targetZoom == currentZoom) return imageData;
-		float scaleFactor = ((float) targetZoom)/((float) currentZoom);
-		return imageData.scaledTo (Math.round (imageData.width * scaleFactor), Math.round (imageData.height * scaleFactor));
-	}
-
-	static int getDeviceZoom () {
-		int zoom = 100;
-		String value = System.getProperty ("org.eclipse.swt.internal.deviceZoom");
-		if (value != null) {
-			try {
-				zoom = Integer.parseInt(value);
-			} catch (NumberFormatException e) {
-				e.printStackTrace();
-			}
-		}
-		return zoom;
-	}
-}
 
 public static void main( String[] args) {
 	Display display = new Display();
@@ -476,8 +443,8 @@ void createImageTransfer(Composite copyParent, Composite pasteParent){
 	b.addSelectionListener(widgetSelectedAdapter(e -> {
 		if (copyImage[0] != null) {
 			status.setText("");
-			// Fetch ImageData at current zoom and save in the clip-board.
-			clipboard.setContents(new Object[] {copyImage[0].getImageDataAtCurrentZoom()}, new Transfer[] {ImageTransfer.getInstance()});
+			// Fetch ImageData and save in the clip-board.
+			clipboard.setContents(new Object[] {copyImage[0].getImageData()}, new Transfer[] {ImageTransfer.getInstance()});
 		} else {
 			status.setText("No image to copy");
 		}
@@ -540,8 +507,7 @@ void createImageTransfer(Composite copyParent, Composite pasteParent){
 				pasteImage[0].dispose();
 			}
 			status.setText("");
-			// Consume the ImageData at current zoom as-is.
-			pasteImage[0] = new Image(e.display, new AutoScaleImageDataProvider(imageData));
+			pasteImage[0] = new Image(e.display, imageData);
 			pasteVBar.setEnabled(true);
 			pasteHBar.setEnabled(true);
 			pasteOrigin.x = 0; pasteOrigin.y = 0;


### PR DESCRIPTION
Copy and paste no longer tries to autoscale the image. The image is always copied and pasted at 100% zoom.

The purpose of this change is to:  
1) Fix an issue in the clipboard example where the pasted image had different zoom levels across monitors  
2) Remove all calls to `DPIUtil.get[Native]DeviceZoom()`

Previously, when copying an image in the clipboard example, the image at the current zoom level was stored to clipboard using `getImageDataAtCurrentZoom()`. However, in normal Windows behavior (e.g., Paint), images are always copied at their original size regardless of the current zoom. When pasting, the image is pasted at 100% zoom, and the application handles zoom internally when displaying the image.

To match this behavior, copy and paste now always handle images at 100% scale, ignoring the current zoom and leaving zoom handling to the image class when it is fetched for display.
