### PR TITLE
Ensure DrawImage deals with scenario ImageData not linearly scaled

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/graphics/ImagesWin32Tests.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/graphics/ImagesWin32Tests.java
@@ -26,6 +26,90 @@ import org.junit.jupiter.api.extension.*;
 class ImagesWin32Tests {
 
 	@Test
+	public void test_imageScaledFrom150_when125PercentImageUnavailable() {
+		Display display = Display.getDefault();
+		GC gc = new GC(display);
+		GCData gcData = gc.getGCData();
+		gcData.nativeZoom = 125;
+		ImageDataProvider imageDataProviderReturnsNullAt125 = zoom -> {
+			if (zoom == 125) {
+				return null;
+			}
+			float scaleFactor = zoom / 100f;
+			int scaledWidth = Math.round(16 * scaleFactor);
+			int scaledHeight = Math.round(16 * scaleFactor);
+			return new ImageData(scaledWidth, scaledHeight, 1, new PaletteData(new RGB(255, 0, 0)));
+		};
+		Image image = new Image(display, imageDataProviderReturnsNullAt125);
+		gc.drawImage(image, 0, 0, 16, 16, 0, 0, 16, 16);
+		gc.dispose();
+		image.dispose();
+	}
+
+	@Test
+	public void test_imageScaledFrom100_when125And150PercentImagesUnavailable() {
+		Display display = Display.getDefault();
+		GC gc = new GC(display);
+		GCData gcData = gc.getGCData();
+		gcData.nativeZoom = 125;
+		ImageDataProvider imageDataProviderReturnsNullAt125and150 = zoom -> {
+			if (zoom == 125) {
+				return null;
+			}
+			if (zoom == 150) {
+				return null;
+			}
+			float scaleFactor = zoom / 100f;
+			int scaledWidth = Math.round(16 * scaleFactor);
+			int scaledHeight = Math.round(16 * scaleFactor);
+			return new ImageData(scaledWidth, scaledHeight, 1, new PaletteData(new RGB(255, 0, 0)));
+		};
+		Image image = new Image(display, imageDataProviderReturnsNullAt125and150);
+		gc.drawImage(image, 0, 0, 16, 16, 0, 0, 16, 16);
+		gc.dispose();
+		image.dispose();
+	}
+
+	@Test
+	public void test_drawImage_when130PercentImageUnavailable() {
+		Display display = Display.getDefault();
+		GC gc = new GC(display);
+		GCData gcData = gc.getGCData();
+		gcData.nativeZoom = 130;
+		ImageDataProvider imageDataProviderReturnsNullAt125 = zoom -> {
+			if (zoom == 130){
+				return null;
+			}
+			float scaleFactor = zoom / 100f;
+			int scaledWidth = Math.round(16 * scaleFactor);
+			int scaledHeight = Math.round(16 * scaleFactor);
+			return new ImageData(scaledWidth, scaledHeight, 1, new PaletteData(new RGB(255, 0, 0)));
+		};
+		Image image = new Image(display, imageDataProviderReturnsNullAt125);
+		gc.drawImage(image, 0, 0, 16, 16, 0, 0, 16, 16);
+		gc.dispose();
+		image.dispose();
+	}
+
+	@Test
+	public void test_drawImageUsesWronglyScaledImageDataProvider() {
+		Display display = Display.getDefault();
+		GC gc = new GC(display);
+		GCData gcData = gc.getGCData();
+		gcData.nativeZoom = 125;
+		ImageDataProvider incorrectlyScaledimageDataProvider = zoom -> {
+			int scaleFactor = zoom / 100;
+			int scaledWidth = Math.round(16 * scaleFactor);
+			int scaledHeight = Math.round(16 * scaleFactor);
+			return new ImageData(scaledWidth, scaledHeight, 1, new PaletteData(new RGB(255, 0, 0)));
+		};
+		Image image = new Image(display, incorrectlyScaledimageDataProvider);
+		gc.drawImage(image, 0, 0, 16, 16, 0, 0, 16, 16);
+		gc.dispose();
+		image.dispose();
+	}
+
+	@Test
 	public void testImageIconTypeShouldNotChangeAfterCallingGetHandleForDifferentZoom() {
 		Image icon = Display.getDefault().getSystemImage(SWT.ICON_ERROR);
 		try {


### PR DESCRIPTION
This change makes sure DrawImage handles the scenario where ImageData may not be linearly scaled across zooms.