### PR TITLE
Develocity integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ pom.tycho
 
 /binaries/org.eclipse.swt.*/src/
 tmpdir/
+.mvn/.develocity/develocity-workspace-id

--- a/.mvn/develocity.xml
+++ b/.mvn/develocity.xml
@@ -1,16 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
 <!--
+  Copyright (c) 2012,2024 Eclipse Foundation and others.
+  All rights reserved. This program and the accompanying materials
+  are made available under the terms of the Eclipse Distribution License v1.0
+  which accompanies this distribution, and is available at
+  http://www.eclipse.org/org/documents/edl-v10.php
 
-    Copyright (c) 2012-2025 Red Hat, Inc. and others.
-    This program and the accompanying materials are made
-    available under the terms of the Eclipse Public License 2.0
-    which is available at https://www.eclipse.org/legal/epl-2.0/
-
-    SPDX-License-Identifier: EPL-2.0
-
-    Contributors:
-      Gasper Kojek
-
+  Contributors:
+    Gasper Kojek
 -->
 <develocity
   xmlns="https://www.gradle.com/develocity-maven" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/.mvn/develocity.xml
+++ b/.mvn/develocity.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<!--
+
+    Copyright (c) 2012-2025 Red Hat, Inc. and others.
+    This program and the accompanying materials are made
+    available under the terms of the Eclipse Public License 2.0
+    which is available at https://www.eclipse.org/legal/epl-2.0/
+
+    SPDX-License-Identifier: EPL-2.0
+
+    Contributors:
+      Gasper Kojek
+
+-->
+<develocity
+  xmlns="https://www.gradle.com/develocity-maven" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="https://www.gradle.com/develocity-maven https://www.gradle.com/schema/develocity-maven.xsd">
+  <server>
+    <url>https://develocity-staging.eclipse.org</url>
+  </server>
+  <projectId>eclipse.platform.swt</projectId>
+  <buildScan>
+    <obfuscation>
+      <ipAddresses>0.0.0.0</ipAddresses>
+    </obfuscation>
+    <publishing>
+      <onlyIf>
+        <![CDATA[authenticated]]>
+      </onlyIf>
+    </publishing>
+    <backgroundBuildScanUpload>#{isFalse(env['CI'])}</backgroundBuildScanUpload>
+  </buildScan>
+  <buildCache>
+    <local>
+      <enabled>#{isFalse(env['CI'])}</enabled>
+    </local>
+    <remote>
+      <enabled>true</enabled>
+      <storeEnabled>#{isTrue(env['CI'])}</storeEnabled>
+    </remote>
+  </buildCache>
+</develocity>

--- a/.mvn/develocity.xml
+++ b/.mvn/develocity.xml
@@ -15,7 +15,7 @@
   <server>
     <url>https://develocity-staging.eclipse.org</url>
   </server>
-  <projectId>eclipse.platform.swt</projectId>
+  <projectId>eclipse.platform</projectId>
   <buildScan>
     <obfuscation>
       <ipAddresses>0.0.0.0</ipAddresses>

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -6,4 +6,14 @@
 		<artifactId>tycho-build</artifactId>
 		<version>4.0.13</version>
 	</extension>
+	<extension>
+		<groupId>com.gradle</groupId>
+		<artifactId>develocity-maven-extension</artifactId>
+		<version>2.0.1</version>
+	</extension>
+	<extension>
+		<groupId>com.gradle</groupId>
+		<artifactId>common-custom-user-data-maven-extension</artifactId>
+		<version>2.0.3</version>
+	</extension>
 </extensions>

--- a/tests/org.eclipse.swt.tests/pom.xml
+++ b/tests/org.eclipse.swt.tests/pom.xml
@@ -88,5 +88,39 @@
 		</dependencies>
       </plugin>
     </plugins>
+
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>com.gradle</groupId>
+          <artifactId>develocity-maven-extension</artifactId>
+          <configuration>
+            <develocity>
+              <plugins>
+                <plugin>
+                  <groupId>org.apache.maven.plugins</groupId>
+                  <artifactId>maven-surefire-plugin</artifactId>
+                  <inputs>
+                    <fileSets>
+                      <fileSet>
+                        <name>user.home</name>
+                        <paths>
+                          <path>${project.build.directory}</path>
+                        </paths>
+                        <normalization>
+                          <strategy>RELATIVE_PATH</strategy>
+                          <ignoreEmptyDirectories>true</ignoreEmptyDirectories>
+                          <ignoreLineEndings>true</ignoreLineEndings>
+                        </normalization>
+                      </fileSet>
+                    </fileSets>
+                  </inputs>
+                </plugin>
+              </plugins>
+            </develocity>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
   </build>
 </project>


