### PR TITLE
Cache all Fonts in ScalingSWTFontRegistry on creation

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/widgets/ControlWin32Tests.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/widgets/ControlWin32Tests.java
@@ -44,6 +44,17 @@ class ControlWin32Tests {
 	}
 
 	@Test
+	public void testSetFontWithMonitorSpecificScalingEnabled() {
+		DPIUtil.setMonitorSpecificScaling(true);
+		Display display = Display.getDefault();
+		Image colorImage = new Image(display, 10, 10);
+		GC gc = new GC(colorImage);
+		gc.setFont(display.getSystemFont());
+		Font font = gc.getFont();
+		assertEquals(display.getSystemFont(), font);
+	}
+
+	@Test
 	public void testDoNotScaleFontCorrectlyInNoAutoScaleSzenario() {
 		DPIUtil.setMonitorSpecificScaling(false);
 		Display display = Display.getDefault();


### PR DESCRIPTION
Previously, system fonts were not cached during their creation in ScalingSWTFontRegistry. This change ensures that  system fonts, are now cached in fontsKeyMap