### PR TITLE
[Win32] Initialize copied image provider wrapper on correct image #2188

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Image.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Image.java
@@ -2084,7 +2084,7 @@ private class ImageDataLoaderStreamProviderWrapper extends ImageFromImageDataPro
 
 	@Override
 	AbstractImageProviderWrapper createCopy(Image image) {
-		return new ImageDataLoaderStreamProviderWrapper(inputStreamData);
+		return image.new ImageDataLoaderStreamProviderWrapper(inputStreamData);
 	}
 }
 

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_Image.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_Image.java
@@ -26,6 +26,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeFalse;
 import static org.junit.Assume.assumeTrue;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
@@ -435,6 +436,23 @@ public void test_ConstructorLorg_eclipse_swt_graphics_Device_ImageGcDrawer() {
 	// Valid provider
 	Image image = new Image(display, imageGcDrawer, 20, 20);
 	image.dispose();
+}
+
+@Test
+public void test_ConstructorLorg_eclipse_swt_graphics_DeviceImageI() throws IOException {
+	byte[] bytes = Files.readAllBytes(Path.of(getPath("collapseall.png")));
+	Image sourceImage = new Image(display, new ByteArrayInputStream(bytes));
+	Image copiedImage = new Image(display, sourceImage, SWT.IMAGE_COPY);
+	Image targetImage = new Image(display, 1, 1);
+	GC gc = new GC(targetImage);
+	gc.drawImage(sourceImage, 0, 0);
+	gc.drawImage(targetImage, 0, 0);
+
+	assertEquals(0, imageDataComparator().compare(sourceImage.getImageData(), copiedImage.getImageData()));
+
+	sourceImage.dispose();
+	copiedImage.dispose();
+	targetImage.dispose();
 }
 
 @Test


### PR DESCRIPTION
When copying an image based on an input stream, the copied provider wrapper was erroneously created on the original image. This change adapts the instantiation to create the warpper on the correct image.

Fixes https://github.com/eclipse-platform/eclipse.platform.swt/issues/2188