### PR DESCRIPTION
As one of the impactful Eclipse projects, we (the Develocity Solutions team) would like to invite you to be a part of the [Eclipse Develocity evaluation initiative](https://www.eclipse.org/lists/cross-project-issues-dev/msg20000.html).

## Description
This improvement will enhance the functionality of the Eclipse SWT build by publishing a build scan for every CI build and for every local build from an authenticated Eclipse committer. The build will not fail if publishing fails. The build scans of the Eclipse SWT project are published to the Develocity instance at [develocity-staging.eclipse.org](https://develocity-staging.eclipse.org), hosted by the Eclipse Foundation and run in partnership between the Eclipse and Gradle. This Develocity instance has all features and extensions enabled and is freely available for use by the Eclipse SWT project and all other Eclipse projects.

On this Develocity instance, the Eclipse SWT project will have access not only to all of the published build scans but also to other aggregate data features such as:

* Dashboards to view all historical build scans, along with performance [trends](https://develocity-staging.eclipse.org/scans/trends?search.relativeStartTime=P28D&trends.timeResolution=week) over time. For example, look at the [Quarkus instance trends dashboard](https://ge.quarkus.io/scans/trends?search.relativeStartTime=P28D&search.tags=ci&search.timeZoneId=Europe%2FLjubljana) with the `ci` filter applied.
* [Build failure analytics](https://develocity-staging.eclipse.org/scans/failures?search.relativeStartTime=P28D) for enhanced investigation and diagnosis of build failures. You can also explore the [Quarkus instance](https://ge.quarkus.io/scans/failures?search.relativeStartTime=P28D&search.timeZoneId=Europe%2FLjubljana) for example of a different OSS projects Develocity instance.
* [Test failure analytics](https://develocity-staging.eclipse.org/scans/tests?search.relativeStartTime=P28D) to better understand trends and causes around slow, failing, and flaky tests. Going to the [Quarkus instance](https://ge.quarkus.io/scans/tests?search.relativeStartTime=P28D&search.timeZoneId=Europe%2FLjubljana) again, this will probably give you a better representation of the type of data available. You can also order it by flakiness, which is a good starting point when deciding which tests need fixing the most.

This will also enable you to (optionally) use build time optimization features, such as (remote) build caching and Predictive Test Selection. In this PR, build caching is enabled, with the local cache being disabled on CI and only allowing CI to write to the remote cache, as per the general recommendations.

I ran [some tests](https://github.com/ribafish/kotlinTests/actions/runs/15851925192) about build speed improvements when caching is configured with the following results. Here are the best-case (no code change) savings:

| Invocation | Build time without cache | Build time with cache | Speedup |
|-----------|--------------------------|-----------------------|-------------------|
| ` install -DskipTests=true` | 4m 13.218s | 2m 0.526s | 2.1x (2m 12.692s savings) |
| `verify -Dscan.tag.failNever --fail-never --batch-mode --threads 1C -V -U -e -Pbree-libs -Papi-check -Pjavadoc -Dcompare-version-with-baselines.skip=true -Dorg.eclipse.swt.tests.junit.disable.test_isLocal=true` | 7m 44.118s | 3m 47.287s | 2.05x (3m 56.831s savings) | 

I also tried other configurations, more similar to what you have in Jenkins, but couldn't get tests to pass (even with test failure ignore). In order to correctly support caching, I have also disabled test failure ignore in your Jenkinsfile, so failed test runs are not cached. There are also some additional savings to be made for the [surefire:test in org.eclipse.swt.tests](https://ge.solutions-team.gradle.com/c/evlirm5l72rqa/ejqc3srzx6blg/goal-inputs?cacheability=cacheable&expanded=WyJudHNvbHFraDZ5NWNhLXVzZXIuaG9tZSIsIm50c29scWtoNnk1Y2EtdXNlci5ob21lLTAtMCJd#ntsolqkh6y5ca), which is using `user.home` as an input, but I'm not familiar enough with how you're using that and how we could normalize the input.

Caching can be tested without setting up the Develocity credentials - simply run 2 or more builds (the first one will fill the local cache, next ones can use it).

More information can be read in the [Eclipse announcement](https://www.eclipse.org/lists/cross-project-issues-dev/msg20000.html). Here is also a [blog post abut Develocity](https://eclipse-cbi.github.io/cbi-website/blog/2025/02/12/2025-02-12_develocity) from Eclipse Foundation, as well as a [Develocity presentation](https://www.youtube.com/watch?v=YWIbzmNFJVM), made in collaboration with Eclipse Foundation (and Gradle).

Please let me know if there are any questions about the value of Develocity or the changes in this pull request and I’d be happy to address them.

### IMPORTANT
**To get scans publishing on CI, a [helpdesk](https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues) ticket needs to be opened in order for those credentials to be created, as explained in the [initiative documentation](https://gitlab.eclipse.org/eclipsefdn/it/releng/develocity/develocity-documentation#ci-integration). If this PR is merged without the credentials vault setup, your CI will not work because of the missing vault! This won't be visible in the PR builds, as they use the current Jenkins setup. To test it on CI, you will need to get the credentials set up and open run these changes from a secure context, which might be a PR in the repo, or from a trusted fork (yours for example), if that's configured.**

Additionally, I would advise verifying with the EF Infra team about the Jenkinsfile secrets vault path, as I set it to `eclipse.platform`, seeing as it's merged in the projects view, but it's not the repository.

