### PR TITLE
Revise the Cursor class to support scaling

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/graphics/Cursor.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/graphics/Cursor.java
@@ -382,6 +382,10 @@ void createNSCursor(int hotspotX, int hotspotY, byte[] buffer, int width, int he
  */
 public Cursor(Device device, ImageData source, int hotspotX, int hotspotY) {
 	super(device);
+	setupCursorFromImageData(source, hotspotX, hotspotY);
+}
+
+private void setupCursorFromImageData(ImageData source, int hotspotX, int hotspotY) {
 	if (source == null) SWT.error(SWT.ERROR_NULL_ARGUMENT);
 	if (hotspotX >= source.width || hotspotX < 0 ||
 		hotspotY >= source.height || hotspotY < 0) {
@@ -446,6 +450,41 @@ public Cursor(Device device, ImageData source, int hotspotX, int hotspotY) {
 	} finally {
 		if (pool != null) pool.release();
 	}
+}
+
+/**
+ * Constructs a new cursor given a device, image describing
+ * the desired cursor appearance, and the x and y coordinates of
+ * the <em>hotspot</em> (that is, the point within the area
+ * covered by the cursor which is considered to be where the
+ * on-screen pointer is "pointing").
+ * <p>
+ * You must dispose the cursor when it is no longer required.
+ * </p>
+ *
+ * @param device the device on which to allocate the cursor
+ * @param imageDataProvider the ImageDataProvider for the cursor
+ * @param hotspotX the x coordinate of the cursor's hotspot
+ * @param hotspotY the y coordinate of the cursor's hotspot
+ *
+ * @exception IllegalArgumentException <ul>
+ *    <li>ERROR_NULL_ARGUMENT - if device is null and there is no current device</li>
+ *    <li>ERROR_NULL_ARGUMENT - if the image is null</li>
+ *    <li>ERROR_INVALID_ARGUMENT - if the hotspot is outside the bounds of the
+ * 		 image</li>
+ * </ul>
+ * @exception SWTError <ul>
+ *    <li>ERROR_NO_HANDLES - if a handle could not be obtained for cursor creation</li>
+ * </ul>
+ *
+ * @see #dispose()
+ *
+ * @since 3.131
+ */
+public Cursor(Device device, ImageDataProvider imageDataProvider, int hotspotX, int hotspotY) {
+	super(device);
+	if (imageDataProvider == null) SWT.error(SWT.ERROR_NULL_ARGUMENT);
+	setupCursorFromImageData(imageDataProvider.getImageData(100), hotspotX, hotspotY);
 }
 
 @Override

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/graphics/Cursor.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/graphics/Cursor.java
@@ -272,6 +272,11 @@ public Cursor(Device device, ImageData source, ImageData mask, int hotspotX, int
  */
 public Cursor(Device device, ImageData source, int hotspotX, int hotspotY) {
 	super(device);
+	setupCursorFromImageData(source, hotspotX, hotspotY);
+
+}
+
+private void setupCursorFromImageData(ImageData source, int hotspotX, int hotspotY) {
 	if (source == null) SWT.error(SWT.ERROR_NULL_ARGUMENT);
 	if (hotspotX >= source.width || hotspotX < 0 ||
 		hotspotY >= source.height || hotspotY < 0) {
@@ -353,6 +358,41 @@ public Cursor(Device device, ImageData source, int hotspotX, int hotspotY) {
 
 	if (handle == 0) SWT.error(SWT.ERROR_NO_HANDLES);
 	init();
+}
+
+/**
+ * Constructs a new cursor given a device, image describing
+ * the desired cursor appearance, and the x and y coordinates of
+ * the <em>hotspot</em> (that is, the point within the area
+ * covered by the cursor which is considered to be where the
+ * on-screen pointer is "pointing").
+ * <p>
+ * You must dispose the cursor when it is no longer required.
+ * </p>
+ *
+ * @param device the device on which to allocate the cursor
+ * @param imageDataProvider the ImageDataProvider for the cursor
+ * @param hotspotX the x coordinate of the cursor's hotspot
+ * @param hotspotY the y coordinate of the cursor's hotspot
+ *
+ * @exception IllegalArgumentException <ul>
+ *    <li>ERROR_NULL_ARGUMENT - if device is null and there is no current device</li>
+ *    <li>ERROR_NULL_ARGUMENT - if the image is null</li>
+ *    <li>ERROR_INVALID_ARGUMENT - if the hotspot is outside the bounds of the
+ * 		 image</li>
+ * </ul>
+ * @exception SWTError <ul>
+ *    <li>ERROR_NO_HANDLES - if a handle could not be obtained for cursor creation</li>
+ * </ul>
+ *
+ * @see #dispose()
+ *
+ * @since 3.131
+ */
+public Cursor(Device device, ImageDataProvider imageDataProvider, int hotspotX, int hotspotY) {
+	super(device);
+	if (imageDataProvider == null) SWT.error(SWT.ERROR_NULL_ARGUMENT);
+	setupCursorFromImageData(imageDataProvider.getImageData(100), hotspotX, hotspotY);
 }
 
 long createCursor(byte[] sourceData, byte[] maskData, int width, int height, int hotspotX, int hotspotY, boolean reverse) {

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_Cursor.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_Cursor.java
@@ -24,7 +24,9 @@ import java.io.InputStream;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Cursor;
+import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.graphics.ImageData;
+import org.eclipse.swt.graphics.ImageDataProvider;
 import org.eclipse.swt.graphics.ImageLoader;
 import org.eclipse.swt.widgets.Display;
 import org.junit.Before;
@@ -150,6 +152,23 @@ public void test_ConstructorLorg_eclipse_swt_graphics_DeviceLorg_eclipse_swt_gra
 		} catch (IOException e) {
 			// continue;
 		}
+	}
+}
+
+@Test
+public void test_ConstructorWithImageDataProvider() {
+	// Test new Cursor(Device device, ImageData source, ImageData mask, int
+	// hotspotX, int hotspotY)
+	Image sourceImage = new Image(display, 10, 10);
+	Cursor cursor = new Cursor(display, sourceImage::getImageData, 0, 0);
+	cursor.dispose();
+	sourceImage.dispose();
+
+	try {
+		cursor = new Cursor(display, (ImageDataProvider) null, 0, 0);
+		cursor.dispose();
+		fail("No exception thrown when ImageDataProvider is null");
+	} catch (IllegalArgumentException e) {
 	}
 }
 


### PR DESCRIPTION
Previously, cursors were initialized with a single ImageData, which caused issues on systems with varying zoom levels, for example, cursors were not scaled at all on Linux, or were blurrily auto-scaled on Windows.

This commit introduces a new constructor for the Cursor class that accepts an Image object instead of ImageData. This allows the code instantiating the cursor to pass an image capable of providing appropriately scaled image data based on the current zoom level.