### PR TITLE
[GTK] Fix NPE in switch page on gtk 4.x

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/TabFolder.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/TabFolder.java
@@ -589,7 +589,10 @@ long gtk_switch_page(long notebook, long page, int page_num) {
 
 	if (GTK.GTK4) {
 		Control control = item.getControl();
-		control.setBoundsInPixels(getClientAreaInPixels());
+		if (control != null && !control.isDisposed()) {
+			control.setBoundsInPixels(getClientAreaInPixels());
+			control.setVisible(true);
+		}
 	} else {
 		int index = GTK.gtk_notebook_get_current_page(handle);
 		if (index != -1) {

--- a/tests/org.eclipse.swt.tests/pom.xml
+++ b/tests/org.eclipse.swt.tests/pom.xml
@@ -78,12 +78,12 @@
 			<dependency>
 			    <groupId>org.junit.vintage</groupId>
 			    <artifactId>junit-vintage-engine</artifactId>
-			    <version>5.13.1</version>
+			    <version>5.13.2</version>
 			</dependency>
 			<dependency>
 			    <groupId>org.junit.platform</groupId>
 			    <artifactId>junit-platform-suite-engine</artifactId>
-			    <version>1.13.1</version>
+			    <version>1.13.2</version>
 			</dependency>
 		</dependencies>
       </plugin>


### PR DESCRIPTION
Added missing null/disposal check for cases when tab has no control set. Issue can be seen and verified fixed using Snippet266.