### PR TITLE
Revert "Replace usages of new Image(device, width, height)..." #2162

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Composite.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Composite.java
@@ -1554,6 +1554,8 @@ LRESULT WM_PAINT (long wParam, long lParam) {
 			data.ps = ps;
 			data.hwnd = handle;
 			GC gc = GC.win32_new (this, data);
+
+			/* Get the system region for the paint HDC */
 			long sysRgn = 0;
 			if ((style & (SWT.DOUBLE_BUFFERED | SWT.TRANSPARENT)) != 0 || (style & SWT.NO_MERGE_PAINTS) != 0) {
 				sysRgn = OS.CreateRectRgn (0, 0, 0, 0);
@@ -1579,25 +1581,14 @@ LRESULT WM_PAINT (long wParam, long lParam) {
 				GC paintGC = null;
 				Image image = null;
 				if ((style & (SWT.DOUBLE_BUFFERED | SWT.TRANSPARENT)) != 0) {
+					image = new Image (display, width, height);
 					paintGC = gc;
-					int originalStyle = gc.getStyle();
-					ImageGcDrawer drawer = new ImageGcDrawer() {
-					    @Override
-					    public void drawOn(GC gc, int iWidth, int iHeight) {
-					    	GCData gcData = gc.getGCData ();
-							gcData.uiState = data.uiState;
-							gc.setForeground (getForeground ());
-							gc.setBackground (getBackground ());
-							gc.setFont (getFont ());
-
-					    }
-
-					    @Override
-					    public int getGcStyle() {
-					        return  originalStyle & SWT.RIGHT_TO_LEFT;
-					    }
-					};
-					image = new Image (display, drawer, width, height);
+					gc = new GC (image, paintGC.getStyle() & SWT.RIGHT_TO_LEFT);
+					GCData gcData = gc.getGCData ();
+					gcData.uiState = data.uiState;
+					gc.setForeground (getForeground ());
+					gc.setBackground (getBackground ());
+					gc.setFont (getFont ());
 					if ((style & SWT.TRANSPARENT) != 0) {
 						OS.BitBlt (gc.handle, 0, 0, width, height, paintGC.handle, ps.left, ps.top, OS.SRCCOPY);
 					}

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Composite.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Composite.java
@@ -197,6 +197,18 @@ public void test_setTabList$Lorg_eclipse_swt_widgets_Control() {
 	button2.dispose();
 }
 
+/*
+ * See https://github.com/eclipse-platform/eclipse.platform.swt/issues/2162
+ */
+@Test
+public void test_bug2162_transparentStyle() {
+	Composite c = new Composite(shell, SWT.TRANSPARENT);
+	c.addPaintListener(e -> {});
+
+	shell.setLayout(new FillLayout());
+	shell.open();
+}
+
 protected Composite getElementExpectedToHaveFocusAfterSetFocusOnParent(Composite visibleChild) {
 	return visibleChild;
 }


### PR DESCRIPTION
This reverts commit 807b159fb65000762a179e6793cdd29e86a99cd4.

Add regression test.

Fixes https://github.com/eclipse-platform/eclipse.platform.swt/issues/2162