### PR TITLE
[GTK] Gtk 4 don't have the concept of window hints

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Shell.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Shell.java
@@ -828,7 +828,9 @@ void createHandle (int index) {
 			gtk_container_set_border_width(shellHandle, 1);
 		}
 		if ((style & SWT.TOOL) != 0) {
-			GTK3.gtk_window_set_type_hint(shellHandle, GDK.GDK_WINDOW_TYPE_HINT_UTILITY);
+			if (!GTK.GTK4) {
+				GTK3.gtk_window_set_type_hint(shellHandle, GDK.GDK_WINDOW_TYPE_HINT_UTILITY);
+			}
 		}
 		if ((style & SWT.NO_TRIM) != 0) {
 			GTK.gtk_window_set_decorated(shellHandle, false);


### PR DESCRIPTION
It's GTK 3 (even X11) concept that Wayland doesn't have - "windows are windows". See
https://discourse.gnome.org/t/replacing-gtk-window-set-type-hint-in-gtk4/22599/2 for explanation from developers.