### PR TITLE
Refactor: Move Cocoa-specific DPI methods to CocoaDPIUtil

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/graphics/Image.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/graphics/Image.java
@@ -1822,11 +1822,28 @@ public String toString () {
  * @noreference This method is not intended to be referenced by clients.
  */
 public static void drawScaled(GC gc, Image original, int width, int height, float scaleFactor) {
-	gc.drawImage (original, 0, 0, DPIUtil.autoScaleDown (width), DPIUtil.autoScaleDown (height),
+	gc.drawImage (original, 0, 0, CocoaDPIUtil.autoScaleDown (width), CocoaDPIUtil.autoScaleDown (height),
 			/* E.g. destWidth here is effectively DPIUtil.autoScaleDown (scaledWidth), but avoiding rounding errors.
 			 * Nevertheless, we still have some rounding errors due to the point-based API GC#drawImage(..).
 			 */
-			0, 0, Math.round (DPIUtil.autoScaleDown (width * scaleFactor)), Math.round (DPIUtil.autoScaleDown (height * scaleFactor)));
+			0, 0, Math.round (CocoaDPIUtil.autoScaleDown (width * scaleFactor)), Math.round (CocoaDPIUtil.autoScaleDown (height * scaleFactor)));
+}
+
+private final class CocoaDPIUtil {
+
+	/**
+	 * Auto-scale down int dimensions.
+	 */
+	public static int autoScaleDown(int size) {
+		return DPIUtil.scaleDown(size, DPIUtil.getDeviceZoom());
+	}
+
+	/**
+	 * Auto-scale down float dimensions.
+	 */
+	public static float autoScaleDown(float size) {
+		return DPIUtil.scaleDown(size, DPIUtil.getDeviceZoom());
+	}
 }
 
 }


### PR DESCRIPTION
The `autoScale` methods no longer have relevance in the Win32 implementation, so this commit extracts the macOS-specific DPI scaling logic into a dedicated `CocoaDPIUtil` class. This improves platform separation and maintains cleaner, OS-specific code boundaries.