### PR TITLE
Mark Deprecated getBoundsInPixel for removal

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/graphics/Image.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/graphics/Image.java
@@ -1306,7 +1306,7 @@ public Rectangle getBounds() {
  * @deprecated This API doesn't serve the purpose in an environment having
  *             multiple monitors with different DPIs, hence deprecated.
  */
-@Deprecated
+@Deprecated(since = "2025-09", forRemoval = true)
 public Rectangle getBoundsInPixels() {
 	Rectangle bounds = getBounds();
 	int scaleFactor = (int) NSScreen.mainScreen().backingScaleFactor();

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/graphics/Image.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/graphics/Image.java
@@ -1014,7 +1014,7 @@ public Rectangle getBounds() {
  * @deprecated This API doesn't serve the purpose in an environment having
  *             multiple monitors with different DPIs, hence deprecated.
  */
-@Deprecated
+@Deprecated(since = "2025-09", forRemoval = true)
 public Rectangle getBoundsInPixels() {
 	if (isDisposed()) SWT.error(SWT.ERROR_GRAPHIC_DISPOSED);
 	if (width != -1 && height != -1) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Caret.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Caret.java
@@ -143,7 +143,7 @@ private void drawInCellEditor(long window) {
 public Rectangle getBounds () {
 	checkWidget();
 	if (image != null) {
-		Rectangle rect = image.getBoundsInPixels ();
+		Rectangle rect = image.getBounds();
 		return new Rectangle (x, y, rect.width, rect.height);
 	} else {
 		if (width == 0) {
@@ -228,7 +228,7 @@ public Canvas getParent () {
 public Point getSize () {
 	checkWidget();
 	if (image != null) {
-		Rectangle rect = image.getBoundsInPixels ();
+		Rectangle rect = image.getBounds();
 		return new Point (rect.width, rect.height);
 	} else {
 		if (width == 0) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Image.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Image.java
@@ -1161,7 +1161,7 @@ Rectangle getBounds(int zoom) {
  * @deprecated This API doesn't serve the purpose in an environment having
  *             multiple monitors with different DPIs, hence deprecated.
  */
-@Deprecated
+@Deprecated(since = "2025-09", forRemoval = true)
 public Rectangle getBoundsInPixels() {
 	return applyUsingAnyHandle(ImageHandle::getBounds);
 }

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_Image.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_Image.java
@@ -584,7 +584,7 @@ public void test_getBounds() {
 	assertEquals(bounds, bounds1);
 }
 
-@SuppressWarnings("deprecation")
+@SuppressWarnings("removal")
 @Test
 public void test_getBoundsInPixels() {
 	Rectangle initialBounds = new Rectangle(0, 0, 10, 20);


### PR DESCRIPTION
The deprecated method getBoundsInPixel() in Image is marked for removal along with its tests.