### PR TITLE
[win32] Refetch GC font on demand

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/GC.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/GC.java
@@ -3947,9 +3947,9 @@ void init(Drawable drawable, GCData data, long hDC) {
 	if (data.nativeZoom == 0) {
 		data.nativeZoom = extractZoom(hDC);
 	}
-	Font font = data.font;
-	if (font != null) {
+	if (data.font != null) {
 		data.state &= ~FONT;
+		data.font = Font.win32_new(data.font, data.nativeZoom);
 	} else {
 		data.font = SWTFontProvider.getFont(device, OS.GetCurrentObject(hDC, OS.OBJ_FONT), data.nativeZoom);
 	}


### PR DESCRIPTION
This PR ensures that the GC always uses the font with the correct zoom in the windows implementation. There is currently no issue caused by this. This is required for the GC to be recreatable on demand. This will be added in a different PR.