### PR TITLE
[Build] Use Eclipse Platform Bot to commit built SWT binaries

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -116,32 +116,31 @@ pipeline {
 					script {
 						def authorMail = sh(script: 'git log -1 --pretty=format:"%ce" HEAD', returnStdout: true)
 						echo 'HEAD commit author: ' + authorMail
-						if ('eclipse-releng-bot@eclipse.org'.equals(authorMail) && !params.forceNativeBuilds) {
+						def buildBotMail = 'platform-bot@eclipse.org'
+						if (buildBotMail.equals(authorMail) && !params.forceNativeBuilds) {
 							// Prevent endless build-loops due to self triggering because of a previous automated build of natives and the associated updates.
 							currentBuild.result = 'ABORTED'
 							error('Abort build only triggered by automated SWT-natives update.')
 						}
-					}
-					sh '''
+						sh """
+						java -version
 						git version
 						git lfs version
+						git config --global user.email '${buildBotMail}'
+						git config --global user.name 'Eclipse Platform Bot'
 						git config --unset core.hooksPath # Jenkins disables hooks by default as security feature, but we need the hooks for LFS
 						git lfs update # Install Git LFS hooks in repository, which has been skipped due to the initially nulled hookspath
 						git lfs pull
 						git fetch --all --tags --quiet
 						git remote set-url --push origin git@github.com:eclipse-platform/eclipse.platform.swt.git
-					'''
+						"""
+					}
 				}
 			}
 		}
 		stage('Check if SWT-binaries build is needed') {
 			steps {
 				dir('eclipse.platform.swt') {
-					sh'''
-						java -version
-						git config --global user.email 'eclipse-releng-bot@eclipse.org'
-						git config --global user.name 'Eclipse Releng Bot'
-					'''
 					script {
 						def allWS = ['cocoa', 'gtk', 'win32']
 						def libraryFilePattern = [ 'cocoa' : 'libswt-*.jnilib', 'gtk' : 'libswt-*.so', 'win32' : 'swt-*.dll' ]


### PR DESCRIPTION
Use the `Eclipse Platform Bot` to commit built SWT binaries with its correct email as recorded in the EF-API (https://api.eclipse.org/bots ) and that is also associated with it's Github account. Before the `Eclipse Releng Bot` was used for that, but with an incorrect email.

Not it's the same bot that is also used for version increments:
https://github.com/eclipse-platform/eclipse.platform.swt/blob/5115799730f502b7c3b2d958d3cf2ec37ba71d11/.github/workflows/pr-checks.yml#L20-L21

I think that is more suitable than using the Releng Bot (even with a fixed mail).

Fixes
- https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/6227

@akurtakov, @iloveeclipse, @HeikoKlare any objection?