### PR TITLE
A strict check 200% image data is double the size of 100% image data

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/DPIUtil.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/DPIUtil.java
@@ -150,9 +150,10 @@ public static ImageData autoScaleImageData (Device device, final ImageData image
 	int height = imageData.height;
 	int scaledWidth = Math.round (width * scaleFactor);
 	int scaledHeight = Math.round (height * scaleFactor);
+	int defaultZoomLevel = 100;
 	boolean useSmoothScaling = isSmoothScalingEnabled() && imageData.getTransparencyType() != SWT.TRANSPARENCY_MASK;
 	if (useSmoothScaling) {
-		Image original = new Image (device, (ImageDataProvider) zoom -> imageData);
+		Image original = new Image(device, (ImageDataProvider) zoom -> (zoom == defaultZoomLevel) ? imageData : null);
 		ImageGcDrawer drawer =  new ImageGcDrawer() {
 			@Override
 			public void drawOn(GC gc, int imageWidth, int imageHeight) {
@@ -166,7 +167,7 @@ public static ImageData autoScaleImageData (Device device, final ImageData image
 			}
 		};
 		Image resultImage = new Image (device, drawer, scaledWidth, scaledHeight);
-		ImageData result = resultImage.getImageData (100);
+		ImageData result = resultImage.getImageData (defaultZoomLevel);
 		original.dispose ();
 		resultImage.dispose ();
 		return result;

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Image.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Image.java
@@ -612,8 +612,31 @@ public Image(Device device, ImageDataProvider imageDataProvider) {
 		SWT.error(SWT.ERROR_INVALID_ARGUMENT, null,
 				": ImageDataProvider [" + imageDataProvider + "] returns null ImageData at 100% zoom.");
 	}
+	if (Device.strictChecks) {
+		validateLinearScaling(imageDataProvider);
+	}
 	init();
 	this.device.registerResourceWithZoomSupport(this);
+}
+
+private void validateLinearScaling(ImageDataProvider provider) {
+	final int baseZoom = 100;
+	final int scaledZoom = 200;
+	final int scaleFactor = scaledZoom / baseZoom;
+	ImageData baseImageData = provider.getImageData(baseZoom);
+	ImageData scaledImageData = provider.getImageData(scaledZoom);
+
+	if (scaledImageData == null) {
+		return;
+	}
+
+	if (scaledImageData.width != scaleFactor * baseImageData.width
+			|| scaledImageData.height != scaleFactor * baseImageData.height) {
+		System.err.println(String.format(
+				"***WARNING: ImageData should be linearly scaled across zooms but size is (%d, %d) at 100%% and (%d, %d) at 200%%.",
+				baseImageData.width, baseImageData.height, scaledImageData.width, scaledImageData.height));
+		new Error().printStackTrace(System.err);
+	}
 }
 
 /**

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_Image.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_Image.java
@@ -1043,13 +1043,15 @@ public void test_imageDataIsCached() {
 public void test_imageDataSameViaDifferentProviders() {
 	assumeFalse("Cocoa generates inconsistent image data", SwtTestUtil.isCocoa);
 	String imagePath = getPath("collapseall.png");
-	ImageFileNameProvider imageFileNameProvider = __ -> {
-		return imagePath;
+	ImageFileNameProvider imageFileNameProvider = zoom -> {
+		return (zoom == 100) ? imagePath : null;
 	};
-	ImageDataProvider dataProvider = __ -> {
-		try (InputStream imageStream = Files.newInputStream(Path.of(imagePath))) {
-			return new ImageData(imageStream);
-		} catch (IOException e) {
+	ImageDataProvider dataProvider = zoom -> {
+		if (zoom == 100) {
+			try (InputStream imageStream = Files.newInputStream(Path.of(imagePath))) {
+				return new ImageData(imageStream);
+			} catch (IOException e) {
+			}
 		}
 		return null;
 	};

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_internal_SVGRasterizer.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_internal_SVGRasterizer.java
@@ -54,17 +54,11 @@ public class Test_org_eclipse_swt_internal_SVGRasterizer {
 
 	@Test
 	public void test_ConstructorLorg_eclipse_swt_graphics_Device_ImageDataProvider() {
-		ImageDataProvider validImageDataProvider = zoom -> {
-			String fileName = "collapseall.svg";
-			return new ImageData(getPath(fileName));
-		};
+		ImageDataProvider validImageDataProvider = zoom -> (zoom == 100) ? new ImageData(getPath("collapseall.svg")) : null;
 		Image image = new Image(Display.getDefault(), validImageDataProvider);
 		image.dispose();
 
-		ImageDataProvider corruptImageDataProvider = zoom -> {
-			String fileName = "corrupt.svg";
-			return new ImageData(getPath(fileName));
-		};
+		ImageDataProvider corruptImageDataProvider = zoom -> (zoom == 100) ? new ImageData(getPath("corrupt.svg")) : null;
 		SWTException e = assertThrows(SWTException.class,
 				() -> new Image(Display.getDefault(), corruptImageDataProvider));
 		assertSWTProblem("Incorrect exception thrown for provider with corrupt images", SWT.ERROR_INVALID_IMAGE, e);


### PR DESCRIPTION
A strict check to be used only for debugging means, this ensures the imageData is scaled linearly for 100 and 200 zooms.
 
**Steps to reproduce**

Out of the blow snippets. Snippet1  which uses an image data provider that always returns the same image, when executed with the VM argument `-Dorg.eclipse.swt.internal.enableStrictChecks=True`, logs the error` "ImageData should be linearly scaled across zooms." to stdout. Whereas snippet 2 which scales ImageData linearly runs without this error log.
<details><summary>snippet 1</summary>

```java
package org.eclipse.swt.snippets;
import org.eclipse.swt.graphics.*;
import org.eclipse.swt.widgets.*;
public class TestImageProvider {
    public static void main(String[] args) {
        Display display = new Display();
        ImageDataProvider provider = (zoom) -> new ImageData(
            16, 16, 32,
            new PaletteData((new RGB(255, 0, 0)))
        );
        Image image = new Image(display, provider);
        System.out.println("Done execution");
    }
}
```
</details>
<details><summary>snippet 2</summary>

```java
package org.eclipse.swt.snippets;
import org.eclipse.swt.graphics.*;
import org.eclipse.swt.widgets.*;
public class TestImageProvider {
    public static void main(String[] args) {
        Display display = new Display();
        ImageDataProvider provider = (zoom) -> new ImageData(
            16*zoom/100, 16*zoom/100, 32,
            new PaletteData((new RGB(255, 0, 0)))
        );
        Image image = new Image(display, provider);  
        System.out.println("Done execution");
    }
}
```
</details>

The below examples demonstrate testing  this again with PNG images. In the first snippet, the ImageDataProvider returns the image data from the same file for both 100% and 200% zoom levels without scaling, which causes the error message "ImageData should be linearly scaled across zooms." to be printed to stdout. In the second snippet it provides properly scaled image data at 200% zoom (using a scaled image), so it executes without logging this error.
To run these snippets, download the following PNG files and place them in your working directory:
[ pause.png](https://github.com/user-attachments/assets/eee3aeb9-1f33-4362-9559-a1ebcfacbf89)

[ pause@2x.png](https://github.com/user-attachments/assets/88380f50-7dbd-4163-aed4-4c9d678117a2)

<details><summary>snippet 1</summary>

```java
package org.eclipse.swt.snippets;
import org.eclipse.swt.graphics.*;
import org.eclipse.swt.widgets.*;
public class TestImageProvider {
    public static void main(String[] args) {
    	System.out.println("Working directory: " + System.getProperty("user.dir"));
        Display display = new Display();

        ImageDataProvider provider = zoom -> {
            if (zoom == 100) {
                return new ImageData("pause.png");
            }
            else if (zoom == 200) {
                return new ImageData("pause.png");
            }
            else {
                return null;
            }
        };

        Image image = new Image(display, provider);
        System.out.println("Done execution");
    }
}

```
</details>


<details><summary>snippet 2</summary>

```java
package org.eclipse.swt.snippets;
import org.eclipse.swt.graphics.*;
import org.eclipse.swt.widgets.*;
public class TestImageProvider {
    public static void main(String[] args) {
    	System.out.println("Working directory: " + System.getProperty("user.dir"));
        Display display = new Display();

        ImageDataProvider provider = zoom -> {
            if (zoom == 100) {
                return new ImageData("pause.png");
            }
            else if (zoom == 200) {
                return new ImageData("pause@2x.png");
            }
            else {
                return null;
            }
        };

        Image image = new Image(display, provider);
        System.out.println("Done execution");
    }
}
```

</details>