### PR TITLE
[win32] Adjust wrong size after DPI fix in Shell

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Shell.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Shell.java
@@ -553,6 +553,14 @@ public void close () {
 	closeWidget ();
 }
 
+@Override
+void createWidget() {
+	super.createWidget ();
+	if (parent != null) {
+		this.nativeZoom = DPIUtil.mapDPIToZoom(OS.GetDpiForWindow(handle));
+	}
+}
+
 void createBalloonTipHandle () {
 	balloonTipHandle = OS.CreateWindowEx (
 		0,


### PR DESCRIPTION
This PR addresses an issue with the logic fixing a missing DPI change event from windows in the Shell#WM_WINDOWPOSCHANGED callback. It is no longer necessary, because the causing issue is that in some scenarios a sub shell is positioned on a random monitor. Solution is to adapt the nativeZoom of the sub Shell after the handle was created.

The PR adapts the implementation done in https://github.com/eclipse-platform/eclipse.platform.swt/pull/1863 which was not correct.

To me this scenario only appears, when starting the RCP from the Explorer (e.g. not a command prompt!). I didn't event have the effect on all RCPs, but at least on the I-Build RCPs, e.g. I can reproduce it on https://download.eclipse.org/eclipse/downloads/drops4/I20250519-0040/download.php?dropFile=eclipse-SDK-I20250519-0040-win32-x86_64.zip. Newer ones will probably have the effect as well.

Primary Monitor 175%, secondary monitor 125%, have the IDE on the Primary monitor and hover over a class. 
![image](https://github.com/user-attachments/assets/ebb3ef7a-7059-4fcf-87ec-e6cba9e115c4)

*Important* This PR sadly doesn't fully solve all issues as there is another issue hidden in Table, that can scale the scroll width/height of the Table to a value, that does not fit into the scaled Shell and scrollbars will appear, when they shouldn't