### PR TITLE
Reduce visibility of test classes in Win32 fragment

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/widgets/CoordinateSystemMapperTests.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/widgets/CoordinateSystemMapperTests.java
@@ -26,7 +26,7 @@ import org.junit.jupiter.params.*;
 import org.junit.jupiter.params.provider.*;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public class CoordinateSystemMapperTests {
+class CoordinateSystemMapperTests {
 
 	Supplier<Monitor[]> getMonitorConsumer;
 	Monitor[] monitors;

--- a/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/widgets/DisplayWin32Test.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/widgets/DisplayWin32Test.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.extension.*;
 
 @ExtendWith(PlatformSpecificExecutionExtension.class)
 @ExtendWith(ResetMonitorSpecificScalingExtension.class)
-public class DisplayWin32Test {
+class DisplayWin32Test {
 
 	@Test
 	public void monitorSpecificScaling_activate() {


### PR DESCRIPTION
Some unit test classes in the Win32 fragment are declared as public. This is unnecessary and may lead to them being erroneously being considered in the API baseline.

Resolves this:
![image](https://github.com/user-attachments/assets/dd99cf4c-e8f4-47fa-9fe9-9cbbfe19c110)
