### PR TITLE
Reintroduce scaling methods for Rectangle

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/widgets/ControlWin32Tests.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/widgets/ControlWin32Tests.java
@@ -100,11 +100,11 @@ class ControlWin32Tests {
 
 		button.setBounds(new Rectangle(0, 47, 200, 47));
 		assertEquals("Control::setBounds(Rectangle) doesn't scale up correctly",
-				new Rectangle(0, 82, 350, 82), button.getBoundsInPixels());
+				new Rectangle(0, 82, 350, 83), button.getBoundsInPixels());
 
 		button.setBounds(0, 47, 200, 47);
 		assertEquals("Control::setBounds(int, int, int, int) doesn't scale up correctly",
-				new Rectangle(0, 82, 350, 82), button.getBoundsInPixels());
+				new Rectangle(0, 82, 350, 83), button.getBoundsInPixels());
 	}
 
 	record FontComparison(int originalFontHeight, int currentFontHeight) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/Win32DPIUtils.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/Win32DPIUtils.java
@@ -108,6 +108,20 @@ public class Win32DPIUtils {
 	}
 
 	public static Rectangle pixelToPoint(Rectangle rect, int zoom) {
+		if (zoom == 100 || rect == null) return rect;
+		if (rect instanceof Rectangle.OfFloat rectOfFloat) return pixelToPoint(rectOfFloat, zoom);
+		Rectangle scaledRect = new Rectangle.OfFloat (0,0,0,0);
+		Point scaledTopLeft = pixelToPoint(new Point (rect.x, rect.y), zoom);
+		Point scaledBottomRight = pixelToPoint(new Point (rect.x + rect.width, rect.y + rect.height), zoom);
+
+		scaledRect.x = scaledTopLeft.x;
+		scaledRect.y = scaledTopLeft.y;
+		scaledRect.width = scaledBottomRight.x - scaledTopLeft.x;
+		scaledRect.height = scaledBottomRight.y - scaledTopLeft.y;
+		return scaledRect;
+	}
+
+	private static Rectangle pixelToPoint(Rectangle.OfFloat rect, int zoom) {
 		return scaleBounds(rect, 100, zoom);
 	}
 
@@ -120,6 +134,21 @@ public class Win32DPIUtils {
 	 * Returns a new rectangle as per the scaleFactor.
 	 */
 	public static Rectangle scaleBounds (Rectangle rect, int targetZoom, int currentZoom) {
+		if (rect == null || targetZoom == currentZoom) return rect;
+		if (rect instanceof Rectangle.OfFloat rectOfFloat) return scaleBounds(rectOfFloat, targetZoom, currentZoom);
+		float scaleFactor = ((float)targetZoom) / (float)currentZoom;
+		Rectangle returnRect = new Rectangle.OfFloat (0,0,0,0);
+		returnRect.x = Math.round (rect.x * scaleFactor);
+		returnRect.y = Math.round (rect.y * scaleFactor);
+		returnRect.width = Math.round (rect.width * scaleFactor);
+		returnRect.height = Math.round (rect.height * scaleFactor);
+		return returnRect;
+	}
+
+	/**
+	 * Returns a new rectangle as per the scaleFactor.
+	 */
+	private static Rectangle scaleBounds (Rectangle.OfFloat rect, int targetZoom, int currentZoom) {
 		if (rect == null || targetZoom == currentZoom) return rect;
 		Rectangle.OfFloat fRect = FloatAwareGeometryFactory.createFrom(rect);
 		float scaleFactor = DPIUtil.getScalingFactor(targetZoom, currentZoom);
@@ -185,6 +214,20 @@ public class Win32DPIUtils {
 	}
 
 	public static Rectangle pointToPixel(Rectangle rect, int zoom) {
+		if (zoom == 100 || rect == null) return rect;
+		if (rect instanceof Rectangle.OfFloat rectOfFloat) return pointToPixel(rectOfFloat, zoom);
+		Rectangle scaledRect = new Rectangle.OfFloat(0,0,0,0);
+		Point scaledTopLeft = pointToPixel (new Point(rect.x, rect.y), zoom);
+		Point scaledBottomRight = pointToPixel (new Point(rect.x + rect.width, rect.y + rect.height), zoom);
+
+		scaledRect.x = scaledTopLeft.x;
+		scaledRect.y = scaledTopLeft.y;
+		scaledRect.width = scaledBottomRight.x - scaledTopLeft.x;
+		scaledRect.height = scaledBottomRight.y - scaledTopLeft.y;
+		return scaledRect;
+	}
+
+	private static Rectangle pointToPixel(Rectangle.OfFloat rect, int zoom) {
 		return scaleBounds(rect, zoom, 100);
 	}
 

--- a/tests/org.eclipse.swt.tests.win32/JUnit Tests/org/eclipse/swt/tests/win32/Win32DPIUtilTests.java
+++ b/tests/org.eclipse.swt.tests.win32/JUnit Tests/org/eclipse/swt/tests/win32/Win32DPIUtilTests.java
@@ -202,7 +202,7 @@ public class Win32DPIUtilTests {
 	@Test
 	public void scaleUpRectangle() {
 		Rectangle valueAt200 = new Rectangle(100, 150, 10, 14);
-		Rectangle valueAt150 = new Rectangle(75, 113, 8, 11);
+		Rectangle valueAt150 = new Rectangle(75, 113, 8, 10);
 		Rectangle valueAt100 = new Rectangle(50, 75, 5, 7);
 
 		Rectangle scaledValue = Win32DPIUtils.pointToPixel(valueAt100, 200);
@@ -225,7 +225,7 @@ public class Win32DPIUtilTests {
 		for (int zoom1 : zooms) {
 			for (int zoom2 : zooms) {
 				for (int i = 1; i <= 10000; i++) {
-					Rectangle rect = new Rectangle(0, 0, i, i);
+					Rectangle rect = new Rectangle.OfFloat(0, 0, i, i);
 					Rectangle scaleDown = Win32DPIUtils.pixelToPoint(rect, zoom1);
 					Rectangle scaleUp = Win32DPIUtils.pointToPixel(scaleDown, zoom2);
 					scaleDown = Win32DPIUtils.pixelToPoint(scaleUp, zoom2);


### PR DESCRIPTION
This commit reintroduces scaling methods for plain Rectangle to provide backwards compatibility to the consumers which explicitly create a Rectangle and want to call scaleBounds or scaleUp/scaleDown since they have different behaviour and Rectangle.OfFloat unifies this.

Note: The values in the tests are changed to 83 even though 82 is the right value. It is because having called DPIUtil:scaleUp/scaleBounds with Rectangle has not so precise result as compared to Rectangle.OfFloat. The test tests a regular rectangle and ofcourse a test with Rectangle.OfFloat will lead to 82 as the expected value.