### PR TITLE
Deprecate DefaultSWTFontRegistry and Completely switch to ScalingSWTFontRegistry

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/internal/LegacySWTFontRegistryTests.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/internal/LegacySWTFontRegistryTests.java
@@ -23,15 +23,16 @@ import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.*;
 
 @ExtendWith(PlatformSpecificExecutionExtension.class)
-class DefaultSWTFontRegistryTests {
+class LegacySWTFontRegistryTests {
 	private static String TEST_FONT = "Helvetica";
 	private Display display;
 	private SWTFontRegistry fontRegistry;
 
+	@SuppressWarnings("removal")
 	@BeforeEach
 	public void setUp() {
 		this.display = Display.getDefault();
-		this.fontRegistry = new DefaultSWTFontRegistry(display);
+		this.fontRegistry = new LegacySWTFontRegistry(display);
 	}
 
 	@AfterEach

--- a/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/widgets/ControlWin32Tests.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/widgets/ControlWin32Tests.java
@@ -32,7 +32,7 @@ import org.junit.jupiter.api.extension.*;
 class ControlWin32Tests {
 
 	@Test
-	public void testScaleFontCorrectlyInAutoScaleSzenario() {
+	public void testScaleFontCorrectlyInAutoScaleScenario() {
 		DPIUtil.setMonitorSpecificScaling(true);
 		Display display = Display.getDefault();
 
@@ -55,15 +55,37 @@ class ControlWin32Tests {
 	}
 
 	@Test
-	public void testDoNotScaleFontCorrectlyInNoAutoScaleSzenario() {
+	public void testScaleFontCorrectlyInNoAutoScaleScenario() {
 		DPIUtil.setMonitorSpecificScaling(false);
 		Display display = Display.getDefault();
 
 		assertFalse("Autoscale property is not set to false", display.isRescalingAtRuntime());
 		int scalingFactor = 2;
 		FontComparison fontComparison = updateFont(scalingFactor);
-		assertEquals("Font height in pixels is different when setting the same font again",
-				fontComparison.originalFontHeight, fontComparison.currentFontHeight);
+		assertEquals("Font height in pixels is not adjusted according to the scale factor",
+				fontComparison.originalFontHeight * scalingFactor, fontComparison.currentFontHeight);
+	}
+
+	@Test
+	public void testDoNotScaleFontInNoAutoScaleScenarioWithLegacyFontRegistry() {
+		DPIUtil.setMonitorSpecificScaling(false);
+		String originalValue = System.getProperty("swt.fontRegistry");
+		System.setProperty("swt.fontRegistry", "legacy");
+		try {
+			Display display = Display.getDefault();
+
+			assertFalse("Autoscale property is not set to false", display.isRescalingAtRuntime());
+			int scalingFactor = 2;
+			FontComparison fontComparison = updateFont(scalingFactor);
+			assertEquals("Font height in pixels is different when setting the same font again",
+					fontComparison.originalFontHeight, fontComparison.currentFontHeight);
+		} finally {
+			if (originalValue != null) {
+				System.setProperty("swt.fontRegistry", originalValue);
+			} else {
+				System.clearProperty("swt.fontRegistry");
+			}
+		}
 	}
 
 	@Test

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/LegacySWTFontRegistry.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/LegacySWTFontRegistry.java
@@ -19,19 +19,25 @@ import org.eclipse.swt.graphics.*;
 import org.eclipse.swt.internal.win32.*;
 
 /**
- * This class is used in the win32 implementation only to support
- * unscaled fonts in multiple DPI zoom levels.
+ * <p>
+ * Formerly {@code DefaultSWTFontRegistry}, this class is deprecated. Use {@code ScalingSWTFontRegistry} instead.
+ * To temporarily fall back to legacy font behavior ({@code LegacySWTFontRegistry})
+ * (e.g., if issues arise in existing RCP products), set the system property: {@code
+ * -Dswt.fontRegistry=legacy
+ * }
+ * </p>
  *
  * As this class is only intended to be used internally via {@code SWTFontProvider},
  * it should neither be instantiated nor referenced in a client application.
  * The behavior can change any time in a future release.
  */
-final class DefaultSWTFontRegistry implements SWTFontRegistry {
+@Deprecated(forRemoval= true, since= "2025-09")
+final class LegacySWTFontRegistry implements SWTFontRegistry {
 	private static FontData KEY_SYSTEM_FONTS = new FontData();
 	private Map<FontData, Font> fontsMap = new HashMap<>();
 	private Device device;
 
-	DefaultSWTFontRegistry(Device device) {
+	LegacySWTFontRegistry(Device device) {
 		this.device = device;
 	}
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/SWTFontProvider.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/SWTFontProvider.java
@@ -105,10 +105,15 @@ public class SWTFontProvider {
 		}
 	}
 
+	private static final String SWT_FONT_REGISTRY = "swt.fontRegistry";
+
+	@SuppressWarnings("removal")
 	private static SWTFontRegistry newFontRegistry(Device device) {
-		if (device instanceof Display display && display.isRescalingAtRuntime()) {
-			return new ScalingSWTFontRegistry(device);
+		if ("legacy".equalsIgnoreCase(System.getProperty(SWT_FONT_REGISTRY)) && device instanceof Display display
+				&& !display.isRescalingAtRuntime()) {
+			return new LegacySWTFontRegistry(device);
 		}
-		return new DefaultSWTFontRegistry(device);
+		return new ScalingSWTFontRegistry(device);
+
 	}
 }


### PR DESCRIPTION
**Summary**
This PR introduces the following changes:

1)Always use ScalingSWTFontRegistry
2)Rename DefaultSWTFontRegistry -> LegacySWTFontRegistry as this is not default anymore
3)Add a system property to use LegacySWTFontRegistry without monitor specific scaling active
4)Deprecate the LegacySWTFontRegistry(DefaultSWTFontRegistry)
5)additionally the change also makes sure all fonts are cached when they are created, this is necessary to make sure the systemfonts would also be cached when they are created (this change is to fix  Test_org_eclipse_swt_graphics_GC.test_setFontLorg_eclipse_swt_graphics_Font which was broken with ScalingSwtFontRegistry)
 

**Reproduction Steps**
To use the legacy font registry instead of the default scaling registry, launch the application with the following system properties:


```
-Dswt.autoScale.updateOnRuntime=false
-Dswt.autoScale=false
-Dswt.fontRegistry=legacy
```
With these flags, the [LegacySWTFontRegistry](https://github.com/eclipse-platform/eclipse.platform.swt/compare/master...vi-eclipse:eclipse.platform.swt:arunjose696/312?expand=1#diff-b9861edb165cd679e5582ba8abf6d666ad53941b3fa4a0ba8c90fca0a675b8ffR134) will be used.

If Dswt.fontRegistry is  not set or Monitorscaling is enabled(current default behaviour) , SWT will default to using [ScalingSWTFontRegistry](https://github.com/eclipse-platform/eclipse.platform.swt/compare/master...vi-eclipse:eclipse.platform.swt:arunjose696/312?expand=1#diff-b9861edb165cd679e5582ba8abf6d666ad53941b3fa4a0ba8c90fca0a675b8ffR136).