### PR TITLE
Refactor Image(Display, int, int) in Tests (No Ops)

### DIFF
--- a/tests/org.eclipse.swt.tests.win32/JUnit Tests/org/eclipse/swt/graphics/ImageWin32Tests.java
+++ b/tests/org.eclipse.swt.tests.win32/JUnit Tests/org/eclipse/swt/graphics/ImageWin32Tests.java
@@ -39,7 +39,8 @@ public class ImageWin32Tests {
 
 	@Test
 	public void testImageDataForDifferentFractionalZoomsShouldBeDifferent() {
-		Image image = new Image(display, 10, 10);
+		ImageGcDrawer noOpGcDrawer = (gc, height, width) -> {};
+		Image image = new Image(display, noOpGcDrawer, 10, 10);
 		int zoom1 = 125;
 		int zoom2 = 150;
 		ImageData imageDataAtZoom1 = image.getImageData(zoom1);
@@ -52,9 +53,10 @@ public class ImageWin32Tests {
 
 	@Test
 	public void testImageShouldHaveDimesionAsPerZoomLevel() {
+		ImageGcDrawer noOpGcDrawer = (gc, height, width) -> {};
 		int zoom = DPIUtil.getDeviceZoom();
 		int scalingFactor = 2;
-		Image image = new Image(display, 10, 10);
+		Image image = new Image(display, noOpGcDrawer, 10, 10);
 		try {
 			ImageData baseImageData = image.getImageData(zoom);
 			assertEquals("Width should equal the initial width on the same zoom", 10, baseImageData.width);

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/SwtTestUtil.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/SwtTestUtil.java
@@ -36,6 +36,7 @@ import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.GC;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.graphics.ImageData;
+import org.eclipse.swt.graphics.ImageGcDrawer;
 import org.eclipse.swt.graphics.PaletteData;
 import org.eclipse.swt.graphics.RGB;
 import org.eclipse.swt.graphics.Rectangle;
@@ -503,8 +504,9 @@ public static boolean hasPixel(Control control, Color expectedColor) {
  *         widget
  */
 public static boolean hasPixel(Control control, Color expectedColor, Rectangle rect) {
+	ImageGcDrawer noOpGcDrawer = (gc, height, width) -> {};
 	GC gc = new GC(control);
-	final Image image = new Image(control.getDisplay(), control.getSize().x, control.getSize().y);
+	final Image image = new Image(control.getDisplay(), noOpGcDrawer, control.getSize().x, control.getSize().y);
 	gc.copyArea(image, 0, 0);
 	gc.dispose();
 	boolean result = hasPixel(image, expectedColor, rect);

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_Image.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_Image.java
@@ -547,7 +547,8 @@ public void test_equalsLjava_lang_Object() {
 
 @Test
 public void test_getBackground() {
-	Image image = new Image(display, (gc, width, height) -> {}, 10, 10);
+	ImageGcDrawer noOpGcDrawer = (gc, width, height) -> {};
+	Image image = new Image(display, noOpGcDrawer, 10, 10);
 	image.dispose();
 	SWTException e = assertThrows(SWTException.class, () -> image.getBackground());
 	assertSWTProblem("Incorrect exception thrown for disposed image", SWT.ERROR_GRAPHIC_DISPOSED, e);
@@ -556,20 +557,21 @@ public void test_getBackground() {
 
 @Test
 public void test_getBounds() {
+	ImageGcDrawer noOpGcDrawer = (gc, width, height) -> {};
 	Rectangle bounds = new Rectangle(0, 0, 10, 20);
-	Image image1 = new Image(display, (gc, width, height) -> {}, bounds.width, bounds.height);
+	Image image1 = new Image(display, noOpGcDrawer, bounds.width, bounds.height);
 	image1.dispose();
 	SWTException e = assertThrows(SWTException.class, () -> image1.getBounds());
 	assertSWTProblem("Incorrect exception thrown for disposed image", SWT.ERROR_GRAPHIC_DISPOSED, e);
 
 	Image image;
 	// creates bitmap image
-	image = new Image(display, (gc, width, height) -> {}, bounds.width, bounds.height);
+	image = new Image(display, noOpGcDrawer, bounds.width, bounds.height);
 	Rectangle bounds1 = image.getBounds();
 	image.dispose();
 	assertEquals(bounds, bounds1);
 
-	image = new Image(display, (gc, width, height) -> {},  bounds.width, bounds.height);
+	image = new Image(display, noOpGcDrawer,  bounds.width, bounds.height);
 	bounds1 = image.getBounds();
 	image.dispose();
 	assertEquals(bounds, bounds1);
@@ -779,9 +781,9 @@ public static Rectangle scaleBounds (Rectangle rect, int targetZoom, int current
 public void test_hashCode() {
 	Image image = null;
 	Image image1 = null;
-
+	ImageGcDrawer noOpGcDrawer = (gc, width, height) -> {};
 	try {
-		image = new Image(display, (gc, width, height) -> {}, 10, 10);
+		image = new Image(display, noOpGcDrawer, 10, 10);
 		image1 = image;
 
 		assertEquals(image1.hashCode(), image.hashCode());
@@ -842,14 +844,15 @@ public void test_setBackgroundLorg_eclipse_swt_graphics_Color() {
 			"Excluded test_setBackgroundLorg_eclipse_swt_graphics_Color(org.eclipse.swt.tests.junit.Test_org_eclipse_swt_graphics_Image)",
 			SwtTestUtil.isGTK);
 	// TODO Fix GTK failure.
-	Image image1 = new Image(display, (gc, width, height) -> {}, 10, 10);
+	ImageGcDrawer noOpGcDrawer = (gc, width, height) -> {};
+	Image image1 = new Image(display, noOpGcDrawer, 10, 10);
 	try {
 		IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> image1.setBackground(null));
 		assertSWTProblem("Incorrect exception thrown for color == null", SWT.ERROR_NULL_ARGUMENT, e);
 	} finally {
 		image1.dispose();
 	}
-	Image image2 = new Image(display, (gc, width, height) -> {}, 10, 10);
+	Image image2 = new Image(display, noOpGcDrawer, 10, 10);
 	Color color2 = new Color(255, 255, 255);
 	color2.dispose();
 	try {
@@ -858,14 +861,14 @@ public void test_setBackgroundLorg_eclipse_swt_graphics_Color() {
 	} finally {
 		image2.dispose();
 	}
-	Image image3 = new Image(display, (gc, width, height) -> {}, 10, 10);
+	Image image3 = new Image(display, noOpGcDrawer, 10, 10);
 	image3.dispose();
 	Color color3 = new Color(255, 255, 255);
 	SWTException e = assertThrows(SWTException.class, () -> image3.setBackground(color3));
 	assertSWTProblem("Incorrect exception thrown for disposed image", SWT.ERROR_GRAPHIC_DISPOSED, e);
 
 	// this image does not have a transparent pixel by default so setBackground has no effect
-	Image image4 = new Image(display, (gc, width, height) -> {}, 10, 10);
+	Image image4 = new Image(display, noOpGcDrawer, 10, 10);
 	image4.setBackground(display.getSystemColor(SWT.COLOR_GREEN));
 	Color color4 = image4.getBackground();
 	assertNull("background color should be null for non-transparent image", color4);
@@ -884,7 +887,8 @@ public void test_setBackgroundLorg_eclipse_swt_graphics_Color() {
 
 @Test
 public void test_toString() {
-	Image image = new Image(display, (gc, width, height) -> {}, 10, 10);
+	ImageGcDrawer noOpGcDrawer = (gc, width, height) -> {};
+	Image image = new Image(display, noOpGcDrawer, 10, 10);
 	try {
 		assertNotNull(image.toString());
 		assertTrue(image.toString().length() > 0);
@@ -983,7 +987,6 @@ public void test_bug566545_efficientGrayscaleImage() {
 
 	Image imageIndexed = new Image(display, imageDataIndexed);
 	Image imageDirect = new Image(display, imageDataDirect);
-
 	ImageGcDrawer gcDrawer1 = (gc, iWidth, iHeight) -> {
 		gc.drawImage(imageIndexed, 0, 0);
 	};
@@ -1006,10 +1009,11 @@ public void test_bug566545_efficientGrayscaleImage() {
 
 @Test
 public void test_updateWidthHeightAfterDPIChange() {
+	ImageGcDrawer noOpGcDrawer = (gc, width, height) -> {};
 	int deviceZoom = DPIUtil.getDeviceZoom();
 	try {
 		Rectangle imageSize = new Rectangle(0, 0, 16, 16);
-		Image baseImage = new Image(display, (gc, width, height) -> {}, imageSize.width, imageSize.height);
+		Image baseImage = new Image(display, noOpGcDrawer, imageSize.width, imageSize.height);
 		GC gc = new GC(display);
 		gc.drawImage(baseImage, 10, 10);
 		assertEquals("Base image size differs unexpectedly", imageSize, baseImage.getBounds());

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Button.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Button.java
@@ -29,6 +29,7 @@ import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.events.SelectionListener;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.Image;
+import org.eclipse.swt.graphics.ImageGcDrawer;
 import org.eclipse.swt.layout.FillLayout;
 import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Button;
@@ -384,7 +385,8 @@ public void test_setImageLorg_eclipse_swt_graphics_Image() {
 	button.setImage(null);
 	assertNull(button.getImage());
 
-	image = new Image(shell.getDisplay(), 10, 10);
+	ImageGcDrawer noOpGcDrawer = (gc, width, height) -> {};
+	image = new Image(shell.getDisplay(), noOpGcDrawer, 10, 10);
 	button.setImage(image);
 	assertEquals(image, button.getImage());
 

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Caret.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Caret.java
@@ -24,6 +24,7 @@ import static org.junit.Assert.fail;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Font;
 import org.eclipse.swt.graphics.Image;
+import org.eclipse.swt.graphics.ImageGcDrawer;
 import org.eclipse.swt.graphics.Rectangle;
 import org.eclipse.swt.widgets.Canvas;
 import org.eclipse.swt.widgets.Caret;
@@ -147,7 +148,8 @@ public void test_setImageLorg_eclipse_swt_graphics_Image() {
 	caret.setImage(null);
 	assertNull(caret.getImage());
 
-	image = new Image(shell.getDisplay(), 10, 10);
+	ImageGcDrawer noOpGcDrawer = (gc, width, height) -> {};
+	image = new Image(shell.getDisplay(), noOpGcDrawer, 10, 10);
 	caret.setImage(image);
 	assertEquals(image, caret.getImage());
 

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Decorations.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Decorations.java
@@ -26,6 +26,7 @@ import java.util.List;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Image;
+import org.eclipse.swt.graphics.ImageGcDrawer;
 import org.eclipse.swt.graphics.Rectangle;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Decorations;
@@ -71,7 +72,8 @@ public void test_getDefaultButton() {
 
 @Test
 public void test_getImage() {
-	Image[] cases = {null, new Image(null, 100, 100)};
+	ImageGcDrawer noOpGcDrawer = (gc, width, height) -> {};
+	Image[] cases = {null, new Image(null, noOpGcDrawer, 100, 100)};
 	for (Image image : cases) {
 		decorations.setImage(image);
 		assertEquals(decorations.getImage(), image);

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Label.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Label.java
@@ -18,6 +18,7 @@ import static org.junit.Assert.fail;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Image;
+import org.eclipse.swt.graphics.ImageGcDrawer;
 import org.eclipse.swt.widgets.Label;
 import org.junit.Before;
 import org.junit.Test;
@@ -71,7 +72,8 @@ public void test_getAlignment(){
 
 @Test
 public void test_getImage(){
-	Image[] cases = {null, new Image(null, 100, 100)};
+	ImageGcDrawer noOpGcDrawer = (gc, width, height) -> {};
+	Image[] cases = {null, new Image(null, noOpGcDrawer, 100, 100)};
 	for (Image image : cases) {
 		label.setImage(image);
 		assertEquals(label.getImage(), image);

--- a/tests/org.eclipse.swt.tests/ManualTests/org/eclipse/swt/tests/manual/Bug569752_DetectNonDisposedOsResources.java
+++ b/tests/org.eclipse.swt.tests/ManualTests/org/eclipse/swt/tests/manual/Bug569752_DetectNonDisposedOsResources.java
@@ -15,10 +15,14 @@ package org.eclipse.swt.tests.manual;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Image;
+import org.eclipse.swt.graphics.ImageGcDrawer;
 import org.eclipse.swt.graphics.Resource;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
-import org.eclipse.swt.widgets.*;
+import org.eclipse.swt.widgets.Button;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Label;
+import org.eclipse.swt.widgets.Shell;
 
 public class Bug569752_DetectNonDisposedOsResources {
 	public static void main(String[] args) {
@@ -41,7 +45,8 @@ public class Bug569752_DetectNonDisposedOsResources {
 		Button btnTest = new Button(shell, SWT.PUSH);
 		btnTest.setText("Leak Image");
 		btnTest.addListener(SWT.Selection, event -> {
-			Image image = new Image(display, 10, 10);
+			ImageGcDrawer noOpGcDrawer = (gc, height, width) -> {};
+			Image image = new Image(display, noOpGcDrawer, 10, 10);
 
 			if (chkDispose.getSelection())
 				image.dispose();


### PR DESCRIPTION
Replacing Image(Display, int, int) with Image(Display, ImageGcDrawer, int, int) in Tests. Basic Case

- [x] requires -> https://github.com/eclipse-platform/eclipse.platform.swt/pull/2229