### PR TITLE
Refactor: Move Win32-specific DPI logic to Win32DPIUtils

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT AWT/win32/org/eclipse/swt/awt/SWT_AWT.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT AWT/win32/org/eclipse/swt/awt/SWT_AWT.java
@@ -250,7 +250,7 @@ public static Frame new_Frame (final Composite parent) {
 
 	parent.getDisplay().asyncExec(() -> {
 		if (parent.isDisposed()) return;
-		final Rectangle clientArea = DPIUtil.scaleUp(parent.getClientArea(), DPIUtil.getZoomForAutoscaleProperty(parent.nativeZoom)); // To Pixels
+		final Rectangle clientArea = Win32DPIUtils.scaleUp(parent.getClientArea(), DPIUtil.getZoomForAutoscaleProperty(parent.nativeZoom)); // To Pixels
 		EventQueue.invokeLater(() -> {
 			frame.setSize (clientArea.width, clientArea.height);
 			frame.validate ();
@@ -286,7 +286,6 @@ public static Shell new_Shell (final Display display, final Canvas parent) {
 		SWT.error (SWT.ERROR_NOT_IMPLEMENTED, e);
 	}
 	if (handle == 0) SWT.error (SWT.ERROR_INVALID_ARGUMENT, null, " [peer not created]");
-
 	final Shell shell = Shell.win32_new (display, handle);
 	final ComponentListener listener = new ComponentAdapter () {
 		@Override
@@ -294,7 +293,7 @@ public static Shell new_Shell (final Display display, final Canvas parent) {
 			display.syncExec (() -> {
 				if (shell.isDisposed()) return;
 				Dimension dim = parent.getSize ();
-				shell.setSize(DPIUtil.scaleDown(new Point(dim.width, dim.height), DPIUtil.getDeviceZoom())); // To Points
+				shell.setSize(Win32DPIUtils.scaleDown(new Point(dim.width, dim.height), DPIUtil.getDeviceZoom())); // To Points
 			});
 		}
 	};

--- a/bundles/org.eclipse.swt/Eclipse SWT AWT/win32/org/eclipse/swt/awt/SWT_AWT.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT AWT/win32/org/eclipse/swt/awt/SWT_AWT.java
@@ -294,7 +294,7 @@ public static Shell new_Shell (final Display display, final Canvas parent) {
 			display.syncExec (() -> {
 				if (shell.isDisposed()) return;
 				Dimension dim = parent.getSize ();
-				shell.setSize(DPIUtil.autoScaleDown(new Point(dim.width, dim.height))); // To Points
+				shell.setSize(DPIUtil.scaleDown(new Point(dim.width, dim.height), DPIUtil.getDeviceZoom())); // To Points
 			});
 		}
 	};

--- a/bundles/org.eclipse.swt/Eclipse SWT Browser/win32/org/eclipse/swt/browser/Edge.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Browser/win32/org/eclipse/swt/browser/Edge.java
@@ -1254,8 +1254,8 @@ int handleContextMenuRequested(long pView, long pArgs) {
 	//   to PIXEL coordinates with the real native zoom value
 	//   independent from the swt.autoScale property:
 	Point pt = new Point( //
-			DPIUtil.scaleUp(win32Point.x, DPIUtil.getNativeDeviceZoom()), //
-			DPIUtil.scaleUp(win32Point.y, DPIUtil.getNativeDeviceZoom()));
+			Win32DPIUtils.scaleUp(win32Point.x, DPIUtil.getNativeDeviceZoom()), //
+			Win32DPIUtils.scaleUp(win32Point.y, DPIUtil.getNativeDeviceZoom()));
 	// - then, scale back down from PIXEL to DISPLAY coordinates, taking
 	//   swt.autoScale property into account
 	//   which is also later considered in Menu#setLocation()

--- a/bundles/org.eclipse.swt/Eclipse SWT Browser/win32/org/eclipse/swt/browser/IE.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Browser/win32/org/eclipse/swt/browser/IE.java
@@ -1880,7 +1880,7 @@ void handleDOMEvent (OleEvent e) {
 	int screenY = pVarResult.getInt();
 	pVarResult.dispose();
 
-	Point position = DPIUtil.scaleDown(new Point(screenX, screenY), DPIUtil.getDeviceZoom()); // To Points
+	Point position = Win32DPIUtils.scaleDown(new Point(screenX, screenY), DPIUtil.getDeviceZoom()); // To Points
 	position = browser.getDisplay().map(null, browser, position);
 	newEvent.x = position.x; newEvent.y = position.y;
 

--- a/bundles/org.eclipse.swt/Eclipse SWT Browser/win32/org/eclipse/swt/browser/IE.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Browser/win32/org/eclipse/swt/browser/IE.java
@@ -1880,7 +1880,7 @@ void handleDOMEvent (OleEvent e) {
 	int screenY = pVarResult.getInt();
 	pVarResult.dispose();
 
-	Point position = DPIUtil.autoScaleDown(new Point(screenX, screenY)); // To Points
+	Point position = DPIUtil.scaleDown(new Point(screenX, screenY), DPIUtil.getDeviceZoom()); // To Points
 	position = browser.getDisplay().map(null, browser, position);
 	newEvent.x = position.x; newEvent.y = position.y;
 

--- a/bundles/org.eclipse.swt/Eclipse SWT Browser/win32/org/eclipse/swt/browser/WebSite.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Browser/win32/org/eclipse/swt/browser/WebSite.java
@@ -320,8 +320,8 @@ int ShowContextMenu(int dwID, long ppt, long pcmdtReserved, long pdispReserved) 
 	Event event = new Event();
 	POINT pt = new POINT();
 	OS.MoveMemory(pt, ppt, POINT.sizeof);
-	pt.x = DPIUtil.autoScaleDown(pt.x); // To Points
-	pt.y = DPIUtil.autoScaleDown(pt.y); // To Points
+	pt.x = DPIUtil.scaleDown(pt.x, DPIUtil.getDeviceZoom()); // To Points
+	pt.y = DPIUtil.scaleDown(pt.y, DPIUtil.getDeviceZoom()); // To Points
 	event.x = pt.x;
 	event.y = pt.y;
 	browser.notifyListeners(SWT.MenuDetect, event);

--- a/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/win32/org/eclipse/swt/dnd/DragSource.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/win32/org/eclipse/swt/dnd/DragSource.java
@@ -510,7 +510,7 @@ private void drag(Event dragEvent) {
 		int offsetX = event.offsetX;
 		hwndDrag = topControl.handle;
 		if ((topControl.getStyle() & SWT.RIGHT_TO_LEFT) != 0) {
-			offsetX = DPIUtil.scaleUp(image.getBounds(), zoom).width - offsetX;
+			offsetX = Win32DPIUtils.scaleUp(image.getBounds(), zoom).width - offsetX;
 			RECT rect = new RECT ();
 			OS.GetClientRect (topControl.handle, rect);
 			hwndDrag = OS.CreateWindowEx (
@@ -538,8 +538,8 @@ private void drag(Event dragEvent) {
 		int flags = OS.RDW_UPDATENOW | OS.RDW_ALLCHILDREN;
 		OS.RedrawWindow (topControl.handle, null, 0, flags);
 		POINT pt = new POINT ();
-		pt.x = DPIUtil.scaleUp(dragEvent.x, zoom);// To Pixels
-		pt.y = DPIUtil.scaleUp(dragEvent.y, zoom);// To Pixels
+		pt.x = Win32DPIUtils.scaleUp(dragEvent.x, zoom);// To Pixels
+		pt.y = Win32DPIUtils.scaleUp(dragEvent.y, zoom);// To Pixels
 		OS.MapWindowPoints (control.handle, 0, pt, 1);
 		RECT rect = new RECT ();
 		OS.GetWindowRect (hwndDrag, rect);

--- a/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/win32/org/eclipse/swt/dnd/DropTarget.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/win32/org/eclipse/swt/dnd/DropTarget.java
@@ -410,7 +410,7 @@ private Point convertPixelToPoint(int xInPixels, int yInPixels) {
 	if (this.control == null) {
 		// If there is no control for context, the behavior remains as before
 		int zoom = DPIUtil.getZoomForAutoscaleProperty(this.nativeZoom);
-		return DPIUtil.scaleDown(new Point(xInPixels, yInPixels), zoom);
+		return Win32DPIUtils.scaleDown(new Point(xInPixels, yInPixels), zoom);
 	}
 	int zoom = DPIUtil.getZoomForAutoscaleProperty(this.control.nativeZoom);
 	// There is no API to convert absolute values in pixels to display relative
@@ -419,7 +419,7 @@ private Point convertPixelToPoint(int xInPixels, int yInPixels) {
 	POINT pt = new POINT ();
 	pt.x = xInPixels;  pt.y = yInPixels;
 	OS.ScreenToClient (this.control.handle, pt);
-	Point p = DPIUtil.scaleDown(new Point (pt.x, pt.y), zoom);
+	Point p = Win32DPIUtils.scaleDown(new Point (pt.x, pt.y), zoom);
 	return this.control.toDisplay(p);
 }
 

--- a/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/win32/org/eclipse/swt/dnd/TableDragSourceEffect.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/win32/org/eclipse/swt/dnd/TableDragSourceEffect.java
@@ -16,7 +16,6 @@ package org.eclipse.swt.dnd;
 import org.eclipse.swt.*;
 import org.eclipse.swt.graphics.*;
 import org.eclipse.swt.internal.*;
-import org.eclipse.swt.internal.DPIUtil.*;
 import org.eclipse.swt.internal.win32.*;
 import org.eclipse.swt.widgets.*;
 
@@ -147,7 +146,7 @@ public class TableDragSourceEffect extends DragSourceEffect {
 					data.transparentPixel = shdi.crColorKey << 8;
 				}
 				Display display = control.getDisplay();
-				dragSourceImage = new Image(display, new AutoScaleImageDataProvider(display, data, DPIUtil.getZoomForAutoscaleProperty(control.nativeZoom)));
+				dragSourceImage = new Image(display, new Win32DPIUtils.AutoScaleImageDataProvider(display, data, DPIUtil.getZoomForAutoscaleProperty(control.nativeZoom)));
 				OS.SelectObject (memHdc, oldMemBitmap);
 				OS.DeleteDC (memHdc);
 				OS.DeleteObject (memDib);

--- a/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/win32/org/eclipse/swt/dnd/TableDropTargetEffect.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/win32/org/eclipse/swt/dnd/TableDropTargetEffect.java
@@ -151,7 +151,7 @@ public class TableDropTargetEffect extends DropTargetEffect {
 		int effect = checkEffect(event.feedback);
 		long handle = table.handle;
 		Point coordinates = new Point(event.x, event.y);
-		coordinates = DPIUtil.scaleUp(table.toControl(coordinates), DPIUtil.getZoomForAutoscaleProperty(table.nativeZoom)); // To Pixels
+		coordinates = Win32DPIUtils.scaleUp(table.toControl(coordinates), DPIUtil.getZoomForAutoscaleProperty(table.nativeZoom)); // To Pixels
 		LVHITTESTINFO pinfo = new LVHITTESTINFO();
 		pinfo.x = coordinates.x;
 		pinfo.y = coordinates.y;

--- a/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/win32/org/eclipse/swt/dnd/TreeDragSourceEffect.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/win32/org/eclipse/swt/dnd/TreeDragSourceEffect.java
@@ -16,7 +16,6 @@ package org.eclipse.swt.dnd;
 import org.eclipse.swt.*;
 import org.eclipse.swt.graphics.*;
 import org.eclipse.swt.internal.*;
-import org.eclipse.swt.internal.DPIUtil.*;
 import org.eclipse.swt.internal.win32.*;
 import org.eclipse.swt.widgets.*;
 
@@ -146,7 +145,7 @@ public class TreeDragSourceEffect extends DragSourceEffect {
 					data.transparentPixel = shdi.crColorKey << 8;
 				}
 				Display display = control.getDisplay ();
-				dragSourceImage = new Image (display, new AutoScaleImageDataProvider(display, data, DPIUtil.getZoomForAutoscaleProperty(control.nativeZoom)));
+				dragSourceImage = new Image (display, new Win32DPIUtils.AutoScaleImageDataProvider(display, data, DPIUtil.getZoomForAutoscaleProperty(control.nativeZoom)));
 				OS.SelectObject (memHdc, oldMemBitmap);
 				OS.DeleteDC (memHdc);
 				OS.DeleteObject (memDib);

--- a/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/win32/org/eclipse/swt/dnd/TreeDropTargetEffect.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/win32/org/eclipse/swt/dnd/TreeDropTargetEffect.java
@@ -165,7 +165,7 @@ public class TreeDropTargetEffect extends DropTargetEffect {
 		int effect = checkEffect(event.feedback);
 		long handle = tree.handle;
 		Point coordinates = new Point(event.x, event.y);
-		coordinates = DPIUtil.scaleUp(tree.toControl(coordinates), DPIUtil.getZoomForAutoscaleProperty(tree.nativeZoom)); // To Pixels
+		coordinates = Win32DPIUtils.scaleUp(tree.toControl(coordinates), DPIUtil.getZoomForAutoscaleProperty(tree.nativeZoom)); // To Pixels
 		TVHITTESTINFO lpht = new TVHITTESTINFO ();
 		lpht.x = coordinates.x;
 		lpht.y = coordinates.y;

--- a/bundles/org.eclipse.swt/Eclipse SWT OLE Win32/win32/org/eclipse/swt/ole/win32/OleClientSite.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT OLE Win32/win32/org/eclipse/swt/ole/win32/OleClientSite.java
@@ -810,7 +810,7 @@ protected int GetWindow(long phwnd) {
 	return COM.S_OK;
 }
 RECT getRect() {
-	Rectangle area = DPIUtil.scaleUp(getClientArea(), DPIUtil.getZoomForAutoscaleProperty(nativeZoom)); // To Pixels
+	Rectangle area = Win32DPIUtils.scaleUp(getClientArea(), DPIUtil.getZoomForAutoscaleProperty(nativeZoom)); // To Pixels
 	RECT rect = new RECT();
 	rect.left   = area.x;
 	rect.top    = area.y;
@@ -987,14 +987,14 @@ private int OnInPlaceDeactivate() {
 	return COM.S_OK;
 }
 private int OnPosRectChange(long lprcPosRect) {
-	Point size = DPIUtil.scaleUp(getSize(), DPIUtil.getZoomForAutoscaleProperty(nativeZoom)); // To Pixels
+	Point size = Win32DPIUtils.scaleUp(getSize(), DPIUtil.getZoomForAutoscaleProperty(nativeZoom)); // To Pixels
 	setExtent(size.x, size.y);
 	return COM.S_OK;
 }
 private void onPaint(Event e) {
 	if (state == STATE_RUNNING || state == STATE_INPLACEACTIVE) {
 		SIZE size = getExtent();
-		Rectangle area = DPIUtil.scaleUp(getClientArea(), DPIUtil.getZoomForAutoscaleProperty(nativeZoom)); // To Pixels
+		Rectangle area = Win32DPIUtils.scaleUp(getClientArea(), DPIUtil.getZoomForAutoscaleProperty(nativeZoom)); // To Pixels
 		RECT rect = new RECT();
 		if (getProgramID().startsWith("Excel.Sheet")) { //$NON-NLS-1$
 			rect.left = area.x; rect.right = area.x + (area.height * size.cx / size.cy);
@@ -1370,7 +1370,7 @@ void setBorderSpace(RECT newBorderwidth) {
 }
 void setBounds() {
 	int zoom = DPIUtil.getZoomForAutoscaleProperty(nativeZoom);
-	Rectangle area = DPIUtil.scaleUp(frame.getClientArea(), zoom); // To Pixels
+	Rectangle area = Win32DPIUtils.scaleUp(frame.getClientArea(), zoom); // To Pixels
 	setBounds(DPIUtil.scaleDown(borderWidths.left, zoom),
 			  DPIUtil.scaleDown(borderWidths.top, zoom),
 			  DPIUtil.scaleDown(area.width - borderWidths.left - borderWidths.right, zoom),

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/ImageData.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/ImageData.java
@@ -2609,35 +2609,36 @@ static void buildDitheredGradientChannel(int from, int to, int steps,
  * @param redBits the number of significant red bits, 0 for palette modes
  * @param greenBits the number of significant green bits, 0 for palette modes
  * @param blueBits the number of significant blue bits, 0 for palette modes
+ * @param zoom the zoom of gc drawer used
  */
 static void fillGradientRectangle(GC gc, Device device,
 	int x, int y, int width, int height, boolean vertical,
 	RGB fromRGB, RGB toRGB,
-	int redBits, int greenBits, int blueBits) {
+	int redBits, int greenBits, int blueBits, int zoom) {
 	/* Create the bitmap and tile it */
 	ImageData band = createGradientBand(width, height, vertical,
 		fromRGB, toRGB, redBits, greenBits, blueBits);
 	Image image = new Image(device, band);
 	if ((band.width == 1) || (band.height == 1)) {
-			gc.drawImage(image, 0, 0, DPIUtil.autoScaleDown(band.width), DPIUtil.autoScaleDown(band.height),
-					DPIUtil.autoScaleDown(x), DPIUtil.autoScaleDown(y), DPIUtil.autoScaleDown(width),
-					DPIUtil.autoScaleDown(height));
+			gc.drawImage(image, 0, 0, DPIUtil.scaleDown(band.width, zoom), DPIUtil.scaleDown(band.height, zoom),
+					DPIUtil.scaleDown(x, zoom), DPIUtil.scaleDown(y, zoom), DPIUtil.scaleDown(width, zoom),
+					DPIUtil.scaleDown(height, zoom));
 		} else {
 		if (vertical) {
 			for (int dx = 0; dx < width; dx += band.width) {
 				int blitWidth = width - dx;
 				if (blitWidth > band.width) blitWidth = band.width;
-					gc.drawImage(image, 0, 0, DPIUtil.autoScaleDown(blitWidth), DPIUtil.autoScaleDown(band.height),
-							DPIUtil.autoScaleDown(dx + x), DPIUtil.autoScaleDown(y), DPIUtil.autoScaleDown(blitWidth),
-							DPIUtil.autoScaleDown(band.height));
+					gc.drawImage(image, 0, 0, DPIUtil.scaleDown(blitWidth, zoom), DPIUtil.scaleDown(band.height, zoom),
+							DPIUtil.scaleDown(dx + x, zoom), DPIUtil.scaleDown(y, zoom), DPIUtil.scaleDown(blitWidth, zoom),
+							DPIUtil.scaleDown(band.height, zoom));
 				}
 		} else {
 			for (int dy = 0; dy < height; dy += band.height) {
 				int blitHeight = height - dy;
 				if (blitHeight > band.height) blitHeight = band.height;
-					gc.drawImage(image, 0, 0, DPIUtil.autoScaleDown(band.width), DPIUtil.autoScaleDown(blitHeight),
-							DPIUtil.autoScaleDown(x), DPIUtil.autoScaleDown(dy + y), DPIUtil.autoScaleDown(band.width),
-							DPIUtil.autoScaleDown(blitHeight));
+					gc.drawImage(image, 0, 0, DPIUtil.scaleDown(band.width, zoom), DPIUtil.scaleDown(blitHeight, zoom),
+							DPIUtil.scaleDown(x, zoom), DPIUtil.scaleDown(dy + y, zoom), DPIUtil.scaleDown(band.width, zoom),
+							DPIUtil.scaleDown(blitHeight, zoom));
 				}
 		}
 	}

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/DPIUtil.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/DPIUtil.java
@@ -116,37 +116,6 @@ public class DPIUtil {
 		autoScaleMethod = AUTO_SCALE_METHOD_SETTING != AutoScaleMethod.AUTO ? AUTO_SCALE_METHOD_SETTING : AutoScaleMethod.NEAREST;
 	}
 
-/**
- * Auto-scale down ImageData
- */
-public static ImageData autoScaleDown (Device device, final ImageData imageData) {
-	if (deviceZoom == 100 || imageData == null || (device != null && !device.isAutoScalable())) return imageData;
-	float scaleFactor = 1.0f / getScalingFactor (deviceZoom);
-	return autoScaleImageData(device, imageData, scaleFactor);
-}
-
-public static int[] autoScaleDown(int[] pointArray) {
-	if (deviceZoom == 100 || pointArray == null) return pointArray;
-	float scaleFactor = getScalingFactor (deviceZoom);
-	int [] returnArray = new int[pointArray.length];
-	for (int i = 0; i < pointArray.length; i++) {
-		returnArray [i] =  Math.round (pointArray [i] / scaleFactor);
-	}
-	return returnArray;
-}
-
-public static int[] autoScaleDown(Drawable drawable, int[] pointArray) {
-	if (drawable != null && !drawable.isAutoScalable ()) return pointArray;
-	return autoScaleDown (pointArray);
-}
-
-/**
- * Auto-scale down float array dimensions.
- */
-public static float[] autoScaleDown(float size[]) {
-	return scaleDown(size, deviceZoom);
-}
-
 public static float[] scaleDown(float size[], int zoom) {
 	if (zoom == 100 || size == null) return size;
 	float scaleFactor = getScalingFactor (zoom);
@@ -157,23 +126,9 @@ public static float[] scaleDown(float size[], int zoom) {
 	return scaledSize;
 }
 
-/**
- * Auto-scale down float array dimensions if enabled for Drawable class.
- */
-public static float[] autoScaleDown(Drawable drawable, float size[]) {
-	return scaleDown(drawable, size, deviceZoom);
-}
-
 public static float[] scaleDown(Drawable drawable, float size[], int zoom) {
 	if (drawable != null && !drawable.isAutoScalable()) return size;
 	return scaleDown(size, zoom);
-}
-
-/**
- * Auto-scale down int dimensions.
- */
-public static int autoScaleDown(int size) {
-	return scaleDown(size, deviceZoom);
 }
 
 public static int scaleDown(int size, int zoom) {
@@ -182,23 +137,9 @@ public static int scaleDown(int size, int zoom) {
 	return Math.round (size / scaleFactor);
 }
 
-/**
- * Auto-scale down int dimensions if enabled for Drawable class.
- */
-public static int autoScaleDown(Drawable drawable, int size) {
-	return scaleDown(drawable, size, deviceZoom);
-}
-
 public static int scaleDown(Drawable drawable, int size, int zoom) {
 	if (drawable != null && !drawable.isAutoScalable()) return size;
 	return scaleDown (size, zoom);
-}
-
-/**
- * Auto-scale down float dimensions.
- */
-public static float autoScaleDown(float size) {
-	return scaleDown(size, deviceZoom);
 }
 
 public static float scaleDown(float size, int zoom) {
@@ -207,23 +148,9 @@ public static float scaleDown(float size, int zoom) {
 	return (size / scaleFactor);
 }
 
-/**
- * Auto-scale down float dimensions if enabled for Drawable class.
- */
-public static float autoScaleDown(Drawable drawable, float size) {
-	return scaleDown (drawable, size, deviceZoom);
-}
-
 public static float scaleDown(Drawable drawable, float size, int zoom) {
 	if (drawable != null && !drawable.isAutoScalable()) return size;
 	return scaleDown (size, zoom);
-}
-
-/**
- * Returns a new scaled down Point.
- */
-public static Point autoScaleDown(Point point) {
-	return scaleDown(point, deviceZoom);
 }
 
 public static Point scaleDown(Point point, int zoom) {
@@ -235,34 +162,13 @@ public static Point scaleDown(Point point, int zoom) {
 	return new Point.OfFloat(scaledX, scaledY);
 }
 
-/**
- * Returns a new scaled down Point if enabled for Drawable class.
- */
-public static Point autoScaleDown(Drawable drawable, Point point) {
-	return scaleDown(drawable, point, deviceZoom);
-}
-
 public static Point scaleDown(Drawable drawable, Point point, int zoom) {
 	if (drawable != null && !drawable.isAutoScalable()) return point;
 	return scaleDown (point, zoom);
 }
 
-/**
- * Returns a new scaled down Rectangle.
- */
-public static Rectangle autoScaleDown(Rectangle rect) {
-	return scaleDown(rect, deviceZoom);
-}
-
 public static Rectangle scaleDown(Rectangle rect, int zoom) {
 	return scaleBounds(rect, 100, zoom);
-}
-/**
- * Returns a new scaled down Rectangle if enabled for Drawable class.
- */
-public static Rectangle autoScaleDown(Drawable drawable, Rectangle rect) {
-	if (drawable != null && !drawable.isAutoScalable()) return rect;
-	return scaleDown(rect, deviceZoom);
 }
 
 public static Rectangle scaleDown(Drawable drawable, Rectangle rect, int zoom) {
@@ -342,17 +248,6 @@ public static ImageData autoScaleImageData (Device device, final ImageData image
 	return autoScaleImageData(device, imageData, scaleFactor);
 }
 
-/**
- * Auto-scale up ImageData to device zoom that is at 100%.
- */
-public static ImageData autoScaleUp (Device device, final ImageData imageData) {
-	return autoScaleImageData(device, imageData, 100);
-}
-
-public static int[] autoScaleUp(int[] pointArray) {
-	return scaleUp(pointArray, deviceZoom);
-}
-
 public static int[] scaleUp(int[] pointArray, int zoom) {
 	if (zoom == 100 || pointArray == null) return pointArray;
 	float scaleFactor = getScalingFactor(zoom);
@@ -363,19 +258,9 @@ public static int[] scaleUp(int[] pointArray, int zoom) {
 	return returnArray;
 }
 
-public static int[] autoScaleUp(Drawable drawable, int[] pointArray) {
-	return scaleUp(drawable, pointArray, deviceZoom);
-}
-
 public static int[] scaleUp(Drawable drawable, int[] pointArray, int zoom) {
 	if (drawable != null && !drawable.isAutoScalable()) return pointArray;
 	return scaleUp (pointArray, zoom);
-}
-/**
- * Auto-scale up int dimensions.
- */
-public static int autoScaleUp(int size) {
-	return scaleUp(size, deviceZoom);
 }
 
 /**
@@ -387,20 +272,9 @@ public static int scaleUp(int size, int zoom) {
 	return Math.round (size * scaleFactor);
 }
 
-/**
- * Auto-scale up int dimensions if enabled for Drawable class.
- */
-public static int autoScaleUp(Drawable drawable, int size) {
-	return scaleUp(drawable, size, deviceZoom);
-}
-
 public static int scaleUp(Drawable drawable, int size, int zoom) {
 	if (drawable != null && !drawable.isAutoScalable()) return size;
 	return scaleUp (size, zoom);
-}
-
-public static float autoScaleUp(float size) {
-	return scaleUp(size, deviceZoom);
 }
 
 public static float scaleUp(float size, int zoom) {
@@ -409,20 +283,9 @@ public static float scaleUp(float size, int zoom) {
 	return (size * scaleFactor);
 }
 
-public static float autoScaleUp(Drawable drawable, float size) {
-	return scaleUp(drawable, size, deviceZoom);
-}
-
 public static float scaleUp(Drawable drawable, float size, int zoom) {
 	if (drawable != null && !drawable.isAutoScalable()) return size;
 	return scaleUp (size, zoom);
-}
-
-/**
- * Returns a new scaled up Point.
- */
-public static Point autoScaleUp(Point point) {
-	return scaleUp(point, deviceZoom);
 }
 
 public static Point scaleUp(Point point, int zoom) {
@@ -434,34 +297,13 @@ public static Point scaleUp(Point point, int zoom) {
 	return new Point.OfFloat(scaledX, scaledY);
 }
 
-/**
- * Returns a new scaled up Point if enabled for Drawable class.
- */
-public static Point autoScaleUp(Drawable drawable, Point point) {
-	return scaleUp (drawable, point, deviceZoom);
-}
-
 public static Point scaleUp(Drawable drawable, Point point, int zoom) {
 	if (drawable != null && !drawable.isAutoScalable()) return point;
 	return scaleUp (point, zoom);
 }
 
-/**
- * Returns a new scaled up Rectangle.
- */
-public static Rectangle autoScaleUp(Rectangle rect) {
-	return scaleUp(rect, deviceZoom);
-}
-
 public static Rectangle scaleUp(Rectangle rect, int zoom) {
 	return scaleBounds(rect, zoom, 100);
-}
-
-/**
- * Returns a new scaled up Rectangle if enabled for Drawable class.
- */
-public static Rectangle autoScaleUp(Drawable drawable, Rectangle rect) {
-	return scaleUp(drawable, rect, deviceZoom);
 }
 
 public static Rectangle scaleUp(Drawable drawable, Rectangle rect, int zoom) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/DPIUtil.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/DPIUtil.java
@@ -59,7 +59,6 @@ public class DPIUtil {
 	private static AutoScaleMethod autoScaleMethod;
 
 	private static String autoScaleValue;
-	private static final boolean USE_CAIRO_AUTOSCALE = SWT.getPlatform().equals("gtk");
 
 	/**
 	 * System property that controls the autoScale functionality.
@@ -116,20 +115,6 @@ public class DPIUtil {
 		autoScaleMethod = AUTO_SCALE_METHOD_SETTING != AutoScaleMethod.AUTO ? AUTO_SCALE_METHOD_SETTING : AutoScaleMethod.NEAREST;
 	}
 
-public static float[] scaleDown(float size[], int zoom) {
-	if (zoom == 100 || size == null) return size;
-	float scaleFactor = getScalingFactor (zoom);
-	float scaledSize[] = new float[size.length];
-	for (int i = 0; i < scaledSize.length; i++) {
-		scaledSize[i] = size[i] / scaleFactor;
-	}
-	return scaledSize;
-}
-
-public static float[] scaleDown(Drawable drawable, float size[], int zoom) {
-	if (drawable != null && !drawable.isAutoScalable()) return size;
-	return scaleDown(size, zoom);
-}
 
 public static int scaleDown(int size, int zoom) {
 	if (zoom == 100 || size == SWT.DEFAULT) return size;
@@ -137,10 +122,6 @@ public static int scaleDown(int size, int zoom) {
 	return Math.round (size / scaleFactor);
 }
 
-public static int scaleDown(Drawable drawable, int size, int zoom) {
-	if (drawable != null && !drawable.isAutoScalable()) return size;
-	return scaleDown (size, zoom);
-}
 
 public static float scaleDown(float size, int zoom) {
 	if (zoom == 100 || size == SWT.DEFAULT) return size;
@@ -148,33 +129,6 @@ public static float scaleDown(float size, int zoom) {
 	return (size / scaleFactor);
 }
 
-public static float scaleDown(Drawable drawable, float size, int zoom) {
-	if (drawable != null && !drawable.isAutoScalable()) return size;
-	return scaleDown (size, zoom);
-}
-
-public static Point scaleDown(Point point, int zoom) {
-	if (zoom == 100 || point == null) return point;
-	Point.OfFloat fPoint = FloatAwareGeometryFactory.createFrom(point);
-	float scaleFactor = getScalingFactor(zoom);
-	float scaledX = fPoint.getX() / scaleFactor;
-	float scaledY = fPoint.getY() / scaleFactor;
-	return new Point.OfFloat(scaledX, scaledY);
-}
-
-public static Point scaleDown(Drawable drawable, Point point, int zoom) {
-	if (drawable != null && !drawable.isAutoScalable()) return point;
-	return scaleDown (point, zoom);
-}
-
-public static Rectangle scaleDown(Rectangle rect, int zoom) {
-	return scaleBounds(rect, 100, zoom);
-}
-
-public static Rectangle scaleDown(Drawable drawable, Rectangle rect, int zoom) {
-	if (drawable != null && !drawable.isAutoScalable()) return rect;
-	return scaleDown (rect, zoom);
-}
 
 /**
  * Auto-scale image with ImageData
@@ -226,20 +180,7 @@ public static boolean isSmoothScalingEnabled() {
 }
 
 /**
- * Returns a new rectangle as per the scaleFactor.
- */
-public static Rectangle scaleBounds (Rectangle rect, int targetZoom, int currentZoom) {
-	if (rect == null || targetZoom == currentZoom) return rect;
-	Rectangle.OfFloat fRect = FloatAwareGeometryFactory.createFrom(rect);
-	float scaleFactor = getScalingFactor(targetZoom, currentZoom);
-	float scaledX = fRect.getX() * scaleFactor;
-	float scaledY = fRect.getY() * scaleFactor;
-	float scaledWidth = fRect.getWidth() * scaleFactor;
-	float scaledHeight = fRect.getHeight() * scaleFactor;
-	return new Rectangle.OfFloat(scaledX, scaledY, scaledWidth, scaledHeight);
-}
 
-/**
  * Auto-scale ImageData to device zoom that are at given zoom factor.
  */
 public static ImageData autoScaleImageData (Device device, final ImageData imageData, int imageDataZoomFactor) {
@@ -248,81 +189,17 @@ public static ImageData autoScaleImageData (Device device, final ImageData image
 	return autoScaleImageData(device, imageData, scaleFactor);
 }
 
-public static int[] scaleUp(int[] pointArray, int zoom) {
-	if (zoom == 100 || pointArray == null) return pointArray;
-	float scaleFactor = getScalingFactor(zoom);
-	int[] returnArray = new int[pointArray.length];
-	for (int i = 0; i < pointArray.length; i++) {
-		returnArray [i] =  Math.round (pointArray [i] * scaleFactor);
-	}
-	return returnArray;
-}
-
-public static int[] scaleUp(Drawable drawable, int[] pointArray, int zoom) {
-	if (drawable != null && !drawable.isAutoScalable()) return pointArray;
-	return scaleUp (pointArray, zoom);
-}
-
-/**
- * Auto-scale up int dimensions to match the given zoom level
- */
-public static int scaleUp(int size, int zoom) {
-	if (zoom == 100 || size == SWT.DEFAULT) return size;
-	float scaleFactor = getScalingFactor(zoom);
-	return Math.round (size * scaleFactor);
-}
-
-public static int scaleUp(Drawable drawable, int size, int zoom) {
-	if (drawable != null && !drawable.isAutoScalable()) return size;
-	return scaleUp (size, zoom);
-}
-
-public static float scaleUp(float size, int zoom) {
-	if (zoom == 100 || size == SWT.DEFAULT) return size;
-	float scaleFactor = getScalingFactor(zoom);
-	return (size * scaleFactor);
-}
-
-public static float scaleUp(Drawable drawable, float size, int zoom) {
-	if (drawable != null && !drawable.isAutoScalable()) return size;
-	return scaleUp (size, zoom);
-}
-
-public static Point scaleUp(Point point, int zoom) {
-	if (zoom == 100 || point == null) return point;
-	Point.OfFloat fPoint = FloatAwareGeometryFactory.createFrom(point);
-	float scaleFactor = getScalingFactor(zoom);
-	float scaledX = fPoint.getX() * scaleFactor;
-	float scaledY = fPoint.getY() * scaleFactor;
-	return new Point.OfFloat(scaledX, scaledY);
-}
-
-public static Point scaleUp(Drawable drawable, Point point, int zoom) {
-	if (drawable != null && !drawable.isAutoScalable()) return point;
-	return scaleUp (point, zoom);
-}
-
-public static Rectangle scaleUp(Rectangle rect, int zoom) {
-	return scaleBounds(rect, zoom, 100);
-}
-
-public static Rectangle scaleUp(Drawable drawable, Rectangle rect, int zoom) {
-	if (drawable != null && !drawable.isAutoScalable()) return rect;
-	return scaleUp (rect, zoom);
-}
 
 /**
  * Returns scaling factor from the given device zoom
  * @return float scaling factor
  */
-private static float getScalingFactor(int zoom) {
+public static float getScalingFactor(int zoom) {
 	return getScalingFactor(zoom, 100);
 }
 
-private static float getScalingFactor(int targetZoom, int currentZoom) {
-	if (USE_CAIRO_AUTOSCALE) {
-		return 1;
-	}
+
+public static float getScalingFactor(int targetZoom, int currentZoom) {
 	if (targetZoom <= 0) {
 		targetZoom = deviceZoom;
 	}
@@ -562,37 +439,4 @@ private static boolean isSupportedAutoScaleForMonitorSpecificScaling() {
 	return false;
 }
 
-/**
- * AutoScale ImageDataProvider.
- */
-public static final class AutoScaleImageDataProvider implements ImageDataProvider {
-	Device device;
-	ImageData imageData;
-	int currentZoom;
-	public AutoScaleImageDataProvider(Device device, ImageData data, int zoom){
-		this.device = device;
-		this.imageData = data;
-		this.currentZoom = zoom;
-	}
-	@Override
-	public ImageData getImageData(int zoom) {
-		return DPIUtil.scaleImageData(device, imageData, zoom, currentZoom);
-	}
-}
-
-private class FloatAwareGeometryFactory {
-	static Rectangle.OfFloat createFrom(Rectangle rectangle) {
-		if (rectangle instanceof Rectangle.OfFloat) {
-			return (Rectangle.OfFloat) rectangle;
-		}
-		return new Rectangle.OfFloat(rectangle.x, rectangle.y, rectangle.width, rectangle.height);
-	}
-
-	static Point.OfFloat createFrom(Point point) {
-		if (point instanceof Point.OfFloat) {
-			return (Point.OfFloat) point;
-		}
-		return new Point.OfFloat(point.x, point.y);
-	}
-}
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Device.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Device.java
@@ -420,7 +420,7 @@ long EnumFontFamProc (long lpelfe, long lpntme, long FontType, long lParam) {
  */
 public Rectangle getBounds() {
 	checkDevice ();
-	return DPIUtil.scaleDown(getBoundsInPixels(), getDeviceZoom());
+	return Win32DPIUtils.scaleDown(getBoundsInPixels(), getDeviceZoom());
 }
 
 private Rectangle getBoundsInPixels () {
@@ -527,7 +527,7 @@ public Point getDPI () {
 	int dpiX = OS.GetDeviceCaps (hDC, OS.LOGPIXELSX);
 	int dpiY = OS.GetDeviceCaps (hDC, OS.LOGPIXELSY);
 	internal_dispose_GC (hDC, null);
-	return DPIUtil.scaleDown(new Point (dpiX, dpiY), DPIUtil.getZoomForAutoscaleProperty(getDeviceZoom()));
+	return Win32DPIUtils.scaleDown(new Point (dpiX, dpiY), DPIUtil.getZoomForAutoscaleProperty(getDeviceZoom()));
 }
 
 /**

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/GC.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/GC.java
@@ -505,8 +505,8 @@ private class CopyAreaToImageOperation extends Operation {
 	@Override
 	void apply() {
 		int zoom = getZoom();
-		int scaledX = DPIUtil.scaleUp(drawable, this.x, zoom);
-		int scaledY = DPIUtil.scaleUp(drawable, this.y, zoom);
+		int scaledX = Win32DPIUtils.scaleUp(drawable, this.x, zoom);
+		int scaledY = Win32DPIUtils.scaleUp(drawable, this.y, zoom);
 		copyAreaInPixels(this.image, scaledX, scaledY);
 	}
 }
@@ -579,8 +579,8 @@ private class CopyAreaOperation extends Operation {
 	@Override
 	void apply() {
 		int zoom = getZoom();
-		Rectangle sourceRect = DPIUtil.scaleUp(drawable, source, zoom);
-		Rectangle destRect = DPIUtil.scaleUp(drawable, destination, zoom);
+		Rectangle sourceRect = Win32DPIUtils.scaleUp(drawable, source, zoom);
+		Rectangle destRect = Win32DPIUtils.scaleUp(drawable, destination, zoom);
 		copyAreaInPixels(sourceRect.x, sourceRect.y, sourceRect.width, sourceRect.height, destRect.x, destRect.y, paint);
 	}
 }
@@ -839,7 +839,7 @@ private class DrawArcOperation extends Operation {
 	}
 	@Override
 	void apply() {
-		Rectangle rect = DPIUtil.scaleUp(drawable, rectangle, getZoom());
+		Rectangle rect = Win32DPIUtils.scaleUp(drawable, rectangle, getZoom());
 		drawArcInPixels(rect.x, rect.y, rect.width, rect.height, startAngle, arcAngle);
 	}
 }
@@ -932,7 +932,7 @@ private class DrawFocusOperation extends Operation {
 
 	@Override
 	void apply() {
-		Rectangle rect = DPIUtil.scaleUp(drawable, rectangle, getZoom());
+		Rectangle rect = Win32DPIUtils.scaleUp(drawable, rectangle, getZoom());
 		drawFocusInPixels(rect.x, rect.y, rect.width, rect.height);
 	}
 }
@@ -1024,7 +1024,7 @@ private class DrawImageOperation extends Operation {
 
 	@Override
 	void apply() {
-		drawImageInPixels(this.image, DPIUtil.scaleUp(drawable, this.location, getZoom()));
+		drawImageInPixels(this.image, Win32DPIUtils.scaleUp(drawable, this.location, getZoom()));
 	}
 
 	private void drawImageInPixels(Image image, Point location) {
@@ -1132,8 +1132,8 @@ private class DrawScalingImageToImageOperation extends Operation {
 
 private void drawImage(Image image, int srcX, int srcY, int srcWidth, int srcHeight, int destX, int destY,
 		int destWidth, int destHeight, int imageZoom, int scaledImageZoom) {
-	Rectangle src = DPIUtil.scaleUp(drawable, new Rectangle(srcX, srcY, srcWidth, srcHeight), scaledImageZoom);
-	Rectangle dest = DPIUtil.scaleUp(drawable, new Rectangle(destX, destY, destWidth, destHeight), imageZoom);
+	Rectangle src = Win32DPIUtils.scaleUp(drawable, new Rectangle(srcX, srcY, srcWidth, srcHeight), scaledImageZoom);
+	Rectangle dest = Win32DPIUtils.scaleUp(drawable, new Rectangle(destX, destY, destWidth, destHeight), imageZoom);
 	if (scaledImageZoom != 100) {
 		/*
 		 * This is a HACK! Due to rounding errors at fractional scale factors,
@@ -1835,8 +1835,8 @@ private class DrawLineOperation extends Operation {
 	@Override
 	void apply() {
 		int deviceZoom = getZoom();
-		Point startInPixels = DPIUtil.scaleUp (drawable, start, deviceZoom);
-		Point endInPixels = DPIUtil.scaleUp (drawable, end, deviceZoom);
+		Point startInPixels = Win32DPIUtils.scaleUp (drawable, start, deviceZoom);
+		Point endInPixels = Win32DPIUtils.scaleUp (drawable, end, deviceZoom);
 		drawLineInPixels(startInPixels.x, startInPixels.y, endInPixels.x, endInPixels.y);
 	}
 }
@@ -1898,7 +1898,7 @@ private class DrawOvalOperation extends Operation {
 
 	@Override
 	void apply() {
-		Rectangle boundsInPixels = DPIUtil.scaleUp(drawable, bounds, getZoom());
+		Rectangle boundsInPixels = Win32DPIUtils.scaleUp(drawable, bounds, getZoom());
 		drawOvalInPixels(boundsInPixels.x, boundsInPixels.y, boundsInPixels.width, boundsInPixels.height);
 	}
 }
@@ -2000,7 +2000,7 @@ private class DrawPointOperation extends Operation {
 
 	@Override
 	void apply() {
-		Point scaleUpLocation = DPIUtil.scaleUp(location, getZoom());
+		Point scaleUpLocation = Win32DPIUtils.scaleUp(location, getZoom());
 		drawPointInPixels(scaleUpLocation.x, scaleUpLocation.y);
 	}
 }
@@ -2046,7 +2046,7 @@ private class DrawPolygonOperation extends Operation {
 
 	@Override
 	void apply() {
-		drawPolygonInPixels(DPIUtil.scaleUp(drawable, pointArray, getZoom()));
+		drawPolygonInPixels(Win32DPIUtils.scaleUp(drawable, pointArray, getZoom()));
 	}
 }
 
@@ -2108,7 +2108,7 @@ private class DrawPolylineOperation extends Operation {
 
 	@Override
 	void apply() {
-		drawPolylineInPixels(DPIUtil.scaleUp(drawable, pointArray, getZoom()));
+		drawPolylineInPixels(Win32DPIUtils.scaleUp(drawable, pointArray, getZoom()));
 	}
 }
 
@@ -2173,7 +2173,7 @@ private class DrawRectangleOperation extends Operation {
 
 	@Override
 	void apply() {
-		Rectangle rect = DPIUtil.scaleUp(drawable, rectangle, getZoom());
+		Rectangle rect = Win32DPIUtils.scaleUp(drawable, rectangle, getZoom());
 		drawRectangleInPixels(rect.x, rect.y, rect.width, rect.height);
 	}
 }
@@ -2273,9 +2273,9 @@ private class DrawRoundRectangleOperation extends Operation {
 	@Override
 	void apply() {
 		int zoom = getZoom();
-		Rectangle rect = DPIUtil.scaleUp(drawable, rectangle, zoom);
-		int scaledArcWidth = DPIUtil.scaleUp (drawable, arcWidth, zoom);
-		int scaledArcHeight = DPIUtil.scaleUp (drawable, arcHeight, zoom);
+		Rectangle rect = Win32DPIUtils.scaleUp(drawable, rectangle, zoom);
+		int scaledArcWidth = Win32DPIUtils.scaleUp (drawable, arcWidth, zoom);
+		int scaledArcHeight = Win32DPIUtils.scaleUp (drawable, arcHeight, zoom);
 		drawRoundRectangleInPixels(rect.x, rect.y, rect.width, rect.height, scaledArcWidth, scaledArcHeight);
 	}
 }
@@ -2418,7 +2418,7 @@ private class DrawStringOperation extends Operation {
 
 	@Override
 	void apply() {
-		Point scaledLocation = DPIUtil.scaleUp(drawable, location, getZoom());
+		Point scaledLocation = Win32DPIUtils.scaleUp(drawable, location, getZoom());
 		drawStringInPixels(string, scaledLocation.x, scaledLocation.y, isTransparent);
 	}
 }
@@ -2604,7 +2604,7 @@ private class DrawTextOperation extends Operation {
 
 	@Override
 	void apply() {
-		Point scaledLocation = DPIUtil.scaleUp(drawable, location, getZoom());
+		Point scaledLocation = Win32DPIUtils.scaleUp(drawable, location, getZoom());
 		drawTextInPixels(string, scaledLocation.x, scaledLocation.y, flags);
 	}
 }
@@ -2997,7 +2997,7 @@ private class FillArcOperation extends Operation {
 
 	@Override
 	void apply() {
-		Rectangle rect = DPIUtil.scaleUp(drawable, bounds, getZoom());
+		Rectangle rect = Win32DPIUtils.scaleUp(drawable, bounds, getZoom());
 		fillArcInPixels(rect.x, rect.y, rect.width, rect.height, startAngle, arcAngle);
 	}
 }
@@ -3088,7 +3088,7 @@ private class FillGradientRectangleOperation extends FillRectangleOperation {
 
 	@Override
 	void apply() {
-		Rectangle rect = DPIUtil.scaleUp(drawable, rectangle, getZoom());
+		Rectangle rect = Win32DPIUtils.scaleUp(drawable, rectangle, getZoom());
 		fillGradientRectangleInPixels(rect.x, rect.y, rect.width, rect.height, vertical, getZoom());
 	}
 }
@@ -3216,7 +3216,7 @@ private class FillOvalOperation extends Operation {
 
 	@Override
 	void apply() {
-		Rectangle rect = DPIUtil.scaleUp(drawable, bounds, getZoom());
+		Rectangle rect = Win32DPIUtils.scaleUp(drawable, bounds, getZoom());
 		fillOvalInPixels(rect.x, rect.y, rect.width, rect.height);
 	}
 }
@@ -3316,7 +3316,7 @@ private class FillPolygonOperation extends Operation {
 
 	@Override
 	void apply() {
-		fillPolygonInPixels(DPIUtil.scaleUp(drawable, pointArray, getZoom()));
+		fillPolygonInPixels(Win32DPIUtils.scaleUp(drawable, pointArray, getZoom()));
 	}
 }
 
@@ -3378,7 +3378,7 @@ private class FillRectangleOperation extends Operation {
 
 	@Override
 	void apply() {
-		Rectangle scaledBounds = DPIUtil.scaleUp(drawable, rectangle, getZoom());
+		Rectangle scaledBounds = Win32DPIUtils.scaleUp(drawable, rectangle, getZoom());
 		fillRectangleInPixels(scaledBounds.x, scaledBounds.y, scaledBounds.width, scaledBounds.height);
 	}
 }
@@ -3459,9 +3459,9 @@ private class FillRoundRectangleOperation extends Operation {
 	@Override
 	void apply() {
 		int zoom = getZoom();
-		Rectangle rect = DPIUtil.scaleUp(drawable, rectangle, zoom);
-		int scaledArcWidth = DPIUtil.scaleUp (drawable, arcWidth, zoom);
-		int scaledArcHeight = DPIUtil.scaleUp (drawable, arcHeight, zoom);
+		Rectangle rect = Win32DPIUtils.scaleUp(drawable, rectangle, zoom);
+		int scaledArcWidth = Win32DPIUtils.scaleUp (drawable, arcWidth, zoom);
+		int scaledArcHeight = Win32DPIUtils.scaleUp (drawable, arcHeight, zoom);
 		fillRoundRectangleInPixels(rect.x, rect.y, rect.width, rect.height, scaledArcWidth, scaledArcHeight);
 	}
 }
@@ -3721,7 +3721,7 @@ public int getCharWidth(char ch) {
  * </ul>
  */
 public Rectangle getClipping () {
-	return DPIUtil.scaleDown(drawable, getClippingInPixels(), getZoom());
+	return Win32DPIUtils.scaleDown(drawable, getClippingInPixels(), getZoom());
 }
 
 Rectangle getClippingInPixels() {
@@ -3980,9 +3980,9 @@ public int getInterpolation() {
 public LineAttributes getLineAttributes () {
 	LineAttributes attributes = getLineAttributesInPixels();
 	int deviceZoom = getZoom();
-	attributes.width = DPIUtil.scaleDown(drawable, attributes.width, deviceZoom);
+	attributes.width = Win32DPIUtils.scaleDown(drawable, attributes.width, deviceZoom);
 	if(attributes.dash != null) {
-		attributes.dash = DPIUtil.scaleDown(drawable, attributes.dash, deviceZoom);
+		attributes.dash = Win32DPIUtils.scaleDown(drawable, attributes.dash, deviceZoom);
 	}
 	return attributes;
 }
@@ -4033,7 +4033,7 @@ public int[] getLineDash() {
 	int[] lineDashes = new int[data.lineDashes.length];
 	int deviceZoom = getZoom();
 	for (int i = 0; i < lineDashes.length; i++) {
-		lineDashes[i] = DPIUtil.scaleDown(drawable, (int)data.lineDashes[i], deviceZoom);
+		lineDashes[i] = Win32DPIUtils.scaleDown(drawable, (int)data.lineDashes[i], deviceZoom);
 	}
 	return lineDashes;
 }
@@ -4086,7 +4086,7 @@ public int getLineStyle() {
  * </ul>
  */
 public int getLineWidth () {
-	return DPIUtil.scaleDown(drawable, getLineWidthInPixels(), getZoom());
+	return Win32DPIUtils.scaleDown(drawable, getLineWidthInPixels(), getZoom());
 }
 
 int getLineWidthInPixels() {
@@ -4762,7 +4762,7 @@ private class SetClippingOperation extends Operation {
 
 	@Override
 	void apply() {
-		Rectangle rect = DPIUtil.scaleUp(drawable, rectangle, getZoom());
+		Rectangle rect = Win32DPIUtils.scaleUp(drawable, rectangle, getZoom());
 		setClippingInPixels(rect.x, rect.y, rect.width, rect.height);
 	}
 }
@@ -5129,7 +5129,7 @@ private class SetLineAttributesOperation extends Operation {
 
 	@Override
 	void apply() {
-		attributes.width = DPIUtil.scaleUp(drawable, attributes.width, getZoom());
+		attributes.width = Win32DPIUtils.scaleUp(drawable, attributes.width, getZoom());
 		setLineAttributesInPixels(attributes);
 	}
 }
@@ -5195,7 +5195,7 @@ private void setLineAttributesInPixels (LineAttributes attributes) {
 			float[] newDashes = new float[dashes.length];
 			int deviceZoom = getZoom();
 			for (int i = 0; i < newDashes.length; i++) {
-				newDashes[i] = DPIUtil.scaleUp(drawable, dashes[i], deviceZoom);
+				newDashes[i] = Win32DPIUtils.scaleUp(drawable, dashes[i], deviceZoom);
 			}
 			dashes = newDashes;
 			mask |= LINE_STYLE;
@@ -5311,7 +5311,7 @@ private class SetLineDashOperation extends Operation {
 			int deviceZoom = getZoom();
 			for (int i = 0; i < dashes.length; i++) {
 				if (dashes[i] <= 0) SWT.error(SWT.ERROR_INVALID_ARGUMENT);
-				newDashes[i] = DPIUtil.scaleUp(drawable, (float) dashes[i], deviceZoom);
+				newDashes[i] = Win32DPIUtils.scaleUp(drawable, (float) dashes[i], deviceZoom);
 				if (!changed && lineDashes[i] != newDashes[i]) changed = true;
 			}
 			if (!changed) return;
@@ -5453,7 +5453,7 @@ private class SetLineWidthOperation extends Operation {
 
 	@Override
 	void apply() {
-		int lineWidth = DPIUtil.scaleUp (drawable, width, getZoom());
+		int lineWidth = Win32DPIUtils.scaleUp (drawable, width, getZoom());
 		setLineWidthInPixels(lineWidth);
 	}
 }
@@ -5644,7 +5644,7 @@ private class SetTransformOperation extends Operation {
  */
 public Point stringExtent (String string) {
 	if (string == null) SWT.error (SWT.ERROR_NULL_ARGUMENT);
-	return DPIUtil.scaleDown(drawable, stringExtentInPixels(string), data.font.zoom);
+	return Win32DPIUtils.scaleDown(drawable, stringExtentInPixels(string), data.font.zoom);
 }
 
 Point stringExtentInPixels (String string) {
@@ -5689,7 +5689,7 @@ Point stringExtentInPixels (String string) {
  * </ul>
  */
 public Point textExtent (String string) {
-	return DPIUtil.scaleDown(drawable, textExtentInPixels(string, SWT.DRAW_DELIMITER | SWT.DRAW_TAB), getZoom());
+	return Win32DPIUtils.scaleDown(drawable, textExtentInPixels(string, SWT.DRAW_DELIMITER | SWT.DRAW_TAB), getZoom());
 }
 
 /**
@@ -5724,7 +5724,7 @@ public Point textExtent (String string) {
  * </ul>
  */
 public Point textExtent (String string, int flags) {
-	return DPIUtil.scaleDown(drawable, textExtentInPixels(string, flags), data.font.zoom);
+	return Win32DPIUtils.scaleDown(drawable, textExtentInPixels(string, flags), data.font.zoom);
 }
 
 Point textExtentInPixels(String string, int flags) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/GC.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/GC.java
@@ -3089,11 +3089,11 @@ private class FillGradientRectangleOperation extends FillRectangleOperation {
 	@Override
 	void apply() {
 		Rectangle rect = DPIUtil.scaleUp(drawable, rectangle, getZoom());
-		fillGradientRectangleInPixels(rect.x, rect.y, rect.width, rect.height, vertical);
+		fillGradientRectangleInPixels(rect.x, rect.y, rect.width, rect.height, vertical, getZoom());
 	}
 }
 
-private void fillGradientRectangleInPixels(int x, int y, int width, int height, boolean vertical) {
+private void fillGradientRectangleInPixels(int x, int y, int width, int height, boolean vertical, int zoom) {
 	if (width == 0 || height == 0) return;
 
 	RGB backgroundRGB, foregroundRGB;
@@ -3183,7 +3183,7 @@ private void fillGradientRectangleInPixels(int x, int y, int width, int height, 
 	final int bitResolution = (depth >= 24) ? 8 : (depth >= 15) ? 5 : 0;
 	ImageData.fillGradientRectangle(this, data.device,
 		x, y, width, height, vertical, fromRGB, toRGB,
-		bitResolution, bitResolution, bitResolution);
+		bitResolution, bitResolution, bitResolution, zoom);
 }
 
 /**

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Image.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Image.java
@@ -1141,7 +1141,7 @@ Rectangle getBounds(int zoom) {
 	if (zoomLevelToImageHandle.containsKey(zoom)) {
 		ImageHandle imageMetadata = zoomLevelToImageHandle.get(zoom);
 		Rectangle rectangle = new Rectangle(0, 0, imageMetadata.width, imageMetadata.height);
-		return DPIUtil.scaleBounds(rectangle, zoom, imageMetadata.zoom);
+		return Win32DPIUtils.scaleBounds(rectangle, zoom, imageMetadata.zoom);
 	}
 	return this.imageProvider.getBounds(zoom);
 }
@@ -1928,7 +1928,7 @@ private class ExistingImageHandleProviderWrapper extends AbstractImageProviderWr
 	@Override
 	protected Rectangle getBounds(int zoom) {
 		Rectangle rectangle = new Rectangle(0, 0, width, height);
-		return DPIUtil.scaleUp(rectangle, zoom);
+		return Win32DPIUtils.scaleUp(rectangle, zoom);
 	}
 
 	@Override
@@ -2004,8 +2004,8 @@ private class PlainImageDataProviderWrapper extends ImageFromImageDataProviderWr
 	@Override
 	protected Rectangle getBounds(int zoom) {
 		Rectangle rectangle = new Rectangle(0, 0, imageDataAtBaseZoom.width, imageDataAtBaseZoom.height);
-		rectangle = DPIUtil.scaleDown(rectangle, baseZoom);
-		return DPIUtil.scaleUp(rectangle, zoom);
+		rectangle = Win32DPIUtils.scaleDown(rectangle, baseZoom);
+		return Win32DPIUtils.scaleUp(rectangle, zoom);
 	}
 
 	@Override
@@ -2032,7 +2032,7 @@ private class MaskedImageDataProviderWrapper extends ImageFromImageDataProviderW
 	@Override
 	protected Rectangle getBounds(int zoom) {
 		Rectangle rectangle = new Rectangle(0, 0, srcAt100.width, srcAt100.height);
-		return DPIUtil.scaleUp(rectangle, zoom);
+		return Win32DPIUtils.scaleUp(rectangle, zoom);
 	}
 
 	@Override
@@ -2110,7 +2110,7 @@ private class PlainImageProviderWrapper extends AbstractImageProviderWrapper {
 	@Override
 	protected Rectangle getBounds(int zoom) {
 		Rectangle rectangle = new Rectangle(0, 0, width, height);
-		return DPIUtil.scaleUp(rectangle, zoom);
+		return Win32DPIUtils.scaleUp(rectangle, zoom);
 	}
 
 	@Override
@@ -2154,8 +2154,8 @@ private class PlainImageProviderWrapper extends AbstractImageProviderWrapper {
 
 	private long initHandle(int zoom) {
 		if (isDisposed()) SWT.error(SWT.ERROR_GRAPHIC_DISPOSED);
-		int scaledWidth = DPIUtil.scaleUp (width, zoom);
-		int scaledHeight = DPIUtil.scaleUp (height, zoom);
+		int scaledWidth = Win32DPIUtils.scaleUp (width, zoom);
+		int scaledHeight = Win32DPIUtils.scaleUp (height, zoom);
 		long hDC = device.internal_new_GC(null);
 		long newHandle = OS.CreateCompatibleBitmap(hDC, scaledWidth, scaledHeight);
 		/*
@@ -2534,7 +2534,7 @@ private class ImageGcDrawerWrapper extends DynamicImageProviderWrapper {
 	@Override
 	protected Rectangle getBounds(int zoom) {
 		Rectangle rectangle = new Rectangle(0, 0, width, height);
-		return DPIUtil.scaleBounds(rectangle, zoom, 100);
+		return Win32DPIUtils.scaleBounds(rectangle, zoom, 100);
 	}
 
 	@Override
@@ -2553,8 +2553,8 @@ private class ImageGcDrawerWrapper extends DynamicImageProviderWrapper {
 		int gcStyle = drawer.getGcStyle();
 		Image image;
 		if ((gcStyle & SWT.TRANSPARENT) != 0) {
-			int scaledHeight = DPIUtil.scaleUp(height, zoom);
-			int scaledWidth = DPIUtil.scaleUp(width, zoom);
+			int scaledHeight = Win32DPIUtils.scaleUp(height, zoom);
+			int scaledWidth = Win32DPIUtils.scaleUp(width, zoom);
 			/* Create a 24 bit image data with alpha channel */
 			final ImageData resultData = new ImageData (scaledWidth, scaledHeight, 24, new PaletteData (0xFF, 0xFF00, 0xFF0000));
 			resultData.alphaData = new byte [scaledWidth * scaledHeight];

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Path.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Path.java
@@ -516,8 +516,8 @@ private static class PathHandle {
 	}
 
 	boolean contains (float x, float y, GC gc, boolean outline) {
-		float xInPixels = DPIUtil.scaleUp(device, x, zoom);
-		float yInPixels = DPIUtil.scaleUp(device, y, zoom);
+		float xInPixels = Win32DPIUtils.scaleUp(device, x, zoom);
+		float yInPixels = Win32DPIUtils.scaleUp(device, y, zoom);
 		return containsInPixels(xInPixels, yInPixels, gc, outline);
 	}
 
@@ -540,7 +540,7 @@ private static class PathHandle {
 
 	void fillBounds (float[] bounds) {
 		getBoundsInPixels(bounds);
-		float[] scaledbounds= DPIUtil.scaleDown(device, bounds, zoom);
+		float[] scaledbounds= Win32DPIUtils.scaleDown(device, bounds, zoom);
 		System.arraycopy(scaledbounds, 0, bounds, 0, 4);
 	}
 
@@ -555,7 +555,7 @@ private static class PathHandle {
 
 	void fillCurrentPoint (float[] point) {
 		getCurrentPointInPixels(point);
-		float[] scaledpoint= DPIUtil.scaleDown(device, point, zoom);
+		float[] scaledpoint= Win32DPIUtils.scaleDown(device, point, zoom);
 		System.arraycopy(scaledpoint, 0, point, 0, 2);
 	}
 
@@ -566,7 +566,7 @@ private static class PathHandle {
 
 	PathData getPathData() {
 		PathData result = getPathDataInPixels();
-		result.points = DPIUtil.scaleDown(device, result.points, zoom);
+		result.points = Win32DPIUtils.scaleDown(device, result.points, zoom);
 		return result;
 	}
 
@@ -643,10 +643,10 @@ private class AddArcOperation implements Operation {
 		if (width == 0 || height == 0 || arcAngle == 0) return;
 		int zoom = pathHandle.zoom;
 		Drawable drawable = getDevice();
-		float xInPixels = DPIUtil.scaleUp(drawable, x, zoom);
-		float yInPixels = DPIUtil.scaleUp(drawable, y, zoom);
-		float widthInPixels = DPIUtil.scaleUp(drawable, width, zoom);
-		float heightInPixels = DPIUtil.scaleUp(drawable, height, zoom);
+		float xInPixels = Win32DPIUtils.scaleUp(drawable, x, zoom);
+		float yInPixels = Win32DPIUtils.scaleUp(drawable, y, zoom);
+		float widthInPixels = Win32DPIUtils.scaleUp(drawable, width, zoom);
+		float heightInPixels = Win32DPIUtils.scaleUp(drawable, height, zoom);
 		addArcInPixels(pathHandle, xInPixels, yInPixels, widthInPixels, heightInPixels, startAngle, arcAngle);
 	}
 
@@ -695,10 +695,10 @@ private class AddRectangleOperation implements Operation {
 	public void apply(PathHandle pathHandle) {
 		int zoom = pathHandle.zoom;
 		Drawable drawable = getDevice();
-		float xInPixels = DPIUtil.scaleUp(drawable, x, zoom);
-		float yInPixels = DPIUtil.scaleUp(drawable, y, zoom);
-		float widthInPixels = DPIUtil.scaleUp(drawable, width, zoom);
-		float heightInPixels = DPIUtil.scaleUp(drawable, height, zoom);
+		float xInPixels = Win32DPIUtils.scaleUp(drawable, x, zoom);
+		float yInPixels = Win32DPIUtils.scaleUp(drawable, y, zoom);
+		float widthInPixels = Win32DPIUtils.scaleUp(drawable, width, zoom);
+		float heightInPixels = Win32DPIUtils.scaleUp(drawable, height, zoom);
 		addRectangleInPixels(pathHandle, xInPixels, yInPixels, widthInPixels, heightInPixels);
 	}
 
@@ -751,8 +751,8 @@ private class AddStringOperation implements Operation {
 	public void apply(PathHandle pathHandle) {
 		int zoom = pathHandle.zoom;
 		Drawable drawable = getDevice();
-		float xInPixels = DPIUtil.scaleUp(drawable, x, zoom);
-		float yInPixels = DPIUtil.scaleUp(drawable, y, zoom);
+		float xInPixels = Win32DPIUtils.scaleUp(drawable, x, zoom);
+		float yInPixels = Win32DPIUtils.scaleUp(drawable, y, zoom);
 		addStringInPixels(pathHandle, xInPixels, yInPixels);
 	}
 
@@ -825,12 +825,12 @@ private class CubicToOperation implements Operation {
 	public void apply(PathHandle pathHandle) {
 		int zoom = pathHandle.zoom;
 		Drawable drawable = getDevice();
-		float cx1InPixels = DPIUtil.scaleUp(drawable, cx1, zoom);
-		float cy1InPixels = DPIUtil.scaleUp(drawable, cy1, zoom);
-		float cx2InPixels = DPIUtil.scaleUp(drawable, cx2, zoom);
-		float cy2InPixels = DPIUtil.scaleUp(drawable, cy2, zoom);
-		float xInPixels = DPIUtil.scaleUp(drawable, x, zoom);
-		float yInPixels = DPIUtil.scaleUp(drawable, y, zoom);
+		float cx1InPixels = Win32DPIUtils.scaleUp(drawable, cx1, zoom);
+		float cy1InPixels = Win32DPIUtils.scaleUp(drawable, cy1, zoom);
+		float cx2InPixels = Win32DPIUtils.scaleUp(drawable, cx2, zoom);
+		float cy2InPixels = Win32DPIUtils.scaleUp(drawable, cy2, zoom);
+		float xInPixels = Win32DPIUtils.scaleUp(drawable, x, zoom);
+		float yInPixels = Win32DPIUtils.scaleUp(drawable, y, zoom);
 		cubicToInPixels(pathHandle, cx1InPixels, cy1InPixels, cx2InPixels, cy2InPixels, xInPixels, yInPixels);
 	}
 
@@ -855,7 +855,7 @@ private class LineToOperation implements Operation {
 	public void apply(PathHandle pathHandle) {
 		int zoom = pathHandle.zoom;
 		Drawable drawable = getDevice();
-		lineToInPixels(pathHandle, DPIUtil.scaleUp(drawable, x, zoom), DPIUtil.scaleUp(drawable, y, zoom));
+		lineToInPixels(pathHandle, Win32DPIUtils.scaleUp(drawable, x, zoom), Win32DPIUtils.scaleUp(drawable, y, zoom));
 	}
 
 	private void lineToInPixels(PathHandle pathHandle, float x, float y) {
@@ -879,7 +879,7 @@ private class MoveToOperation implements Operation {
 	public void apply(PathHandle pathHandle) {
 		int zoom = pathHandle.zoom;
 		Drawable drawable = getDevice();
-		moveToInPixels(pathHandle, DPIUtil.scaleUp(drawable, x, zoom), DPIUtil.scaleUp(drawable, y, zoom));
+		moveToInPixels(pathHandle, Win32DPIUtils.scaleUp(drawable, x, zoom), Win32DPIUtils.scaleUp(drawable, y, zoom));
 	}
 
 	void moveToInPixels(PathHandle pathHandle, float x, float y) {
@@ -909,10 +909,10 @@ private class QuadToOperation implements Operation {
 	public void apply(PathHandle pathHandle) {
 		Drawable drawable = getDevice();
 		int zoom = pathHandle.zoom;
-		float cxInPixels = DPIUtil.scaleUp(drawable, cx, zoom);
-		float cyInPixels = DPIUtil.scaleUp(drawable, cy, zoom);
-		float xInPixels = DPIUtil.scaleUp(drawable, x, zoom);
-		float yInPixels = DPIUtil.scaleUp(drawable, y, zoom);
+		float cxInPixels = Win32DPIUtils.scaleUp(drawable, cx, zoom);
+		float cyInPixels = Win32DPIUtils.scaleUp(drawable, cy, zoom);
+		float xInPixels = Win32DPIUtils.scaleUp(drawable, x, zoom);
+		float yInPixels = Win32DPIUtils.scaleUp(drawable, y, zoom);
 		quadToInPixels(pathHandle, cxInPixels, cyInPixels, xInPixels, yInPixels);
 	}
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Pattern.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Pattern.java
@@ -261,10 +261,10 @@ private class BasePatternHandle extends PatternHandle {
 	@Override
 	long createHandle(int zoom) {
 		long handle;
-		float x1 = DPIUtil.scaleUp(baseX1, zoom);
-		float y1 = DPIUtil.scaleUp(baseY1, zoom);
-		float x2 = DPIUtil.scaleUp(baseX2, zoom);
-		float y2 = DPIUtil.scaleUp(baseY2, zoom);
+		float x1 = Win32DPIUtils.scaleUp(baseX1, zoom);
+		float y1 = Win32DPIUtils.scaleUp(baseY1, zoom);
+		float x2 = Win32DPIUtils.scaleUp(baseX2, zoom);
+		float y2 = Win32DPIUtils.scaleUp(baseY2, zoom);
 		if (color1 == null) SWT.error(SWT.ERROR_NULL_ARGUMENT);
 		if (color1.isDisposed()) SWT.error(SWT.ERROR_INVALID_ARGUMENT);
 		if (color2 == null) SWT.error(SWT.ERROR_NULL_ARGUMENT);

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Region.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Region.java
@@ -193,8 +193,8 @@ public boolean contains (int x, int y) {
 	if (isDisposed()) SWT.error(SWT.ERROR_GRAPHIC_DISPOSED);
 	return applyUsingAnyHandle(regionHandle -> {
 		int zoom = regionHandle.zoom();
-		int xInPixels = DPIUtil.scaleUp(x, zoom);
-		int yInPixels = DPIUtil.scaleUp(y, zoom);
+		int xInPixels = Win32DPIUtils.scaleUp(x, zoom);
+		int yInPixels = Win32DPIUtils.scaleUp(y, zoom);
 		return containsInPixels(regionHandle.handle(), xInPixels, yInPixels);
 	});
 }
@@ -223,7 +223,7 @@ public boolean contains (Point pt) {
 	if (pt == null) SWT.error(SWT.ERROR_NULL_ARGUMENT);
 	return applyUsingAnyHandle(regionHandle -> {
 		int zoom = regionHandle.zoom();
-		Point p = DPIUtil.scaleUp(pt, zoom);
+		Point p = Win32DPIUtils.scaleUp(pt, zoom);
 		return containsInPixels(regionHandle.handle(), p.x, p.y);
 	});
 }
@@ -280,7 +280,7 @@ public boolean equals (Object object) {
 public Rectangle getBounds () {
 	if (isDisposed()) SWT.error(SWT.ERROR_GRAPHIC_DISPOSED);
 	return applyUsingAnyHandle(regionHandle -> {
-		return DPIUtil.scaleDown(getBoundsInPixels(regionHandle.handle()), regionHandle.zoom());
+		return Win32DPIUtils.scaleDown(getBoundsInPixels(regionHandle.handle()), regionHandle.zoom());
 	});
 }
 
@@ -427,7 +427,7 @@ public boolean intersects (Rectangle rect) {
 	if (isDisposed()) SWT.error(SWT.ERROR_GRAPHIC_DISPOSED);
 	if (rect == null) SWT.error(SWT.ERROR_NULL_ARGUMENT);
 	return applyUsingAnyHandle(regionHandle -> {
-		Rectangle r = DPIUtil.scaleUp(rect, regionHandle.zoom());
+		Rectangle r = Win32DPIUtils.scaleUp(rect, regionHandle.zoom());
 		return intersectsInPixels(regionHandle.handle(), r.x, r.y, r.width, r.height);
 	});
 }
@@ -761,7 +761,7 @@ private static class OperationWithRectangle extends Operation {
 	}
 
 	private Rectangle getScaledRectangle(int zoom) {
-		return DPIUtil.scaleUp(data, zoom);
+		return Win32DPIUtils.scaleUp(data, zoom);
 	}
 
 }
@@ -809,7 +809,7 @@ private static class OperationWithArray extends Operation {
 	}
 
 	private int[] getScaledPoints(int zoom) {
-		return DPIUtil.scaleUp(data, zoom);
+		return Win32DPIUtils.scaleUp(data, zoom);
 	}
 }
 
@@ -838,7 +838,7 @@ private static class OperationWithPoint extends Operation {
 
 	@Override
 	void translate(long handle, int zoom) {
-		Point pt = DPIUtil.scaleUp((Point) data, zoom);
+		Point pt = Win32DPIUtils.scaleUp((Point) data, zoom);
 		OS.OffsetRgn (handle, pt.x, pt.y);
 	}
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/TextLayout.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/TextLayout.java
@@ -379,10 +379,10 @@ void computeRuns (GC gc) {
 	}
 	SCRIPT_LOGATTR logAttr = new SCRIPT_LOGATTR();
 	SCRIPT_PROPERTIES properties = new SCRIPT_PROPERTIES();
-	int wrapIndentInPixels = DPIUtil.scaleUp(wrapIndent, getZoom(gc));
-	int indentInPixels = DPIUtil.scaleUp(indent, getZoom(gc));
-	int wrapWidthInPixels = DPIUtil.scaleUp(wrapWidth, getZoom(gc));
-	int[] tabsInPixels = DPIUtil.scaleUp(tabs, getZoom(gc));
+	int wrapIndentInPixels = Win32DPIUtils.scaleUp(wrapIndent, getZoom(gc));
+	int indentInPixels = Win32DPIUtils.scaleUp(indent, getZoom(gc));
+	int wrapWidthInPixels = Win32DPIUtils.scaleUp(wrapWidth, getZoom(gc));
+	int[] tabsInPixels = Win32DPIUtils.scaleUp(tabs, getZoom(gc));
 	int lineWidth = indentInPixels, lineStart = 0, lineCount = 1;
 	for (int i=0; i<allRuns.length - 1; i++) {
 		StyleItem run = allRuns[i];
@@ -549,8 +549,8 @@ void computeRuns (GC gc) {
 				TEXTMETRIC lptm = new TEXTMETRIC();
 				OS.SelectObject(srcHdc, getItemFont(run, gc));
 				metricsAdapter.GetTextMetrics(srcHdc, lptm);
-				run.ascentInPoints = DPIUtil.scaleDown(getDevice(), lptm.tmAscent, getZoom(gc));
-				run.descentInPoints = DPIUtil.scaleDown(getDevice(), lptm.tmDescent, getZoom(gc));
+				run.ascentInPoints = Win32DPIUtils.scaleDown(getDevice(), lptm.tmAscent, getZoom(gc));
+				run.descentInPoints = Win32DPIUtils.scaleDown(getDevice(), lptm.tmDescent, getZoom(gc));
 				ascentInPoints = Math.max(ascentInPoints, run.ascentInPoints);
 				descentInPoints = Math.max(descentInPoints, run.descentInPoints);
 			}
@@ -835,16 +835,16 @@ void drawInPixels (GC gc, int xInPoints, int yInPoints, int selectionStart, int 
 			selectionEnd = translateOffset(Math.min(Math.max(0, selectionEnd), length - 1));
 		}
 	}
-	int x = DPIUtil.scaleUp(getDevice(), xInPoints, getZoom(gc));
+	int x = Win32DPIUtils.scaleUp(getDevice(), xInPoints, getZoom(gc));
 	RECT rect = new RECT();
 	OS.SetBkMode(hdc, OS.TRANSPARENT);
 	for (int line=0; line<runs.length; line++) {
 		int drawX = x + getLineIndentInPixel(line);
-		int drawY = DPIUtil.scaleUp(getDevice(), yInPoints + lineY[line], getZoom(gc));
+		int drawY = Win32DPIUtils.scaleUp(getDevice(), yInPoints + lineY[line], getZoom(gc));
 		StyleItem[] lineRuns = runs[line];
-		int drawYWithLineHeight = DPIUtil.scaleUp(getDevice(), yInPoints + lineY[line+1] - lineSpacingInPoints, getZoom(gc));
-		int drawYWithLineHeightWithSpacing = DPIUtil.scaleUp(getDevice(), yInPoints + lineY[line+1], getZoom(gc));
-		int lineHeight = DPIUtil.scaleUp(getDevice(), lineY[line+1] - lineY[line] - lineSpacingInPoints, getZoom(gc));
+		int drawYWithLineHeight = Win32DPIUtils.scaleUp(getDevice(), yInPoints + lineY[line+1] - lineSpacingInPoints, getZoom(gc));
+		int drawYWithLineHeightWithSpacing = Win32DPIUtils.scaleUp(getDevice(), yInPoints + lineY[line+1], getZoom(gc));
+		int lineHeight = Win32DPIUtils.scaleUp(getDevice(), lineY[line+1] - lineY[line] - lineSpacingInPoints, getZoom(gc));
 		int lineHeightWithSpacing = drawYWithLineHeightWithSpacing - drawY;
 		//Draw last line selection
 		boolean extents = false;
@@ -903,10 +903,10 @@ void drawInPixels (GC gc, int xInPoints, int yInPoints, int selectionStart, int 
 		}
 
 		//Draw the text, underline, strikeout, and border of the runs in the line
-		int baselineInPixels = Math.max(0, DPIUtil.scaleUp(getDevice(), ascent, getZoom(gc)));
+		int baselineInPixels = Math.max(0, Win32DPIUtils.scaleUp(getDevice(), ascent, getZoom(gc)));
 		int lineUnderlinePos = 0;
 		for (StyleItem run : lineRuns) {
-			baselineInPixels = Math.max(baselineInPixels, DPIUtil.scaleUp(getDevice(), run.ascentInPoints, getZoom(gc)));
+			baselineInPixels = Math.max(baselineInPixels, Win32DPIUtils.scaleUp(getDevice(), run.ascentInPoints, getZoom(gc)));
 			lineUnderlinePos = Math.min(lineUnderlinePos, run.underlinePos);
 		}
 		RECT borderClip = null, underlineClip = null, strikeoutClip = null, pRect = null;
@@ -1186,7 +1186,7 @@ RECT drawRunText(GC gc, long hdc, StyleItem run, RECT rect, int baselineInPixels
 	boolean partialSelection = hasSelection && !fullSelection && !(selectionStart > end || run.start > selectionEnd);
 	int offset = (orientation & SWT.RIGHT_TO_LEFT) != 0 ? -1 : 0;
 	int x = rect.left + offset;
-	int y = rect.top + (baselineInPixels - DPIUtil.scaleUp(getDevice(), run.ascentInPoints, getZoom(gc)));
+	int y = rect.top + (baselineInPixels - Win32DPIUtils.scaleUp(getDevice(), run.ascentInPoints, getZoom(gc)));
 	long hFont = getItemFont(run, gc);
 	OS.SelectObject(hdc, hFont);
 	if (fullSelection) {
@@ -1217,7 +1217,7 @@ RECT drawRunTextGDIP(GC gc, long graphics, StyleItem run, RECT rect, long gdipFo
 	// rendering (such as ScriptTextOut()) which put top of the character
 	// at requested position.
 	int drawY = rect.top + baselineInPixels;
-	if (run.style != null && run.style.rise != 0) drawY -= DPIUtil.scaleUp(getDevice(), run.style.rise, getZoom(gc));
+	if (run.style != null && run.style.rise != 0) drawY -= Win32DPIUtils.scaleUp(getDevice(), run.style.rise, getZoom(gc));
 
 	int drawX = rect.left;
 	long brush = color;
@@ -1369,7 +1369,7 @@ RECT drawStrikeout(GC gc, long hdc, int x, int baselineInPixels, StyleItem[] lin
 			}
 		}
 		RECT rect = new RECT();
-		int riseInPixels = DPIUtil.scaleUp(getDevice(), style.rise, getZoom(gc));
+		int riseInPixels = Win32DPIUtils.scaleUp(getDevice(), style.rise, getZoom(gc));
 		OS.SetRect(rect, x + left, baselineInPixels - run.strikeoutPos - riseInPixels, x + run.x + run.width, baselineInPixels - run.strikeoutPos + run.strikeoutThickness - riseInPixels);
 		long brush = OS.CreateSolidBrush(color);
 		OS.FillRect(hdc, rect, brush);
@@ -1419,7 +1419,7 @@ RECT drawStrikeoutGDIP(GC gc, long graphics, int x, int baselineInPixels, StyleI
 				}
 			}
 		}
-		int riseInPixels = DPIUtil.scaleUp(getDevice(), style.rise, getZoom(gc));
+		int riseInPixels = Win32DPIUtils.scaleUp(getDevice(), style.rise, getZoom(gc));
 		if (clipRect != null) {
 			int gstate = Gdip.Graphics_Save(graphics);
 			if (clipRect.left == -1) clipRect.left = 0;
@@ -1477,7 +1477,7 @@ RECT drawUnderline(GC gc, long hdc, int x, int baselineInPixels, int lineUnderli
 			}
 		}
 		RECT rect = new RECT();
-		int riseInPixels = DPIUtil.scaleUp(getDevice(), style.rise, getZoom(gc));
+		int riseInPixels = Win32DPIUtils.scaleUp(getDevice(), style.rise, getZoom(gc));
 		OS.SetRect(rect, x + left, baselineInPixels - lineUnderlinePos - riseInPixels, x + run.x + run.width, baselineInPixels - lineUnderlinePos + run.underlineThickness - riseInPixels);
 		if (clipRect != null) {
 			if (clipRect.left == -1) clipRect.left = 0;
@@ -1553,7 +1553,7 @@ RECT drawUnderline(GC gc, long hdc, int x, int baselineInPixels, int lineUnderli
 				int penStyle = style.underlineStyle == UNDERLINE_IME_DASH ? OS.PS_DASH : OS.PS_DOT;
 				long pen = OS.CreatePen(penStyle, 1, color);
 				long oldPen = OS.SelectObject(hdc, pen);
-				int descentInPixels = DPIUtil.scaleUp(getDevice(), run.descentInPoints, getZoom(gc));
+				int descentInPixels = Win32DPIUtils.scaleUp(getDevice(), run.descentInPoints, getZoom(gc));
 				OS.SetRect(rect, rect.left, baselineInPixels + descentInPixels, rect.right, baselineInPixels + descentInPixels + run.underlineThickness);
 				OS.MoveToEx(hdc, rect.left, rect.top, 0);
 				OS.LineTo(hdc, rect.right, rect.top);
@@ -1609,7 +1609,7 @@ RECT drawUnderlineGDIP (GC gc, long graphics, int x, int baselineInPixels, int l
 			}
 		}
 		RECT rect = new RECT();
-		int riseInPixels = DPIUtil.scaleUp(getDevice(), style.rise, getZoom(gc));
+		int riseInPixels = Win32DPIUtils.scaleUp(getDevice(), style.rise, getZoom(gc));
 		OS.SetRect(rect, x + left, baselineInPixels - lineUnderlinePos - riseInPixels, x + run.x + run.width, baselineInPixels - lineUnderlinePos + run.underlineThickness - riseInPixels);
 		Rect gdipRect = null;
 		if (clipRect != null) {
@@ -1705,7 +1705,7 @@ RECT drawUnderlineGDIP (GC gc, long graphics, int x, int baselineInPixels, int l
 					gstate = Gdip.Graphics_Save(graphics);
 					Gdip.Graphics_SetClip(graphics, gdipRect, Gdip.CombineModeExclude);
 				}
-				int descentInPixels = DPIUtil.scaleUp(getDevice(), run.descentInPoints, getZoom(gc));
+				int descentInPixels = Win32DPIUtils.scaleUp(getDevice(), run.descentInPoints, getZoom(gc));
 				Gdip.Graphics_DrawLine(graphics, pen, rect.left, baselineInPixels + descentInPixels, run.width - run.length, baselineInPixels + descentInPixels);
 				if (gdipRect != null) {
 					Gdip.Graphics_Restore(graphics, gstate);
@@ -1818,7 +1818,7 @@ public Rectangle getBounds () {
  */
 public Rectangle getBounds (int start, int end) {
 	checkLayout();
-	return DPIUtil.scaleDown(getDevice(), getBoundsInPixels(start, end), getZoom(null));
+	return Win32DPIUtils.scaleDown(getDevice(), getBoundsInPixels(start, end), getZoom(null));
 }
 
 Rectangle getBoundsInPixels (int start, int end) {
@@ -1864,7 +1864,7 @@ Rectangle getBoundsInPixels (int start, int end) {
 			int cx = 0;
 			if (run.style != null && run.style.metrics != null) {
 				GlyphMetrics metrics = run.style.metrics;
-				cx = DPIUtil.scaleUp(getDevice(), metrics.width, getZoom()) * (start - run.start);
+				cx = Win32DPIUtils.scaleUp(getDevice(), metrics.width, getZoom()) * (start - run.start);
 			} else if (!run.tab) {
 				int iX = ScriptCPtoX(start - run.start, false, run);
 				cx = isRTL ? run.width - iX : iX;
@@ -1879,7 +1879,7 @@ Rectangle getBoundsInPixels (int start, int end) {
 			int cx = run.width;
 			if (run.style != null && run.style.metrics != null) {
 				GlyphMetrics metrics = run.style.metrics;
-				cx = DPIUtil.scaleUp(getDevice(), metrics.width, getZoom()) * (end - run.start + 1);
+				cx = Win32DPIUtils.scaleUp(getDevice(), metrics.width, getZoom()) * (end - run.start + 1);
 			} else if (!run.tab) {
 				int iX = ScriptCPtoX(end - run.start, true, run);
 				cx = isRTL ? run.width - iX : iX;
@@ -1896,8 +1896,8 @@ Rectangle getBoundsInPixels (int start, int end) {
 		}
 		left = Math.min(left, runLead);
 		right = Math.max(right, runTrail);
-		top = Math.min(top, DPIUtil.scaleUp(lineY[lineIndex], getZoom(null)));
-		bottom = Math.max(bottom, DPIUtil.scaleUp(lineY[lineIndex + 1] - lineSpacingInPoints, getZoom(null)));
+		top = Math.min(top, Win32DPIUtils.scaleUp(lineY[lineIndex], getZoom(null)));
+		bottom = Math.max(bottom, Win32DPIUtils.scaleUp(lineY[lineIndex + 1] - lineSpacingInPoints, getZoom(null)));
 	}
 	return new Rectangle(left, top, right - left, bottom - top + getScaledVerticalIndent());
 }
@@ -2023,16 +2023,16 @@ public int getLevel (int offset) {
  */
 public Rectangle getLineBounds (int lineIndex) {
 	checkLayout();
-	return DPIUtil.scaleDown(getDevice(), getLineBoundsInPixels(lineIndex), getZoom());
+	return Win32DPIUtils.scaleDown(getDevice(), getLineBoundsInPixels(lineIndex), getZoom());
 }
 
 Rectangle getLineBoundsInPixels(int lineIndex) {
 	computeRuns(null);
 	if (!(0 <= lineIndex && lineIndex < runs.length)) SWT.error(SWT.ERROR_INVALID_RANGE);
 	int x = getLineIndentInPixel(lineIndex);
-	int y = DPIUtil.scaleUp(getDevice(), lineY[lineIndex], getZoom());
+	int y = Win32DPIUtils.scaleUp(getDevice(), lineY[lineIndex], getZoom());
 	int width = lineWidthInPixels[lineIndex];
-	int height = DPIUtil.scaleUp(getDevice(), lineY[lineIndex + 1] - lineY[lineIndex] - lineSpacingInPoints, getZoom());
+	int height = Win32DPIUtils.scaleUp(getDevice(), lineY[lineIndex + 1] - lineY[lineIndex] - lineSpacingInPoints, getZoom());
 	return new Rectangle (x, y, width, height);
 }
 
@@ -2057,14 +2057,14 @@ int getLineIndent(int lineIndex) {
 }
 
 int getLineIndentInPixel (int lineIndex) {
-	int lineIndent = DPIUtil.scaleUp(wrapIndent, getZoom());
+	int lineIndent = Win32DPIUtils.scaleUp(wrapIndent, getZoom());
 	if (lineIndex == 0) {
-		lineIndent = DPIUtil.scaleUp(indent, getZoom());
+		lineIndent = Win32DPIUtils.scaleUp(indent, getZoom());
 	} else {
 		StyleItem[] previousLine = runs[lineIndex - 1];
 		StyleItem previousRun = previousLine[previousLine.length - 1];
 		if (previousRun.lineBreak && !previousRun.softBreak) {
-			lineIndent = DPIUtil.scaleUp(indent, getZoom());
+			lineIndent = Win32DPIUtils.scaleUp(indent, getZoom());
 		}
 	}
 	if (wrapWidth != -1) {
@@ -2078,8 +2078,8 @@ int getLineIndentInPixel (int lineIndex) {
 		if (partialLine) {
 			int lineWidth = this.lineWidthInPixels[lineIndex] + lineIndent;
 			switch (alignment) {
-				case SWT.CENTER: lineIndent += (DPIUtil.scaleUp(wrapWidth, getZoom()) - lineWidth) / 2; break;
-				case SWT.RIGHT: lineIndent += DPIUtil.scaleUp(wrapWidth, getZoom()) - lineWidth; break;
+				case SWT.CENTER: lineIndent += (Win32DPIUtils.scaleUp(wrapWidth, getZoom()) - lineWidth) / 2; break;
+				case SWT.RIGHT: lineIndent += Win32DPIUtils.scaleUp(wrapWidth, getZoom()) - lineWidth; break;
 			}
 		}
 	}
@@ -2140,9 +2140,9 @@ public FontMetrics getLineMetrics (int lineIndex) {
 	metricsAdapter.GetTextMetrics(srcHdc, lptm);
 	OS.DeleteDC(srcHdc);
 	device.internal_dispose_GC(hDC, null);
-	int ascentInPoints = Math.max(DPIUtil.scaleDown(this.device, lptm.tmAscent, zoom), this.ascent);
-	int descentInPoints = Math.max(DPIUtil.scaleDown(this.device, lptm.tmDescent, zoom), this.descent);
-	int leadingInPoints = DPIUtil.scaleDown(this.device, lptm.tmInternalLeading, zoom);
+	int ascentInPoints = Math.max(Win32DPIUtils.scaleDown(this.device, lptm.tmAscent, zoom), this.ascent);
+	int descentInPoints = Math.max(Win32DPIUtils.scaleDown(this.device, lptm.tmDescent, zoom), this.descent);
+	int leadingInPoints = Win32DPIUtils.scaleDown(this.device, lptm.tmInternalLeading, zoom);
 	if (text.length() != 0) {
 		for (StyleItem run : runs[lineIndex]) {
 			if (run.ascentInPoints > ascentInPoints) {
@@ -2152,10 +2152,10 @@ public FontMetrics getLineMetrics (int lineIndex) {
 			descentInPoints = Math.max(descentInPoints, run.descentInPoints);
 		}
 	}
-	lptm.tmAscent = DPIUtil.scaleUp(this.device, ascentInPoints, zoom);
-	lptm.tmDescent = DPIUtil.scaleUp(this.device, descentInPoints, zoom);
-	lptm.tmHeight = DPIUtil.scaleUp(this.device, ascentInPoints + descentInPoints, zoom);
-	lptm.tmInternalLeading = DPIUtil.scaleUp(this.device, leadingInPoints, zoom);
+	lptm.tmAscent = Win32DPIUtils.scaleUp(this.device, ascentInPoints, zoom);
+	lptm.tmDescent = Win32DPIUtils.scaleUp(this.device, descentInPoints, zoom);
+	lptm.tmHeight = Win32DPIUtils.scaleUp(this.device, ascentInPoints + descentInPoints, zoom);
+	lptm.tmInternalLeading = Win32DPIUtils.scaleUp(this.device, leadingInPoints, zoom);
 	lptm.tmAveCharWidth = 0;
 	return FontMetrics.win32_new(lptm, nativeZoom);
 }
@@ -2199,7 +2199,7 @@ public int[] getLineOffsets () {
  */
 public Point getLocation (int offset, boolean trailing) {
 	checkLayout();
-	return DPIUtil.scaleDown(getDevice(), getLocationInPixels(offset, trailing), getZoom());
+	return Win32DPIUtils.scaleDown(getDevice(), getLocationInPixels(offset, trailing), getZoom());
 }
 
 Point getLocationInPixels (int offset, boolean trailing) {
@@ -2214,7 +2214,7 @@ Point getLocationInPixels (int offset, boolean trailing) {
 	}
 	line = Math.min(line, runs.length - 1);
 	if (offset == length) {
-		return new Point(getLineIndentInPixel(line) + lineWidthInPixels[line], DPIUtil.scaleUp(getDevice(), lineY[line], getZoom()));
+		return new Point(getLineIndentInPixel(line) + lineWidthInPixels[line], Win32DPIUtils.scaleUp(getDevice(), lineY[line], getZoom()));
 	}
 	/* For trailing use the low surrogate and for lead use the high surrogate */
 	char ch = segmentsText.charAt(offset);
@@ -2250,7 +2250,7 @@ Point getLocationInPixels (int offset, boolean trailing) {
 			int width;
 			if (run.style != null && run.style.metrics != null) {
 				GlyphMetrics metrics = run.style.metrics;
-				width = DPIUtil.scaleUp(getDevice(), metrics.width, getZoom()) * (offset - run.start + (trailing ? 1 : 0));
+				width = Win32DPIUtils.scaleUp(getDevice(), metrics.width, getZoom()) * (offset - run.start + (trailing ? 1 : 0));
 			} else if (run.tab) {
 				width = (trailing || (offset == length)) ? run.width : 0;
 			} else {
@@ -2258,7 +2258,7 @@ Point getLocationInPixels (int offset, boolean trailing) {
 				final int iX = ScriptCPtoX(runOffset, trailing, run);
 				width = (orientation & SWT.RIGHT_TO_LEFT) != 0 ? run.width - iX : iX;
 			}
-			return new Point(run.x + width, DPIUtil.scaleUp(getDevice(), lineY[line], getZoom()) + getScaledVerticalIndent());
+			return new Point(run.x + width, Win32DPIUtils.scaleUp(getDevice(), lineY[line], getZoom()) + getScaledVerticalIndent());
 		}
 	}
 	return new Point(0, 0);
@@ -2409,7 +2409,7 @@ int _getOffset(int offset, int movement, boolean forward) {
  */
 public int getOffset (Point point, int[] trailing) {
 	checkLayout();
-	if (point == null) SWT.error (SWT.ERROR_NULL_ARGUMENT);	return getOffsetInPixels(DPIUtil.scaleUp(getDevice(), point, getZoom()), trailing);
+	if (point == null) SWT.error (SWT.ERROR_NULL_ARGUMENT);	return getOffsetInPixels(Win32DPIUtils.scaleUp(getDevice(), point, getZoom()), trailing);
 }
 
 int getOffsetInPixels (Point point, int[] trailing) {
@@ -2441,7 +2441,7 @@ int getOffsetInPixels (Point point, int[] trailing) {
  */
 public int getOffset (int x, int y, int[] trailing) {
 	checkLayout();
-	return getOffsetInPixels(DPIUtil.scaleUp(getDevice(), x, getZoom()), DPIUtil.scaleUp(getDevice(), y, getZoom()), trailing);
+	return getOffsetInPixels(Win32DPIUtils.scaleUp(getDevice(), x, getZoom()), Win32DPIUtils.scaleUp(getDevice(), y, getZoom()), trailing);
 }
 
 int getOffsetInPixels (int x, int y, int[] trailing) {
@@ -2450,7 +2450,7 @@ int getOffsetInPixels (int x, int y, int[] trailing) {
 	int line;
 	int lineCount = runs.length;
 	for (line=0; line<lineCount; line++) {
-		if (DPIUtil.scaleUp(getDevice(), lineY[line + 1], getZoom()) > y) break;
+		if (Win32DPIUtils.scaleUp(getDevice(), lineY[line + 1], getZoom()) > y) break;
 	}
 	line = Math.min(line, runs.length - 1);
 	StyleItem[] lineRuns = runs[line];
@@ -2472,7 +2472,7 @@ int getOffsetInPixels (int x, int y, int[] trailing) {
 			if (run.style != null && run.style.metrics != null) {
 				GlyphMetrics metrics = run.style.metrics;
 				if (metrics.width > 0) {
-					final int metricsWidthInPixels = DPIUtil.scaleUp(getDevice(), metrics.width, getZoom());
+					final int metricsWidthInPixels = Win32DPIUtils.scaleUp(getDevice(), metrics.width, getZoom());
 					if (trailing != null) {
 						trailing[0] = (xRun % metricsWidthInPixels < metricsWidthInPixels / 2) ? 0 : 1;
 					}
@@ -2709,7 +2709,7 @@ private int getScaledVerticalIndent() {
 	if (verticalIndentInPoints == 0) {
 		return verticalIndentInPoints;
 	}
-	return DPIUtil.scaleUp(getDevice(), verticalIndentInPoints, getZoom());
+	return Win32DPIUtils.scaleUp(getDevice(), verticalIndentInPoints, getZoom());
 }
 
 /**
@@ -3918,7 +3918,7 @@ void shape (GC  gc, final long hdc, final StyleItem run) {
 			 *  equals zero for FFFC (possibly other unicode code points), the fix
 			 *  is to make sure the glyph is at least one pixel wide.
 			 */
-			run.width = DPIUtil.scaleUp(getDevice(), metrics.width, getZoom()) * Math.max (1, run.glyphCount);
+			run.width = Win32DPIUtils.scaleUp(getDevice(), metrics.width, getZoom()) * Math.max (1, run.glyphCount);
 			run.ascentInPoints = metrics.ascent;
 			run.descentInPoints = metrics.descent;
 			run.leadingInPoints = 0;
@@ -3930,9 +3930,9 @@ void shape (GC  gc, final long hdc, final StyleItem run) {
 				lptm = new TEXTMETRIC();
 				metricsAdapter.GetTextMetrics(hdc, lptm);
 			}
-			run.ascentInPoints = DPIUtil.scaleDown(getDevice(), lptm.tmAscent, getZoom(gc));
-			run.descentInPoints = DPIUtil.scaleDown(getDevice(), lptm.tmDescent, getZoom(gc));
-			run.leadingInPoints = DPIUtil.scaleDown(getDevice(), lptm.tmInternalLeading, getZoom(gc));
+			run.ascentInPoints = Win32DPIUtils.scaleDown(getDevice(), lptm.tmAscent, getZoom(gc));
+			run.descentInPoints = Win32DPIUtils.scaleDown(getDevice(), lptm.tmDescent, getZoom(gc));
+			run.leadingInPoints = Win32DPIUtils.scaleDown(getDevice(), lptm.tmInternalLeading, getZoom(gc));
 		}
 		if (lotm != null) {
 			run.underlinePos = lotm.otmsUnderscorePosition;
@@ -3942,7 +3942,7 @@ void shape (GC  gc, final long hdc, final StyleItem run) {
 		} else {
 			run.underlinePos = 1;
 			run.underlineThickness = 1;
-			run.strikeoutPos = DPIUtil.scaleUp(getDevice(), run.ascentInPoints, getZoom(gc)) / 2;
+			run.strikeoutPos = Win32DPIUtils.scaleUp(getDevice(), run.ascentInPoints, getZoom(gc)) / 2;
 			run.strikeoutThickness = 1;
 		}
 		run.ascentInPoints += style.rise;
@@ -3950,9 +3950,9 @@ void shape (GC  gc, final long hdc, final StyleItem run) {
 	} else {
 		TEXTMETRIC lptm = new TEXTMETRIC();
 		metricsAdapter.GetTextMetrics(hdc, lptm);
-		run.ascentInPoints = DPIUtil.scaleDown(getDevice(), lptm.tmAscent, getZoom(gc));
-		run.descentInPoints = DPIUtil.scaleDown(getDevice(), lptm.tmDescent, getZoom(gc));
-		run.leadingInPoints = DPIUtil.scaleDown(getDevice(), lptm.tmInternalLeading, getZoom(gc));
+		run.ascentInPoints = Win32DPIUtils.scaleDown(getDevice(), lptm.tmAscent, getZoom(gc));
+		run.descentInPoints = Win32DPIUtils.scaleDown(getDevice(), lptm.tmDescent, getZoom(gc));
+		run.leadingInPoints = Win32DPIUtils.scaleDown(getDevice(), lptm.tmInternalLeading, getZoom(gc));
 	}
 }
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Transform.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Transform.java
@@ -190,8 +190,8 @@ public void getElements(float[] elements) {
 		Gdip.Matrix_GetElements(transformHandle.handle, elements);
 		Drawable drawable = getDevice();
 		int zoom = transformHandle.zoom;
-		elements[4] = DPIUtil.scaleDown(drawable, elements[4], zoom);
-		elements[5] = DPIUtil.scaleDown(drawable, elements[5], zoom);
+		elements[4] = Win32DPIUtils.scaleDown(drawable, elements[4], zoom);
+		elements[5] = Win32DPIUtils.scaleDown(drawable, elements[5], zoom);
 		return true;
 	});
 }
@@ -372,11 +372,11 @@ public void transform(float[] pointArray) {
 	applyUsingAnyHandle(transformHandle -> {
 		int length = pointArray.length;
 		for (int i = 0; i < length; i++) {
-			pointArray[i] = DPIUtil.scaleUp(drawable, pointArray[i], transformHandle.zoom);
+			pointArray[i] = Win32DPIUtils.scaleUp(drawable, pointArray[i], transformHandle.zoom);
 		}
 		Gdip.Matrix_TransformPoints(transformHandle.handle, pointArray, length / 2);
 		for (int i = 0; i < length; i++) {
-			pointArray[i] = DPIUtil.scaleDown(drawable, pointArray[i], transformHandle.zoom);
+			pointArray[i] = Win32DPIUtils.scaleDown(drawable, pointArray[i], transformHandle.zoom);
 		}
 		return pointArray;
 	});
@@ -428,7 +428,7 @@ private class MultiplyOperation implements Operation {
 	public void apply(TransformHandle transformHandle) {
 		long handle = transformHandle.handle;
 		int zoom = transformHandle.zoom;
-		long newHandle = Gdip.Matrix_new(elements[0], elements[1], elements[2], elements[3], DPIUtil.scaleUp(elements[4], zoom), DPIUtil.scaleUp(elements[5], zoom));
+		long newHandle = Gdip.Matrix_new(elements[0], elements[1], elements[2], elements[3], Win32DPIUtils.scaleUp(elements[4], zoom), Win32DPIUtils.scaleUp(elements[5], zoom));
 		if (newHandle == 0) SWT.error(SWT.ERROR_NO_HANDLES);
 		try {
 			Gdip.Matrix_Multiply(handle, newHandle, Gdip.MatrixOrderPrepend);
@@ -476,7 +476,7 @@ private class SetElementsOperation implements Operation {
 		Drawable drawable = getDevice();
 		long handle = transformHandle.handle;
 		int zoom = transformHandle.zoom;
-		Gdip.Matrix_SetElements(handle, m11, m12, m21, m22, DPIUtil.scaleUp(drawable, dx, zoom), DPIUtil.scaleUp(drawable, dy, zoom));
+		Gdip.Matrix_SetElements(handle, m11, m12, m21, m22, Win32DPIUtils.scaleUp(drawable, dx, zoom), Win32DPIUtils.scaleUp(drawable, dy, zoom));
 	}
 }
 
@@ -502,7 +502,7 @@ private class TranslateOperation implements Operation {
 		Drawable drawable = getDevice();
 		long handle = transformHandle.handle;
 		int zoom = transformHandle.zoom;
-		Gdip.Matrix_Translate(handle, DPIUtil.scaleUp(drawable, offsetX, zoom), DPIUtil.scaleUp(drawable, offsetY, zoom), Gdip.MatrixOrderPrepend);
+		Gdip.Matrix_Translate(handle, Win32DPIUtils.scaleUp(drawable, offsetX, zoom), Win32DPIUtils.scaleUp(drawable, offsetY, zoom), Gdip.MatrixOrderPrepend);
 	}
 }
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/ImageList.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/ImageList.java
@@ -58,7 +58,7 @@ public int add (Image image) {
 		index++;
 	}
 	if (count == 0) {
-		Rectangle rect = DPIUtil.scaleBounds(image.getBounds(), zoom, 100);
+		Rectangle rect = Win32DPIUtils.scaleBounds(image.getBounds(), zoom, 100);
 		OS.ImageList_SetIconSize (handle, rect.width, rect.height);
 	}
 	setForAllHandles(index, image, count);
@@ -332,8 +332,8 @@ public int getStyle () {
 
 public long getHandle(int targetZoom) {
 	if (!zoomToHandle.containsKey(targetZoom)) {
-		int scaledWidth = DPIUtil.scaleUp(DPIUtil.scaleDown(width, this.zoom), targetZoom);
-		int scaledHeight = DPIUtil.scaleUp(DPIUtil.scaleDown(height, this.zoom), targetZoom);
+		int scaledWidth = Win32DPIUtils.scaleUp(DPIUtil.scaleDown(width, this.zoom), targetZoom);
+		int scaledHeight = Win32DPIUtils.scaleUp(DPIUtil.scaleDown(height, this.zoom), targetZoom);
 		long newImageListHandle = OS.ImageList_Create(scaledWidth, scaledHeight, flags, 16, 16);
 		int count = OS.ImageList_GetImageCount (handle);
 		for (int i = 0; i < count; i++) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/Win32DPIUtils.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/Win32DPIUtils.java
@@ -15,6 +15,8 @@ package org.eclipse.swt.internal;
 
 import java.util.function.*;
 
+import org.eclipse.swt.*;
+import org.eclipse.swt.graphics.*;
 import org.eclipse.swt.internal.win32.*;
 import org.eclipse.swt.internal.win32.version.*;
 
@@ -63,6 +65,165 @@ public class Win32DPIUtils {
 			if (previousDPIAwareness > 0) {
 				OS.SetThreadDpiAwarenessContext(previousDPIAwareness);
 			}
+		}
+	}
+
+	public static float[] scaleDown(float size[], int zoom) {
+		if (zoom == 100 || size == null) return size;
+		float scaleFactor = DPIUtil.getScalingFactor (zoom);
+		float scaledSize[] = new float[size.length];
+		for (int i = 0; i < scaledSize.length; i++) {
+			scaledSize[i] = size[i] / scaleFactor;
+		}
+		return scaledSize;
+	}
+
+	public static float[] scaleDown(Drawable drawable, float size[], int zoom) {
+		if (drawable != null && !drawable.isAutoScalable()) return size;
+		return scaleDown(size, zoom);
+	}
+
+	public static int scaleDown(Drawable drawable, int size, int zoom) {
+		if (drawable != null && !drawable.isAutoScalable()) return size;
+		return DPIUtil.scaleDown (size, zoom);
+	}
+
+	public static float scaleDown(Drawable drawable, float size, int zoom) {
+		if (drawable != null && !drawable.isAutoScalable()) return size;
+		return DPIUtil.scaleDown (size, zoom);
+	}
+
+	public static Point scaleDown(Point point, int zoom) {
+		if (zoom == 100 || point == null) return point;
+		Point.OfFloat fPoint = FloatAwareGeometryFactory.createFrom(point);
+		float scaleFactor = DPIUtil.getScalingFactor(zoom);
+		float scaledX = fPoint.getX() / scaleFactor;
+		float scaledY = fPoint.getY() / scaleFactor;
+		return new Point.OfFloat(scaledX, scaledY);
+	}
+
+	public static Point scaleDown(Drawable drawable, Point point, int zoom) {
+		if (drawable != null && !drawable.isAutoScalable()) return point;
+		return scaleDown (point, zoom);
+	}
+
+	public static Rectangle scaleDown(Rectangle rect, int zoom) {
+		return scaleBounds(rect, 100, zoom);
+	}
+
+	public static Rectangle scaleDown(Drawable drawable, Rectangle rect, int zoom) {
+		if (drawable != null && !drawable.isAutoScalable()) return rect;
+		return scaleDown (rect, zoom);
+	}
+
+	/**
+	 * Returns a new rectangle as per the scaleFactor.
+	 */
+	public static Rectangle scaleBounds (Rectangle rect, int targetZoom, int currentZoom) {
+		if (rect == null || targetZoom == currentZoom) return rect;
+		Rectangle.OfFloat fRect = FloatAwareGeometryFactory.createFrom(rect);
+		float scaleFactor = DPIUtil.getScalingFactor(targetZoom, currentZoom);
+		float scaledX = fRect.getX() * scaleFactor;
+		float scaledY = fRect.getY() * scaleFactor;
+		float scaledWidth = fRect.getWidth() * scaleFactor;
+		float scaledHeight = fRect.getHeight() * scaleFactor;
+		return new Rectangle.OfFloat(scaledX, scaledY, scaledWidth, scaledHeight);
+	}
+
+	public static int[] scaleUp(int[] pointArray, int zoom) {
+		if (zoom == 100 || pointArray == null) return pointArray;
+		float scaleFactor = DPIUtil.getScalingFactor(zoom);
+		int[] returnArray = new int[pointArray.length];
+		for (int i = 0; i < pointArray.length; i++) {
+			returnArray [i] =  Math.round (pointArray [i] * scaleFactor);
+		}
+		return returnArray;
+	}
+
+	public static int[] scaleUp(Drawable drawable, int[] pointArray, int zoom) {
+		if (drawable != null && !drawable.isAutoScalable()) return pointArray;
+		return scaleUp (pointArray, zoom);
+	}
+
+	/**
+	 * Auto-scale up int dimensions to match the given zoom level
+	 */
+	public static int scaleUp(int size, int zoom) {
+		if (zoom == 100 || size == SWT.DEFAULT) return size;
+		float scaleFactor = DPIUtil.getScalingFactor(zoom);
+		return Math.round (size * scaleFactor);
+	}
+
+	public static int scaleUp(Drawable drawable, int size, int zoom) {
+		if (drawable != null && !drawable.isAutoScalable()) return size;
+		return scaleUp (size, zoom);
+	}
+
+	public static float scaleUp(float size, int zoom) {
+		if (zoom == 100 || size == SWT.DEFAULT) return size;
+		float scaleFactor = DPIUtil.getScalingFactor(zoom);
+		return (size * scaleFactor);
+	}
+
+	public static float scaleUp(Drawable drawable, float size, int zoom) {
+		if (drawable != null && !drawable.isAutoScalable()) return size;
+		return scaleUp (size, zoom);
+	}
+
+	public static Point scaleUp(Point point, int zoom) {
+		if (zoom == 100 || point == null) return point;
+		Point.OfFloat fPoint = FloatAwareGeometryFactory.createFrom(point);
+		float scaleFactor = DPIUtil.getScalingFactor(zoom);
+		float scaledX = fPoint.getX() * scaleFactor;
+		float scaledY = fPoint.getY() * scaleFactor;
+		return new Point.OfFloat(scaledX, scaledY);
+	}
+
+	public static Point scaleUp(Drawable drawable, Point point, int zoom) {
+		if (drawable != null && !drawable.isAutoScalable()) return point;
+		return scaleUp (point, zoom);
+	}
+
+	public static Rectangle scaleUp(Rectangle rect, int zoom) {
+		return scaleBounds(rect, zoom, 100);
+	}
+
+	public static Rectangle scaleUp(Drawable drawable, Rectangle rect, int zoom) {
+		if (drawable != null && !drawable.isAutoScalable()) return rect;
+		return scaleUp (rect, zoom);
+	}
+
+	/**
+	 * AutoScale ImageDataProvider.
+	 */
+	public static final class AutoScaleImageDataProvider implements ImageDataProvider {
+		Device device;
+		ImageData imageData;
+		int currentZoom;
+		public AutoScaleImageDataProvider(Device device, ImageData data, int zoom){
+			this.device = device;
+			this.imageData = data;
+			this.currentZoom = zoom;
+		}
+		@Override
+		public ImageData getImageData(int zoom) {
+			return DPIUtil.scaleImageData(device, imageData, zoom, currentZoom);
+		}
+	}
+
+	private class FloatAwareGeometryFactory {
+		static Rectangle.OfFloat createFrom(Rectangle rectangle) {
+			if (rectangle instanceof Rectangle.OfFloat) {
+				return (Rectangle.OfFloat) rectangle;
+			}
+			return new Rectangle.OfFloat(rectangle.x, rectangle.y, rectangle.width, rectangle.height);
+		}
+
+		static Point.OfFloat createFrom(Point point) {
+			if (point instanceof Point.OfFloat) {
+				return (Point.OfFloat) point;
+			}
+			return new Point.OfFloat(point.x, point.y);
 		}
 	}
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Button.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Button.java
@@ -297,7 +297,7 @@ int computeLeftMargin () {
 	if ((style & (SWT.PUSH | SWT.TOGGLE)) == 0) return MARGIN;
 	int margin = 0;
 	if (image != null && text.length () != 0) {
-		Rectangle bounds = DPIUtil.scaleBounds(image.getBounds(), this.getZoom(), 100);
+		Rectangle bounds = Win32DPIUtils.scaleBounds(image.getBounds(), this.getZoom(), 100);
 		margin += bounds.width + MARGIN * 2;
 		long oldFont = 0;
 		long hDC = OS.GetDC (handle);
@@ -359,13 +359,13 @@ int computeLeftMargin () {
 			boolean hasImage = image != null, hasText = true;
 			if (hasImage) {
 				if (image != null) {
-					Rectangle rect = DPIUtil.scaleBounds(image.getBounds(), this.getZoom(), 100);
+					Rectangle rect = Win32DPIUtils.scaleBounds(image.getBounds(), this.getZoom(), 100);
 					width = rect.width;
 					if (hasText && text.length () != 0) {
-						width += DPIUtil.scaleUp(MARGIN * 2, getZoom());;
+						width += Win32DPIUtils.scaleUp(MARGIN * 2, getZoom());;
 					}
 					height = rect.height;
-					extra = DPIUtil.scaleUp(MARGIN * 2, getZoom());;
+					extra = Win32DPIUtils.scaleUp(MARGIN * 2, getZoom());;
 				}
 			}
 			if (hasText) {
@@ -379,7 +379,7 @@ int computeLeftMargin () {
 				if (length == 0) {
 					height = Math.max (height, lptm.tmHeight);
 				} else {
-					extra = Math.max (DPIUtil.scaleUp(MARGIN * 2, getZoom()), lptm.tmAveCharWidth);
+					extra = Math.max (Win32DPIUtils.scaleUp(MARGIN * 2, getZoom()), lptm.tmAveCharWidth);
 					char [] buffer = text.toCharArray ();
 					RECT rect = new RECT ();
 					int flags = OS.DT_CALCRECT | OS.DT_SINGLELINE;
@@ -1315,7 +1315,7 @@ private int getCheckboxTextOffset(long hdc) {
 		OS.GetThemePartSize(display.hButtonTheme(nativeZoom), hdc, OS.BP_CHECKBOX, OS.CBS_UNCHECKEDNORMAL, null, OS.TS_TRUE, size);
 		result += size.cx;
 	} else {
-		result += DPIUtil.scaleUp(13, nativeZoom);
+		result += Win32DPIUtils.scaleUp(13, nativeZoom);
 	}
 
 	// Windows uses half width of '0' as checkbox-to-text distance.
@@ -1392,7 +1392,7 @@ LRESULT wmNotifyChild (NMHDR hdr, long wParam, long lParam) {
 							GC gc = createNewGC(nmcd.hdc, data);
 
 							int margin = computeLeftMargin();
-							Rectangle imageBounds = DPIUtil.scaleBounds(image.getBounds(), this.getZoom(), 100);
+							Rectangle imageBounds = Win32DPIUtils.scaleBounds(image.getBounds(), this.getZoom(), 100);
 							int imageWidth = imageBounds.width;
 							left += (imageWidth + (isRadioOrCheck() ? 2 * MARGIN : MARGIN)); // for SWT.RIGHT_TO_LEFT right and left are inverted
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Canvas.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Canvas.java
@@ -104,7 +104,7 @@ public Canvas (Composite parent, int style) {
  */
 public void drawBackground (GC gc, int x, int y, int width, int height) {
 	int zoom = getZoom();
-	Rectangle rectangle = DPIUtil.scaleUp(new Rectangle(x, y, width, height), zoom);
+	Rectangle rectangle = Win32DPIUtils.scaleUp(new Rectangle(x, y, width, height), zoom);
 	drawBackgroundInPixels(gc, rectangle.x, rectangle.y, rectangle.width, rectangle.height, 0, 0);
 }
 
@@ -198,9 +198,9 @@ void reskinChildren (int flags) {
 public void scroll (int destX, int destY, int x, int y, int width, int height, boolean all) {
 	checkWidget ();
 	int zoom = getZoom();
-	destX = DPIUtil.scaleUp(destX, zoom);
-	destY = DPIUtil.scaleUp(destY, zoom);
-	Rectangle rectangle = DPIUtil.scaleUp(new Rectangle(x, y, width, height), zoom);
+	destX = Win32DPIUtils.scaleUp(destX, zoom);
+	destY = Win32DPIUtils.scaleUp(destY, zoom);
+	Rectangle rectangle = Win32DPIUtils.scaleUp(new Rectangle(x, y, width, height), zoom);
 	scrollInPixels(destX, destY, rectangle.x, rectangle.y, rectangle.width, rectangle.height, all);
 }
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Caret.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Caret.java
@@ -121,12 +121,12 @@ long defaultFont () {
  */
 public Rectangle getBounds () {
 	checkWidget();
-	return DPIUtil.scaleDown(getBoundsInPixels(), getZoom());
+	return Win32DPIUtils.scaleDown(getBoundsInPixels(), getZoom());
 }
 
 Rectangle getBoundsInPixels () {
 	if (image != null) {
-		Rectangle rect = DPIUtil.scaleUp(image.getBounds(), getZoom());
+		Rectangle rect = Win32DPIUtils.scaleUp(image.getBounds(), getZoom());
 		return new Rectangle (getXInPixels(), getYInPixels(), rect.width, rect.height);
 	}
 	if (width == 0) {
@@ -215,12 +215,12 @@ public Canvas getParent () {
  */
 public Point getSize () {
 	checkWidget();
-	return DPIUtil.scaleDown(getSizeInPixels(), getZoom());
+	return Win32DPIUtils.scaleDown(getSizeInPixels(), getZoom());
 }
 
 Point getSizeInPixels () {
 	if (image != null) {
-		Rectangle rect = DPIUtil.scaleUp(image.getBounds(), getZoom());
+		Rectangle rect = Win32DPIUtils.scaleUp(image.getBounds(), getZoom());
 		return new Point (rect.width, rect.height);
 	}
 	if (width == 0) {
@@ -233,19 +233,19 @@ Point getSizeInPixels () {
 }
 
 private int getWidthInPixels() {
-	return DPIUtil.scaleUp(width, getZoom());
+	return Win32DPIUtils.scaleUp(width, getZoom());
 }
 
 private int getHeightInPixels() {
-	return DPIUtil.scaleUp(height, getZoom());
+	return Win32DPIUtils.scaleUp(height, getZoom());
 }
 
 private int getXInPixels() {
-	return DPIUtil.scaleUp(x, getZoom());
+	return Win32DPIUtils.scaleUp(x, getZoom());
 }
 
 private int getYInPixels() {
-	return DPIUtil.scaleUp(y, getZoom());
+	return Win32DPIUtils.scaleUp(y, getZoom());
 }
 
 /**

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Combo.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Combo.java
@@ -911,7 +911,7 @@ boolean dragDetect (long hwnd, int x, int y, boolean filter, boolean [] detect, 
  */
 public Point getCaretLocation () {
 	checkWidget ();
-	return DPIUtil.scaleDown(getCaretLocationInPixels(), getZoom());
+	return Win32DPIUtils.scaleDown(getCaretLocationInPixels(), getZoom());
 }
 
 Point getCaretLocationInPixels () {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Composite.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Composite.java
@@ -219,7 +219,7 @@ Point computeSizeInPixels (int wHint, int hHint, boolean changed) {
 			changed |= (state & LAYOUT_CHANGED) != 0;
 			state &= ~LAYOUT_CHANGED;
 			int zoom = getZoom();
-			size = DPIUtil.scaleUp(layout.computeSize (this, DPIUtil.scaleDown(wHint, zoom), DPIUtil.scaleDown(hHint, zoom), changed), zoom);
+			size = Win32DPIUtils.scaleUp(layout.computeSize (this, DPIUtil.scaleDown(wHint, zoom), DPIUtil.scaleDown(hHint, zoom), changed), zoom);
 		} else {
 			size = new Point (wHint, hHint);
 		}
@@ -235,7 +235,7 @@ Point computeSizeInPixels (int wHint, int hHint, boolean changed) {
 	 * call computeTrimInPixels directly.
 	 */
 	int zoom = getZoom();
-	Rectangle trim = DPIUtil.scaleUp(computeTrim (0, 0, DPIUtil.scaleDown(size.x, zoom), DPIUtil.scaleDown(size.y, zoom)), zoom);
+	Rectangle trim = Win32DPIUtils.scaleUp(computeTrim (0, 0, DPIUtil.scaleDown(size.x, zoom), DPIUtil.scaleDown(size.y, zoom)), zoom);
 	return new Point (trim.width, trim.height);
 }
 
@@ -356,9 +356,9 @@ int applyThemeBackground () {
 public void drawBackground (GC gc, int x, int y, int width, int height, int offsetX, int offsetY) {
 	checkWidget ();
 	int zoom = getZoom();
-	Rectangle rectangle = DPIUtil.scaleUp(new Rectangle(x, y, width, height), zoom);
-	offsetX = DPIUtil.scaleUp(offsetX, zoom);
-	offsetY = DPIUtil.scaleUp(offsetY, zoom);
+	Rectangle rectangle = Win32DPIUtils.scaleUp(new Rectangle(x, y, width, height), zoom);
+	offsetX = Win32DPIUtils.scaleUp(offsetX, zoom);
+	offsetY = Win32DPIUtils.scaleUp(offsetY, zoom);
 	drawBackgroundInPixels(gc, rectangle.x, rectangle.y, rectangle.width, rectangle.height, offsetX, offsetY);
 }
 
@@ -879,10 +879,10 @@ Point minimumSize (int wHint, int hHint, boolean changed) {
 	 * call getClientAreaInPixels directly.
 	 */
 	int zoom = getZoom();
-	Rectangle clientArea = DPIUtil.scaleUp(getClientArea (), zoom);
+	Rectangle clientArea = Win32DPIUtils.scaleUp(getClientArea (), zoom);
 	int width = 0, height = 0;
 	for (Control element : _getChildren ()) {
-		Rectangle rect = DPIUtil.scaleUp(element.getBounds (), zoom);
+		Rectangle rect = Win32DPIUtils.scaleUp(element.getBounds (), zoom);
 		width = Math.max (width, rect.x - clientArea.x + rect.width);
 		height = Math.max (height, rect.y - clientArea.y + rect.height);
 	}
@@ -1539,7 +1539,7 @@ LRESULT WM_PAINT (long wParam, long lParam) {
 
 					Event event = new Event ();
 					event.gc = gc;
-					event.setBounds(DPIUtil.scaleDown(new Rectangle(ps.left, ps.top, width, height), getZoom()));
+					event.setBounds(Win32DPIUtils.scaleDown(new Rectangle(ps.left, ps.top, width, height), getZoom()));
 					sendEvent (SWT.Paint, event);
 					if (data.focusDrawn && !isDisposed ()) updateUIState ();
 					gc.dispose ();
@@ -1622,7 +1622,7 @@ LRESULT WM_PAINT (long wParam, long lParam) {
 						if ((style & (SWT.DOUBLE_BUFFERED | SWT.NO_BACKGROUND | SWT.TRANSPARENT)) == 0) {
 							drawBackground (gc.handle, rect);
 						}
-						event.setBounds(DPIUtil.scaleDown(new Rectangle(rect.left, rect.top, rect.right - rect.left, rect.bottom - rect.top), zoom));
+						event.setBounds(Win32DPIUtils.scaleDown(new Rectangle(rect.left, rect.top, rect.right - rect.left, rect.bottom - rect.top), zoom));
 						event.count = count - 1 - i;
 						sendEvent (SWT.Paint, event);
 					}
@@ -1632,7 +1632,7 @@ LRESULT WM_PAINT (long wParam, long lParam) {
 						OS.SetRect (rect, ps.left, ps.top, ps.right, ps.bottom);
 						drawBackground (gc.handle, rect);
 					}
-					event.setBounds(DPIUtil.scaleDown(new Rectangle(ps.left, ps.top, width, height), zoom));
+					event.setBounds(Win32DPIUtils.scaleDown(new Rectangle(ps.left, ps.top, width, height), zoom));
 					sendEvent (SWT.Paint, event);
 				}
 				// widget could be disposed at this point
@@ -1707,7 +1707,7 @@ LRESULT WM_PRINTCLIENT (long wParam, long lParam) {
 			GC gc = createNewGC(wParam, data);
 			Event event = new Event ();
 			event.gc = gc;
-			event.setBounds(DPIUtil.scaleDown(new Rectangle(rect.left, rect.top, rect.right - rect.left, rect.bottom - rect.top), getZoom()));
+			event.setBounds(Win32DPIUtils.scaleDown(new Rectangle(rect.left, rect.top, rect.right - rect.left, rect.bottom - rect.top), getZoom()));
 			sendEvent (SWT.Paint, event);
 			event.gc = null;
 			gc.dispose ();

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Control.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Control.java
@@ -618,9 +618,9 @@ public Point computeSize (int wHint, int hHint) {
 public Point computeSize (int wHint, int hHint, boolean changed){
 	checkWidget ();
 	int zoom = getZoom();
-	wHint = (wHint != SWT.DEFAULT ? DPIUtil.scaleUp(wHint, zoom) : wHint);
-	hHint = (hHint != SWT.DEFAULT ? DPIUtil.scaleUp(hHint, zoom) : hHint);
-	return DPIUtil.scaleDown(computeSizeInPixels(wHint, hHint, changed), zoom);
+	wHint = (wHint != SWT.DEFAULT ? Win32DPIUtils.scaleUp(wHint, zoom) : wHint);
+	hHint = (hHint != SWT.DEFAULT ? Win32DPIUtils.scaleUp(hHint, zoom) : hHint);
+	return Win32DPIUtils.scaleDown(computeSizeInPixels(wHint, hHint, changed), zoom);
 }
 
 Point computeSizeInPixels (int wHint, int hHint, boolean changed) {
@@ -782,7 +782,7 @@ public boolean dragDetect (Event event) {
 	if (event == null) error (SWT.ERROR_NULL_ARGUMENT);
 	Point loc = event.getLocation();
 	int zoom = getZoom();
-	return dragDetect (event.button, event.count, event.stateMask, DPIUtil.scaleUp(loc.x, zoom), DPIUtil.scaleUp(loc.y, zoom));
+	return dragDetect (event.button, event.count, event.stateMask, Win32DPIUtils.scaleUp(loc.x, zoom), Win32DPIUtils.scaleUp(loc.y, zoom));
 }
 
 /**
@@ -825,7 +825,7 @@ public boolean dragDetect (MouseEvent event) {
 	checkWidget ();
 	if (event == null) error (SWT.ERROR_NULL_ARGUMENT);
 	int zoom = getZoom();
-	return dragDetect (event.button, event.count, event.stateMask, DPIUtil.scaleUp(event.x, zoom), DPIUtil.scaleUp(event.y, zoom)); // To Pixels
+	return dragDetect (event.button, event.count, event.stateMask, Win32DPIUtils.scaleUp(event.x, zoom), Win32DPIUtils.scaleUp(event.y, zoom)); // To Pixels
 }
 
 boolean dragDetect (int button, int count, int stateMask, int x, int y) {
@@ -1199,7 +1199,7 @@ int getBorderWidthInPixels () {
  */
 public Rectangle getBounds (){
 	checkWidget ();
-	return DPIUtil.scaleDown(getBoundsInPixels (), getZoom());
+	return Win32DPIUtils.scaleDown(getBoundsInPixels (), getZoom());
 }
 
 Rectangle getBoundsInPixels () {
@@ -1372,7 +1372,7 @@ public Object getLayoutData () {
  */
 public Point getLocation () {
 	checkWidget ();
-	return DPIUtil.scaleDown(getLocationInPixels(), getZoom());
+	return Win32DPIUtils.scaleDown(getLocationInPixels(), getZoom());
 }
 
 Point getLocationInPixels () {
@@ -1528,7 +1528,7 @@ public Shell getShell () {
  */
 public Point getSize (){
 	checkWidget ();
-	return DPIUtil.scaleDown(getSizeInPixels (), getZoom());
+	return Win32DPIUtils.scaleDown(getSizeInPixels (), getZoom());
 }
 
 Point getSizeInPixels () {
@@ -1987,8 +1987,8 @@ void mapEvent (long hwnd, Event event) {
 		POINT point = new POINT ();
 		Point loc = event.getLocation();
 		int zoom = getZoom();
-		point.x = DPIUtil.scaleUp(loc.x, zoom);
-		point.y = DPIUtil.scaleUp(loc.y, zoom);
+		point.x = Win32DPIUtils.scaleUp(loc.x, zoom);
+		point.y = Win32DPIUtils.scaleUp(loc.y, zoom);
 		OS.MapWindowPoints (hwnd, handle, point, 1);
 		event.setLocation(DPIUtil.scaleDown(point.x, zoom), DPIUtil.scaleDown(point.y, zoom));
 	}
@@ -2450,7 +2450,7 @@ public void redraw (int x, int y, int width, int height, boolean all) {
 	checkWidget ();
 	int zoom = getZoom();
 	if (width <= 0 || height <= 0) return;
-	Rectangle rectangle = DPIUtil.scaleUp(new Rectangle(x, y, width, height), zoom);
+	Rectangle rectangle = Win32DPIUtils.scaleUp(new Rectangle(x, y, width, height), zoom);
 
 	RECT rect = new RECT ();
 	OS.SetRect (rect, rectangle.x, rectangle.y, rectangle.x + rectangle.width, rectangle.y + rectangle.height);
@@ -3264,7 +3264,7 @@ public void setBounds (Rectangle rect) {
 	checkWidget ();
 	if (rect == null) error (SWT.ERROR_NULL_ARGUMENT);
 	int zoom = autoScaleDisabled ? parent.getZoom() : getZoom();
-	setBoundsInPixels(DPIUtil.scaleUp(rect, zoom));
+	setBoundsInPixels(Win32DPIUtils.scaleUp(rect, zoom));
 }
 
 void setBoundsInPixels (Rectangle rect) {
@@ -3522,8 +3522,8 @@ public void setLayoutData (Object layoutData) {
 public void setLocation (int x, int y) {
 	checkWidget ();
 	int zoom = getZoom();
-	x = DPIUtil.scaleUp(x, zoom);
-	y = DPIUtil.scaleUp(y, zoom);
+	x = Win32DPIUtils.scaleUp(x, zoom);
+	y = Win32DPIUtils.scaleUp(y, zoom);
 	setLocationInPixels(x, y);
 }
 
@@ -3552,7 +3552,7 @@ void setLocationInPixels (int x, int y) {
 public void setLocation (Point location) {
 	checkWidget ();
 	if (location == null) error (SWT.ERROR_NULL_ARGUMENT);
-	location = DPIUtil.scaleUp(location, getZoom());
+	location = Win32DPIUtils.scaleUp(location, getZoom());
 	setLocationInPixels(location.x, location.y);
 }
 
@@ -3779,8 +3779,8 @@ public void setRegion (Region region) {
 public void setSize (int width, int height) {
 	checkWidget ();
 	int zoom = getZoom();
-	width = DPIUtil.scaleUp(width, zoom);
-	height = DPIUtil.scaleUp(height, zoom);
+	width = Win32DPIUtils.scaleUp(width, zoom);
+	height = Win32DPIUtils.scaleUp(height, zoom);
 	setSizeInPixels(width, height);
 }
 
@@ -3815,7 +3815,7 @@ void setSizeInPixels (int width, int height) {
 public void setSize (Point size) {
 	checkWidget ();
 	if (size == null) error (SWT.ERROR_NULL_ARGUMENT);
-	size = DPIUtil.scaleUp(size, getZoom());
+	size = Win32DPIUtils.scaleUp(size, getZoom());
 	setSizeInPixels(size.x, size.y);
 }
 
@@ -4031,7 +4031,7 @@ public Point toControl (int x, int y) {
 	int zoom = getZoom();
 	Point displayPointInPixels = getDisplay().translateToDisplayCoordinates(new Point(x, y), zoom);
 	final Point controlPointInPixels = toControlInPixels(displayPointInPixels.x, displayPointInPixels.y);
-	return DPIUtil.scaleDown(controlPointInPixels, zoom);
+	return Win32DPIUtils.scaleDown(controlPointInPixels, zoom);
 }
 
 Point toControlInPixels (int x, int y) {
@@ -4090,7 +4090,7 @@ public Point toControl (Point point) {
 public Point toDisplay (int x, int y) {
 	checkWidget ();
 	int zoom = getZoom();
-	Point displayPointInPixels = toDisplayInPixels(DPIUtil.scaleUp(x, zoom), DPIUtil.scaleUp(y, zoom));
+	Point displayPointInPixels = toDisplayInPixels(Win32DPIUtils.scaleUp(x, zoom), Win32DPIUtils.scaleUp(y, zoom));
 	return getDisplay().translateFromDisplayCoordinates(displayPointInPixels, zoom);
 }
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/CoolBar.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/CoolBar.java
@@ -412,7 +412,7 @@ int getMargin (int index) {
 	}
 	if ((style & SWT.FLAT) == 0) {
 		if (!isLastItemOfRow (index)) {
-			margin += DPIUtil.scaleUp(SEPARATOR_WIDTH, getZoom());
+			margin += Win32DPIUtils.scaleUp(SEPARATOR_WIDTH, getZoom());
 		}
 	}
 	return margin;
@@ -549,7 +549,7 @@ public Point [] getItemSizes () {
 	Point [] sizes = getItemSizesInPixels();
 	if (sizes != null) {
 		for (int i = 0; i < sizes.length; i++) {
-			sizes[i] = DPIUtil.scaleDown(sizes[i], getZoom());
+			sizes[i] = Win32DPIUtils.scaleDown(sizes[i], getZoom());
 		}
 	}
 	return sizes;
@@ -809,7 +809,7 @@ public void setItemLayout (int [] itemOrder, int [] wrapIndices, Point [] sizes)
 	if (sizes == null) error (SWT.ERROR_NULL_ARGUMENT);
 	Point [] sizesInPoints = new Point [sizes.length];
 	for (int i = 0; i < sizes.length; i++) {
-		sizesInPoints[i] = DPIUtil.scaleUp(sizes[i], getZoom());
+		sizesInPoints[i] = Win32DPIUtils.scaleUp(sizes[i], getZoom());
 	}
 	setItemLayoutInPixels (itemOrder, wrapIndices, sizesInPoints);
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/CoolItem.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/CoolItem.java
@@ -186,9 +186,9 @@ protected void checkSubclass () {
 public Point computeSize (int wHint, int hHint) {
 	checkWidget ();
 	int zoom = getZoom();
-	wHint = (wHint != SWT.DEFAULT ? DPIUtil.scaleUp(wHint, zoom) : wHint);
-	hHint = (hHint != SWT.DEFAULT ? DPIUtil.scaleUp(hHint, zoom) : hHint);
-	return DPIUtil.scaleDown(computeSizeInPixels(wHint, hHint), zoom);
+	wHint = (wHint != SWT.DEFAULT ? Win32DPIUtils.scaleUp(wHint, zoom) : wHint);
+	hHint = (hHint != SWT.DEFAULT ? Win32DPIUtils.scaleUp(hHint, zoom) : hHint);
+	return Win32DPIUtils.scaleDown(computeSizeInPixels(wHint, hHint), zoom);
 }
 Point computeSizeInPixels (int wHint, int hHint) {
 	int index = parent.indexOf (this);
@@ -223,7 +223,7 @@ void destroyWidget () {
  */
 public Rectangle getBounds () {
 	checkWidget ();
-	return DPIUtil.scaleDown(getBoundsInPixels(), getZoom());
+	return Win32DPIUtils.scaleDown(getBoundsInPixels(), getZoom());
 }
 
 Rectangle getBoundsInPixels () {
@@ -383,7 +383,7 @@ public void setControl (Control control) {
  */
 public Point getPreferredSize () {
 	checkWidget ();
-	return DPIUtil.scaleDown(getPreferredSizeInPixels(), getZoom());
+	return Win32DPIUtils.scaleDown(getPreferredSizeInPixels(), getZoom());
 }
 
 Point getPreferredSizeInPixels () {
@@ -415,7 +415,7 @@ Point getPreferredSizeInPixels () {
 public void setPreferredSize (int width, int height) {
 	checkWidget ();
 	int zoom = getZoom();
-	setPreferredSizeInPixels(DPIUtil.scaleUp(width, zoom), DPIUtil.scaleUp(height, zoom));
+	setPreferredSizeInPixels(Win32DPIUtils.scaleUp(width, zoom), Win32DPIUtils.scaleUp(height, zoom));
 }
 
 void setPreferredSizeInPixels (int width, int height) {
@@ -464,7 +464,7 @@ void setPreferredSizeInPixels (int width, int height) {
 public void setPreferredSize (Point size) {
 	checkWidget ();
 	if (size == null) error(SWT.ERROR_NULL_ARGUMENT);
-	size = DPIUtil.scaleUp(size, getZoom());
+	size = Win32DPIUtils.scaleUp(size, getZoom());
 	setPreferredSizeInPixels(size.x, size.y);
 }
 
@@ -483,7 +483,7 @@ public void setPreferredSize (Point size) {
  */
 public Point getSize () {
 	checkWidget ();
-	return DPIUtil.scaleDown(getSizeInPixels(), getZoom());
+	return Win32DPIUtils.scaleDown(getSizeInPixels(), getZoom());
 }
 
 Point getSizeInPixels() {
@@ -526,7 +526,7 @@ Point getSizeInPixels() {
 public void setSize (int width, int height) {
 	checkWidget ();
 	int zoom = getZoom();
-	setSizeInPixels(DPIUtil.scaleUp(width, zoom), DPIUtil.scaleUp(height, zoom));
+	setSizeInPixels(Win32DPIUtils.scaleUp(width, zoom), Win32DPIUtils.scaleUp(height, zoom));
 }
 
 void setSizeInPixels (int width, int height) {
@@ -592,7 +592,7 @@ void setSizeInPixels (int width, int height) {
 public void setSize (Point size) {
 	checkWidget ();
 	if (size == null) error(SWT.ERROR_NULL_ARGUMENT);
-	size = DPIUtil.scaleUp(size, getZoom());
+	size = Win32DPIUtils.scaleUp(size, getZoom());
 	setSizeInPixels(size.x, size.y);
 }
 
@@ -611,7 +611,7 @@ public void setSize (Point size) {
  */
 public Point getMinimumSize () {
 	checkWidget ();
-	return DPIUtil.scaleDown(getMinimumSizeInPixels(), getZoom());
+	return Win32DPIUtils.scaleDown(getMinimumSizeInPixels(), getZoom());
 }
 
 Point getMinimumSizeInPixels () {
@@ -645,7 +645,7 @@ Point getMinimumSizeInPixels () {
 public void setMinimumSize (int width, int height) {
 	checkWidget ();
 	int zoom = getZoom();
-	setMinimumSizeInPixels(DPIUtil.scaleUp(width, zoom), DPIUtil.scaleUp(height, zoom));
+	setMinimumSizeInPixels(Win32DPIUtils.scaleUp(width, zoom), Win32DPIUtils.scaleUp(height, zoom));
 }
 
 void setMinimumSizeInPixels (int width, int height) {
@@ -695,7 +695,7 @@ void setMinimumSizeInPixels (int width, int height) {
 public void setMinimumSize (Point size) {
 	checkWidget ();
 	if (size == null) error (SWT.ERROR_NULL_ARGUMENT);
-	size = DPIUtil.scaleUp(size, getZoom());
+	size = Win32DPIUtils.scaleUp(size, getZoom());
 	setMinimumSizeInPixels(size.x, size.y);
 }
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Display.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Display.java
@@ -1592,7 +1592,7 @@ public Menu getMenuBar () {
 @Override
 public Rectangle getBounds() {
 	checkDevice ();
-	return DPIUtil.scaleDown(getBoundsInPixels(), DPIUtil.getDeviceZoom());
+	return Win32DPIUtils.scaleDown(getBoundsInPixels(), DPIUtil.getDeviceZoom());
 }
 
 Rectangle getBoundsInPixels () {
@@ -1665,7 +1665,7 @@ int getClickCount (int type, int button, long hwnd, long lParam) {
 @Override
 public Rectangle getClientArea () {
 	checkDevice ();
-	return DPIUtil.scaleDown(getClientAreaInPixels(), DPIUtil.getDeviceZoom());
+	return Win32DPIUtils.scaleDown(getClientAreaInPixels(), DPIUtil.getDeviceZoom());
 }
 
 Rectangle getClientAreaInPixels () {
@@ -2608,7 +2608,7 @@ public Image getSystemImage (int id) {
 
 private ImageDataProvider getImageDataProviderForIcon(int iconName) {
 	return zoom -> {
-		int scaledIconSize = DPIUtil.scaleUp(ICON_SIZE_AT_100, zoom);
+		int scaledIconSize = Win32DPIUtils.scaleUp(ICON_SIZE_AT_100, zoom);
 		long [] hIcon = new long [1];
 		OS.LoadIconWithScaleDown(0, iconName, scaledIconSize, scaledIconSize, hIcon);
 		Image image = Image.win32_new (this, SWT.ICON, hIcon[0], zoom);
@@ -3639,7 +3639,7 @@ public boolean post (Event event) {
 					int y = OS.GetSystemMetrics (OS.SM_YVIRTUALSCREEN);
 					int width = OS.GetSystemMetrics (OS.SM_CXVIRTUALSCREEN);
 					int height = OS.GetSystemMetrics (OS.SM_CYVIRTUALSCREEN);
-					Point loc = DPIUtil.scaleUp(event.getLocation(), getDeviceZoom());
+					Point loc = Win32DPIUtils.scaleUp(event.getLocation(), getDeviceZoom());
 					inputs.dx = ((loc.x - x) * 65535 + width - 2) / (width - 1);
 					inputs.dy = ((loc.y - y) * 65535 + height - 2) / (height - 1);
 				} else {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Display.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Display.java
@@ -1592,7 +1592,7 @@ public Menu getMenuBar () {
 @Override
 public Rectangle getBounds() {
 	checkDevice ();
-	return DPIUtil.autoScaleDown(getBoundsInPixels());
+	return DPIUtil.scaleDown(getBoundsInPixels(), DPIUtil.getDeviceZoom());
 }
 
 Rectangle getBoundsInPixels () {
@@ -1665,7 +1665,7 @@ int getClickCount (int type, int button, long hwnd, long lParam) {
 @Override
 public Rectangle getClientArea () {
 	checkDevice ();
-	return DPIUtil.autoScaleDown(getClientAreaInPixels());
+	return DPIUtil.scaleDown(getClientAreaInPixels(), DPIUtil.getDeviceZoom());
 }
 
 Rectangle getClientAreaInPixels () {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ExpandBar.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ExpandBar.java
@@ -561,7 +561,7 @@ void setScrollbar () {
  */
 public void setSpacing (int spacing) {
 	checkWidget ();
-	setSpacingInPixels(DPIUtil.scaleUp(spacing, getZoom()));
+	setSpacingInPixels(Win32DPIUtils.scaleUp(spacing, getZoom()));
 }
 
 void setSpacingInPixels (int spacing) {
@@ -789,7 +789,7 @@ LRESULT WM_PAINT (long wParam, long lParam) {
 			if (hooks (SWT.Paint) || filters (SWT.Paint)) {
 				Event event = new Event ();
 				event.gc = gc;
-				event.setBounds(DPIUtil.scaleDown(new Rectangle(rect.left, rect.top, width, height), getZoom()));
+				event.setBounds(Win32DPIUtils.scaleDown(new Rectangle(rect.left, rect.top, width, height), getZoom()));
 				sendEvent (SWT.Paint, event);
 				event.gc = null;
 			}

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ExpandItem.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ExpandItem.java
@@ -186,8 +186,8 @@ void drawItem (GC gc, long hTheme, RECT clipRect, boolean drawFocus) {
 	long hDC = gc.handle;
 	int headerHeightinPixels = getHeaderHeightInPixels();
 	int zoom = getZoom();
-	int imageHeightInPixels = DPIUtil.scaleUp(imageHeight, zoom);
-	int imageWidthInPixels = DPIUtil.scaleUp(imageWidth, zoom);
+	int imageHeightInPixels = Win32DPIUtils.scaleUp(imageHeight, zoom);
+	int imageWidthInPixels = Win32DPIUtils.scaleUp(imageWidth, zoom);
 
 	RECT rect = new RECT ();
 	OS.SetRect (rect, x, y, x + width, y + headerHeightinPixels);
@@ -311,7 +311,7 @@ public int getHeaderHeight () {
 
 int getHeaderHeightInPixels () {
 	int headerHeightInPixels = parent.getBandHeight();
-	int imageHeightInPixels = DPIUtil.scaleUp(imageHeight, getZoom());
+	int imageHeightInPixels = Win32DPIUtils.scaleUp(imageHeight, getZoom());
 	int imageHeaderDiff = headerHeightInPixels - imageHeightInPixels;
 	if (imageHeaderDiff < IMAGE_MARGIN) {
 		headerHeightInPixels = imageHeightInPixels + IMAGE_MARGIN;
@@ -380,8 +380,8 @@ void redraw (boolean all) {
 	long parentHandle = parent.handle;
 	int headerHeightInPixels = getHeaderHeightInPixels();
 	int zoom = getZoom();
-	int imageHeightInPixels = DPIUtil.scaleUp(imageHeight, zoom);
-	int imageWidthInPixels = DPIUtil.scaleUp(imageWidth, zoom);
+	int imageHeightInPixels = Win32DPIUtils.scaleUp(imageHeight, zoom);
+	int imageWidthInPixels = Win32DPIUtils.scaleUp(imageWidth, zoom);
 	RECT rect = new RECT ();
 	int left = all ? x : x + width - headerHeightInPixels;
 	OS.SetRect (rect, left, y, x + width, y + headerHeightInPixels);
@@ -496,7 +496,7 @@ public void setExpanded (boolean expanded) {
  */
 public void setHeight (int height) {
 	checkWidget ();
-	setHeightInPixels(DPIUtil.scaleUp(height, getZoom()));
+	setHeightInPixels(Win32DPIUtils.scaleUp(height, getZoom()));
 }
 
 void setHeightInPixels (int height) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Label.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Label.java
@@ -147,7 +147,7 @@ static int checkStyle (int style) {
 		return new Point (width, height);
 	}
 	if (isImageMode) {
-		Rectangle rect = DPIUtil.scaleBounds(image.getBounds(), this.getZoom(), 100);
+		Rectangle rect = Win32DPIUtils.scaleBounds(image.getBounds(), this.getZoom(), 100);
 		width += rect.width;
 		height += rect.height;
 	} else {
@@ -554,7 +554,7 @@ void wmDrawChildImage(DRAWITEMSTRUCT struct) {
 	if (width == 0 || height == 0) return;
 
 	int zoom = getZoom();
-	Rectangle imageRect = DPIUtil.scaleBounds(image.getBounds(), zoom, 100);
+	Rectangle imageRect = Win32DPIUtils.scaleBounds(image.getBounds(), zoom, 100);
 
 	int x = 0;
 	if ((style & SWT.CENTER) != 0) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/MenuItem.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/MenuItem.java
@@ -1252,7 +1252,7 @@ LRESULT wmMeasureChild (long wParam, long lParam) {
 		if (parent.needsMenuCallback()) {
 			Point point = calculateRenderedTextSize();
 			int menuZoom = getDisplay().isRescalingAtRuntime() ? super.getZoom() : getMonitorZoom();
-			struct.itemHeight = DPIUtil.scaleUp(point.y, menuZoom);
+			struct.itemHeight = Win32DPIUtils.scaleUp(point.y, menuZoom);
 			/*
 			 * Weirdness in Windows. Setting `HBMMENU_CALLBACK` causes
 			 * item sizes to mean something else. It seems that it is
@@ -1262,7 +1262,7 @@ LRESULT wmMeasureChild (long wParam, long lParam) {
 			 * that value of 5 works well in matching text to mnemonic.
 			 */
 			int horizontalSpaceImage = this.image != null ? this.image.getBounds().width + IMAGE_TEXT_GAP: 0;
-			struct.itemWidth = DPIUtil.scaleUp(LEFT_TEXT_MARGIN + point.x - WINDOWS_OVERHEAD + horizontalSpaceImage, menuZoom);
+			struct.itemWidth = Win32DPIUtils.scaleUp(LEFT_TEXT_MARGIN + point.x - WINDOWS_OVERHEAD + horizontalSpaceImage, menuZoom);
 			OS.MoveMemory (lParam, struct, MEASUREITEMSTRUCT.sizeof);
 			return null;
 		}
@@ -1270,7 +1270,7 @@ LRESULT wmMeasureChild (long wParam, long lParam) {
 
 	int width = 0, height = 0;
 	if (image != null) {
-		Rectangle rect = DPIUtil.scaleUp(image.getBounds(), getZoom());
+		Rectangle rect = Win32DPIUtils.scaleUp(image.getBounds(), getZoom());
 		width = rect.width;
 		height = rect.height;
 	} else {
@@ -1292,7 +1292,7 @@ LRESULT wmMeasureChild (long wParam, long lParam) {
 		if ((lpcmi.dwStyle & OS.MNS_CHECKORBMP) == 0) {
 			for (MenuItem item : parent.getItems ()) {
 				if (item.image != null) {
-					Rectangle rect = DPIUtil.scaleUp(item.image.getBounds(), getZoom());
+					Rectangle rect = Win32DPIUtils.scaleUp(item.image.getBounds(), getZoom());
 					width = Math.max (width, rect.width);
 				}
 			}
@@ -1326,7 +1326,7 @@ private Point calculateRenderedTextSize() {
 			// GC calculated height of 15px, scales down with adjusted zoom of 100% and returns 15pt -> should be 10pt
 			// this calculation is corrected by the following line
 			// This is the only place, where the GC needs to use the native zoom to do that, therefore it is fixed only here
-			points = DPIUtil.scaleDown(DPIUtil.scaleUp(points, adjustedPrimaryMonitorZoom), primaryMonitorZoom);
+			points = Win32DPIUtils.scaleDown(Win32DPIUtils.scaleUp(points, adjustedPrimaryMonitorZoom), primaryMonitorZoom);
 		}
 	}
 	return points;

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/MultiZoomCoordinateSystemMapper.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/MultiZoomCoordinateSystemMapper.java
@@ -49,14 +49,14 @@ class MultiZoomCoordinateSystemMapper implements CoordinateSystemMapper {
 		if (from == null) {
 			Point mappedPointInpixels = display.mapInPixels(from, to,
 					getPixelsFromPoint(to.getShell().getMonitor(), x, y));
-			mappedPointInPoints = DPIUtil.scaleDown(mappedPointInpixels, to.getZoom());
+			mappedPointInPoints = Win32DPIUtils.scaleDown(mappedPointInpixels, to.getZoom());
 		} else if (to == null) {
-			Point mappedPointInpixels = display.mapInPixels(from, to, DPIUtil.scaleUp(new Point(x, y), from.getZoom()));
+			Point mappedPointInpixels = display.mapInPixels(from, to, Win32DPIUtils.scaleUp(new Point(x, y), from.getZoom()));
 			mappedPointInPoints = getPointFromPixels(from.getShell().getMonitor(), mappedPointInpixels.x,
 					mappedPointInpixels.y);
 		} else {
-			Point mappedPointInpixels = display.mapInPixels(from, to, DPIUtil.scaleUp(new Point(x, y), from.getZoom()));
-			mappedPointInPoints = DPIUtil.scaleDown(mappedPointInpixels, to.getZoom());
+			Point mappedPointInpixels = display.mapInPixels(from, to, Win32DPIUtils.scaleUp(new Point(x, y), from.getZoom()));
+			mappedPointInPoints = Win32DPIUtils.scaleDown(mappedPointInpixels, to.getZoom());
 		}
 		return mappedPointInPoints;
 	}
@@ -68,24 +68,24 @@ class MultiZoomCoordinateSystemMapper implements CoordinateSystemMapper {
 			Rectangle mappedRectangleInPixels = display.mapInPixels(from, to,
 					translateRectangleInPointsToPixels(x, y, width, height,
 							to.getShell().getMonitor()));
-			mappedRectangleInPoints = DPIUtil.scaleDown(mappedRectangleInPixels, to.getZoom());
+			mappedRectangleInPoints = Win32DPIUtils.scaleDown(mappedRectangleInPixels, to.getZoom());
 		} else if (to == null) {
 			Rectangle mappedRectangleInPixels = display.mapInPixels(from, to,
-					DPIUtil.scaleUp(new Rectangle(x, y, width, height), from.getZoom()));
+					Win32DPIUtils.scaleUp(new Rectangle(x, y, width, height), from.getZoom()));
 			mappedRectangleInPoints = translateRectangleInPixelsToPoints(mappedRectangleInPixels.x,
 					mappedRectangleInPixels.y, mappedRectangleInPixels.width, mappedRectangleInPixels.height,
 					from.getShell().getMonitor());
 		} else {
 			Rectangle mappedRectangleInPixels = display.mapInPixels(from, to,
-					DPIUtil.scaleUp(new Rectangle(x, y, width, height), from.getZoom()));
-			mappedRectangleInPoints = DPIUtil.scaleDown(mappedRectangleInPixels, to.getZoom());
+					Win32DPIUtils.scaleUp(new Rectangle(x, y, width, height), from.getZoom()));
+			mappedRectangleInPoints = Win32DPIUtils.scaleDown(mappedRectangleInPixels, to.getZoom());
 		}
 		return mappedRectangleInPoints;
 	}
 
 	@Override
 	public Rectangle mapMonitorBounds(Rectangle rect, int zoom) {
-		Rectangle bounds = DPIUtil.scaleDown(rect, zoom);
+		Rectangle bounds = Win32DPIUtils.scaleDown(rect, zoom);
 		bounds.x = rect.x;
 		bounds.y = rect.y;
 		return bounds;
@@ -140,8 +140,8 @@ class MultiZoomCoordinateSystemMapper implements CoordinateSystemMapper {
 		monitor = getValidMonitorIfApplicable(x, y, width, height, monitor);
 		Point topLeft = getPixelsFromPoint(monitor, x, y);
 		int zoom = getApplicableMonitorZoom(monitor);
-		int widthInPixels = DPIUtil.scaleUp(width, zoom);
-		int heightInPixels = DPIUtil.scaleUp(height, zoom);
+		int widthInPixels = Win32DPIUtils.scaleUp(width, zoom);
+		int heightInPixels = Win32DPIUtils.scaleUp(height, zoom);
 		return new Rectangle(topLeft.x, topLeft.y, widthInPixels, heightInPixels);
 	}
 
@@ -201,8 +201,8 @@ class MultiZoomCoordinateSystemMapper implements CoordinateSystemMapper {
 		for (Monitor currentMonitor : monitors) {
 			// Obtain the rectangle in pixels per monitor for absolute comparison
 			Point topLeftOfRectangle = getPixelsFromPoint(currentMonitor, x, y);
-			int widthInPixels = DPIUtil.scaleUp(width, getApplicableMonitorZoom(currentMonitor));
-			int heightInPixels = DPIUtil.scaleUp(height, getApplicableMonitorZoom(currentMonitor));
+			int widthInPixels = Win32DPIUtils.scaleUp(width, getApplicableMonitorZoom(currentMonitor));
+			int heightInPixels = Win32DPIUtils.scaleUp(height, getApplicableMonitorZoom(currentMonitor));
 			Rectangle boundsInPixel = new Rectangle(topLeftOfRectangle.x, topLeftOfRectangle.y, widthInPixels, heightInPixels);
 			Rectangle clientArea = getMonitorClientAreaInPixels(currentMonitor);
 			Rectangle intersection = clientArea.intersection(boundsInPixel);
@@ -248,15 +248,15 @@ class MultiZoomCoordinateSystemMapper implements CoordinateSystemMapper {
 
 	private Rectangle getMonitorClientAreaInPixels(Monitor monitor) {
 		int zoom = getApplicableMonitorZoom(monitor);
-		int widthInPixels = DPIUtil.scaleUp(monitor.clientWidth, zoom);
-		int heightInPixels = DPIUtil.scaleUp(monitor.clientHeight, zoom);
+		int widthInPixels = Win32DPIUtils.scaleUp(monitor.clientWidth, zoom);
+		int heightInPixels = Win32DPIUtils.scaleUp(monitor.clientHeight, zoom);
 		return new Rectangle(monitor.clientX, monitor.clientY, widthInPixels, heightInPixels);
 	}
 
 	private Point getPixelsFromPoint(Monitor monitor, int x, int y) {
 		int zoom = getApplicableMonitorZoom(monitor);
-		int mappedX = DPIUtil.scaleUp(x - monitor.clientX, zoom) + monitor.clientX;
-		int mappedY = DPIUtil.scaleUp(y - monitor.clientY, zoom) + monitor.clientY;
+		int mappedX = Win32DPIUtils.scaleUp(x - monitor.clientX, zoom) + monitor.clientX;
+		int mappedY = Win32DPIUtils.scaleUp(y - monitor.clientY, zoom) + monitor.clientY;
 		return new Point(mappedX, mappedY);
 	}
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Sash.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Sash.java
@@ -244,7 +244,7 @@ LRESULT WM_KEYDOWN (long wParam, long lParam) {
 			OS.SetCursorPos (cursorPt.x, cursorPt.y);
 
 			Event event = new Event ();
-			event.setBounds(DPIUtil.scaleDown(new Rectangle(newX, newY, width, height), getZoom()));
+			event.setBounds(Win32DPIUtils.scaleDown(new Rectangle(newX, newY, width, height), getZoom()));
 			sendSelectionEvent  (SWT.Selection, event, true);
 			if (isDisposed ()) return LRESULT.ZERO;
 			if (event.doit) {
@@ -284,7 +284,7 @@ LRESULT WM_LBUTTONDOWN (long wParam, long lParam) {
 
 	/* The event must be sent because doit flag is used */
 	Event event = new Event ();
-	event.setBounds(DPIUtil.scaleDown(new Rectangle(lastX, lastY, width, height), getZoom()));
+	event.setBounds(Win32DPIUtils.scaleDown(new Rectangle(lastX, lastY, width, height), getZoom()));
 	if ((style & SWT.SMOOTH) == 0) {
 		event.detail = SWT.DRAG;
 	}
@@ -292,7 +292,7 @@ LRESULT WM_LBUTTONDOWN (long wParam, long lParam) {
 	if (isDisposed ()) return LRESULT.ZERO;
 
 	/* Draw the banding rectangle */
-	Rectangle boundsInPixels = DPIUtil.scaleUp(event.getBounds(), getZoom());
+	Rectangle boundsInPixels = Win32DPIUtils.scaleUp(event.getBounds(), getZoom());
 	if (event.doit) {
 		dragging = true;
 		lastX = boundsInPixels.x;
@@ -325,7 +325,7 @@ LRESULT WM_LBUTTONUP (long wParam, long lParam) {
 
 	/* The event must be sent because doit flag is used */
 	Event event = new Event ();
-	event.setBounds(DPIUtil.scaleDown(new Rectangle(lastX, lastY, width, height), getZoom()));
+	event.setBounds(Win32DPIUtils.scaleDown(new Rectangle(lastX, lastY, width, height), getZoom()));
 	drawBand (lastX, lastY, width, height);
 	sendSelectionEvent (SWT.Selection, event, true);
 	if (isDisposed ()) return result;
@@ -369,7 +369,7 @@ LRESULT WM_MOUSEMOVE (long wParam, long lParam) {
 	int zoom = getZoom();
 	/* The event must be sent because doit flag is used */
 	Event event = new Event ();
-	event.setBounds(DPIUtil.scaleDown(new Rectangle(newX, newY, width, height), zoom));
+	event.setBounds(Win32DPIUtils.scaleDown(new Rectangle(newX, newY, width, height), zoom));
 	if ((style & SWT.SMOOTH) == 0) {
 		event.detail = SWT.DRAG;
 	}
@@ -377,8 +377,8 @@ LRESULT WM_MOUSEMOVE (long wParam, long lParam) {
 	if (isDisposed ()) return LRESULT.ZERO;
 	if (event.doit) {
 		Rectangle bounds = event.getBounds();
-		lastX = DPIUtil.scaleUp(bounds.x, zoom);
-		lastY = DPIUtil.scaleUp(bounds.y, zoom);
+		lastX = Win32DPIUtils.scaleUp(bounds.x, zoom);
+		lastY = Win32DPIUtils.scaleUp(bounds.y, zoom);
 	}
 	int flags = OS.RDW_UPDATENOW | OS.RDW_ALLCHILDREN;
 	OS.RedrawWindow (hwndTrack, null, 0, flags);

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ScrollBar.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ScrollBar.java
@@ -355,7 +355,7 @@ public int getSelection () {
  */
 public Point getSize () {
 	checkWidget();
-	return DPIUtil.scaleDown(getSizeInPixels(), getZoom());
+	return Win32DPIUtils.scaleDown(getSizeInPixels(), getZoom());
 }
 
 Point getSizeInPixels () {
@@ -412,7 +412,7 @@ public int getThumb () {
  */
 public Rectangle getThumbBounds () {
 	checkWidget();
-	return DPIUtil.scaleDown(getThumbBoundsInPixels(), getZoom());
+	return Win32DPIUtils.scaleDown(getThumbBoundsInPixels(), getZoom());
 }
 
 Rectangle getThumbBoundsInPixels () {
@@ -458,7 +458,7 @@ Rectangle getThumbBoundsInPixels () {
  */
 public Rectangle getThumbTrackBounds () {
 	checkWidget();
-	return DPIUtil.scaleDown(getThumbTrackBoundsInPixels(), getZoom());
+	return Win32DPIUtils.scaleDown(getThumbTrackBoundsInPixels(), getZoom());
 }
 
 Rectangle getThumbTrackBoundsInPixels () {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Scrollable.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Scrollable.java
@@ -121,8 +121,8 @@ long callWindowProc (long hwnd, int msg, long wParam, long lParam) {
 public Rectangle computeTrim (int x, int y, int width, int height) {
 	checkWidget ();
 	int zoom = getZoom();
-	Rectangle rectangle = DPIUtil.scaleUp(new Rectangle(x, y, width, height), zoom);
-	return DPIUtil.scaleDown(computeTrimInPixels(rectangle.x, rectangle.y, rectangle.width, rectangle.height), zoom);
+	Rectangle rectangle = Win32DPIUtils.scaleUp(new Rectangle(x, y, width, height), zoom);
+	return Win32DPIUtils.scaleDown(computeTrimInPixels(rectangle.x, rectangle.y, rectangle.width, rectangle.height), zoom);
 }
 
 Rectangle computeTrimInPixels (int x, int y, int width, int height) {
@@ -210,7 +210,7 @@ void destroyScrollBar (int type) {
  */
 public Rectangle getClientArea () {
 	checkWidget ();
-	return DPIUtil.scaleDown(getClientAreaInPixels(), getZoom());
+	return Win32DPIUtils.scaleDown(getClientAreaInPixels(), getZoom());
 }
 
 Rectangle getClientAreaInPixels () {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Shell.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Shell.java
@@ -1043,7 +1043,7 @@ public boolean getMaximized () {
  */
 public Point getMaximumSize () {
 	checkWidget ();
-	return DPIUtil.scaleDown(getMaximumSizeInPixels(), getZoom());
+	return Win32DPIUtils.scaleDown(getMaximumSizeInPixels(), getZoom());
 }
 
 Point getMaximumSizeInPixels () {
@@ -1084,7 +1084,7 @@ Point getMaximumSizeInPixels () {
  */
 public Point getMinimumSize () {
 	checkWidget ();
-	return DPIUtil.scaleDown(getMinimumSizeInPixels(), getZoom());
+	return Win32DPIUtils.scaleDown(getMinimumSizeInPixels(), getZoom());
 }
 
 Point getMinimumSizeInPixels () {
@@ -1592,8 +1592,8 @@ public void setBounds(Rectangle rect) {
 	// the WM_DPICHANGED event processing. So to avoid duplicate scaling, we always
 	// have to scale width and height with the zoom of the original monitor (still
 	// returned by getZoom()) here.
-	setBoundsInPixels(boundsInPixels.x, boundsInPixels.y, DPIUtil.scaleUp(rect.width, getZoom()),
-			DPIUtil.scaleUp(rect.height, getZoom()));
+	setBoundsInPixels(boundsInPixels.x, boundsInPixels.y, Win32DPIUtils.scaleUp(rect.width, getZoom()),
+			Win32DPIUtils.scaleUp(rect.height, getZoom()));
 }
 
 @Override
@@ -1769,7 +1769,7 @@ public void setImeInputMode (int mode) {
 public void setMaximumSize (int width, int height) {
 	checkWidget ();
 	int zoom = getZoom();
-	setMaximumSizeInPixels(DPIUtil.scaleUp(width, zoom), DPIUtil.scaleUp(height, zoom));
+	setMaximumSizeInPixels(Win32DPIUtils.scaleUp(width, zoom), Win32DPIUtils.scaleUp(height, zoom));
 }
 
 /**
@@ -1797,7 +1797,7 @@ public void setMaximumSize (int width, int height) {
 public void setMaximumSize (Point size) {
 	checkWidget ();
 	if (size == null) error (SWT.ERROR_NULL_ARGUMENT);
-	size = DPIUtil.scaleUp(size, getZoom());
+	size = Win32DPIUtils.scaleUp(size, getZoom());
 	setMaximumSizeInPixels(size.x, size.y);
 }
 
@@ -1844,7 +1844,7 @@ void setMaximumSizeInPixels (int width, int height) {
 public void setMinimumSize (int width, int height) {
 	checkWidget ();
 	int zoom = getZoom();
-	setMinimumSizeInPixels(DPIUtil.scaleUp(width, zoom), DPIUtil.scaleUp(height, zoom));
+	setMinimumSizeInPixels(Win32DPIUtils.scaleUp(width, zoom), Win32DPIUtils.scaleUp(height, zoom));
 }
 
 void setMinimumSizeInPixels (int width, int height) {
@@ -1892,7 +1892,7 @@ void setMinimumSizeInPixels (int width, int height) {
 public void setMinimumSize (Point size) {
 	checkWidget ();
 	if (size == null) error (SWT.ERROR_NULL_ARGUMENT);
-	size = DPIUtil.scaleUp(size, getZoom());
+	size = Win32DPIUtils.scaleUp(size, getZoom());
 	setMinimumSizeInPixels(size.x, size.y);
 }
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/SingleZoomCoordinateSystemMapper.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/SingleZoomCoordinateSystemMapper.java
@@ -72,7 +72,7 @@ class SingleZoomCoordinateSystemMapper implements CoordinateSystemMapper {
 
 	@Override
 	public Rectangle mapMonitorBounds(Rectangle rect, int zoom) {
-		return DPIUtil.autoScaleDown(rect);
+		return DPIUtil.scaleDown(rect, DPIUtil.getDeviceZoom());
 	}
 
 	@Override
@@ -98,12 +98,13 @@ class SingleZoomCoordinateSystemMapper implements CoordinateSystemMapper {
 	@Override
 	public Point getCursorLocation() {
 		Point cursorLocationInPixels = display.getCursorLocationInPixels();
-		return DPIUtil.autoScaleDown(cursorLocationInPixels);
+		return DPIUtil.scaleDown(cursorLocationInPixels, DPIUtil.getDeviceZoom());
 	}
 
 	@Override
 	public void setCursorLocation(int x, int y) {
-		display.setCursorLocationInPixels(DPIUtil.autoScaleUp(x), DPIUtil.autoScaleUp(y));
+		int zoom = DPIUtil.getDeviceZoom();
+		display.setCursorLocationInPixels(DPIUtil.scaleUp(x, zoom), DPIUtil.scaleUp(y, zoom));
 	}
 
 	@Override

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/SingleZoomCoordinateSystemMapper.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/SingleZoomCoordinateSystemMapper.java
@@ -41,78 +41,79 @@ class SingleZoomCoordinateSystemMapper implements CoordinateSystemMapper {
 	@Override
 	public Point map(Control from, Control to, Point point) {
 		int zoom = getZoomLevelForMapping(from, to);
-		point = DPIUtil.scaleUp(point, zoom);
-		return DPIUtil.scaleDown(display.mapInPixels(from, to, point), zoom);
+		point = Win32DPIUtils.scaleUp(point, zoom);
+		return Win32DPIUtils.scaleDown(display.mapInPixels(from, to, point), zoom);
 	}
 
 	@Override
 	public Rectangle map(Control from, Control to, Rectangle rectangle) {
 		int zoom = getZoomLevelForMapping(from, to);
-		rectangle = DPIUtil.scaleUp(rectangle, zoom);
-		return DPIUtil.scaleDown(display.mapInPixels(from, to, rectangle), zoom);
+		rectangle = Win32DPIUtils.scaleUp(rectangle, zoom);
+		return Win32DPIUtils.scaleDown(display.mapInPixels(from, to, rectangle), zoom);
 	}
 
 	@Override
 	public Point map(Control from, Control to, int x, int y) {
 		int zoom = getZoomLevelForMapping(from, to);
-		x = DPIUtil.scaleUp(x, zoom);
-		y = DPIUtil.scaleUp(y, zoom);
-		return DPIUtil.scaleDown(display.mapInPixels(from, to, x, y), zoom);
+		x = Win32DPIUtils.scaleUp(x, zoom);
+		y = Win32DPIUtils.scaleUp(y, zoom);
+		return Win32DPIUtils.scaleDown(display.mapInPixels(from, to, x, y), zoom);
 	}
 
 	@Override
 	public Rectangle map(Control from, Control to, int x, int y, int width, int height) {
 		int zoom = getZoomLevelForMapping(from, to);
-		x = DPIUtil.scaleUp(x, zoom);
-		y = DPIUtil.scaleUp(y, zoom);
-		width = DPIUtil.scaleUp(width, zoom);
-		height = DPIUtil.scaleUp(height, zoom);
-		return DPIUtil.scaleDown(display.mapInPixels(from, to, x, y, width, height), zoom);
+		x = Win32DPIUtils.scaleUp(x, zoom);
+		y = Win32DPIUtils.scaleUp(y, zoom);
+		width = Win32DPIUtils.scaleUp(width, zoom);
+		height = Win32DPIUtils.scaleUp(height, zoom);
+		return Win32DPIUtils.scaleDown(display.mapInPixels(from, to, x, y, width, height), zoom);
 	}
 
 	@Override
 	public Rectangle mapMonitorBounds(Rectangle rect, int zoom) {
-		return DPIUtil.scaleDown(rect, DPIUtil.getDeviceZoom());
+		return Win32DPIUtils.scaleDown(rect, zoom);
 	}
 
 	@Override
 	public Point translateFromDisplayCoordinates(Point point, int zoom) {
-		return DPIUtil.scaleDown(point, zoom);
+		return Win32DPIUtils.scaleDown(point, zoom);
 	}
 
 	@Override
 	public Point translateToDisplayCoordinates(Point point, int zoom) {
-		return DPIUtil.scaleUp(point, zoom);
+		return Win32DPIUtils.scaleUp(point, zoom);
 	}
 
 	@Override
 	public Rectangle translateFromDisplayCoordinates(Rectangle rect, int zoom) {
-		return DPIUtil.scaleDown(rect, zoom);
+		return Win32DPIUtils.scaleDown(rect, zoom);
 	}
 
 	@Override
 	public Rectangle translateToDisplayCoordinates(Rectangle rect, int zoom) {
-		return DPIUtil.scaleUp(rect, zoom);
+		return Win32DPIUtils.scaleUp(rect, zoom);
 	}
 
 	@Override
 	public Point getCursorLocation() {
+		int zoom = DPIUtil.getDeviceZoom();
 		Point cursorLocationInPixels = display.getCursorLocationInPixels();
-		return DPIUtil.scaleDown(cursorLocationInPixels, DPIUtil.getDeviceZoom());
+		return Win32DPIUtils.scaleDown(cursorLocationInPixels, zoom);
 	}
 
 	@Override
 	public void setCursorLocation(int x, int y) {
 		int zoom = DPIUtil.getDeviceZoom();
-		display.setCursorLocationInPixels(DPIUtil.scaleUp(x, zoom), DPIUtil.scaleUp(y, zoom));
+		display.setCursorLocationInPixels(Win32DPIUtils.scaleUp(x, zoom), Win32DPIUtils.scaleUp(y, zoom));
 	}
 
 	@Override
 	public Rectangle getContainingMonitorBoundsInPixels(Point point) {
 		int zoom = DPIUtil.getDeviceZoom();
-		point = DPIUtil.scaleUp(point, zoom);
+		point = Win32DPIUtils.scaleUp(point, zoom);
 		for (Monitor monitor : display.getMonitors()) {
-			Rectangle monitorBounds = DPIUtil.scaleUp(monitor.getBounds(), zoom);
+			Rectangle monitorBounds = Win32DPIUtils.scaleUp(monitor.getBounds(), zoom);
 			if (monitorBounds.contains(point)) {
 				return monitorBounds;
 			}

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TabFolder.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TabFolder.java
@@ -455,7 +455,7 @@ int imageIndex (Image image) {
 	 */
 	if (image == null) return -1;
 	if (imageList == null) {
-		Rectangle bounds = DPIUtil.scaleBounds(image.getBounds(), this.getZoom(), 100);
+		Rectangle bounds = Win32DPIUtils.scaleBounds(image.getBounds(), this.getZoom(), 100);
 		imageList = display.getImageList (style & SWT.RIGHT_TO_LEFT, bounds.width, bounds.height, this.getZoom());
 		int index = imageList.add (image);
 		long hImageList = imageList.getHandle(getZoom());
@@ -510,7 +510,7 @@ Point minimumSize (int wHint, int hHint, boolean flushCache) {
 		}
 		int zoom = getZoom();
 		if (index == count) {
-			Rectangle rect = DPIUtil.scaleUp(child.getBounds (), zoom);
+			Rectangle rect = Win32DPIUtils.scaleUp(child.getBounds (), zoom);
 			width = Math.max (width, rect.x + rect.width);
 			height = Math.max (height, rect.y + rect.height);
 		} else {
@@ -518,7 +518,7 @@ Point minimumSize (int wHint, int hHint, boolean flushCache) {
 			 * Since computeSize can be overridden by subclasses, we cannot
 			 * call computeSizeInPixels directly.
 			 */
-			Point size = DPIUtil.scaleUp(child.computeSize (DPIUtil.scaleDown(wHint, zoom), DPIUtil.scaleDown(hHint, zoom), flushCache), zoom);
+			Point size = Win32DPIUtils.scaleUp(child.computeSize (DPIUtil.scaleDown(wHint, zoom), DPIUtil.scaleDown(hHint, zoom), flushCache), zoom);
 			width = Math.max (width, size.x);
 			height = Math.max (height, size.y);
 		}

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TabItem.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TabItem.java
@@ -191,7 +191,7 @@ public Control getControl () {
  */
 public Rectangle getBounds () {
 	checkWidget();
-	return DPIUtil.scaleDown(getBoundsInPixels(), getZoom());
+	return Win32DPIUtils.scaleDown(getBoundsInPixels(), getZoom());
 }
 
 Rectangle getBoundsInPixels() {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Table.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Table.java
@@ -2476,7 +2476,7 @@ public TableItem getItem (int index) {
 public TableItem getItem (Point point) {
 	checkWidget ();
 	if (point == null) error (SWT.ERROR_NULL_ARGUMENT);
-	return getItemInPixels (DPIUtil.scaleUp(point, getZoom()));
+	return getItemInPixels (Win32DPIUtils.scaleUp(point, getZoom()));
 }
 
 TableItem getItemInPixels (Point point) {
@@ -2832,7 +2832,7 @@ boolean hitTestSelection (int index, int x, int y) {
 		long hFont = item.fontHandle (0);
 		if (hFont != -1) hFont = OS.SelectObject (hDC, hFont);
 		Event event = sendMeasureItemEvent (item, index, 0, hDC);
-		if (DPIUtil.scaleUp(event.getBounds(), getZoom()).contains (x, y)) result = true;
+		if (Win32DPIUtils.scaleUp(event.getBounds(), getZoom()).contains (x, y)) result = true;
 		if (hFont != -1) hFont = OS.SelectObject (hDC, hFont);
 		if (newFont != 0) OS.SelectObject (hDC, oldFont);
 		OS.ReleaseDC (handle, hDC);
@@ -2849,7 +2849,7 @@ int imageIndex (Image image, int column) {
 		setSubImagesVisible (true);
 	}
 	if (imageList == null) {
-		Rectangle bounds = DPIUtil.scaleBounds(image.getBounds(), this.getZoom(), 100);
+		Rectangle bounds = Win32DPIUtils.scaleBounds(image.getBounds(), this.getZoom(), 100);
 		imageList = display.getImageList (style & SWT.RIGHT_TO_LEFT, bounds.width, bounds.height, getZoom());
 		int index = imageList.indexOf (image);
 		if (index == -1) index = imageList.add (image);
@@ -2889,7 +2889,7 @@ int imageIndex (Image image, int column) {
 int imageIndexHeader (Image image) {
 	if (image == null) return OS.I_IMAGENONE;
 	if (headerImageList == null) {
-		Rectangle bounds = DPIUtil.scaleBounds(image.getBounds(), this.getZoom(), 100);
+		Rectangle bounds = Win32DPIUtils.scaleBounds(image.getBounds(), this.getZoom(), 100);
 		headerImageList = display.getImageList (style & SWT.RIGHT_TO_LEFT, bounds.width, bounds.height, getZoom());
 		int index = headerImageList.indexOf (image);
 		if (index == -1) index = headerImageList.add (image);
@@ -3484,7 +3484,7 @@ void sendEraseItemEvent (TableItem item, NMLVCUSTOMDRAW nmcd, long lParam, Event
 	if (drawHot) event.detail |= SWT.HOT;
 	if (drawSelected) event.detail |= SWT.SELECTED;
 	if (drawBackground) event.detail |= SWT.BACKGROUND;
-	Rectangle bounds = DPIUtil.scaleDown(new Rectangle (cellRect.left, cellRect.top, cellRect.right - cellRect.left, cellRect.bottom - cellRect.top), getZoom());
+	Rectangle bounds = Win32DPIUtils.scaleDown(new Rectangle (cellRect.left, cellRect.top, cellRect.right - cellRect.left, cellRect.bottom - cellRect.top), getZoom());
 	event.setBounds (bounds);
 	gc.setClipping (bounds);
 	sendEvent (SWT.EraseItem, event);
@@ -3530,7 +3530,7 @@ void sendEraseItemEvent (TableItem item, NMLVCUSTOMDRAW nmcd, long lParam, Event
 		RECT textRect = item.getBounds ((int)nmcd.dwItemSpec, nmcd.iSubItem, true, false, fullText, false, hDC);
 		if ((style & SWT.FULL_SELECTION) == 0) {
 			if (measureEvent != null) {
-				Rectangle boundsInPixels = DPIUtil.scaleUp(measureEvent.getBounds(), getZoom());
+				Rectangle boundsInPixels = Win32DPIUtils.scaleUp(measureEvent.getBounds(), getZoom());
 				textRect.right = Math.min (cellRect.right, boundsInPixels.x + boundsInPixels.width);
 			}
 			if (!ignoreDrawFocus) {
@@ -3605,7 +3605,7 @@ Event sendEraseItemEvent (TableItem item, NMTTCUSTOMDRAW nmcd, int column, RECT 
 	event.index = column;
 	event.gc = gc;
 	event.detail |= SWT.FOREGROUND;
-	event.setBounds(DPIUtil.scaleDown(new Rectangle(cellRect.left, cellRect.top, cellRect.right - cellRect.left, cellRect.bottom - cellRect.top), getZoom()));
+	event.setBounds(Win32DPIUtils.scaleDown(new Rectangle(cellRect.left, cellRect.top, cellRect.right - cellRect.left, cellRect.bottom - cellRect.top), getZoom()));
 	//gc.setClipping (event.x, event.y, event.width, event.height);
 	sendEvent (SWT.EraseItem, event);
 	event.gc = null;
@@ -3626,7 +3626,7 @@ Event sendMeasureItemEvent (TableItem item, int row, int column, long hDC) {
 	event.item = item;
 	event.gc = gc;
 	event.index = column;
-	event.setBounds(DPIUtil.scaleDown(new Rectangle(itemRect.left, itemRect.top, itemRect.right - itemRect.left, itemRect.bottom - itemRect.top), getZoom()));
+	event.setBounds(Win32DPIUtils.scaleDown(new Rectangle(itemRect.left, itemRect.top, itemRect.right - itemRect.left, itemRect.bottom - itemRect.top), getZoom()));
 	boolean drawSelected = false;
 	if (OS.IsWindowEnabled (handle)) {
 		LVITEM lvItem = new LVITEM ();
@@ -3649,7 +3649,7 @@ Event sendMeasureItemEvent (TableItem item, int row, int column, long hDC) {
 	gc.dispose ();
 	OS.RestoreDC (hDC, nSavedDC);
 	if (!isDisposed () && !item.isDisposed ()) {
-		Rectangle boundsInPixels = DPIUtil.scaleUp(event.getBounds(), getZoom());
+		Rectangle boundsInPixels = Win32DPIUtils.scaleUp(event.getBounds(), getZoom());
 		if (columnCount == 0) {
 			int width = (int)OS.SendMessage (handle, OS.LVM_GETCOLUMNWIDTH, 0, 0);
 			if (boundsInPixels.x + boundsInPixels.width > width) setScrollWidth (boundsInPixels.x + boundsInPixels.width);
@@ -3926,11 +3926,11 @@ void sendPaintItemEvent (TableItem item, NMLVCUSTOMDRAW nmcd) {
 	if (drawHot) event.detail |= SWT.HOT;
 	if (drawSelected) event.detail |= SWT.SELECTED;
 	if (drawBackground) event.detail |= SWT.BACKGROUND;
-	event.setBounds(DPIUtil.scaleDown(new Rectangle(itemRect.left, itemRect.top, itemRect.right - itemRect.left, itemRect.bottom - itemRect.top), getZoom()));
+	event.setBounds(Win32DPIUtils.scaleDown(new Rectangle(itemRect.left, itemRect.top, itemRect.right - itemRect.left, itemRect.bottom - itemRect.top), getZoom()));
 	RECT cellRect = item.getBounds ((int)nmcd.dwItemSpec, nmcd.iSubItem, true, true, true, true, hDC);
 	int cellWidth = cellRect.right - cellRect.left;
 	int cellHeight = cellRect.bottom - cellRect.top;
-	gc.setClipping (DPIUtil.scaleDown(new Rectangle (cellRect.left, cellRect.top, cellWidth, cellHeight), getZoom()));
+	gc.setClipping (Win32DPIUtils.scaleDown(new Rectangle (cellRect.left, cellRect.top, cellWidth, cellHeight), getZoom()));
 	sendEvent (SWT.PaintItem, event);
 	if (data.focusDrawn) focusRect = null;
 	event.gc = null;
@@ -3954,7 +3954,7 @@ Event sendPaintItemEvent (TableItem item, NMTTCUSTOMDRAW nmcd, int column, RECT 
 	event.index = column;
 	event.gc = gc;
 	event.detail |= SWT.FOREGROUND;
-	event.setBounds(DPIUtil.scaleDown(new Rectangle(itemRect.left, itemRect.top, itemRect.right - itemRect.left, itemRect.bottom - itemRect.top), getZoom()));
+	event.setBounds(Win32DPIUtils.scaleDown(new Rectangle(itemRect.left, itemRect.top, itemRect.right - itemRect.left, itemRect.bottom - itemRect.top), getZoom()));
 	//gc.setClipping (cellRect.left, cellRect.top, cellWidth, cellHeight);
 	sendEvent (SWT.PaintItem, event);
 	event.gc = null;
@@ -6915,7 +6915,7 @@ LRESULT wmNotifyHeader (NMHDR hdr, long wParam, long lParam) {
 							 * Sort indicator size needs to scale as per the Native Windows OS DPI level
 							 * when header is custom drawn. For more details refer bug 537097.
 							 */
-							int leg = DPIUtil.scaleUp(3, nativeZoom);
+							int leg = Win32DPIUtils.scaleUp(3, nativeZoom);
 							if (sortDirection == SWT.UP) {
 								OS.Polyline(nmcd.hdc, new int[] {center-leg, 1+leg, center+1, 0}, 2);
 								OS.Polyline(nmcd.hdc, new int[] {center+leg, 1+leg, center-1, 0}, 2);
@@ -6966,10 +6966,10 @@ LRESULT wmNotifyHeader (NMHDR hdr, long wParam, long lParam) {
 							GCData data = new GCData();
 							data.device = display;
 							GC gc = createNewGC(nmcd.hdc, data);
-							int y = Math.max (0, (nmcd.bottom - DPIUtil.scaleUp(columns[i].image.getBounds(), getZoom()).height) / 2);
+							int y = Math.max (0, (nmcd.bottom - Win32DPIUtils.scaleUp(columns[i].image.getBounds(), getZoom()).height) / 2);
 							int zoom = getZoom();
 							gc.drawImage (columns[i].image, DPIUtil.scaleDown(x, zoom), DPIUtil.scaleDown(y, zoom));
-							x += DPIUtil.scaleUp(columns[i].image.getBounds(), getZoom()).width + 12;
+							x += Win32DPIUtils.scaleUp(columns[i].image.getBounds(), getZoom()).width + 12;
 							gc.dispose ();
 						}
 
@@ -7191,7 +7191,7 @@ private LRESULT positionTooltip(NMHDR hdr, long lParam) {
 		Event event = sendMeasureItemEvent (item, pinfo.iItem, pinfo.iSubItem, hDC);
 		if (!isDisposed () && !item.isDisposed ()) {
 			RECT itemRect = new RECT ();
-			Rectangle boundsInPixels = DPIUtil.scaleUp(event.getBounds(), getZoom());
+			Rectangle boundsInPixels = Win32DPIUtils.scaleUp(event.getBounds(), getZoom());
 			OS.SetRect (itemRect, boundsInPixels.x, boundsInPixels.y, boundsInPixels.x + boundsInPixels.width, boundsInPixels.y + boundsInPixels.height);
 			if (hdr.code == OS.TTN_SHOW) {
 				RECT toolRect = isCustomToolTip() ? toolTipRect (itemRect) : itemRect;
@@ -7288,12 +7288,12 @@ LRESULT wmNotifyToolTip (NMTTCUSTOMDRAW nmcd, long lParam) {
 					if (pinfo.iSubItem != 0) x -= gridWidth;
 					Image image = item.getImage (pinfo.iSubItem);
 					if (image != null) {
-						Rectangle rect = DPIUtil.scaleUp(image.getBounds(), getZoom());
+						Rectangle rect = Win32DPIUtils.scaleUp(image.getBounds(), getZoom());
 						RECT imageRect = item.getBounds (pinfo.iItem, pinfo.iSubItem, false, true, false, false, hDC);
 						Point size = imageList == null ? new Point (rect.width, rect.height) : imageList.getImageSize ();
 						int y = imageRect.top + Math.max (0, (imageRect.bottom - imageRect.top - size.y) / 2);
 						int zoom = getZoom();
-						rect = DPIUtil.scaleDown(rect, zoom);
+						rect = Win32DPIUtils.scaleDown(rect, zoom);
 						gc.drawImage (image, rect.x, rect.y, rect.width, rect.height, DPIUtil.scaleDown(x, zoom), DPIUtil.scaleDown(y, zoom), DPIUtil.scaleDown(size.x, zoom), DPIUtil.scaleDown(size.y, zoom));
 						x += size.x + INSET + (pinfo.iSubItem == 0 ? -2 : 4);
 					} else {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TableColumn.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TableColumn.java
@@ -413,7 +413,7 @@ public void pack () {
 		if (parent.sortColumn == this && parent.sortDirection != SWT.NONE) {
 			headerWidth += Table.SORT_WIDTH;
 		} else if (image != null) {
-			Rectangle bounds = DPIUtil.scaleUp(image.getBounds(), getZoom());
+			Rectangle bounds = Win32DPIUtils.scaleUp(image.getBounds(), getZoom());
 			headerWidth += bounds.width;
 		}
 		long hwndHeader = OS.SendMessage (hwnd, OS.LVM_GETHEADER, 0, 0);
@@ -440,7 +440,7 @@ public void pack () {
 				if (hFont != -1) hFont = OS.SelectObject (hDC, hFont);
 				if (isDisposed () || parent.isDisposed ()) break;
 				Rectangle bounds = event.getBounds();
-				columnWidth = Math.max (columnWidth, DPIUtil.scaleUp(bounds.x + bounds.width, getZoom()) - headerRect.left);
+				columnWidth = Math.max (columnWidth, Win32DPIUtils.scaleUp(bounds.x + bounds.width, getZoom()) - headerRect.left);
 			}
 		}
 		if (newFont != 0) OS.SelectObject (hDC, oldFont);
@@ -854,7 +854,7 @@ public void setToolTipText (String string) {
  */
 public void setWidth (int width) {
 	checkWidget ();
-	setWidthInPixels(DPIUtil.scaleUp(width, getZoom()));
+	setWidthInPixels(Win32DPIUtils.scaleUp(width, getZoom()));
 }
 
 void setWidthInPixels (int width) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TableItem.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TableItem.java
@@ -218,7 +218,7 @@ public Color getBackground (int index) {
  */
 public Rectangle getBounds () {
 	checkWidget();
-	return DPIUtil.scaleDown(getBoundsInPixels(), getZoom());
+	return Win32DPIUtils.scaleDown(getBoundsInPixels(), getZoom());
 }
 
 Rectangle getBoundsInPixels () {
@@ -244,7 +244,7 @@ Rectangle getBoundsInPixels () {
  */
 public Rectangle getBounds (int index) {
 	checkWidget();
-	return DPIUtil.scaleDown(getBoundsInPixels(index), getZoom());
+	return Win32DPIUtils.scaleDown(getBoundsInPixels(index), getZoom());
 }
 
 Rectangle getBoundsInPixels (int index) {
@@ -590,7 +590,7 @@ public Image getImage (int index) {
  */
 public Rectangle getImageBounds (int index) {
 	checkWidget();
-	return DPIUtil.scaleDown(getImageBoundsInPixels(index), getZoom());
+	return Win32DPIUtils.scaleDown(getImageBoundsInPixels(index), getZoom());
 }
 
 Rectangle getImageBoundsInPixels (int index) {
@@ -691,7 +691,7 @@ public String getText (int index) {
  */
 public Rectangle getTextBounds (int index) {
 	checkWidget();
-	return DPIUtil.scaleDown(getTextBoundsInPixels(index), getZoom());
+	return Win32DPIUtils.scaleDown(getTextBoundsInPixels(index), getZoom());
 }
 
 Rectangle getTextBoundsInPixels (int index) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Text.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Text.java
@@ -986,7 +986,7 @@ public int getCaretLineNumber () {
  */
 public Point getCaretLocation () {
 	checkWidget ();
-	return DPIUtil.scaleDown(getCaretLocationInPixels(), getZoom());
+	return Win32DPIUtils.scaleDown(getCaretLocationInPixels(), getZoom());
 }
 
 Point getCaretLocationInPixels () {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ToolBar.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ToolBar.java
@@ -570,7 +570,7 @@ public ToolItem getItem (int index) {
 public ToolItem getItem (Point point) {
 	checkWidget ();
 	if (point == null) error (SWT.ERROR_NULL_ARGUMENT);
-	return getItemInPixels(DPIUtil.scaleUp(point, getZoom()));
+	return getItemInPixels(Win32DPIUtils.scaleUp(point, getZoom()));
 }
 
 ToolItem getItemInPixels (Point point) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ToolItem.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ToolItem.java
@@ -235,7 +235,7 @@ void destroyWidget () {
  */
 public Rectangle getBounds () {
 	checkWidget();
-	return DPIUtil.scaleDown(getBoundsInPixels(), getZoom());
+	return Win32DPIUtils.scaleDown(getBoundsInPixels(), getZoom());
 }
 
 Rectangle getBoundsInPixels () {
@@ -1076,7 +1076,7 @@ public void setToolTipText (String string) {
  */
 public void setWidth (int width) {
 	checkWidget();
-	setWidthInPixels(DPIUtil.scaleUp(width, getZoom()));
+	setWidthInPixels(Win32DPIUtils.scaleUp(width, getZoom()));
 }
 
 void setWidthInPixels (int width) {
@@ -1103,7 +1103,7 @@ void updateImages (boolean enabled) {
 	ImageList hotImageList = parent.getHotImageList ();
 	ImageList disabledImageList = parent.getDisabledImageList();
 	if (info.iImage == OS.I_IMAGENONE) {
-		Rectangle bounds = DPIUtil.scaleBounds(image.getBounds(), getParent().getZoom(), 100);
+		Rectangle bounds = Win32DPIUtils.scaleBounds(image.getBounds(), getParent().getZoom(), 100);
 		int listStyle = parent.style & SWT.RIGHT_TO_LEFT;
 		if (imageList == null) {
 			imageList = display.getImageListToolBar (listStyle, bounds.width, bounds.height, getZoom());

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ToolTip.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ToolTip.java
@@ -358,7 +358,7 @@ public void setAutoHide (boolean autoHide) {
 public void setLocation (int x, int y) {
 	checkWidget ();
 	int zoom = getZoom();
-	setLocationInPixels(DPIUtil.scaleUp(x, zoom), DPIUtil.scaleUp(y, zoom));
+	setLocationInPixels(Win32DPIUtils.scaleUp(x, zoom), Win32DPIUtils.scaleUp(y, zoom));
 }
 
 void setLocationInPixels (int x, int y) {
@@ -393,7 +393,7 @@ void setLocationInPixels (int x, int y) {
 public void setLocation (Point location) {
 	checkWidget ();
 	if (location == null) error (SWT.ERROR_NULL_ARGUMENT);
-	location = DPIUtil.scaleUp(location, getZoom());
+	location = Win32DPIUtils.scaleUp(location, getZoom());
 	setLocationInPixels(location.x, location.y);
 }
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Tracker.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Tracker.java
@@ -405,7 +405,7 @@ public Rectangle [] getRectangles () {
 	checkWidget();
 	Rectangle [] result = getRectanglesInPixels();
 	for (int i = 0; i < result.length; i++) {
-		result[i] = DPIUtil.scaleDown(result[i], getZoom());
+		result[i] = Win32DPIUtils.scaleDown(result[i], getZoom());
 	}
 	return result;
 }
@@ -846,7 +846,7 @@ public void setRectangles (Rectangle [] rectangles) {
 	if (rectangles == null) error (SWT.ERROR_NULL_ARGUMENT);
 	Rectangle [] rectanglesInPixels = new Rectangle [rectangles.length];
 	for (int i = 0; i < rectangles.length; i++) {
-		rectanglesInPixels [i] = DPIUtil.scaleUp (rectangles [i], getZoom());
+		rectanglesInPixels [i] = Win32DPIUtils.scaleUp (rectangles [i], getZoom());
 	}
 	setRectanglesInPixels (rectanglesInPixels);
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Tree.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Tree.java
@@ -524,13 +524,13 @@ LRESULT CDDS_ITEMPOSTPAINT (NMTVCUSTOMDRAW nmcd, long wParam, long lParam) {
 							}
 							if (image != null) {
 								Rectangle bounds = image.getBounds (); // Points
-								if (size == null) size = DPIUtil.scaleDown (getImageSize (), zoom); // To Points
+								if (size == null) size = Win32DPIUtils.scaleDown (getImageSize (), zoom); // To Points
 								if (!ignoreDrawForeground) {
 									GCData data = new GCData();
 									data.device = display;
 									GC gc = createNewGC(hDC, data);
 									RECT iconRect = item.getBounds (index, false, true, false, false, true, hDC); // Pixels
-									gc.setClipping (DPIUtil.scaleDown(new Rectangle(iconRect.left, iconRect.top, iconRect.right - iconRect.left, iconRect.bottom - iconRect.top), zoom));
+									gc.setClipping (Win32DPIUtils.scaleDown(new Rectangle(iconRect.left, iconRect.top, iconRect.right - iconRect.left, iconRect.bottom - iconRect.top), zoom));
 									gc.drawImage (image, 0, 0, bounds.width, bounds.height, DPIUtil.scaleDown(iconRect.left, zoom), DPIUtil.scaleDown(iconRect.top, zoom), size.x, size.y);
 									OS.SelectClipRgn (hDC, 0);
 									gc.dispose ();
@@ -646,7 +646,7 @@ LRESULT CDDS_ITEMPOSTPAINT (NMTVCUSTOMDRAW nmcd, long wParam, long lParam) {
 								}
 							}
 						}
-						Rectangle bounds = DPIUtil.scaleDown(new Rectangle (cellRect.left, cellRect.top, cellRect.right - cellRect.left, cellRect.bottom - cellRect.top), getZoom());
+						Rectangle bounds = Win32DPIUtils.scaleDown(new Rectangle (cellRect.left, cellRect.top, cellRect.right - cellRect.left, cellRect.bottom - cellRect.top), getZoom());
 						event.setBounds (bounds);
 						gc.setClipping (bounds);
 						sendEvent (SWT.EraseItem, event);
@@ -762,20 +762,20 @@ LRESULT CDDS_ITEMPOSTPAINT (NMTVCUSTOMDRAW nmcd, long wParam, long lParam) {
 					int offset = i != 0 ? INSET : INSET + 2;
 					if (image != null) {
 						Rectangle bounds = image.getBounds (); // Points
-						if (size == null) size = DPIUtil.scaleDown (getImageSize (), zoom); // To Points
+						if (size == null) size = Win32DPIUtils.scaleDown (getImageSize (), zoom); // To Points
 						if (!ignoreDrawForeground) {
 							//int y1 = rect.top + (index == 0 ? (getItemHeight () - size.y) / 2 : 0);
-							int y1 = rect.top + DPIUtil.scaleUp((getItemHeight () - size.y) / 2, zoom);
+							int y1 = rect.top + Win32DPIUtils.scaleUp((getItemHeight () - size.y) / 2, zoom);
 							int x1 = Math.max (rect.left, rect.left - inset + 1);
 							GCData data = new GCData();
 							data.device = display;
 							GC gc = createNewGC(hDC, data);
-							gc.setClipping (DPIUtil.scaleDown(new Rectangle(x1, rect.top, rect.right - x1, rect.bottom - rect.top), zoom));
+							gc.setClipping (Win32DPIUtils.scaleDown(new Rectangle(x1, rect.top, rect.right - x1, rect.bottom - rect.top), zoom));
 							gc.drawImage (image, 0, 0, bounds.width, bounds.height, DPIUtil.scaleDown(x1, zoom), DPIUtil.scaleDown(y1, zoom), size.x, size.y);
 							OS.SelectClipRgn (hDC, 0);
 							gc.dispose ();
 						}
-						OS.SetRect (rect, rect.left + DPIUtil.scaleUp(size.x, zoom) + offset, rect.top, rect.right - inset, rect.bottom);
+						OS.SetRect (rect, rect.left + Win32DPIUtils.scaleUp(size.x, zoom) + offset, rect.top, rect.right - inset, rect.bottom);
 					} else {
 						if (i == 0) {
 							if (OS.SendMessage (handle, OS.TVM_GETIMAGELIST, OS.TVSIL_NORMAL, 0) != 0) {
@@ -864,11 +864,11 @@ LRESULT CDDS_ITEMPOSTPAINT (NMTVCUSTOMDRAW nmcd, long wParam, long lParam) {
 						}
 					}
 				}
-				event.setBounds(DPIUtil.scaleDown(new Rectangle(itemRect.left, itemRect.top, itemRect.right - itemRect.left, itemRect.bottom - itemRect.top), getZoom()));
+				event.setBounds(Win32DPIUtils.scaleDown(new Rectangle(itemRect.left, itemRect.top, itemRect.right - itemRect.left, itemRect.bottom - itemRect.top), getZoom()));
 				RECT cellRect = item.getBounds (index, true, true, true, true, true, hDC);
 				int cellWidth = cellRect.right - cellRect.left;
 				int cellHeight = cellRect.bottom - cellRect.top;
-				gc.setClipping (DPIUtil.scaleDown(new Rectangle(cellRect.left, cellRect.top, cellWidth, cellHeight), zoom));
+				gc.setClipping (Win32DPIUtils.scaleDown(new Rectangle(cellRect.left, cellRect.top, cellWidth, cellHeight), zoom));
 				sendEvent (SWT.PaintItem, event);
 				if (data.focusDrawn) focusRect = null;
 				event.gc = null;
@@ -1031,7 +1031,7 @@ LRESULT CDDS_ITEMPREPAINT (NMTVCUSTOMDRAW nmcd, long wParam, long lParam) {
 		Rectangle boundsInPixels = null;
 		if (hooks (SWT.MeasureItem)) {
 			measureEvent = sendMeasureItemEvent (item, index, hDC, selected ? SWT.SELECTED : 0);
-			boundsInPixels = DPIUtil.scaleUp(measureEvent.getBounds(), getZoom());
+			boundsInPixels = Win32DPIUtils.scaleUp(measureEvent.getBounds(), getZoom());
 			if (isDisposed () || item.isDisposed ()) return null;
 		}
 		selectionForeground = -1;
@@ -1085,7 +1085,7 @@ LRESULT CDDS_ITEMPREPAINT (NMTVCUSTOMDRAW nmcd, long wParam, long lParam) {
 					}
 				}
 			}
-			Rectangle bounds = DPIUtil.scaleDown(new Rectangle (cellRect.left, cellRect.top, cellRect.right - cellRect.left, cellRect.bottom - cellRect.top), getZoom());
+			Rectangle bounds = Win32DPIUtils.scaleDown(new Rectangle (cellRect.left, cellRect.top, cellRect.right - cellRect.left, cellRect.bottom - cellRect.top), getZoom());
 			event.setBounds (bounds);
 			gc.setClipping (bounds);
 			sendEvent (SWT.EraseItem, event);
@@ -2804,7 +2804,7 @@ boolean findCell (int x, int y, TreeItem [] item, int [] index, RECT [] cellRect
 						int detail = (state & OS.TVIS_SELECTED) != 0 ? SWT.SELECTED : 0;
 						Event event = sendMeasureItemEvent (item [0], order [index [0]], hDC, detail);
 						if (isDisposed () || item [0].isDisposed ()) break;
-						Rectangle boundsInPixels = DPIUtil.scaleUp(event.getBounds(), getZoom());
+						Rectangle boundsInPixels = Win32DPIUtils.scaleUp(event.getBounds(), getZoom());
 						itemRect [0] = new RECT ();
 						itemRect [0].left = boundsInPixels.x;
 						itemRect [0].right = boundsInPixels.x + boundsInPixels.width;
@@ -3287,7 +3287,7 @@ TreeItem getItem (NMTVCUSTOMDRAW nmcd) {
 public TreeItem getItem (Point point) {
 	checkWidget ();
 	if (point == null) error (SWT.ERROR_NULL_ARGUMENT);
-	return getItemInPixels(DPIUtil.scaleUp(point, getZoom()));
+	return getItemInPixels(Win32DPIUtils.scaleUp(point, getZoom()));
 }
 
 TreeItem getItemInPixels (Point point) {
@@ -3730,7 +3730,7 @@ boolean hitTestSelection (long hItem, int x, int y) {
 	int state = (int)OS.SendMessage (handle, OS.TVM_GETITEMSTATE, hItem, OS.TVIS_SELECTED);
 	int detail = (state & OS.TVIS_SELECTED) != 0 ? SWT.SELECTED : 0;
 	Event event = sendMeasureItemEvent (item, order [index [0]], hDC, detail);
-	if (DPIUtil.scaleUp(event.getBounds(), getZoom()).contains (x, y)) result = true;
+	if (Win32DPIUtils.scaleUp(event.getBounds(), getZoom()).contains (x, y)) result = true;
 	if (newFont != 0) OS.SelectObject (hDC, oldFont);
 	OS.ReleaseDC (handle, hDC);
 //	if (isDisposed () || item.isDisposed ()) return false;
@@ -3740,7 +3740,7 @@ boolean hitTestSelection (long hItem, int x, int y) {
 int imageIndex (Image image, int index) {
 	if (image == null) return OS.I_IMAGENONE;
 	if (imageList == null) {
-		Rectangle bounds = DPIUtil.scaleBounds(image.getBounds(), this.getZoom(), 100);
+		Rectangle bounds = Win32DPIUtils.scaleBounds(image.getBounds(), this.getZoom(), 100);
 		imageList = display.getImageList (style & SWT.RIGHT_TO_LEFT, bounds.width, bounds.height, getZoom());
 	}
 	int imageIndex = imageList.indexOf (image);
@@ -3764,7 +3764,7 @@ int imageIndex (Image image, int index) {
 int imageIndexHeader (Image image) {
 	if (image == null) return OS.I_IMAGENONE;
 	if (headerImageList == null) {
-		Rectangle bounds = DPIUtil.scaleBounds(image.getBounds(), this.getZoom(), 100);
+		Rectangle bounds = Win32DPIUtils.scaleBounds(image.getBounds(), this.getZoom(), 100);
 		headerImageList = display.getImageList (style & SWT.RIGHT_TO_LEFT, bounds.width, bounds.height, getZoom());
 		int index = headerImageList.indexOf (image);
 		if (index == -1) index = headerImageList.add (image);
@@ -4530,7 +4530,7 @@ Event sendEraseItemEvent (TreeItem item, NMTTCUSTOMDRAW nmcd, int column, RECT c
 	event.index = column;
 	event.gc = gc;
 	event.detail |= SWT.FOREGROUND;
-	event.setBounds(DPIUtil.scaleDown(new Rectangle(cellRect.left, cellRect.top, cellRect.right - cellRect.left, cellRect.bottom - cellRect.top), getZoom()));
+	event.setBounds(Win32DPIUtils.scaleDown(new Rectangle(cellRect.left, cellRect.top, cellRect.right - cellRect.left, cellRect.bottom - cellRect.top), getZoom()));
 	//gc.setClipping (event.x, event.y, event.width, event.height);
 	sendEvent (SWT.EraseItem, event);
 	event.gc = null;
@@ -4551,14 +4551,14 @@ Event sendMeasureItemEvent (TreeItem item, int index, long hDC, int detail) {
 	event.item = item;
 	event.gc = gc;
 	event.index = index;
-	event.setBounds(DPIUtil.scaleDown(new Rectangle(itemRect.left, itemRect.top, itemRect.right - itemRect.left, itemRect.bottom - itemRect.top), getZoom()));
+	event.setBounds(Win32DPIUtils.scaleDown(new Rectangle(itemRect.left, itemRect.top, itemRect.right - itemRect.left, itemRect.bottom - itemRect.top), getZoom()));
 	event.detail = detail;
 	sendEvent (SWT.MeasureItem, event);
 	event.gc = null;
 	gc.dispose ();
 	OS.RestoreDC (hDC, nSavedDC);
 	if (isDisposed () || item.isDisposed ()) return null;
-	Rectangle rect = DPIUtil.scaleUp(event.getBounds(), getZoom());
+	Rectangle rect = Win32DPIUtils.scaleUp(event.getBounds(), getZoom());
 	if (hwndHeader != 0) {
 		if (columnCount == 0) {
 			if (rect.x + rect.width > scrollWidth) {
@@ -4586,7 +4586,7 @@ Event sendPaintItemEvent (TreeItem item, NMTTCUSTOMDRAW nmcd, int column, RECT i
 	event.index = column;
 	event.gc = gc;
 	event.detail |= SWT.FOREGROUND;
-	event.setBounds(DPIUtil.scaleDown(new Rectangle(itemRect.left, itemRect.top, itemRect.right - itemRect.left, itemRect.bottom - itemRect.top), getZoom()));
+	event.setBounds(Win32DPIUtils.scaleDown(new Rectangle(itemRect.left, itemRect.top, itemRect.right - itemRect.left, itemRect.bottom - itemRect.top), getZoom()));
 	//gc.setClipping (cellRect.left, cellRect.top, cellWidth, cellHeight);
 	sendEvent (SWT.PaintItem, event);
 	event.gc = null;
@@ -5371,7 +5371,7 @@ public void setTopItem (TreeItem item) {
  * In a Tree without imageList, the indent also controls the chevron (glyph) size.
  */
 private void calculateAndApplyIndentSize() {
-	int indent = DPIUtil.scaleUp(DEFAULT_INDENT, nativeZoom);
+	int indent = Win32DPIUtils.scaleUp(DEFAULT_INDENT, nativeZoom);
 	OS.SendMessage(handle, OS.TVM_SETINDENT, indent, 0);
 }
 
@@ -7152,7 +7152,7 @@ LRESULT WM_PAINT (long wParam, long lParam) {
 				if (hooksPaint) {
 					Event event = new Event ();
 					event.gc = gc;
-					event.setBounds(DPIUtil.scaleDown(new Rectangle(ps.left, ps.top, ps.right - ps.left, ps.bottom - ps.top), getZoom()));
+					event.setBounds(Win32DPIUtils.scaleDown(new Rectangle(ps.left, ps.top, ps.right - ps.left, ps.bottom - ps.top), getZoom()));
 					sendEvent (SWT.Paint, event);
 					// widget could be disposed at this point
 					event.gc = null;
@@ -7886,7 +7886,7 @@ LRESULT wmNotifyHeader (NMHDR hdr, long wParam, long lParam) {
 							 * Sort indicator size needs to scale as per the Native Windows OS DPI level
 							 * when header is custom drawn. For more details refer bug 537097.
 							 */
-							int leg = DPIUtil.scaleUp(3, nativeZoom);
+							int leg = Win32DPIUtils.scaleUp(3, nativeZoom);
 							if (sortDirection == SWT.UP) {
 								OS.Polyline(nmcd.hdc, new int[] {center-leg, 1+leg, center+1, 0}, 2);
 								OS.Polyline(nmcd.hdc, new int[] {center+leg, 1+leg, center-1, 0}, 2);
@@ -7931,7 +7931,7 @@ LRESULT wmNotifyHeader (NMHDR hdr, long wParam, long lParam) {
 							data.device = display;
 							GC gc = createNewGC(nmcd.hdc, data);
 							int zoom = getZoom();
-							Rectangle imageBounds = DPIUtil.scaleBounds(columns[i].image.getBounds(), zoom, 100);
+							Rectangle imageBounds = Win32DPIUtils.scaleBounds(columns[i].image.getBounds(), zoom, 100);
 							int y = Math.max (0, (nmcd.bottom - imageBounds.height) / 2);
 							gc.drawImage (columns[i].image, DPIUtil.scaleDown(x, zoom), DPIUtil.scaleDown(y, zoom));
 							x += imageBounds.width + 12;

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TreeColumn.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TreeColumn.java
@@ -359,7 +359,7 @@ public void pack () {
 				Event event = parent.sendMeasureItemEvent (item, index, hDC, detail);
 				if (isDisposed () || parent.isDisposed ()) break;
 				Rectangle bounds = event.getBounds();
-				itemRight = DPIUtil.scaleUp(bounds.x + bounds.width, getZoom());
+				itemRight = Win32DPIUtils.scaleUp(bounds.x + bounds.width, getZoom());
 			} else {
 				long hFont = item.fontHandle (index);
 				if (hFont != -1) hFont = OS.SelectObject (hDC, hFont);
@@ -385,7 +385,7 @@ public void pack () {
 			headerImage = image;
 		}
 		if (headerImage != null) {
-			Rectangle bounds = DPIUtil.scaleUp(headerImage.getBounds(), getZoom());
+			Rectangle bounds = Win32DPIUtils.scaleUp(headerImage.getBounds(), getZoom());
 			headerWidth += bounds.width;
 		}
 		int margin = 0;
@@ -717,7 +717,7 @@ public void setToolTipText (String string) {
  */
 public void setWidth (int width) {
 	checkWidget ();
-	setWidthInPixels(DPIUtil.scaleUp(width, getZoom()));
+	setWidthInPixels(Win32DPIUtils.scaleUp(width, getZoom()));
 }
 
 void setWidthInPixels (int width) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TreeItem.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TreeItem.java
@@ -375,7 +375,7 @@ public Color getBackground (int index) {
  */
 public Rectangle getBounds () {
 	checkWidget ();
-	return DPIUtil.scaleDown(getBoundsInPixels(), getZoom());
+	return Win32DPIUtils.scaleDown(getBoundsInPixels(), getZoom());
 }
 
 Rectangle getBoundsInPixels () {
@@ -401,7 +401,7 @@ Rectangle getBoundsInPixels () {
  */
 public Rectangle getBounds (int index) {
 	checkWidget();
-	return DPIUtil.scaleDown(getBoundsInPixels(index), getZoom());
+	return Win32DPIUtils.scaleDown(getBoundsInPixels(index), getZoom());
 }
 
 Rectangle getBoundsInPixels (int index) {
@@ -817,7 +817,7 @@ public Image getImage (int index) {
  */
 public Rectangle getImageBounds (int index) {
 	checkWidget();
-	return DPIUtil.scaleDown(getImageBoundsInPixels(index), getZoom());
+	return Win32DPIUtils.scaleDown(getImageBoundsInPixels(index), getZoom());
 }
 
 Rectangle getImageBoundsInPixels (int index) {
@@ -912,7 +912,7 @@ public String getText (int index) {
  */
 public Rectangle getTextBounds (int index) {
 	checkWidget();
-	return DPIUtil.scaleDown(getTextBoundsInPixels(index), getZoom());
+	return Win32DPIUtils.scaleDown(getTextBoundsInPixels(index), getZoom());
 }
 
 Rectangle getTextBoundsInPixels (int index) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Widget.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Widget.java
@@ -1708,7 +1708,7 @@ boolean showMenu (int x, int y, int detail) {
 	if (!event.doit) return true;
 	Menu menu = getMenu ();
 	if (menu != null && !menu.isDisposed ()) {
-		Point locInPixels = DPIUtil.scaleUp(event.getLocation(), getZoom()); // In Pixels
+		Point locInPixels = Win32DPIUtils.scaleUp(event.getLocation(), getZoom()); // In Pixels
 		if (x != locInPixels.x || y != locInPixels.y) {
 			menu.setLocation (event.getLocation());
 		}
@@ -2362,7 +2362,7 @@ LRESULT wmPaint (long hwnd, long wParam, long lParam) {
 			OS.SetMetaRgn (hDC);
 			Event event = new Event ();
 			event.gc = gc;
-			event.setBounds(DPIUtil.scaleDown(new Rectangle(rect.left, rect.top, width, height), getZoom()));
+			event.setBounds(Win32DPIUtils.scaleDown(new Rectangle(rect.left, rect.top, width, height), getZoom()));
 			sendEvent (SWT.Paint, event);
 			// widget could be disposed at this point
 			event.gc = null;

--- a/tests/org.eclipse.swt.tests.win32/JUnit Tests/org/eclipse/swt/tests/win32/AllWin32Tests.java
+++ b/tests/org.eclipse.swt.tests.win32/JUnit Tests/org/eclipse/swt/tests/win32/AllWin32Tests.java
@@ -27,7 +27,8 @@ import org.junit.runners.Suite;
 	Test_org_eclipse_swt_dnd_DND.class,
 	Test_org_eclipse_swt_events_KeyEvent.class,
 	Test_org_eclipse_swt_widgets_Display.class,
-	TestTreeColumn.class
+	TestTreeColumn.class,
+	Win32DPIUtilTests.class
 })
 
 public class AllWin32Tests {

--- a/tests/org.eclipse.swt.tests.win32/JUnit Tests/org/eclipse/swt/tests/win32/Win32DPIUtilTests.java
+++ b/tests/org.eclipse.swt.tests.win32/JUnit Tests/org/eclipse/swt/tests/win32/Win32DPIUtilTests.java
@@ -1,0 +1,258 @@
+/*******************************************************************************
+ * Copyright (c) 2024, 2025 Yatta Solutions and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Yatta Solutions - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.swt.tests.win32;
+
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import org.eclipse.swt.graphics.Device;
+import org.eclipse.swt.graphics.Point;
+import org.eclipse.swt.graphics.Rectangle;
+import org.eclipse.swt.internal.Win32DPIUtils;
+import org.junit.Test;
+/**
+ * Automated Test Suite for class org.eclipse.swt.internal.Win32DPIUtils
+ *
+ * @see org.eclipse.swt.internal.Win32DPIUtils
+ */
+@SuppressWarnings("restriction")
+public class Win32DPIUtilTests {
+
+	@Test
+	public void scaleDownFloatArray() {
+		float[] valueAt200 = new float[] { 2, 3, 4 };
+		float[] valueAt150 = new float[] { 1.5f, 2.25f, 3 };
+		float[] valueAt100 = new float[] { 1, 1.5f, 2 };
+
+		float[] scaledValue = Win32DPIUtils.scaleDown(valueAt200, 200);
+		assertArrayEquals(valueAt100, scaledValue, .001f, "Scaling down float array from 200 failed");
+		scaledValue = Win32DPIUtils.scaleDown((Device) null, valueAt200, 200);
+		assertArrayEquals(valueAt100, scaledValue, .001f, "Scaling down float array from 200 with device failed");
+		scaledValue = Win32DPIUtils.scaleDown(valueAt150, 150);
+		assertArrayEquals(valueAt100, scaledValue, .001f, "Scaling down float array from 150 failed");
+		scaledValue = Win32DPIUtils.scaleDown((Device) null, valueAt150, 150);
+		assertArrayEquals(valueAt100, scaledValue, .001f, "Scaling down float array from 150 with device failed");
+		scaledValue = Win32DPIUtils.scaleDown(valueAt100, 100);
+		assertSame(valueAt100, scaledValue, "Scaling down float array without zoom change failed");
+		scaledValue = Win32DPIUtils.scaleDown((Device) null, valueAt100, 100);
+		assertSame(valueAt100, scaledValue, "Scaling down float array without zoom change with device failed");
+	}
+
+	@Test
+	public void scaleDownInteger() {
+		int valueAt200 = 10;
+		int valueAt150 = 7;
+		int valueAt100 = 5;
+
+		int scaledValue = Win32DPIUtils.scaleDown((Device) null, valueAt200, 200);
+		assertEquals(valueAt100, scaledValue, "Scaling down integer from 200 with device failed");
+		scaledValue = Win32DPIUtils.scaleDown((Device) null, valueAt150, 150);
+		assertEquals(valueAt100, scaledValue, "Scaling down integer from 150 with device failed");
+		scaledValue = Win32DPIUtils.scaleDown((Device) null, valueAt100, 100);
+		assertSame(valueAt100, scaledValue, "Scaling down integer without zoom change with device failed");
+	}
+
+	@Test
+	public void scaleDownFloat() {
+		float valueAt200 = 10f;
+		float valueAt150 = 7.5f;
+		float valueAt100 = 5f;
+
+		float scaledValue = Win32DPIUtils.scaleDown((Device) null, valueAt200, 200);
+		assertEquals(valueAt100, scaledValue, .001f, "Scaling down float from 200 with device failed");
+		scaledValue = Win32DPIUtils.scaleDown((Device) null, valueAt150, 150);
+		assertEquals(valueAt100, scaledValue, .001f, "Scaling down float without zoom change failed");
+		scaledValue = Win32DPIUtils.scaleDown((Device) null, valueAt100, 100);
+		assertEquals(valueAt100, scaledValue, .001f, "Scaling down float without zoom change with device failed");
+	}
+
+	@Test
+	public void scaleDownPoint() {
+		Point valueAt200 = new Point(10, 14);
+		Point valueAt150 = new Point(7, 10);
+		Point valueAt100 = new Point(5, 7);
+
+		Point scaledValue = Win32DPIUtils.scaleDown(valueAt200, 200);
+		assertEquals(valueAt100, scaledValue, "Scaling down Point from 200 failed");
+		scaledValue = Win32DPIUtils.scaleDown((Device) null, valueAt200, 200);
+		assertEquals(valueAt100, scaledValue, "Scaling down Point from 200 with device failed");
+		scaledValue = Win32DPIUtils.scaleDown(valueAt150, 150);
+		assertEquals(valueAt100, scaledValue, "Scaling down Point from 150 failed");
+		scaledValue = Win32DPIUtils.scaleDown((Device) null, valueAt150, 150);
+		assertEquals(valueAt100, scaledValue, "Scaling down Point from 150 with device failed");
+		scaledValue = Win32DPIUtils.scaleDown(valueAt100, 100);
+		assertSame(valueAt100, scaledValue, "Scaling down Point without zoom change failed");
+		scaledValue = Win32DPIUtils.scaleDown((Device) null, valueAt100, 100);
+		assertSame(valueAt100, scaledValue, "Scaling down Point without zoom change with device failed");
+	}
+
+	@Test
+	public void scaleDownRectangle() {
+		Rectangle valueAt200 = new Rectangle(100, 150, 10, 14);
+		Rectangle valueAt150 = new Rectangle(75, 113, 7, 10);
+		Rectangle valueAt100 = new Rectangle(50, 75, 5, 7);
+
+		Rectangle scaledValue = Win32DPIUtils.scaleDown(valueAt200, 200);
+		assertEquals(valueAt100, scaledValue, "Scaling down Rectangle from 200 failed");
+		scaledValue = Win32DPIUtils.scaleDown((Device) null, valueAt200, 200);
+		assertEquals(valueAt100, scaledValue, "Scaling down Rectangle from 200 with device failed");
+		scaledValue = Win32DPIUtils.scaleDown(valueAt150, 150);
+		assertEquals(valueAt100, scaledValue, "Scaling down Rectangle from 150 failed");
+		scaledValue = Win32DPIUtils.scaleDown((Device) null, valueAt150, 150);
+		assertEquals(valueAt100, scaledValue, "Scaling down Rectangle from 150 with device failed");
+		scaledValue = Win32DPIUtils.scaleDown(valueAt100, 100);
+		assertSame(valueAt100, scaledValue, "Scaling down Rectangle without zoom change failed");
+		scaledValue = Win32DPIUtils.scaleDown((Device) null, valueAt100, 100);
+		assertSame(valueAt100, scaledValue, "Scaling down Rectangle without zoom change with device failed");
+	}
+
+	@Test
+	public void scaleUpIntArray() {
+		int[] valueAt200 = new int[] { 10, 12, 14 };
+		int[] valueAt150 = new int[] { 8, 9, 11 };
+		int[] valueAt100 = new int[] { 5, 6, 7 };
+
+		int[] scaledValue = Win32DPIUtils.scaleUp(valueAt100, 200);
+		assertArrayEquals(valueAt200, scaledValue, "Scaling up int array to 200 failed");
+		scaledValue = Win32DPIUtils.scaleUp((Device) null, valueAt100, 200);
+		assertArrayEquals(valueAt200, scaledValue, "Scaling up int array to 200 with device failed");
+		scaledValue = Win32DPIUtils.scaleUp(valueAt100, 150);
+		assertArrayEquals(valueAt150, scaledValue, "Scaling up int array to 150 failed");
+		scaledValue = Win32DPIUtils.scaleUp((Device) null, valueAt100, 150);
+		assertArrayEquals(valueAt150, scaledValue, "Scaling up int array to 150 with device failed");
+		scaledValue = Win32DPIUtils.scaleUp(valueAt100, 100);
+		assertSame(valueAt100, scaledValue, "Scaling up int array without zoom change failed");
+		scaledValue = Win32DPIUtils.scaleUp((Device) null, valueAt100, 100);
+		assertSame(valueAt100, scaledValue, "Scaling up int array without zoom change with device failed");
+	}
+
+	@Test
+	public void scaleUpInteger() {
+		int valueAt200 = 10;
+		int valueAt150 = 8;
+		int valueAt100 = 5;
+
+		int scaledValue = Win32DPIUtils.scaleUp(valueAt100, 200);
+		assertEquals(valueAt200, scaledValue, "Scaling up integer to 200 failed");
+		scaledValue = Win32DPIUtils.scaleUp((Device) null, valueAt100, 200);
+		assertEquals(valueAt200, scaledValue, "Scaling up integer to 200 with device failed");
+		scaledValue = Win32DPIUtils.scaleUp(valueAt100, 150);
+		assertEquals(valueAt150, scaledValue, "Scaling up integer to 150 failed");
+		scaledValue = Win32DPIUtils.scaleUp((Device) null, valueAt100, 150);
+		assertEquals(valueAt150, scaledValue, "Scaling up integer to 150 with device failed");
+		scaledValue = Win32DPIUtils.scaleUp(valueAt100, 100);
+		assertSame(valueAt100, scaledValue, "Scaling up integer without zoom change failed");
+		scaledValue = Win32DPIUtils.scaleUp((Device) null, valueAt100, 100);
+		assertSame(valueAt100, scaledValue,"Scaling up integer without zoom change with device failed");
+	}
+
+	@Test
+	public void scaleUpFloat() {
+		float valueAt200 = 10;
+		float valueAt150 = 7.5f;
+		float valueAt100 = 5;
+
+		float scaledValue = Win32DPIUtils.scaleUp(valueAt100, 200);
+		assertEquals(valueAt200, scaledValue, 0.001f, "Scaling up integer to 200 failed");
+		scaledValue = Win32DPIUtils.scaleUp((Device) null, valueAt100, 200);
+		assertEquals(valueAt200, scaledValue, 0.001f, "Scaling up integer to 200 with device failed");
+		scaledValue = Win32DPIUtils.scaleUp(valueAt100, 150);
+		assertEquals(valueAt150, scaledValue, 0.001f, "Scaling up integer to 150 failed");
+		scaledValue = Win32DPIUtils.scaleUp((Device) null, valueAt100, 150);
+		assertEquals(valueAt150, scaledValue, 0.001f, "Scaling up integer to 150 with device failed");
+		scaledValue = Win32DPIUtils.scaleUp(valueAt100, 100);
+		assertEquals(valueAt100, scaledValue, 0.001f, "Scaling up integer without zoom change failed");
+		scaledValue = Win32DPIUtils.scaleUp((Device) null, valueAt100, 100);
+		assertEquals(valueAt100, scaledValue, 0.001f, "Scaling up integer without zoom change with device failed");
+	}
+
+	@Test
+	public void scaleUpPoint() {
+		Point valueAt200 = new Point(10, 14);
+		Point valueAt150 = new Point(8, 11);
+		Point valueAt100 = new Point(5, 7);
+
+		Point scaledValue = Win32DPIUtils.scaleUp(valueAt100, 200);
+		assertEquals(valueAt200, scaledValue, "Scaling up Point to 200 failed");
+		scaledValue = Win32DPIUtils.scaleUp((Device) null, valueAt100, 200);
+		assertEquals(valueAt200, scaledValue, "Scaling up Point to 200 with device failed");
+		scaledValue = Win32DPIUtils.scaleUp(valueAt100, 150);
+		assertEquals(valueAt150, scaledValue, "Scaling up Point to 150 failed");
+		scaledValue = Win32DPIUtils.scaleUp((Device) null, valueAt100, 150);
+		assertEquals(valueAt150, scaledValue, "Scaling up Point to 150 with device failed");
+		scaledValue = Win32DPIUtils.scaleUp(valueAt100, 100);
+		assertSame(valueAt100, scaledValue, "Scaling up Point without zoom change failed");
+		scaledValue = Win32DPIUtils.scaleUp((Device) null, valueAt100, 100);
+		assertSame(valueAt100, scaledValue, "Scaling up Point without zoom change with device failed");
+	}
+
+	@Test
+	public void scaleUpRectangle() {
+		Rectangle valueAt200 = new Rectangle(100, 150, 10, 14);
+		Rectangle valueAt150 = new Rectangle(75, 113, 8, 11);
+		Rectangle valueAt100 = new Rectangle(50, 75, 5, 7);
+
+		Rectangle scaledValue = Win32DPIUtils.scaleUp(valueAt100, 200);
+		assertEquals(valueAt200, scaledValue, "Scaling up Rectangle to 200 failed");
+		scaledValue = Win32DPIUtils.scaleUp((Device) null, valueAt100, 200);
+		assertEquals(valueAt200, scaledValue, "Scaling up Rectangle to 200 with device failed");
+		scaledValue = Win32DPIUtils.scaleUp(valueAt100, 150);
+		assertEquals(valueAt150, scaledValue, "Scaling up Rectangle to 150 failed");
+		scaledValue = Win32DPIUtils.scaleUp((Device) null, valueAt100, 150);
+		assertEquals(valueAt150, scaledValue, "Scaling up Rectangle to 150 with device failed");
+		scaledValue = Win32DPIUtils.scaleUp(valueAt100, 100);
+		assertSame(valueAt100, scaledValue, "Scaling up Rectangle without zoom change failed");
+		scaledValue = Win32DPIUtils.scaleUp((Device) null, valueAt100, 100);
+		assertSame(valueAt100, scaledValue, "Scaling up Rectangle without zoom change with device failed");
+	}
+
+	@Test
+	public void scaleDownscaleUpRectangleInvertible() {
+		int[] zooms = new int[] {25, 50, 75, 100, 125, 150, 175, 200, 225, 250, 275, 300, 325, 350, 375, 400};
+		for (int zoom1 : zooms) {
+			for (int zoom2 : zooms) {
+				for (int i = 1; i <= 10000; i++) {
+					Rectangle rect = new Rectangle(0, 0, i, i);
+					Rectangle scaleDown = Win32DPIUtils.scaleDown(rect, zoom1);
+					Rectangle scaleUp = Win32DPIUtils.scaleUp(scaleDown, zoom2);
+					scaleDown = Win32DPIUtils.scaleDown(scaleUp, zoom2);
+					scaleUp = Win32DPIUtils.scaleUp(scaleDown, zoom1);
+					assertEquals(rect.width, scaleUp.width);
+					assertEquals(rect.height, scaleUp.height);
+				}
+			}
+		}
+	}
+
+	@Test
+	public void scaleDownscaleUpPointInvertible() {
+		int[] zooms = new int[] {25, 50, 75, 100, 125, 150, 175, 200, 225, 250, 275, 300, 325, 350, 375, 400};
+		for (int zoom1 : zooms) {
+			for (int zoom2 : zooms) {
+				for (int i = 1; i <= 10000; i++) {
+					Point pt = new Point(i, i);
+					Point scaleDown = Win32DPIUtils.scaleDown(pt, zoom1);
+					Point scaleUp = Win32DPIUtils.scaleUp(scaleDown, zoom2);
+					scaleDown = Win32DPIUtils.scaleDown(scaleUp, zoom2);
+					scaleUp = Win32DPIUtils.scaleUp(scaleDown, zoom1);
+					assertEquals(pt.x, scaleUp.x);
+					assertEquals(pt.y, scaleUp.y);
+				}
+			}
+		}
+	}
+
+}

--- a/tests/org.eclipse.swt.tests.win32/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.swt.tests.win32/META-INF/MANIFEST.MF
@@ -9,3 +9,4 @@ Require-Bundle: org.junit;bundle-version="4.12.0",
 Eclipse-BundleShape: dir
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Automatic-Module-Name: org.eclipse.swt.tests.win32
+Import-Package: org.junit.jupiter.api;version="[5.13.0,6.0.0)"

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/DPIUtilTests.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/DPIUtilTests.java
@@ -56,14 +56,7 @@ public class DPIUtilTests {
 		float[] valueAt150 = new float[] { 1.5f, 2.25f, 3 };
 		float[] valueAt100 = new float[] { 1, 1.5f, 2 };
 
-		float[] scaledValue = DPIUtil.autoScaleDown(valueAt200);
-		assertArrayEquals(valueAt100, scaledValue, .001f, String.format("Scaling down float array from device zoom (%d) to 100 failed",
-				ZOOM_200));
-		scaledValue = DPIUtil.autoScaleDown((Device) null, valueAt200);
-		assertArrayEquals(valueAt100, scaledValue, .001f, String.format("Scaling down float array from device zoom (%d) to 100 with device failed",
-				ZOOM_200));
-
-		scaledValue = DPIUtil.scaleDown(valueAt200, 200);
+		float[] scaledValue = DPIUtil.scaleDown(valueAt200, 200);
 		assertArrayEquals(valueAt100, scaledValue, .001f, "Scaling down float array from 200 failed");
 		scaledValue = DPIUtil.scaleDown((Device) null, valueAt200, 200);
 		assertArrayEquals(valueAt100, scaledValue, .001f, "Scaling down float array from 200 with device failed");
@@ -83,14 +76,7 @@ public class DPIUtilTests {
 		int valueAt150 = 7;
 		int valueAt100 = 5;
 
-		int scaledValue = DPIUtil.autoScaleDown(valueAt200);
-		assertEquals(
-				valueAt100, scaledValue, String.format("Scaling down integer from device zoom (%d) to 100 failed", ZOOM_200));
-		scaledValue = DPIUtil.autoScaleDown((Device) null, valueAt200);
-		assertEquals(
-				 valueAt100, scaledValue, String.format("Scaling down integer from device zoom (%d) to 100 with device failed", ZOOM_200));
-
-		scaledValue = DPIUtil.scaleDown(valueAt200, 200);
+		int scaledValue = DPIUtil.scaleDown(valueAt200, 200);
 		assertEquals(valueAt100, scaledValue, "Scaling down integer from 200 failed");
 		scaledValue = DPIUtil.scaleDown((Device) null, valueAt200, 200);
 		assertEquals(valueAt100, scaledValue, "Scaling down integer from 200 with device failed");
@@ -110,14 +96,7 @@ public class DPIUtilTests {
 		float valueAt150 = 7.5f;
 		float valueAt100 = 5f;
 
-		float scaledValue = DPIUtil.autoScaleDown(valueAt200);
-		assertEquals(valueAt100, scaledValue, .001f,
-				String.format("Scaling down float from device zoom (%d) to 100 failed", ZOOM_200));
-		scaledValue = DPIUtil.autoScaleDown((Device) null, valueAt200);
-		assertEquals(valueAt100, scaledValue, .001f, String
-				.format("Scaling down float from device zoom (%d) to 100 with device failed", ZOOM_200));
-
-		scaledValue = DPIUtil.scaleDown(valueAt200, 200);
+		float scaledValue = DPIUtil.scaleDown(valueAt200, 200);
 		assertEquals(valueAt100, scaledValue, .001f, "Scaling down float from 200 failed");
 		scaledValue = DPIUtil.scaleDown((Device) null, valueAt200, 200);
 		assertEquals(valueAt100, scaledValue, .001f, "Scaling down float from 200 with device failed");
@@ -137,14 +116,7 @@ public class DPIUtilTests {
 		Point valueAt150 = new Point(7, 10);
 		Point valueAt100 = new Point(5, 7);
 
-		Point scaledValue = DPIUtil.autoScaleDown(valueAt200);
-		assertEquals(valueAt100, scaledValue,
-				String.format("Scaling down Point from device zoom (%d) to 100 failed", ZOOM_200));
-		scaledValue = DPIUtil.autoScaleDown((Device) null, valueAt200);
-		assertEquals(valueAt100, scaledValue, String
-				.format("Scaling down Point from device zoom (%d) to 100 with device failed", ZOOM_200));
-
-		scaledValue = DPIUtil.scaleDown(valueAt200, 200);
+		Point scaledValue = DPIUtil.scaleDown(valueAt200, 200);
 		assertEquals(valueAt100, scaledValue, "Scaling down Point from 200 failed");
 		scaledValue = DPIUtil.scaleDown((Device) null, valueAt200, 200);
 		assertEquals(valueAt100, scaledValue, "Scaling down Point from 200 with device failed");
@@ -164,14 +136,7 @@ public class DPIUtilTests {
 		Rectangle valueAt150 = new Rectangle(75, 113, 7, 10);
 		Rectangle valueAt100 = new Rectangle(50, 75, 5, 7);
 
-		Rectangle scaledValue = DPIUtil.autoScaleDown(valueAt200);
-		assertEquals(valueAt100, scaledValue,
-				String.format("Scaling down Rectangle from device zoom (%d) to 100 failed", ZOOM_200));
-		scaledValue = DPIUtil.autoScaleDown((Device) null, valueAt200);
-		assertEquals(valueAt100, scaledValue, String.format(
-				"Scaling down Rectangle from device zoom (%d) to 100 with device failed", ZOOM_200));
-
-		scaledValue = DPIUtil.scaleDown(valueAt200, 200);
+		Rectangle scaledValue = DPIUtil.scaleDown(valueAt200, 200);
 		assertEquals(valueAt100, scaledValue, "Scaling down Rectangle from 200 failed");
 		scaledValue = DPIUtil.scaleDown((Device) null, valueAt200, 200);
 		assertEquals(valueAt100, scaledValue, "Scaling down Rectangle from 200 with device failed");
@@ -191,14 +156,7 @@ public class DPIUtilTests {
 		int[] valueAt150 = new int[] { 8, 9, 11 };
 		int[] valueAt100 = new int[] { 5, 6, 7 };
 
-		int[] scaledValue = DPIUtil.autoScaleUp(valueAt100);
-		assertArrayEquals(valueAt200, scaledValue,
-				String.format("Scaling up int array to device zoom (%d) to 100 failed", ZOOM_200));
-		scaledValue = DPIUtil.autoScaleUp((Device) null, valueAt100);
-		assertArrayEquals(valueAt200, scaledValue, String
-				.format("Scaling up int array to device zoom (%d) to 100 with device failed", ZOOM_200));
-
-		scaledValue = DPIUtil.scaleUp(valueAt100, 200);
+		int[] scaledValue = DPIUtil.scaleUp(valueAt100, 200);
 		assertArrayEquals(valueAt200, scaledValue, "Scaling up int array to 200 failed");
 		scaledValue = DPIUtil.scaleUp((Device) null, valueAt100, 200);
 		assertArrayEquals(valueAt200, scaledValue, "Scaling up int array to 200 with device failed");
@@ -218,14 +176,7 @@ public class DPIUtilTests {
 		int valueAt150 = 8;
 		int valueAt100 = 5;
 
-		int scaledValue = DPIUtil.autoScaleUp(valueAt100);
-		assertEquals(valueAt200, scaledValue,
-				String.format("Scaling up integer to device zoom (%d) to 100 failed", ZOOM_200));
-		scaledValue = DPIUtil.autoScaleUp((Device) null, valueAt100);
-		assertEquals(valueAt200, scaledValue, String
-				.format("Scaling up integer to device zoom (%d) to 100 with device failed", ZOOM_200));
-
-		scaledValue = DPIUtil.scaleUp(valueAt100, 200);
+		int scaledValue = DPIUtil.scaleUp(valueAt100, 200);
 		assertEquals(valueAt200, scaledValue, "Scaling up integer to 200 failed");
 		scaledValue = DPIUtil.scaleUp((Device) null, valueAt100, 200);
 		assertEquals(valueAt200, scaledValue, "Scaling up integer to 200 with device failed");
@@ -245,14 +196,7 @@ public class DPIUtilTests {
 		float valueAt150 = 7.5f;
 		float valueAt100 = 5;
 
-		float scaledValue = DPIUtil.autoScaleUp(valueAt100);
-		assertEquals(valueAt200, scaledValue, 0.001f,
-				String.format("Scaling up integer to device zoom (%d) to 100 failed", ZOOM_200));
-		scaledValue = DPIUtil.autoScaleUp((Device) null, valueAt100);
-		assertEquals(valueAt200, scaledValue, 0.001f, String
-				.format("Scaling up integer to device zoom (%d) to 100 with device failed", ZOOM_200));
-
-		scaledValue = DPIUtil.scaleUp(valueAt100, 200);
+		float scaledValue = DPIUtil.scaleUp(valueAt100, 200);
 		assertEquals(valueAt200, scaledValue, 0.001f, "Scaling up integer to 200 failed");
 		scaledValue = DPIUtil.scaleUp((Device) null, valueAt100, 200);
 		assertEquals(valueAt200, scaledValue, 0.001f, "Scaling up integer to 200 with device failed");
@@ -272,14 +216,7 @@ public class DPIUtilTests {
 		Point valueAt150 = new Point(8, 11);
 		Point valueAt100 = new Point(5, 7);
 
-		Point scaledValue = DPIUtil.autoScaleUp(valueAt100);
-		assertEquals(valueAt200, scaledValue,
-				String.format("Scaling up Point to device zoom (%d) to 100 failed", ZOOM_200));
-		scaledValue = DPIUtil.autoScaleUp((Device) null, valueAt100);
-		assertEquals(valueAt200, scaledValue, String
-				.format("Scaling up Point to device zoom (%d) to 100 with device failed", ZOOM_200));
-
-		scaledValue = DPIUtil.scaleUp(valueAt100, 200);
+		Point scaledValue = DPIUtil.scaleUp(valueAt100, 200);
 		assertEquals(valueAt200, scaledValue, "Scaling up Point to 200 failed");
 		scaledValue = DPIUtil.scaleUp((Device) null, valueAt100, 200);
 		assertEquals(valueAt200, scaledValue, "Scaling up Point to 200 with device failed");
@@ -299,14 +236,7 @@ public class DPIUtilTests {
 		Rectangle valueAt150 = new Rectangle(75, 113, 8, 11);
 		Rectangle valueAt100 = new Rectangle(50, 75, 5, 7);
 
-		Rectangle scaledValue = DPIUtil.autoScaleUp(valueAt100);
-		assertEquals(valueAt200, scaledValue,
-				String.format("Scaling up Rectangle to device zoom (%d) to 100 failed", ZOOM_200));
-		scaledValue = DPIUtil.autoScaleUp((Device) null, valueAt100);
-		assertEquals(valueAt200, scaledValue, String
-				.format("Scaling up Rectangle to device zoom (%d) to 100 with device failed", ZOOM_200));
-
-		scaledValue = DPIUtil.scaleUp(valueAt100, 200);
+		Rectangle scaledValue = DPIUtil.scaleUp(valueAt100, 200);
 		assertEquals(valueAt200, scaledValue, "Scaling up Rectangle to 200 failed");
 		scaledValue = DPIUtil.scaleUp((Device) null, valueAt100, 200);
 		assertEquals(valueAt200, scaledValue, "Scaling up Rectangle to 200 with device failed");

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/DPIUtilTests.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/DPIUtilTests.java
@@ -14,16 +14,10 @@
 package org.eclipse.swt.tests.junit;
 
 
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 
-import org.eclipse.swt.graphics.Device;
-import org.eclipse.swt.graphics.Point;
-import org.eclipse.swt.graphics.Rectangle;
 import org.eclipse.swt.internal.DPIUtil;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 
@@ -36,58 +30,16 @@ import org.junit.jupiter.api.condition.DisabledOnOs;
 @DisabledOnOs(value = org.junit.jupiter.api.condition.OS.LINUX, disabledReason = "Linux uses Cairo auto scaling, thus DPIUtil scaling is disabled")
 public class DPIUtilTests {
 
-	private int deviceZoom;
-	private static final int ZOOM_200 = 200;
-
-	@BeforeEach
-	public void setup() {
-		deviceZoom = DPIUtil.getDeviceZoom();
-		DPIUtil.setDeviceZoom(ZOOM_200);
-	}
-
-	@AfterEach
-	public void tearDown() {
-		DPIUtil.setDeviceZoom(deviceZoom);
-	}
-
-	@Test
-	public void scaleDownFloatArray() {
-		float[] valueAt200 = new float[] { 2, 3, 4 };
-		float[] valueAt150 = new float[] { 1.5f, 2.25f, 3 };
-		float[] valueAt100 = new float[] { 1, 1.5f, 2 };
-
-		float[] scaledValue = DPIUtil.scaleDown(valueAt200, 200);
-		assertArrayEquals(valueAt100, scaledValue, .001f, "Scaling down float array from 200 failed");
-		scaledValue = DPIUtil.scaleDown((Device) null, valueAt200, 200);
-		assertArrayEquals(valueAt100, scaledValue, .001f, "Scaling down float array from 200 with device failed");
-		scaledValue = DPIUtil.scaleDown(valueAt150, 150);
-		assertArrayEquals(valueAt100, scaledValue, .001f, "Scaling down float array from 150 failed");
-		scaledValue = DPIUtil.scaleDown((Device) null, valueAt150, 150);
-		assertArrayEquals(valueAt100, scaledValue, .001f, "Scaling down float array from 150 with device failed");
-		scaledValue = DPIUtil.scaleDown(valueAt100, 100);
-		assertSame(valueAt100, scaledValue, "Scaling down float array without zoom change failed");
-		scaledValue = DPIUtil.scaleDown((Device) null, valueAt100, 100);
-		assertSame(valueAt100, scaledValue, "Scaling down float array without zoom change with device failed");
-	}
-
-	@Test
 	public void scaleDownInteger() {
 		int valueAt200 = 10;
 		int valueAt150 = 7;
 		int valueAt100 = 5;
-
 		int scaledValue = DPIUtil.scaleDown(valueAt200, 200);
 		assertEquals(valueAt100, scaledValue, "Scaling down integer from 200 failed");
-		scaledValue = DPIUtil.scaleDown((Device) null, valueAt200, 200);
-		assertEquals(valueAt100, scaledValue, "Scaling down integer from 200 with device failed");
 		scaledValue = DPIUtil.scaleDown(valueAt150, 150);
 		assertEquals(valueAt100, scaledValue, "Scaling down integer from 150 failed");
-		scaledValue = DPIUtil.scaleDown((Device) null, valueAt150, 150);
-		assertEquals(valueAt100, scaledValue, "Scaling down integer from 150 with device failed");
 		scaledValue = DPIUtil.scaleDown(valueAt100, 100);
 		assertSame(valueAt100, scaledValue, "Scaling down integer without zoom change failed");
-		scaledValue = DPIUtil.scaleDown((Device) null, valueAt100, 100);
-		assertSame(valueAt100, scaledValue, "Scaling down integer without zoom change with device failed");
 	}
 
 	@Test
@@ -95,194 +47,12 @@ public class DPIUtilTests {
 		float valueAt200 = 10f;
 		float valueAt150 = 7.5f;
 		float valueAt100 = 5f;
-
 		float scaledValue = DPIUtil.scaleDown(valueAt200, 200);
 		assertEquals(valueAt100, scaledValue, .001f, "Scaling down float from 200 failed");
-		scaledValue = DPIUtil.scaleDown((Device) null, valueAt200, 200);
-		assertEquals(valueAt100, scaledValue, .001f, "Scaling down float from 200 with device failed");
 		scaledValue = DPIUtil.scaleDown(valueAt150, 150);
 		assertEquals(valueAt100, scaledValue, .001f, "Scaling down float from 150 failed");
-		scaledValue = DPIUtil.scaleDown((Device) null, valueAt150, 150);
-		assertEquals(valueAt100, scaledValue, .001f, "Scaling down float from 150 with device failed");
 		scaledValue = DPIUtil.scaleDown(valueAt100, 100);
 		assertEquals(valueAt100, scaledValue, .001f, "Scaling down float without zoom change failed");
-		scaledValue = DPIUtil.scaleDown((Device) null, valueAt100, 100);
-		assertEquals(valueAt100, scaledValue, .001f, "Scaling down float without zoom change with device failed");
 	}
 
-	@Test
-	public void scaleDownPoint() {
-		Point valueAt200 = new Point(10, 14);
-		Point valueAt150 = new Point(7, 10);
-		Point valueAt100 = new Point(5, 7);
-
-		Point scaledValue = DPIUtil.scaleDown(valueAt200, 200);
-		assertEquals(valueAt100, scaledValue, "Scaling down Point from 200 failed");
-		scaledValue = DPIUtil.scaleDown((Device) null, valueAt200, 200);
-		assertEquals(valueAt100, scaledValue, "Scaling down Point from 200 with device failed");
-		scaledValue = DPIUtil.scaleDown(valueAt150, 150);
-		assertEquals(valueAt100, scaledValue, "Scaling down Point from 150 failed");
-		scaledValue = DPIUtil.scaleDown((Device) null, valueAt150, 150);
-		assertEquals(valueAt100, scaledValue, "Scaling down Point from 150 with device failed");
-		scaledValue = DPIUtil.scaleDown(valueAt100, 100);
-		assertSame(valueAt100, scaledValue, "Scaling down Point without zoom change failed");
-		scaledValue = DPIUtil.scaleDown((Device) null, valueAt100, 100);
-		assertSame(valueAt100, scaledValue, "Scaling down Point without zoom change with device failed");
-	}
-
-	@Test
-	public void scaleDownRectangle() {
-		Rectangle valueAt200 = new Rectangle(100, 150, 10, 14);
-		Rectangle valueAt150 = new Rectangle(75, 113, 7, 10);
-		Rectangle valueAt100 = new Rectangle(50, 75, 5, 7);
-
-		Rectangle scaledValue = DPIUtil.scaleDown(valueAt200, 200);
-		assertEquals(valueAt100, scaledValue, "Scaling down Rectangle from 200 failed");
-		scaledValue = DPIUtil.scaleDown((Device) null, valueAt200, 200);
-		assertEquals(valueAt100, scaledValue, "Scaling down Rectangle from 200 with device failed");
-		scaledValue = DPIUtil.scaleDown(valueAt150, 150);
-		assertEquals(valueAt100, scaledValue, "Scaling down Rectangle from 150 failed");
-		scaledValue = DPIUtil.scaleDown((Device) null, valueAt150, 150);
-		assertEquals(valueAt100, scaledValue, "Scaling down Rectangle from 150 with device failed");
-		scaledValue = DPIUtil.scaleDown(valueAt100, 100);
-		assertSame(valueAt100, scaledValue, "Scaling down Rectangle without zoom change failed");
-		scaledValue = DPIUtil.scaleDown((Device) null, valueAt100, 100);
-		assertSame(valueAt100, scaledValue, "Scaling down Rectangle without zoom change with device failed");
-	}
-
-	@Test
-	public void scaleUpIntArray() {
-		int[] valueAt200 = new int[] { 10, 12, 14 };
-		int[] valueAt150 = new int[] { 8, 9, 11 };
-		int[] valueAt100 = new int[] { 5, 6, 7 };
-
-		int[] scaledValue = DPIUtil.scaleUp(valueAt100, 200);
-		assertArrayEquals(valueAt200, scaledValue, "Scaling up int array to 200 failed");
-		scaledValue = DPIUtil.scaleUp((Device) null, valueAt100, 200);
-		assertArrayEquals(valueAt200, scaledValue, "Scaling up int array to 200 with device failed");
-		scaledValue = DPIUtil.scaleUp(valueAt100, 150);
-		assertArrayEquals(valueAt150, scaledValue, "Scaling up int array to 150 failed");
-		scaledValue = DPIUtil.scaleUp((Device) null, valueAt100, 150);
-		assertArrayEquals(valueAt150, scaledValue, "Scaling up int array to 150 with device failed");
-		scaledValue = DPIUtil.scaleUp(valueAt100, 100);
-		assertSame(valueAt100, scaledValue, "Scaling up int array without zoom change failed");
-		scaledValue = DPIUtil.scaleUp((Device) null, valueAt100, 100);
-		assertSame(valueAt100, scaledValue, "Scaling up int array without zoom change with device failed");
-	}
-
-	@Test
-	public void scaleUpInteger() {
-		int valueAt200 = 10;
-		int valueAt150 = 8;
-		int valueAt100 = 5;
-
-		int scaledValue = DPIUtil.scaleUp(valueAt100, 200);
-		assertEquals(valueAt200, scaledValue, "Scaling up integer to 200 failed");
-		scaledValue = DPIUtil.scaleUp((Device) null, valueAt100, 200);
-		assertEquals(valueAt200, scaledValue, "Scaling up integer to 200 with device failed");
-		scaledValue = DPIUtil.scaleUp(valueAt100, 150);
-		assertEquals(valueAt150, scaledValue, "Scaling up integer to 150 failed");
-		scaledValue = DPIUtil.scaleUp((Device) null, valueAt100, 150);
-		assertEquals(valueAt150, scaledValue, "Scaling up integer to 150 with device failed");
-		scaledValue = DPIUtil.scaleUp(valueAt100, 100);
-		assertSame(valueAt100, scaledValue, "Scaling up integer without zoom change failed");
-		scaledValue = DPIUtil.scaleUp((Device) null, valueAt100, 100);
-		assertSame(valueAt100, scaledValue,"Scaling up integer without zoom change with device failed");
-	}
-
-	@Test
-	public void scaleUpFloat() {
-		float valueAt200 = 10;
-		float valueAt150 = 7.5f;
-		float valueAt100 = 5;
-
-		float scaledValue = DPIUtil.scaleUp(valueAt100, 200);
-		assertEquals(valueAt200, scaledValue, 0.001f, "Scaling up integer to 200 failed");
-		scaledValue = DPIUtil.scaleUp((Device) null, valueAt100, 200);
-		assertEquals(valueAt200, scaledValue, 0.001f, "Scaling up integer to 200 with device failed");
-		scaledValue = DPIUtil.scaleUp(valueAt100, 150);
-		assertEquals(valueAt150, scaledValue, 0.001f, "Scaling up integer to 150 failed");
-		scaledValue = DPIUtil.scaleUp((Device) null, valueAt100, 150);
-		assertEquals(valueAt150, scaledValue, 0.001f, "Scaling up integer to 150 with device failed");
-		scaledValue = DPIUtil.scaleUp(valueAt100, 100);
-		assertEquals(valueAt100, scaledValue, 0.001f, "Scaling up integer without zoom change failed");
-		scaledValue = DPIUtil.scaleUp((Device) null, valueAt100, 100);
-		assertEquals(valueAt100, scaledValue, 0.001f, "Scaling up integer without zoom change with device failed");
-	}
-
-	@Test
-	public void scaleUpPoint() {
-		Point valueAt200 = new Point(10, 14);
-		Point valueAt150 = new Point(8, 11);
-		Point valueAt100 = new Point(5, 7);
-
-		Point scaledValue = DPIUtil.scaleUp(valueAt100, 200);
-		assertEquals(valueAt200, scaledValue, "Scaling up Point to 200 failed");
-		scaledValue = DPIUtil.scaleUp((Device) null, valueAt100, 200);
-		assertEquals(valueAt200, scaledValue, "Scaling up Point to 200 with device failed");
-		scaledValue = DPIUtil.scaleUp(valueAt100, 150);
-		assertEquals(valueAt150, scaledValue, "Scaling up Point to 150 failed");
-		scaledValue = DPIUtil.scaleUp((Device) null, valueAt100, 150);
-		assertEquals(valueAt150, scaledValue, "Scaling up Point to 150 with device failed");
-		scaledValue = DPIUtil.scaleUp(valueAt100, 100);
-		assertSame(valueAt100, scaledValue, "Scaling up Point without zoom change failed");
-		scaledValue = DPIUtil.scaleUp((Device) null, valueAt100, 100);
-		assertSame(valueAt100, scaledValue, "Scaling up Point without zoom change with device failed");
-	}
-
-	@Test
-	public void scaleUpRectangle() {
-		Rectangle valueAt200 = new Rectangle(100, 150, 10, 14);
-		Rectangle valueAt150 = new Rectangle(75, 113, 8, 11);
-		Rectangle valueAt100 = new Rectangle(50, 75, 5, 7);
-
-		Rectangle scaledValue = DPIUtil.scaleUp(valueAt100, 200);
-		assertEquals(valueAt200, scaledValue, "Scaling up Rectangle to 200 failed");
-		scaledValue = DPIUtil.scaleUp((Device) null, valueAt100, 200);
-		assertEquals(valueAt200, scaledValue, "Scaling up Rectangle to 200 with device failed");
-		scaledValue = DPIUtil.scaleUp(valueAt100, 150);
-		assertEquals(valueAt150, scaledValue, "Scaling up Rectangle to 150 failed");
-		scaledValue = DPIUtil.scaleUp((Device) null, valueAt100, 150);
-		assertEquals(valueAt150, scaledValue, "Scaling up Rectangle to 150 with device failed");
-		scaledValue = DPIUtil.scaleUp(valueAt100, 100);
-		assertSame(valueAt100, scaledValue, "Scaling up Rectangle without zoom change failed");
-		scaledValue = DPIUtil.scaleUp((Device) null, valueAt100, 100);
-		assertSame(valueAt100, scaledValue, "Scaling up Rectangle without zoom change with device failed");
-	}
-
-	@Test
-	public void scaleDownscaleUpRectangleInvertible() {
-		int[] zooms = new int[] {25, 50, 75, 100, 125, 150, 175, 200, 225, 250, 275, 300, 325, 350, 375, 400};
-		for (int zoom1 : zooms) {
-			for (int zoom2 : zooms) {
-				for (int i = 1; i <= 10000; i++) {
-					Rectangle rect = new Rectangle(0, 0, i, i);
-					Rectangle scaleDown = DPIUtil.scaleDown(rect, zoom1);
-					Rectangle scaleUp = DPIUtil.scaleUp(scaleDown, zoom2);
-					scaleDown = DPIUtil.scaleDown(scaleUp, zoom2);
-					scaleUp = DPIUtil.scaleUp(scaleDown, zoom1);
-					assertEquals(rect.width, scaleUp.width);
-					assertEquals(rect.height, scaleUp.height);
-				}
-			}
-		}
-	}
-
-	@Test
-	public void scaleDownscaleUpPointInvertible() {
-		int[] zooms = new int[] {25, 50, 75, 100, 125, 150, 175, 200, 225, 250, 275, 300, 325, 350, 375, 400};
-		for (int zoom1 : zooms) {
-			for (int zoom2 : zooms) {
-				for (int i = 1; i <= 10000; i++) {
-					Point pt = new Point(i, i);
-					Point scaleDown = DPIUtil.scaleDown(pt, zoom1);
-					Point scaleUp = DPIUtil.scaleUp(scaleDown, zoom2);
-					scaleDown = DPIUtil.scaleDown(scaleUp, zoom2);
-					scaleUp = DPIUtil.scaleUp(scaleDown, zoom1);
-					assertEquals(pt.x, scaleUp.x);
-					assertEquals(pt.y, scaleUp.y);
-				}
-			}
-		}
-	}
 }

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_Image.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_Image.java
@@ -600,7 +600,7 @@ public void test_getBoundsInPixels() {
 	Rectangle bounds = image.getBounds();
 	image.dispose();
 	assertEquals("Image.getBounds method doesn't return original bounds.", initialBounds, bounds);
-	assertEquals("Image.getBoundsInPixels method doesn't return bounds in Pixel values.", DPIUtil.autoScaleUp(initialBounds), boundsInPixels);
+	assertEquals("Image.getBoundsInPixels method doesn't return bounds in Pixel values.", initialBounds, boundsInPixels);
 
 	// create icon image
 	ImageData imageData = new ImageData(initialBounds.width, initialBounds.height, 1, new PaletteData(new RGB[] {new RGB(0, 0, 0)}));
@@ -609,21 +609,21 @@ public void test_getBoundsInPixels() {
 	bounds = image.getBounds();
 	image.dispose();
 	assertEquals("Image.getBounds method doesn't return original bounds.", initialBounds, bounds);
-	assertEquals("Image.getBoundsInPixels method doesn't return bounds in Pixel values.", DPIUtil.autoScaleUp(initialBounds), boundsInPixels);
+	assertEquals("Image.getBoundsInPixels method doesn't return bounds in Pixel values.", initialBounds, boundsInPixels);
 
 	// create image with FileNameProvider
 	image = new Image(display, imageFileNameProvider);
 	boundsInPixels = image.getBoundsInPixels();
 	bounds = image.getBounds();
 	image.dispose();
-	assertEquals("Image.getBoundsInPixels method doesn't return bounds in Pixel values.", DPIUtil.autoScaleUp(bounds), boundsInPixels);
+	assertEquals("Image.getBoundsInPixels method doesn't return bounds in Pixel values.", bounds, boundsInPixels);
 
 	// create image with ImageDataProvider
 	image = new Image(display, imageDataProvider);
 	boundsInPixels = image.getBoundsInPixels();
 	bounds = image.getBounds();
 	image.dispose();
-	assertEquals("Image.getBoundsInPixels method doesn't return bounds in Pixel values.", DPIUtil.autoScaleUp(bounds), boundsInPixels);
+	assertEquals("Image.getBoundsInPixels method doesn't return bounds in Pixel values.", bounds, boundsInPixels);
 
 	// create image with ImageGcDrawer
 	image = new Image(display, imageGcDrawer, initialBounds.width, initialBounds.height);
@@ -631,7 +631,7 @@ public void test_getBoundsInPixels() {
 	bounds = image.getBounds();
 	image.dispose();
 	assertEquals("Image.getBounds method doesn't return original bounds.", initialBounds, bounds);
-	assertEquals("Image.getBoundsInPixels method doesn't return bounds in Pixel values for ImageGcDrawer.", DPIUtil.autoScaleUp(initialBounds), boundsInPixels);
+	assertEquals("Image.getBoundsInPixels method doesn't return bounds in Pixel values for ImageGcDrawer.", initialBounds, boundsInPixels);
 }
 
 @SuppressWarnings("deprecation")
@@ -649,7 +649,7 @@ public void test_getImageDataCurrentZoom() {
 	ImageData imageDataAtCurrentZoom = image.getImageDataAtCurrentZoom();
 	image.dispose();
 	Rectangle boundsAtCurrentZoom = new Rectangle(0, 0, imageDataAtCurrentZoom.width, imageDataAtCurrentZoom.height);
-	assertEquals(":a: Size of ImageData returned from Image.getImageDataAtCurrentZoom method doesn't return matches with bounds in Pixel values.", boundsAtCurrentZoom, DPIUtil.autoScaleUp(bounds));
+	assertEquals(":a: Size of ImageData returned from Image.getImageDataAtCurrentZoom method doesn't return matches with bounds in Pixel values.", boundsAtCurrentZoom, bounds);
 
 	// create icon image and compare size of imageData
 	ImageData imageData = new ImageData(bounds.width, bounds.height, 1, new PaletteData(new RGB[] {new RGB(0, 0, 0)}));
@@ -657,7 +657,7 @@ public void test_getImageDataCurrentZoom() {
 	imageDataAtCurrentZoom = image.getImageDataAtCurrentZoom();
 	image.dispose();
 	boundsAtCurrentZoom = new Rectangle(0, 0, imageDataAtCurrentZoom.width, imageDataAtCurrentZoom.height);
-	assertEquals(":b: Size of ImageData returned from Image.getImageDataAtCurrentZoom method doesn't return matches with bounds in Pixel values.", boundsAtCurrentZoom, DPIUtil.autoScaleUp(bounds));
+	assertEquals(":b: Size of ImageData returned from Image.getImageDataAtCurrentZoom method doesn't return matches with bounds in Pixel values.", boundsAtCurrentZoom, bounds);
 
 	// create image with FileNameProvider
 	image = new Image(display, imageFileNameProvider);
@@ -665,7 +665,7 @@ public void test_getImageDataCurrentZoom() {
 	boundsAtCurrentZoom = new Rectangle(0, 0, imageDataAtCurrentZoom.width, imageDataAtCurrentZoom.height);
 	bounds = image.getBounds();
 	image.dispose();
-	assertEquals(":c: Size of ImageData returned from Image.getImageDataAtCurrentZoom method doesn't return matches with bounds in Pixel values.", boundsAtCurrentZoom, DPIUtil.autoScaleUp(bounds));
+	assertEquals(":c: Size of ImageData returned from Image.getImageDataAtCurrentZoom method doesn't return matches with bounds in Pixel values.", boundsAtCurrentZoom, bounds);
 
 	// create image with ImageDataProvider
 	image = new Image(display, imageDataProvider);
@@ -673,7 +673,7 @@ public void test_getImageDataCurrentZoom() {
 	boundsAtCurrentZoom = new Rectangle(0, 0, imageDataAtCurrentZoom.width, imageDataAtCurrentZoom.height);
 	bounds = image.getBounds();
 	image.dispose();
-	assertEquals(":d: Size of ImageData returned from Image.getImageDataAtCurrentZoom method doesn't return matches with bounds in Pixel values.", boundsAtCurrentZoom, DPIUtil.autoScaleUp(bounds));
+	assertEquals(":d: Size of ImageData returned from Image.getImageDataAtCurrentZoom method doesn't return matches with bounds in Pixel values.", boundsAtCurrentZoom, bounds);
 }
 
 @Test


### PR DESCRIPTION
This commit introduces a dedicated Win32DPIUtils class to isolate Win32-specific DPI logic, improving platform separation and maintainability.

This PR:

- Remove all the usages of autoScale methods in windows.
- Move the scaleDown/Up method to windows specific DPIUtil
- Move Win32 DPIUtil related test to Win32 DPIUtil test class.

- [x] Required: https://github.com/eclipse-platform/eclipse.platform.swt/pull/2280