### PR TITLE
[win32] Ensure correct DPI awareness for DnD

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/win32/org/eclipse/swt/dnd/DropTarget.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/win32/org/eclipse/swt/dnd/DropTarget.java
@@ -242,29 +242,35 @@ void createCOMInterfaces() {
 		public long method2(long[] args) {return Release();}
 		@Override
 		public long method3(long[] args) {
-			if (args.length == 5) {
-				return DragEnter(args[0], (int)args[1], (int)args[2], (int)args[3], args[4]);
-			} else {
-				return DragEnter_64(args[0], (int)args[1], args[2], args[3]);
-			}
+			return Win32DPIUtils.runWithProperDPIAwareness(() -> {
+				if (args.length == 5) {
+					return DragEnter(args[0], (int)args[1], (int)args[2], (int)args[3], args[4]);
+				} else {
+					return DragEnter_64(args[0], (int)args[1], args[2], args[3]);
+				}
+			});
 		}
 		@Override
 		public long method4(long[] args) {
-			if (args.length == 4) {
-				return DragOver((int)args[0], (int)args[1], (int)args[2], args[3]);
-			} else {
-				return DragOver_64((int)args[0], args[1], args[2]);
-			}
+			return Win32DPIUtils.runWithProperDPIAwareness(() -> {
+				if (args.length == 4) {
+					return DragOver((int)args[0], (int)args[1], (int)args[2], args[3]);
+				} else {
+					return DragOver_64((int)args[0], args[1], args[2]);
+				}
+			});
 		}
 		@Override
 		public long method5(long[] args) {return DragLeave();}
 		@Override
 		public long method6(long[] args) {
-			if (args.length == 5) {
-				return Drop(args[0], (int)args[1], (int)args[2], (int)args[3], args[4]);
-			} else {
-				return Drop_64(args[0], (int)args[1], args[2], args[3]);
-			}
+			return Win32DPIUtils.runWithProperDPIAwareness(() -> {
+				if (args.length == 5) {
+					return Drop(args[0], (int)args[1], (int)args[2], (int)args[3], args[4]);
+				} else {
+					return Drop_64(args[0], (int)args[1], args[2], args[3]);
+				}
+			});
 		}
 	};
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/Win32DPIUtils.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/Win32DPIUtils.java
@@ -1,0 +1,68 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Yatta Solutions and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Yatta Solutions - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.swt.internal;
+
+import java.util.function.*;
+
+import org.eclipse.swt.internal.win32.*;
+import org.eclipse.swt.internal.win32.version.*;
+
+/**
+ * This class is used in the win32 implementation only to provide
+ * DPI related utility methods.
+ * <p>
+ * <b>IMPORTANT:</b> This class is <em>not</em> part of the public
+ * API for SWT. It is marked public only so that it can be shared
+ * within the packages provided by SWT. It is not available on all
+ * platforms, and should never be called from application code.
+ * </p>
+ * @noreference This class is not intended to be referenced by clients
+ */
+public class Win32DPIUtils {
+	public static boolean setDPIAwareness(int desiredDpiAwareness) {
+		if (desiredDpiAwareness == OS.GetThreadDpiAwarenessContext()) {
+			return true;
+		}
+		if (desiredDpiAwareness == OS.DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2) {
+			// "Per Monitor V2" only available in more recent Windows version
+			boolean perMonitorV2Available = OsVersion.IS_WIN10_1809;
+			if (!perMonitorV2Available) {
+				System.err.println("***WARNING: the OS version does not support DPI awareness mode PerMonitorV2.");
+				return false;
+			}
+		}
+		long setDpiAwarenessResult = OS.SetThreadDpiAwarenessContext(desiredDpiAwareness);
+		if (setDpiAwarenessResult == 0L) {
+			System.err.println("***WARNING: setting DPI awareness failed.");
+			return false;
+		}
+		return true;
+	}
+
+	public static <T> T runWithProperDPIAwareness(Supplier<T> operation) {
+		// refreshing is only necessary, when monitor specific scaling is active
+		long previousDPIAwareness = OS.GetThreadDpiAwarenessContext();
+		try {
+			if (!setDPIAwareness(OS.DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2)) {
+				// awareness was not changed, so no need to reset it
+				previousDPIAwareness = 0;
+			}
+			return operation.get();
+		} finally {
+			if (previousDPIAwareness > 0) {
+				OS.SetThreadDpiAwarenessContext(previousDPIAwareness);
+			}
+		}
+	}
+}


### PR DESCRIPTION
This PR sets temporarily the DPI awareness of the thread to PerMonitorV2 if necessary, when DnD operations are executed. This is necessary as the process could be started with System Aware DPI mode which is inherited from the native methods related to DnD.

### How to test

Its a bit complicated because its not reproducible with runtime. You will need to replace the three affected classes e.g. in the SWT jar of an I-Build with the changes in this PR to see the improvement.

fixes https://github.com/eclipse-platform/eclipse.platform.swt/issues/2246