### PR TITLE
Incorrect Zoom Level Applied When Dragging

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/win32/org/eclipse/swt/dnd/DragSource.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/win32/org/eclipse/swt/dnd/DragSource.java
@@ -383,6 +383,7 @@ public DragSource(Control control, int style) {
 	};
 	control.addListener(SWT.Dispose, controlListener);
 	control.addListener(SWT.DragDetect, controlListener);
+	control.addListener(SWT.ZoomChanged, e -> this.nativeZoom = e.detail);
 
 	this.addListener(SWT.Dispose, e -> DragSource.this.onDispose());
 


### PR DESCRIPTION
When dragging and dropping a file from the Package Explorer or a field/method from the Outline view, the dragged item appears at an incorrect zoom level. Thats because the zoom for DragSource was not updated on zoom change and we use that zoom in DragListener to update the size of the imageList.

**Reproduction**
Steps to reproduce the behavior:

**Scenario 1**
1. Start the runtime workspace with 175% zoom on primary monitor. 
2. Now change the display zoom from windows setting to 250%
3. Try to drag the class or method from package explorer as showed below
4. The dragged item looks bigger than the original one

https://github.com/user-attachments/assets/398fc226-b76a-46d5-9a62-e01930492e9d

**Scenario 2**
1. Start the runtime workspace with 175% zoom on primary monitor. 
2. Now move the window to secondary monitor with 150% Zoom
3. Try to drag the class or method from package explorer as showed below
4. The dragged item looks bigger than the original one

https://github.com/user-attachments/assets/026ee4db-e91e-4613-8d26-7a6195b940d6

**Expected Behavior**
The dragged item should be of the same size as it shows in the package explorer. 

**Necessary configuration:**
Use these arguments before starting the runtime workspace:
```
-Dswt.autoScale=quarter
-Dswt.autoScale.updateOnRuntime=true
```
