### PR TITLE
Use the existing image to initialize the GC in ImageGcDrawerWrapper

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/graphics/Image.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/graphics/Image.java
@@ -903,24 +903,22 @@ public Image(Device device, ImageGcDrawer imageGcDrawer, int width, int height) 
 
 private ImageData drawWithImageGcDrawer(ImageGcDrawer imageGcDrawer, int width, int height, int zoom) {
 	int gcStyle = imageGcDrawer.getGcStyle();
-	Image image;
 	if ((gcStyle & SWT.TRANSPARENT) != 0) {
 		/* Create a 24 bit image data with alpha channel */
 		final ImageData resultData = new ImageData (width, height, 24, new PaletteData (0xFF, 0xFF00, 0xFF0000));
 		resultData.alphaData = new byte [width * height];
-		image = new Image(device, resultData);
+		init(resultData, zoom);
 	} else {
-		image = new Image(device, width, height);
+		init(width, height);
 	}
-	GC gc = new GC(image, gcStyle);
+	GC gc = new GC(Image.this, gcStyle);
 	try {
 		imageGcDrawer.drawOn(gc, width, height);
-		ImageData imageData = image.getImageData(zoom);
+		ImageData imageData = Image.this.getImageData(zoom);
 		imageGcDrawer.postProcess(imageData);
 		return imageData;
 	} finally {
 		gc.dispose();
-		image.dispose();
 	}
 }
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/graphics/Image.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/graphics/Image.java
@@ -1452,7 +1452,11 @@ private void init(ImageData image, int zoom) {
 @Override
 public long internal_new_GC (GCData data) {
 	if (isDisposed()) SWT.error(SWT.ERROR_GRAPHIC_DISPOSED);
-	if (type != SWT.BITMAP || memGC != null) {
+	if (type != SWT.BITMAP) {
+		SWT.error(SWT.ERROR_INVALID_ARGUMENT);
+	}
+
+	if(memGC != null) {
 		SWT.error(SWT.ERROR_INVALID_ARGUMENT);
 	}
 	long gc = Cairo.cairo_create(surface);

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/graphics/Image.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/graphics/Image.java
@@ -1453,7 +1453,7 @@ private void init(ImageData image, int zoom) {
 public long internal_new_GC (GCData data) {
 	if (isDisposed()) SWT.error(SWT.ERROR_GRAPHIC_DISPOSED);
 	if (type != SWT.BITMAP) {
-		SWT.error(SWT.ERROR_INVALID_ARGUMENT);
+		SWT.error(SWT.ERROR_INVALID_ARGUMENT, null, "The type is " + type);
 	}
 
 	if(memGC != null) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/graphics/Image.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/graphics/Image.java
@@ -1169,24 +1169,22 @@ public ImageData getImageData (int zoom) {
 
 private ImageData drawWithImageGcDrawer(int width, int height, int zoom) {
 	int gcStyle = imageGcDrawer.getGcStyle();
-	Image image;
 	if ((gcStyle & SWT.TRANSPARENT) != 0) {
 		/* Create a 24 bit image data with alpha channel */
 		final ImageData resultData = new ImageData(width, height, 24, new PaletteData (0xFF, 0xFF00, 0xFF0000));
 		resultData.alphaData = new byte [width * height];
-		image = new Image(device, resultData, zoom);
+		init(resultData, zoom);
 	} else {
-		image = new Image(device, width, height);
+		init(width, height);
 	}
-	GC gc = new GC(image, gcStyle);
+	GC gc = new GC(Image.this, gcStyle);
 	try {
 		imageGcDrawer.drawOn(gc, width, height);
-		ImageData imageData = image.getImageData(zoom);
+		ImageData imageData = Image.this.getImageData(zoom);
 		imageGcDrawer.postProcess(imageData);
 		return imageData;
 	} finally {
 		gc.dispose();
-		image.dispose();
 	}
 }
 


### PR DESCRIPTION
In ImageGCDrawerWrapper#newImageHandle, we create a new image with existing data to initialize the GC, instead we could use the existing image object and the base handle should be created as it is done in PlainImageDataProvider.