### PR TITLE
Fix Double Click not Registering Snippet 62 

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Control.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Control.java
@@ -3428,8 +3428,15 @@ int gtk_gesture_press_event (long gesture, int n_press, double x, double y, long
 				}
 			}
 		}
-	} else if (n_press == 2) {
+	} else if (n_press >= 2) {
 		boolean cancelled = sendMouseEvent(SWT.MouseDoubleClick, eventButton, n_press, 0, false, eventTime, x, y, false, eventState);
+		
+		//Issue 344, DoubleClick event currently unsupported below sendMouseEvent(). Until DoubleClickSupport is 
+		//added this will catch failed events and try MouseDown instead.
+		if (cancelled) {
+			cancelled = sendMouseEvent(SWT.MouseDown, eventButton, n_press, 0, false, eventTime, x, y, false, eventState);
+		}
+		
 		if (!cancelled) {
 			result = GTK4.GTK_EVENT_SEQUENCE_CLAIMED;
 		}


### PR DESCRIPTION
Fixes #344.

Running snippet 62 and double clicking used to register two up events but only one down event when there should also have been two. This was due to the use of SWT.MouseDoubleClick instead of SWT.MouseDown. I have modified it such that in the event SWT.MouseDoubleClick fails, SWT.MouseDown is tried instead. This keeps the double click as an option for the future if support is added.

I also changed the behaviour so triple clicks and higher are now treated as double clicks rather than being ignored.
