### PR TITLE
[win32] Adapt GC zoom when using plain images

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Image.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Image.java
@@ -2108,6 +2108,11 @@ private class PlainImageProviderWrapper extends AbstractImageProviderWrapper {
 	}
 
 	@Override
+	protected long configureGCData(GCData data) {
+		return configureGC(data, DPIUtil.getDeviceZoom());
+	}
+
+	@Override
 	protected Rectangle getBounds(int zoom) {
 		Rectangle rectangle = new Rectangle(0, 0, width, height);
 		return DPIUtil.scaleUp(rectangle, zoom);


### PR DESCRIPTION
This PR adapts the zoom passed to the GC when it is initialized for a plain Image created via Image#Image(Device, int, int) with a given width and height. It will fall back to DPIUtil#getDeviceZoom() again to revert to original bevahiour and prevent blurry rescaling of old usages.