### PR TITLE
Increase right margin for check- and combo-box

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/org/eclipse/swt/internal/gtk/swt_theming_fixes_gtk_3_20.css
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/org/eclipse/swt/internal/gtk/swt_theming_fixes_gtk_3_20.css
@@ -23,3 +23,11 @@ tab {
 	padding-left: 6px;
 	padding-right: 6px;
 }
+
+check, radio {
+	margin: 0 2px;
+}
+
+combobox button.combo box arrow {
+	margin: 0 2px;
+}


### PR DESCRIPTION
Both the text and the arrow are truncated when using the Breeze theme in KDE/Fedora 42.

Closes https://github.com/eclipse-platform/eclipse.platform.swt/issues/1758