### PR TITLE
Convert FileDialog#setFilterExtensions to varargs

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/FileDialog.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/FileDialog.java
@@ -630,7 +630,7 @@ public void setFileName (String string) {
  * @see #setFilterNames to specify the user-friendly
  * names corresponding to the extensions
  */
-public void setFilterExtensions (String [] extensions) {
+public void setFilterExtensions (String... extensions) {
 	filterExtensions = extensions;
 }
 
@@ -668,7 +668,7 @@ public void setFilterIndex (int index) {
  *
  * @see #setFilterExtensions
  */
-public void setFilterNames (String [] names) {
+public void setFilterNames (String... names) {
 	filterNames = names;
 }
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/FileDialog.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/FileDialog.java
@@ -745,7 +745,7 @@ public void setFileName (String string) {
  * @see #setFilterNames to specify the user-friendly
  * names corresponding to the extensions
  */
-public void setFilterExtensions (String [] extensions) {
+public void setFilterExtensions (String... extensions) {
 	filterExtensions = extensions;
 }
 /**
@@ -781,7 +781,7 @@ public void setFilterIndex (int index) {
  *
  * @see #setFilterExtensions
  */
-public void setFilterNames (String [] names) {
+public void setFilterNames (String... names) {
 	filterNames = names;
 }
 /**

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/FileDialog.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/FileDialog.java
@@ -457,7 +457,7 @@ public void setFileName (String string) {
  * @see #setFilterNames to specify the user-friendly
  * names corresponding to the extensions
  */
-public void setFilterExtensions (String [] extensions) {
+public void setFilterExtensions (String... extensions) {
 	filterExtensions = extensions;
 }
 
@@ -495,7 +495,7 @@ public void setFilterIndex (int index) {
  *
  * @see #setFilterExtensions
  */
-public void setFilterNames (String [] names) {
+public void setFilterNames (String... names) {
 	filterNames = names;
 }
 


### PR DESCRIPTION
Nicer to use for end user and API compliant. If this change is integrated we must update the usage of this method in platform to avoid compiler warnings.