### PR TITLE
Refactor: Move GTK-specific DPI logic to GtkDPIUtil

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/DPIUtil.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/DPIUtil.java
@@ -284,7 +284,7 @@ public static ImageData scaleImageData (Device device, final ElementAtZoom<Image
 	return scaleImageData(device, elementAtZoom.element(), targetZoom, elementAtZoom.zoom());
 }
 
-private static ImageData autoScaleImageData (Device device, final ImageData imageData, float scaleFactor) {
+public static ImageData autoScaleImageData (Device device, final ImageData imageData, float scaleFactor) {
 	// Guards are already implemented in callers: if (deviceZoom == 100 || imageData == null || scaleFactor == 1.0f) return imageData;
 	int width = imageData.width;
 	int height = imageData.height;

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/graphics/GC.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/graphics/GC.java
@@ -343,7 +343,7 @@ void checkGC (int mask) {
 		Cairo.cairo_set_line_join(cairo, join_style);
 	}
 	if ((state & LINE_WIDTH) != 0) {
-		Cairo.cairo_set_line_width(cairo, data.lineWidth == 0 ? DPIUtil.autoScaleUp(drawable, 1) : data.lineWidth);
+		Cairo.cairo_set_line_width(cairo, data.lineWidth == 0 ? 1 : data.lineWidth);
 		switch (data.lineStyle) {
 			case SWT.LINE_DOT:
 			case SWT.LINE_DASH:
@@ -467,7 +467,7 @@ public void copyArea(Image image, int x, int y) {
 	if (handle == 0) SWT.error(SWT.ERROR_GRAPHIC_DISPOSED);
 	if (image == null) SWT.error(SWT.ERROR_NULL_ARGUMENT);
 	if (image.type != SWT.BITMAP || image.isDisposed()) SWT.error(SWT.ERROR_INVALID_ARGUMENT);
-	Point loc = DPIUtil.autoScaleUp(drawable, new Point(x, y));
+	Point loc = new Point(x, y);
 	copyAreaInPixels(image, loc.x, loc.y);
 }
 void copyAreaInPixels(Image image, int x, int y) {
@@ -507,8 +507,8 @@ void copyAreaInPixels(Image image, int x, int y) {
  */
 public void copyArea(int srcX, int srcY, int width, int height, int destX, int destY) {
 	if (handle == 0) SWT.error(SWT.ERROR_GRAPHIC_DISPOSED);
-	Rectangle src = DPIUtil.autoScaleUp(drawable, new Rectangle(srcX, srcY, width, height));
-	Point dest = DPIUtil.autoScaleUp(drawable, new Point(destX, destY));
+	Rectangle src = new Rectangle(srcX, srcY, width, height);
+	Point dest = new Point(destX, destY);
 	copyAreaInPixels(src.x, src.y, src.width, src.height, dest.x, dest.y);
 }
 
@@ -535,8 +535,8 @@ void copyAreaInPixels(int srcX, int srcY, int width, int height, int destX, int 
  */
 public void copyArea(int srcX, int srcY, int width, int height, int destX, int destY, boolean paint) {
 	if (handle == 0) SWT.error(SWT.ERROR_GRAPHIC_DISPOSED);
-	Rectangle srcLoc = DPIUtil.autoScaleUp(drawable, new Rectangle(srcX, srcY, width, height));
-	Point destLoc = DPIUtil.autoScaleUp(drawable, new Point(destX, destY));
+	Rectangle srcLoc = new Rectangle(srcX, srcY, width, height);
+	Point destLoc = new Point(destX, destY);
 	copyAreaInPixels(srcLoc.x, srcLoc.y, srcLoc.width, srcLoc.height, destLoc.x, destLoc.y, paint);
 }
 void copyAreaInPixels(int srcX, int srcY, int width, int height, int destX, int destY, boolean paint) {
@@ -726,7 +726,7 @@ void destroy() {
  */
 public void drawArc(int x, int y, int width, int height, int startAngle, int arcAngle) {
 	if (handle == 0) SWT.error(SWT.ERROR_GRAPHIC_DISPOSED);
-	Rectangle loc = DPIUtil.autoScaleUp(drawable, new Rectangle(x, y, width, height));
+	Rectangle loc = new Rectangle(x, y, width, height);
 	drawArcInPixels(loc.x, loc.y, loc.width, loc.height, startAngle, arcAngle);
 }
 void drawArcInPixels(int x, int y, int width, int height, int startAngle, int arcAngle) {
@@ -781,7 +781,7 @@ void drawArcInPixels(int x, int y, int width, int height, int startAngle, int ar
  */
 public void drawFocus(int x, int y, int width, int height) {
 	if (handle == 0) SWT.error(SWT.ERROR_GRAPHIC_DISPOSED);
-	Rectangle loc = DPIUtil.autoScaleUp(drawable, new Rectangle(x, y, width, height));
+	Rectangle loc = new Rectangle(x, y, width, height);
 	drawFocusInPixels(loc.x, loc.y, loc.width, loc.height);
 }
 void drawFocusInPixels(int x, int y, int width, int height) {
@@ -814,7 +814,7 @@ public void drawImage(Image image, int x, int y) {
 	if (handle == 0) SWT.error(SWT.ERROR_GRAPHIC_DISPOSED);
 	if (image == null) SWT.error(SWT.ERROR_NULL_ARGUMENT);
 	if (image.isDisposed()) SWT.error(SWT.ERROR_INVALID_ARGUMENT);
-	Point loc = DPIUtil.autoScaleUp(drawable, new Point(x, y));
+	Point loc = new Point(x, y);
 	drawImageInPixels(image, loc.x, loc.y);
 }
 void drawImageInPixels(Image image, int x, int y) {
@@ -861,7 +861,7 @@ public void drawImage(Image image, int srcX, int srcY, int srcWidth, int srcHeig
 	}
 	if (image == null) SWT.error(SWT.ERROR_NULL_ARGUMENT);
 	if (image.isDisposed()) SWT.error(SWT.ERROR_INVALID_ARGUMENT);
-	Rectangle destRect = DPIUtil.autoScaleUp(drawable, new Rectangle(destX, destY, destWidth, destHeight));
+	Rectangle destRect = new Rectangle(destX, destY, destWidth, destHeight);
 	drawImage(image, srcX, srcY, srcWidth, srcHeight, destRect.x, destRect.y, destRect.width, destRect.height, false);
 }
 void drawImage(Image srcImage, int srcX, int srcY, int srcWidth, int srcHeight, int destX, int destY, int destWidth, int destHeight, boolean simple) {
@@ -939,8 +939,8 @@ void drawImage(Image srcImage, int srcX, int srcY, int srcWidth, int srcHeight, 
  */
 public void drawLine(int x1, int y1, int x2, int y2) {
 	if (handle == 0) SWT.error(SWT.ERROR_GRAPHIC_DISPOSED);
-	Point loc1 = DPIUtil.autoScaleUp(drawable, new Point(x1, y1));
-	Point loc2 = DPIUtil.autoScaleUp(drawable, new Point(x2, y2));
+	Point loc1 = new Point(x1, y1);
+	Point loc2 = new Point(x2, y2);
 	drawLineInPixels(loc1.x, loc1.y, loc2.x, loc2.y);
 }
 void drawLineInPixels(int x1, int y1, int x2, int y2) {
@@ -978,7 +978,7 @@ void drawLineInPixels(int x1, int y1, int x2, int y2) {
  */
 public void drawOval(int x, int y, int width, int height) {
 	if (handle == 0) SWT.error(SWT.ERROR_GRAPHIC_DISPOSED);
-	Rectangle rect = DPIUtil.autoScaleUp(drawable, new Rectangle(x, y, width, height));
+	Rectangle rect = new Rectangle(x, y, width, height);
 	drawOvalInPixels(rect.x, rect.y, rect.width, rect.height);
 }
 void drawOvalInPixels(int x, int y, int width, int height) {
@@ -1065,7 +1065,7 @@ public void drawPath(Path path) {
  */
 public void drawPoint (int x, int y) {
 	if (handle == 0) SWT.error(SWT.ERROR_GRAPHIC_DISPOSED);
-	Point loc = DPIUtil.autoScaleUp(drawable, new Point(x, y));
+	Point loc = new Point(x, y);
 	drawPointInPixels(loc.x, loc.y);
 }
 void drawPointInPixels (int x, int y) {
@@ -1095,7 +1095,7 @@ void drawPointInPixels (int x, int y) {
 public void drawPolygon(int[] pointArray) {
 	if (handle == 0) SWT.error(SWT.ERROR_GRAPHIC_DISPOSED);
 	if (pointArray == null) SWT.error(SWT.ERROR_NULL_ARGUMENT);
-	int [] scaledPointArray = DPIUtil.autoScaleUp(drawable, pointArray);
+	int [] scaledPointArray = pointArray;
 	drawPolygonInPixels(scaledPointArray);
 }
 void drawPolygonInPixels(int[] pointArray) {
@@ -1125,7 +1125,7 @@ void drawPolygonInPixels(int[] pointArray) {
 public void drawPolyline(int[] pointArray) {
 	if (handle == 0) SWT.error(SWT.ERROR_GRAPHIC_DISPOSED);
 	if (pointArray == null) SWT.error(SWT.ERROR_NULL_ARGUMENT);
-	int [] scaledPointArray = DPIUtil.autoScaleUp(drawable, pointArray);
+	int [] scaledPointArray = pointArray;
 	drawPolylineInPixels(scaledPointArray);
 }
 void drawPolylineInPixels(int[] pointArray) {
@@ -1199,7 +1199,7 @@ void drawRectangleInPixels(int x, int y, int width, int height) {
  */
 public void drawRectangle(Rectangle rect) {
 	if (rect == null) SWT.error(SWT.ERROR_NULL_ARGUMENT);
-	drawRectangleInPixels(DPIUtil.autoScaleUp(drawable, rect));
+	drawRectangleInPixels(rect);
 }
 void drawRectangleInPixels(Rectangle rect) {
 	drawRectangleInPixels (rect.x, rect.y, rect.width, rect.height);
@@ -1227,8 +1227,8 @@ void drawRectangleInPixels(Rectangle rect) {
  */
 public void drawRoundRectangle(int x, int y, int width, int height, int arcWidth, int arcHeight) {
 	if (handle == 0) SWT.error(SWT.ERROR_GRAPHIC_DISPOSED);
-	Rectangle rect = DPIUtil.autoScaleUp(drawable, new Rectangle(x, y, width, height));
-	Point arcSize = DPIUtil.autoScaleUp(drawable, new Point(arcWidth, arcHeight));
+	Rectangle rect = new Rectangle(x, y, width, height);
+	Point arcSize = new Point(arcWidth, arcHeight);
 	drawRoundRectangleInPixels(rect.x, rect.y, rect.width, rect.height, arcSize.x, arcSize.y);
 }
 void drawRoundRectangleInPixels(int x, int y, int width, int height, int arcWidth, int arcHeight) {
@@ -1333,7 +1333,7 @@ void drawStringInPixels (String string, int x, int y) {
 public void drawString(String string, int x, int y, boolean isTransparent) {
 	if (handle == 0) SWT.error(SWT.ERROR_GRAPHIC_DISPOSED);
 	if (string == null) SWT.error(SWT.ERROR_NULL_ARGUMENT);
-	Point loc = DPIUtil.autoScaleUp(drawable, new Point(x, y));
+	Point loc = new Point(x, y);
 	drawStringInPixels(string, loc.x, loc.y, isTransparent);
 }
 
@@ -1395,7 +1395,7 @@ void drawTextInPixels(String string, int x, int y) {
  * </ul>
  */
 public void drawText(String string, int x, int y, boolean isTransparent) {
-	Point loc = DPIUtil.autoScaleUp(drawable, new Point (x, y));
+	Point loc = new Point (x, y);
 	drawTextInPixels(string, loc.x, loc.y, isTransparent);
 }
 void drawTextInPixels(String string, int x, int y, boolean isTransparent) {
@@ -1444,7 +1444,7 @@ void drawTextInPixels(String string, int x, int y, boolean isTransparent) {
  * </ul>
  */
 public void drawText (String string, int x, int y, int flags) {
-	Point loc = DPIUtil.autoScaleUp(drawable, new Point (x, y));
+	Point loc = new Point (x, y);
 	drawTextInPixels(string, loc.x, loc.y, flags);
 }
 void drawTextInPixels (String string, int x, int y, int flags) {
@@ -1530,7 +1530,7 @@ public boolean equals(Object object) {
  */
 public void fillArc(int x, int y, int width, int height, int startAngle, int arcAngle) {
 	if (handle == 0) SWT.error(SWT.ERROR_GRAPHIC_DISPOSED);
-	Rectangle rect = DPIUtil.autoScaleUp(drawable, new Rectangle(x, y, width, height));
+	Rectangle rect = new Rectangle(x, y, width, height);
 	fillArcInPixels(rect.x, rect.y, rect.width, rect.height, startAngle, arcAngle);
 }
 void fillArcInPixels(int x, int y, int width, int height, int startAngle, int arcAngle) {
@@ -1589,7 +1589,7 @@ void fillArcInPixels(int x, int y, int width, int height, int startAngle, int ar
  */
 public void fillGradientRectangle(int x, int y, int width, int height, boolean vertical) {
 	if (handle == 0) SWT.error(SWT.ERROR_GRAPHIC_DISPOSED);
-	Rectangle rect = DPIUtil.autoScaleUp(drawable, new Rectangle(x, y, width, height));
+	Rectangle rect = new Rectangle(x, y, width, height);
 	fillGradientRectangleInPixels(rect.x, rect.y, rect.width, rect.height, vertical);
 }
 
@@ -1673,7 +1673,7 @@ void fillGradientRectangleInPixels(int x, int y, int width, int height, boolean 
  */
 public void fillOval(int x, int y, int width, int height) {
 	if (handle == 0) SWT.error(SWT.ERROR_GRAPHIC_DISPOSED);
-	Rectangle rect = DPIUtil.autoScaleUp(drawable, new Rectangle(x, y, width, height));
+	Rectangle rect = new Rectangle(x, y, width, height);
 	fillOvalInPixels(rect.x, rect.y, rect.width, rect.height);
 }
 void fillOvalInPixels(int x, int y, int width, int height) {
@@ -1758,7 +1758,7 @@ public void fillPath (Path path) {
 public void fillPolygon(int[] pointArray) {
 	if (handle == 0) SWT.error(SWT.ERROR_GRAPHIC_DISPOSED);
 	if (pointArray == null) SWT.error(SWT.ERROR_NULL_ARGUMENT);
-	int [] scaledPointArray = DPIUtil.autoScaleUp(drawable, pointArray);
+	int [] scaledPointArray = pointArray;
 	fillPolygonInPixels(scaledPointArray);
 }
 void fillPolygonInPixels(int[] pointArray) {
@@ -1824,7 +1824,7 @@ void fillRectangleInPixels(int x, int y, int width, int height) {
 public void fillRectangle(Rectangle rect) {
 	if (handle == 0) SWT.error(SWT.ERROR_GRAPHIC_DISPOSED);
 	if (rect == null) SWT.error(SWT.ERROR_NULL_ARGUMENT);
-	fillRectangleInPixels(DPIUtil.autoScaleUp(drawable, rect));
+	fillRectangleInPixels(rect);
 }
 void fillRectangleInPixels(Rectangle rect) {
 	fillRectangleInPixels(rect.x, rect.y, rect.width, rect.height);
@@ -1849,8 +1849,8 @@ void fillRectangleInPixels(Rectangle rect) {
  */
 public void fillRoundRectangle(int x, int y, int width, int height, int arcWidth, int arcHeight) {
 	if (handle == 0) SWT.error(SWT.ERROR_GRAPHIC_DISPOSED);
-	Rectangle rect = DPIUtil.autoScaleUp(drawable, new Rectangle(x, y, width, height));
-	Point arcSize = DPIUtil.autoScaleUp(drawable, new Point(arcWidth, arcHeight));
+	Rectangle rect = new Rectangle(x, y, width, height);
+	Point arcSize = new Point(arcWidth, arcHeight);
 	fillRoundRectangleInPixels(rect.x, rect.y, rect.width, rect.height, arcSize.x, arcSize.y);
 }
 void fillRoundRectangleInPixels(int x, int y, int width, int height, int arcWidth, int arcHeight) {
@@ -2074,7 +2074,7 @@ public int getCharWidth(char ch) {
  */
 public Rectangle getClipping() {
 	if (handle == 0) SWT.error(SWT.ERROR_GRAPHIC_DISPOSED);
-	return DPIUtil.autoScaleDown(drawable, getClippingInPixels());
+	return getClippingInPixels();
 }
 Rectangle getClippingInPixels() {
 	/* Calculate visible bounds in device space */
@@ -2251,11 +2251,11 @@ public FontMetrics getFontMetrics() {
 	FontMetrics fm = new FontMetrics();
 	int ascent = OS.pango_font_metrics_get_ascent(metrics);
 	int descent = OS.pango_font_metrics_get_descent(metrics);
-	int ascentInPoints = DPIUtil.autoScaleDown(drawable, OS.PANGO_PIXELS(ascent));
+	int ascentInPoints = OS.PANGO_PIXELS(ascent);
 	fm.ascentInPoints = ascentInPoints;
-	int heightInPoints = DPIUtil.autoScaleDown(drawable, OS.PANGO_PIXELS(ascent + descent));
+	int heightInPoints = OS.PANGO_PIXELS(ascent + descent);
 	fm.descentInPoints = heightInPoints - ascentInPoints;
-	fm.averageCharWidthInPoints = DPIUtil.autoScaleDown(drawable, OS.PANGO_PIXELS(OS.pango_font_metrics_get_approximate_char_width(metrics)));
+	fm.averageCharWidthInPoints = OS.PANGO_PIXELS(OS.pango_font_metrics_get_approximate_char_width(metrics));
 	OS.pango_font_metrics_unref(metrics);
 	return fm;
 }
@@ -2352,7 +2352,7 @@ public int getInterpolation() {
 public LineAttributes getLineAttributes() {
 	if (handle == 0) SWT.error(SWT.ERROR_GRAPHIC_DISPOSED);
 	LineAttributes attributes = getLineAttributesInPixels();
-	attributes.width = DPIUtil.autoScaleDown(drawable, attributes.width);
+	attributes.width = attributes.width;
 	return attributes;
 }
 LineAttributes getLineAttributesInPixels() {
@@ -2453,7 +2453,7 @@ public int getLineStyle() {
  */
 public int getLineWidth() {
 	if (handle == 0) SWT.error(SWT.ERROR_GRAPHIC_DISPOSED);
-	return (int)DPIUtil.autoScaleDown(drawable, data.lineWidth);
+	return getLineWidthInPixels();
 }
 int getLineWidthInPixels() {
 	return (int)data.lineWidth;
@@ -3112,7 +3112,7 @@ void setClipping(long clipRgn) {
  */
 public void setClipping(int x, int y, int width, int height) {
 	if (handle == 0) SWT.error(SWT.ERROR_GRAPHIC_DISPOSED);
-	setClippingInPixels(DPIUtil.autoScaleUp(drawable, x), DPIUtil.autoScaleUp(drawable, y), DPIUtil.autoScaleUp(drawable, width), DPIUtil.autoScaleUp(drawable, height));
+	setClippingInPixels(x, y, width, height);
 }
 void setClippingInPixels(int x, int y, int width, int height) {
 	if (width < 0) {
@@ -3190,7 +3190,7 @@ public void setClipping(Path path) {
  */
 public void setClipping(Rectangle rect) {
 	if (handle == 0) SWT.error(SWT.ERROR_GRAPHIC_DISPOSED);
-	setClippingInPixels(DPIUtil.autoScaleUp(drawable, rect));
+	setClippingInPixels(rect);
 }
 void setClippingInPixels(Rectangle rect) {
 	if (rect == null) {
@@ -3415,7 +3415,7 @@ public void setInterpolation(int interpolation) {
 public void setLineAttributes(LineAttributes attributes) {
 	if (handle == 0) SWT.error(SWT.ERROR_GRAPHIC_DISPOSED);
 	if (attributes == null) SWT.error(SWT.ERROR_NULL_ARGUMENT);
-	attributes.width = DPIUtil.autoScaleUp(drawable, attributes.width);
+	attributes.width = attributes.width;
 	setLineAttributesInPixels(attributes);
 }
 void setLineAttributesInPixels(LineAttributes attributes) {
@@ -3669,7 +3669,7 @@ public void setLineStyle(int lineStyle) {
  */
 public void setLineWidth(int lineWidth) {
 	if (handle == 0) SWT.error(SWT.ERROR_GRAPHIC_DISPOSED);
-	setLineWidthInPixels(DPIUtil.autoScaleUp(drawable, lineWidth));
+	setLineWidthInPixels(lineWidth);
 }
 void setLineWidthInPixels(int lineWidth) {
 	if (data.lineWidth == lineWidth) return;
@@ -3853,7 +3853,7 @@ public void setXORMode(boolean xor) {
  * </ul>
  */
 public Point stringExtent(String string) {
-	return DPIUtil.autoScaleDown(drawable, stringExtentInPixels(string));
+	return stringExtentInPixels(string);
 }
 Point stringExtentInPixels(String string) {
 	return textExtentInPixels(string, 0);
@@ -3879,7 +3879,7 @@ Point stringExtentInPixels(String string) {
  * </ul>
  */
 public Point textExtent(String string) {
-	return DPIUtil.autoScaleDown(drawable, textExtentInPixels(string));
+	return textExtentInPixels(string);
 }
 
 Point textExtentInPixels(String string) {
@@ -3920,7 +3920,7 @@ Point textExtentInPixels(String string) {
 public Point textExtent(String string, int flags) {
 	if (handle == 0) SWT.error(SWT.ERROR_GRAPHIC_DISPOSED);
 	if (string == null) SWT.error(SWT.ERROR_NULL_ARGUMENT);
-	return DPIUtil.autoScaleDown(drawable, textExtentInPixels(string, flags));
+	return textExtentInPixels(string, flags);
 }
 Point textExtentInPixels(String string, int flags) {
 	setString(string, flags);

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/graphics/Image.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/graphics/Image.java
@@ -214,7 +214,7 @@ Image(Device device) {
  */
 public Image(Device device, int width, int height) {
 	super(device);
-	Point size = DPIUtil.autoScaleUp(new Point(width, height));
+	Point size = new Point(width, height);
 	currentDeviceZoom = DPIUtil.getDeviceZoom();
 	init(size.x, size.y);
 	init();
@@ -411,8 +411,7 @@ public Image(Device device, Rectangle bounds) {
 	super(device);
 	if (bounds == null) SWT.error(SWT.ERROR_NULL_ARGUMENT);
 	currentDeviceZoom = DPIUtil.getDeviceZoom();
-	Rectangle bounds1 = DPIUtil.autoScaleUp (bounds);
-	init(bounds1.width, bounds1.height);
+	init(bounds.width, bounds.height);
 	init();
 }
 
@@ -440,7 +439,7 @@ public Image(Device device, Rectangle bounds) {
  * @see #dispose()
  */
 public Image(Device device, ImageData data) {
-	this(device, DPIUtil.autoScaleUp(device, data), DPIUtil.getDeviceZoom());
+	this(device, GtkDPIUtil.autoScaleUp(device, data), DPIUtil.getDeviceZoom());
 }
 
 private Image(Device device, ImageData data, int zoom) {
@@ -489,8 +488,8 @@ public Image(Device device, ImageData source, ImageData mask) {
 		SWT.error(SWT.ERROR_INVALID_ARGUMENT);
 	}
 	currentDeviceZoom = DPIUtil.getDeviceZoom();
-	source = DPIUtil.autoScaleUp (device, source);
-	mask = DPIUtil.autoScaleUp (device, mask);
+	source = GtkDPIUtil.autoScaleUp (device, source);
+	mask = GtkDPIUtil.autoScaleUp (device, mask);
 	mask = ImageData.convertMask (mask);
 	ImageData image = new ImageData(source.width, source.height, source.depth, source.palette, source.scanlinePad, source.data);
 	image.maskPad = mask.scanlinePad;
@@ -997,7 +996,7 @@ public Color getBackground() {
  */
 public Rectangle getBounds() {
 	if (isDisposed()) SWT.error(SWT.ERROR_GRAPHIC_DISPOSED);
-	return DPIUtil.autoScaleDown(getBoundsInPixels());
+	return getBoundsInPixels();
 }
 
 /**
@@ -1586,11 +1585,24 @@ public String toString () {
  * @noreference This method is not intended to be referenced by clients.
  */
 public static void drawScaled(GC gc, Image original, int width, int height, float scaleFactor) {
-	gc.drawImage (original, 0, 0, DPIUtil.autoScaleDown (width), DPIUtil.autoScaleDown (height),
+	gc.drawImage (original, 0, 0, width, height,
 			/* E.g. destWidth here is effectively DPIUtil.autoScaleDown (scaledWidth), but avoiding rounding errors.
 			 * Nevertheless, we still have some rounding errors due to the point-based API GC#drawImage(..).
 			 */
-			0, 0, Math.round (DPIUtil.autoScaleDown (width * scaleFactor)), Math.round (DPIUtil.autoScaleDown (height * scaleFactor)));
+			0, 0, Math.round (width * scaleFactor), Math.round (height * scaleFactor));
+}
+
+private final class GtkDPIUtil {
+
+	/**
+	 * Auto-scale up ImageData to device zoom that is at 100%.
+	 */
+	public static ImageData autoScaleUp (Device device, final ImageData imageData) {
+		int imageDataZoomFactor = 100;
+		if (DPIUtil.getDeviceZoom() == imageDataZoomFactor || imageData == null || (device != null && !device.isAutoScalable())) return imageData;
+		float scaleFactor = (float) DPIUtil.getDeviceZoom() / imageDataZoomFactor;
+		return DPIUtil.autoScaleImageData(device, imageData, scaleFactor);
+	}
 }
 
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/graphics/TextLayout.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/graphics/TextLayout.java
@@ -107,9 +107,9 @@ private static class MetricsAdapter {
 		}
 
 		FontMetrics result = new FontMetrics();
-		result.ascentInPoints = DPIUtil.autoScaleDown(device, lineMetricsInPixels.ascentInPoints);
-		result.descentInPoints = DPIUtil.autoScaleDown(device, lineMetricsInPixels.descentInPoints);
-		result.averageCharWidthInPoints = DPIUtil.autoScaleDown(device, lineMetricsInPixels.averageCharWidthInPoints);
+		result.ascentInPoints = lineMetricsInPixels.ascentInPoints;
+		result.descentInPoints = lineMetricsInPixels.descentInPoints;
+		result.averageCharWidthInPoints =lineMetricsInPixels.averageCharWidthInPoints;
 
 		return result;
 	}
@@ -121,9 +121,9 @@ private static class MetricsAdapter {
 		}
 
 		FontMetrics result = new FontMetrics();
-		result.ascentInPoints = DPIUtil.autoScaleUp(device, metrics.ascentInPoints);
-		result.descentInPoints = DPIUtil.autoScaleUp(device, metrics.descentInPoints);
-		result.averageCharWidthInPoints = DPIUtil.autoScaleUp(device, metrics.averageCharWidthInPoints);
+		result.ascentInPoints = metrics.ascentInPoints;
+		result.descentInPoints = metrics.descentInPoints;
+		result.averageCharWidthInPoints = metrics.averageCharWidthInPoints;
 
 		lineMetricsInPixels = result;
 	}
@@ -296,8 +296,8 @@ void computeRuns () {
 	boolean useMinAscentDescent = !metricsAdapter.isFixedMetrics() && (ascentInPoints != -1 || descentInPoints != -1);
 	if (useMinAscentDescent && segementsLength > 0) {
 		PangoRectangle rect = new PangoRectangle();
-		if (ascentInPoints != -1) rect.y =  -(DPIUtil.autoScaleUp(getDevice(), ascentInPoints)  * OS.PANGO_SCALE);
-		rect.height = DPIUtil.autoScaleUp(getDevice(), (Math.max(0, ascentInPoints) + Math.max(0, descentInPoints))) * OS.PANGO_SCALE;
+		if (ascentInPoints != -1) rect.y =  -(ascentInPoints * OS.PANGO_SCALE);
+		rect.height = (Math.max(0, ascentInPoints) + Math.max(0, descentInPoints)) * OS.PANGO_SCALE;
 		int lineCount = OS.pango_layout_get_line_count(layout);
 		chars = new char[segementsLength + lineCount * 2];
 		lineOffsets = new int [lineCount];
@@ -481,9 +481,9 @@ void computeRuns () {
 		GlyphMetrics metrics = style.metrics;
 		if (metrics != null) {
 			PangoRectangle rect = new PangoRectangle();
-			rect.y =  -(DPIUtil.autoScaleUp(getDevice(), metrics.ascent) * OS.PANGO_SCALE);
-			rect.height = DPIUtil.autoScaleUp(getDevice(), (metrics.ascent + metrics.descent)) * OS.PANGO_SCALE;
-			rect.width = DPIUtil.autoScaleUp(getDevice(), metrics.width) * OS.PANGO_SCALE;
+			rect.y =  -(metrics.ascent * OS.PANGO_SCALE);
+			rect.height = (metrics.ascent + metrics.descent) * OS.PANGO_SCALE;
+			rect.width = metrics.width * OS.PANGO_SCALE;
 			long attr = OS.pango_attr_shape_new (rect, rect);
 			OS.memmove (attribute, attr, PangoAttribute.sizeof);
 			attribute.start_index = byteStart;
@@ -494,7 +494,7 @@ void computeRuns () {
 		}
 		int rise = style.rise;
 		if (rise != 0) {
-			long attr = OS.pango_attr_rise_new (DPIUtil.autoScaleUp(getDevice(), rise) * OS.PANGO_SCALE);
+			long attr = OS.pango_attr_rise_new (rise * OS.PANGO_SCALE);
 			OS.memmove (attribute, attr, PangoAttribute.sizeof);
 			attribute.start_index = byteStart;
 			attribute.end_index = byteEnd;
@@ -559,8 +559,6 @@ void destroy() {
  * </ul>
  */
 public void draw(GC gc, int x, int y) {
-	x = DPIUtil.autoScaleUp(getDevice(), x);
-	y = DPIUtil.autoScaleUp(getDevice(), y);
 	drawInPixels(gc, x, y);
 }
 
@@ -589,8 +587,6 @@ void drawInPixels(GC gc, int x, int y) {
  */
 public void draw(GC gc, int x, int y, int selectionStart, int selectionEnd, Color selectionForeground, Color selectionBackground) {
 	checkLayout ();
-	x = DPIUtil.autoScaleUp(getDevice(), x);
-	y = DPIUtil.autoScaleUp(getDevice(), y);
 	drawInPixels(gc, x, y, selectionStart, selectionEnd, selectionForeground, selectionBackground);
 }
 void drawInPixels(GC gc, int x, int y, int selectionStart, int selectionEnd, Color selectionForeground, Color selectionBackground) {
@@ -626,8 +622,6 @@ void drawInPixels(GC gc, int x, int y, int selectionStart, int selectionEnd, Col
  */
 public void draw(GC gc, int x, int y, int selectionStart, int selectionEnd, Color selectionForeground, Color selectionBackground, int flags) {
 	checkLayout ();
-	x = DPIUtil.autoScaleUp(getDevice(), x);
-	y = DPIUtil.autoScaleUp(getDevice(), y);
 	drawInPixels(gc, x, y, selectionStart, selectionEnd, selectionForeground, selectionBackground, flags);
 }
 void drawInPixels(GC gc, int x, int y, int selectionStart, int selectionEnd, Color selectionForeground, Color selectionBackground, int flags) {
@@ -685,7 +679,7 @@ void drawInPixels(GC gc, int x, int y, int selectionStart, int selectionEnd, Col
 				int lineY = y + OS.PANGO_PIXELS(rect.y);
 				int height = OS.PANGO_PIXELS(rect.height);
 				if (ascentInPoints != -1 && descentInPoints != -1) {
-					height = Math.max (height, DPIUtil.autoScaleUp(getDevice(), ascentInPoints + descentInPoints));
+					height = Math.max (height, ascentInPoints + descentInPoints);
 				}
 				height += getSpacingInPixels();
 				int width = (flags & SWT.FULL_SELECTION) != 0 ? 0x7fff : height / 3;
@@ -918,7 +912,7 @@ public int getAscent () {
  */
 public Rectangle getBounds() {
 	int spacingInPixels = getSpacingInPixels();
-	return DPIUtil.autoScaleDown(getDevice(), getBoundsInPixels(spacingInPixels));
+	return getBoundsInPixels(spacingInPixels);
 }
 
 Rectangle getBoundsInPixels(int spacingInPixels) {
@@ -931,7 +925,7 @@ Rectangle getBoundsInPixels(int spacingInPixels) {
 	int width = OS.PANGO_PIXELS(w[0]);
 	int height = OS.PANGO_PIXELS(h[0]);
 	if (ascentInPoints != -1 && descentInPoints != -1) {
-		height = Math.max (height, DPIUtil.autoScaleUp(getDevice(), ascentInPoints + descentInPoints));
+		height = Math.max (height, ascentInPoints + descentInPoints);
 	}
 	height += spacingInPixels;
 	return new Rectangle(0, 0, width, height + getScaledVerticalIndent());
@@ -953,7 +947,7 @@ Rectangle getBoundsInPixels(int spacingInPixels) {
  */
 public Rectangle getBounds(int start, int end) {
 	checkLayout();
-	return DPIUtil.autoScaleDown(getDevice(), getBoundsInPixels(start, end));
+	return getBoundsInPixels(start, end);
 }
 
 Rectangle getBoundsInPixels(int start, int end) {
@@ -1059,7 +1053,7 @@ public Font getFont () {
 */
 public int getIndent () {
 	checkLayout();
-	return DPIUtil.autoScaleDown(getDevice(), getIndentInPixels());
+	return getIndentInPixels();
 }
 
 int getIndentInPixels () {
@@ -1141,7 +1135,7 @@ public int getLevel(int offset) {
  */
 public Rectangle getLineBounds(int lineIndex) {
 	checkLayout();
-	return DPIUtil.autoScaleDown(getDevice(), getLineBoundsInPixels(lineIndex));
+	return getLineBoundsInPixels(lineIndex);
 }
 
 Rectangle getLineBoundsInPixels(int lineIndex) {
@@ -1166,7 +1160,7 @@ private Rectangle getLineBoundsInPixels(int lineIndex, long iter) {
 	int width = OS.PANGO_PIXELS(rect.width);
 	int height = OS.PANGO_PIXELS(rect.height);
 	if (ascentInPoints != -1 && descentInPoints != -1) {
-		height = Math.max (height, DPIUtil.autoScaleUp(getDevice(), ascentInPoints + descentInPoints));
+		height = Math.max (height, ascentInPoints + descentInPoints);
 	}
 	x += Math.min (indent, wrapIndent);
 	return new Rectangle(x, y, width, height);
@@ -1255,14 +1249,14 @@ public FontMetrics getLineMetrics (int lineIndex) {
 		long metrics = OS.pango_context_get_metrics(context, font, lang);
 		int ascent = OS.pango_font_metrics_get_ascent(metrics);
 		int descent = OS.pango_font_metrics_get_descent(metrics);
-		ascentInPoints = DPIUtil.autoScaleDown(getDevice(), OS.PANGO_PIXELS(ascent));
-		heightInPoints = DPIUtil.autoScaleDown(getDevice(), OS.PANGO_PIXELS(ascent + descent));
+		ascentInPoints = OS.PANGO_PIXELS(ascent);
+		heightInPoints = OS.PANGO_PIXELS(ascent + descent);
 		OS.pango_font_metrics_unref(metrics);
 	} else {
 		PangoRectangle rect = new PangoRectangle();
 		metricsAdapter.pango_layout_line_get_extents(OS.pango_layout_get_line(layout, lineIndex), null, rect);
-		ascentInPoints = DPIUtil.autoScaleDown(getDevice(), OS.PANGO_PIXELS(-rect.y));
-		heightInPoints = DPIUtil.autoScaleDown(getDevice(), OS.PANGO_PIXELS(rect.height));
+		ascentInPoints = OS.PANGO_PIXELS(-rect.y);
+		heightInPoints = OS.PANGO_PIXELS(rect.height);
 	}
 	heightInPoints = Math.max(this.ascentInPoints + this.descentInPoints, heightInPoints);
 	ascentInPoints = Math.max(this.ascentInPoints, ascentInPoints);
@@ -1320,7 +1314,7 @@ public int[] getLineOffsets() {
  */
 public Point getLocation(int offset, boolean trailing) {
 	checkLayout();
-	return DPIUtil.autoScaleDown(getDevice(), getLocationInPixels(offset, trailing));
+	return getLocationInPixels(offset, trailing);
 }
 
 Point getLocationInPixels(int offset, boolean trailing) {
@@ -1459,7 +1453,7 @@ int _getOffset (int offset, int movement, boolean forward) {
  */
 public int getOffset(Point point, int[] trailing) {
 	checkLayout();
-	return getOffsetInPixels(DPIUtil.autoScaleUp(getDevice(), point), trailing);
+	return getOffsetInPixels(point, trailing);
 }
 
 int getOffsetInPixels(Point point, int[] trailing) {
@@ -1685,7 +1679,7 @@ String getSegmentsText() {
  */
 public int getSpacing () {
 	checkLayout();
-	return DPIUtil.autoScaleDown(getDevice(), getSpacingInPixels());
+	return getSpacingInPixels();
 }
 
 int getSpacingInPixels () {
@@ -1717,7 +1711,7 @@ private int getScaledVerticalIndent() {
 	if (verticalIndentInPoints == 0) {
 		return verticalIndentInPoints;
 	}
-	return DPIUtil.autoScaleUp(getDevice(), verticalIndentInPoints);
+	return verticalIndentInPoints;
 }
 
 /**
@@ -1787,7 +1781,7 @@ public TextStyle[] getStyles () {
  */
 public int[] getTabs() {
 	checkLayout();
-	return DPIUtil.autoScaleDown (getDevice(), getTabsInPixels ());
+	return getTabsInPixels ();
 }
 
 int[] getTabsInPixels () {
@@ -1834,7 +1828,7 @@ public int getTextDirection () {
  */
 public int getWidth () {
 	checkLayout ();
-	return DPIUtil.autoScaleDown(getDevice(), getWidthInPixels());
+	return getWidthInPixels();
 }
 
 int getWidthInPixels () {
@@ -1854,7 +1848,7 @@ int getWidthInPixels () {
 */
 public int getWrapIndent () {
 	checkLayout ();
-	return DPIUtil.autoScaleDown(getDevice(), getWrapIndentInPixels());
+	return getWrapIndentInPixels();
 }
 int getWrapIndentInPixels () {
 	return wrapIndent;
@@ -2042,7 +2036,7 @@ public void setFont (Font font) {
  */
 public void setIndent (int indent) {
 	checkLayout ();
-	setIndentInPixels(DPIUtil.autoScaleUp(getDevice(), indent));
+	setIndentInPixels(indent);
 }
 
 void setIndentInPixels (int indent) {
@@ -2115,7 +2109,7 @@ public void setOrientation(int orientation) {
 public void setSpacing (int spacing) {
 	checkLayout();
 	if (spacing < 0) SWT.error(SWT.ERROR_INVALID_ARGUMENT);
-	setSpacingInPixels(DPIUtil.autoScaleUp(getDevice(), spacing));
+	setSpacingInPixels(spacing);
 }
 
 void setSpacingInPixels (int spacing) {
@@ -2338,7 +2332,7 @@ public void setStyle (TextStyle style, int start, int end) {
 public void setTabs(int[] tabs) {
 	checkLayout();
 	if (this.tabs == null && tabs == null) return;
-	setTabsInPixels (DPIUtil.autoScaleUp (getDevice(), tabs));
+	setTabsInPixels (tabs);
 }
 
 void setTabsInPixels (int[] tabs) {
@@ -2434,7 +2428,7 @@ public void setTextDirection (int textDirection) {
 public void setWidth (int width) {
 	checkLayout ();
 	if (width < -1 || width == 0) SWT.error(SWT.ERROR_INVALID_ARGUMENT);
-	setWidthInPixels(DPIUtil.autoScaleUp(getDevice(), width));
+	setWidthInPixels(width);
 }
 
 void setWidthInPixels (int width) {
@@ -2472,7 +2466,7 @@ void setWidth () {
 public void setWrapIndent (int wrapIndent) {
 	checkLayout();
 	if (wrapIndent < 0) return;
-	setWrapIndentInPixels(DPIUtil.autoScaleUp(getDevice(), wrapIndent));
+	setWrapIndentInPixels(wrapIndent);
 }
 
 void setWrapIndentInPixels (int wrapIndent) {


### PR DESCRIPTION
This commit introduces a dedicated `GtkDPIUtil` class to isolate GTK-specific DPI logic, improving platform separation and maintainability.

Since the GTK scaling factor is always 1, the `autoScaleUp` and `autoScaleDown` methods effectively return the input unchanged. These methods and their usages have been removed from the GTK implementation to eliminate unnecessary code.

Also clarifies that `autoScale` no longer applies to the Win32 implementation and is being decoupled accordingly.