### PR TITLE
Add search capabilities to WebKit based Browser

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT WebKit/gtk/org/eclipse/swt/internal/webkit/WebKitGTK.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT WebKit/gtk/org/eclipse/swt/internal/webkit/WebKitGTK.java
@@ -90,6 +90,9 @@ public class WebKitGTK extends C {
 	public static final int WEBKIT_USER_SCRIPT_INJECT_AT_DOCUMENT_START = 0;
 	public static final int WEBKIT_USER_CONTENT_INJECT_TOP_FRAME = 1;
 
+	public static final int G_MAXUINT = 65535;
+	public static final int WEBKIT_FIND_OPTIONS_WRAP_AROUND = 1 << 4;
+
 	/** Signals */
 
 	// Authentication.


### PR DESCRIPTION
This changes adds a search dialog to WebKit browsers. The search dialog is opened with Ctrl+F and has next/previous word matching capabilities.

Fixes: #2222