### PR TITLE
Stop generating feature source

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -179,46 +179,6 @@
         </plugins>
       </build>
     </profile>
-    <profile>
-      <id>generate-feature-source</id>
-      <activation>
-        <file>
-          <exists>feature.xml</exists>
-        </file>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.eclipse.tycho</groupId>
-            <artifactId>tycho-source-plugin</artifactId>
-            <version>${tycho.version}</version>
-            <executions>
-              <execution>
-                <phase>package</phase>
-                <id>feature-source</id>
-                <goals>
-                  <goal>feature-source</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
-          <plugin>
-            <groupId>org.eclipse.tycho</groupId>
-            <artifactId>tycho-p2-plugin</artifactId>
-            <version>${tycho.version}</version>
-            <executions>
-              <execution>
-                <id>attach-p2-metadata</id>
-                <phase>package</phase>
-                <goals>
-                  <goal>p2-metadata</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
   </profiles>
 
 


### PR DESCRIPTION
With https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/3140 they will no longer be published thus it makes no sense to generate them anymore.