### PR TITLE
Mark Deprecated getImageDataAtCurrentZoom for removal

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/graphics/Image.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/graphics/Image.java
@@ -1353,7 +1353,7 @@ public ImageData getImageData() {
  *             multiple monitors with different DPIs, hence deprecated. Use
  *             {@link #getImageData(int)} instead.
  */
-@Deprecated
+@Deprecated(since = "2025-09", forRemoval = true)
 public ImageData getImageDataAtCurrentZoom() {
 	return getImageData(DPIUtil.getDeviceZoom());
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/graphics/Image.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/graphics/Image.java
@@ -1064,7 +1064,7 @@ public ImageData getImageData () {
  *             multiple monitors with different DPIs, hence deprecated. Use
  *             {@link #getImageData(int)} instead.
  */
-@Deprecated
+@Deprecated(since = "2025-09", forRemoval = true)
 public ImageData getImageDataAtCurrentZoom () {
 	if (isDisposed()) SWT.error(SWT.ERROR_GRAPHIC_DISPOSED);
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Image.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Image.java
@@ -1243,7 +1243,7 @@ public ImageData getImageData (int zoom) {
  *             multiple monitors with different DPIs, hence deprecated. Use
  *             {@link #getImageData(int)} instead.
  */
-@Deprecated
+@Deprecated(since = "2025-09", forRemoval = true)
 public ImageData getImageDataAtCurrentZoom() {
 	return applyUsingAnyHandle(ImageHandle::getImageData);
 }

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_Image.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_Image.java
@@ -634,7 +634,7 @@ public void test_getBoundsInPixels() {
 	assertEquals("Image.getBoundsInPixels method doesn't return bounds in Pixel values for ImageGcDrawer.", DPIUtil.autoScaleUp(initialBounds), boundsInPixels);
 }
 
-@SuppressWarnings("deprecation")
+@SuppressWarnings("removal")
 @Test
 public void test_getImageDataCurrentZoom() {
 	Rectangle bounds = new Rectangle(0, 0, 10, 20);


### PR DESCRIPTION
The deprecated method getImageDataAtCurrentZoom() in Image is marked for removal along with its tests.