### PR TITLE
Control: remove dependency on Browser and OleClientSite

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Browser/common/org/eclipse/swt/browser/Browser.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Browser/common/org/eclipse/swt/browser/Browser.java
@@ -1267,4 +1267,10 @@ public void stop () {
 	checkWidget();
 	webBrowser.stop ();
 }
+
+//@Override not marked as overridden because the super method does not exist for GTK/Cocoa
+protected boolean embedsWin32Control () {
+	// The Edge browser embeds webView2
+	return !isDisposed() && isVisible() && "edge".equals(getBrowserType());
+}
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT OLE Win32/win32/org/eclipse/swt/ole/win32/OleClientSite.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT OLE Win32/win32/org/eclipse/swt/ole/win32/OleClientSite.java
@@ -1511,4 +1511,10 @@ private SIZE xFormPixelsToHimetric(SIZE aSize) {
 	size.cy = cy;
 	return size;
 }
+
+@Override
+protected boolean embedsWin32Control () {
+	// OLE objects are always embedded by windows
+	return !isDisposed() && isVisible();
+}
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Composite.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Composite.java
@@ -1986,4 +1986,17 @@ private static void handleDPIChange(Widget widget, int newZoom, float scalingFac
 	}
 	composite.redrawInPixels (null, true);
 }
+
+@Override
+protected boolean embedsWin32Control () {
+	if (isDisposed() || !isVisible()) {
+		return false;
+	}
+	for (Control child : getChildren()) {
+		if (child.embedsWin32Control()) {
+			return true;
+		}
+	}
+	return false;
+}
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Control.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Control.java
@@ -20,7 +20,6 @@ import java.util.stream.*;
 
 import org.eclipse.swt.*;
 import org.eclipse.swt.accessibility.*;
-import org.eclipse.swt.browser.*;
 import org.eclipse.swt.events.*;
 import org.eclipse.swt.graphics.*;
 import org.eclipse.swt.internal.*;
@@ -3698,25 +3697,7 @@ public void setRedraw (boolean redraw) {
 	}
 }
 
-private boolean embedsWin32Control () {
-	if (this.isDisposed() || !this.isVisible()) {
-		return false;
-	}
-	if (this instanceof Browser browser) {
-		// The Edge browser embeds webView2
-		return "edge".equals(browser.getBrowserType());
-	}
-
-	if (this instanceof OleClientSite) {
-		// OLE objects are always embedded by windows
-		return true;
-	}
-
-	// This needs to be checked AFTER OleClientSite because OleClientSite itself is a Composite
-	if (this instanceof Composite comp) {
-		return Stream.of(comp.getChildren()).anyMatch(Control::embedsWin32Control);
-	}
-
+protected boolean embedsWin32Control () {
 	return false;
 }
 


### PR DESCRIPTION
This is better design and allows to compile SWT without the "bundles\org.eclipse.swt\Eclipse SWT Browser\" source path.