### PR TITLE
[win32] Apply Operation pattern on GC

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/GCData.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/GCData.java
@@ -58,4 +58,19 @@ public final class GCData {
 	public float gdipXOffset, gdipYOffset;
 	public int uiState = 0;
 	public boolean focusDrawn;
+
+	void copyTo(GCData originalData) {
+		originalData.device = device;
+		originalData.style = style;
+		originalData.foreground = foreground;
+		originalData.background = background;
+		originalData.font = font;
+		originalData.nativeZoom = nativeZoom;
+		originalData.image = image;
+		originalData.ps = ps;
+		originalData.layout = layout;
+		originalData.hwnd = hwnd;
+		originalData.uiState = uiState;
+		originalData.focusDrawn = focusDrawn;
+	}
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Pattern.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Pattern.java
@@ -219,6 +219,13 @@ void destroyHandlesExcept(Set<Integer> zoomLevels) {
 	});
 }
 
+Pattern copy() {
+	if (image != null) {
+		return new Pattern(device, image);
+	}
+	return new Pattern(device, baseX1, baseY1, baseX2, baseY2, color1, alpha1, color2, alpha2);
+}
+
 /**
  * Returns <code>true</code> if the Pattern has been disposed,
  * and <code>false</code> otherwise.


### PR DESCRIPTION
This PR provides a minimal implementation to apply the operation pattern on GC that is used on most other resources to re-create resources on zoom changes. A difference in this implementation is that there is always exactly one OS handle per GC. On zoom change the existing handle is cleaned up a created for the new zoom. There is no use case that requires managing of multiple handles per GC.

This PR does not change any existing behavior. It encapsulated all actions inside the GC into operations. A different PR will utilize this to trigger a re-creation of an existing GC for a different zoom level.