### PR TITLE
Use font zoom in stringExtent and textExtent

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/GC.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/GC.java
@@ -5644,7 +5644,7 @@ private class SetTransformOperation extends Operation {
  */
 public Point stringExtent (String string) {
 	if (string == null) SWT.error (SWT.ERROR_NULL_ARGUMENT);
-	return DPIUtil.scaleDown(drawable, stringExtentInPixels(string), getZoom());
+	return DPIUtil.scaleDown(drawable, stringExtentInPixels(string), data.font.zoom);
 }
 
 Point stringExtentInPixels (String string) {
@@ -5724,7 +5724,7 @@ public Point textExtent (String string) {
  * </ul>
  */
 public Point textExtent (String string, int flags) {
-	return DPIUtil.scaleDown(drawable, textExtentInPixels(string, flags), getZoom());
+	return DPIUtil.scaleDown(drawable, textExtentInPixels(string, flags), data.font.zoom);
 }
 
 Point textExtentInPixels(String string, int flags) {


### PR DESCRIPTION
Previously, stringExtent calculated the width of a string in pixels using GC.getZoom(), which could lead to inconsistencies if the provided font had a different zoom level. This change ensures that the pixels-to-points conversion uses the zoom of the specified font.

Fixes #2311 

Reproduction Steps
On a 100% monitor, set these parameters:

```
-Dswt.enable.autoScale=true
-Dswt.autoScale=150
-Dswt.autoScale.method=nearest
```

Screenshots

<table>
  <tr>
    <td align="center" valign="top">
      <img src="https://github.com/user-attachments/assets/5997797c-1ff6-4b32-99e9-7ee599605b9b" />
      <br/>
      <sub>Current Behaviour</sub>
    </td>
    <td align="center" valign="top">
      <img src="https://github.com/user-attachments/assets/1bb12a7d-c1f8-4621-994d-407229f8d0e9" />
      <br/>
      <sub>With This Change</sub>
    </td>
  </tr>
</table>


Have tested the changes on zooms **100,150,200&225** with` -Dswt.autoScale`=**150 ,100 &200,** 