### PR TITLE
Remove duplicate representation of alpha values in image data from SVG

### DIFF
--- a/bundles/org.eclipse.swt.svg/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.swt.svg/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.swt.svg
-Bundle-Version: 3.130.0.qualifier
+Bundle-Version: 3.130.100.qualifier
 Automatic-Module-Name: org.eclipse.swt.svg
 Bundle-Name: %fragmentName
 Bundle-Vendor: %providerName

--- a/bundles/org.eclipse.swt.svg/src/org/eclipse/swt/svg/JSVGRasterizer.java
+++ b/bundles/org.eclipse.swt.svg/src/org/eclipse/swt/svg/JSVGRasterizer.java
@@ -121,14 +121,14 @@ public class JSVGRasterizer implements SVGRasterizer {
 		int width = rasterizedImage.getWidth();
 		int height = rasterizedImage.getHeight();
 		int[] pixels = ((DataBufferInt) rasterizedImage.getRaster().getDataBuffer()).getData();
-		PaletteData paletteData = new PaletteData(0x00FF0000, 0x0000FF00, 0x000000FF);
-		ImageData imageData = new ImageData(width, height, 32, paletteData);
+		PaletteData paletteData = new PaletteData(0xFF0000, 0x00FF00, 0x0000FF);
+		ImageData imageData = new ImageData(width, height, 24, paletteData);
 		int index = 0;
 		for (int y = 0; y < imageData.height; y++) {
 			for (int x = 0; x < imageData.width; x++) {
 				int alpha = (pixels[index] >> 24) & 0xFF;
 				imageData.setAlpha(x, y, alpha);
-				imageData.setPixel(x, y, pixels[index++]);
+				imageData.setPixel(x, y, pixels[index++] & 0x00FFFFFF);
 			}
 		}
 		return imageData;


### PR DESCRIPTION
The image data generated for a rasterized SVG currently uses a 32 bit data array and an alpha values array. The alpha values for every pixel are stored in both the alpha values array as well as the alpha channel of the 32 bit data array. This is a redundant representation not giving any benefits but just leading to unnecessary memory consumption.

This change adapts the SVG rasterization to create image data with a 24 bit data array, such that the alpha values are only stored in the alpha array.

This was detected via and would also resolve:
- https://github.com/eclipse-platform/eclipse.platform.ui/issues/3047

I have to admit that I am not completely sure when a 32 bit data array can/must be used together with an alpha data array, thus having duplicate representation of alpha data. When searching in platform code, I see several places creating a 24bit data array and an additional alpha array, but I see about the same number of places that create a 32bit data array and an additional alpha array. I guess there is some difference depending on whether the RGB values _encode_ the alpha values as well (I have seen something like in disabled image generation on Linux/GTK), but if that's not the case I am not sure whether or when one or the other option is useful or even necessary.
If possible, I would be in favor of having a redundancy-free representation of data, which is why I think the proposed change is reasonable. Even more considering that it will fix the mentioned issue.

So far, I have tested this change on macOS and Windows and did not find any issues. <s>It needs to be tested on Linux as well to ensure that there is no different in how the Linux implementation of `Image` treats such data.</s>
I've also tested the proposal on Linux and did not find any issues with the loaded SVGs.
I would assume that whether this works or not does not depend on the usage context but as long as we see that the alpha value handling of the loaded image data works in general, it will work everywhere since after loading the image data it is usually transformed into an image with an according OS handle to which the data is transformed.