### PR TITLE
Fix size of DateTime widget on Gtk 4

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/gtk4.c
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/gtk4.c
@@ -741,6 +741,20 @@ JNIEXPORT void JNICALL GTK4_NATIVE(gtk_1editable_1set_1max_1width_1chars)
 }
 #endif
 
+#ifndef NO_gtk_1editable_1set_1text
+JNIEXPORT void JNICALL GTK4_NATIVE(gtk_1editable_1set_1text)
+	(JNIEnv *env, jclass that, jlong arg0, jbyteArray arg1)
+{
+	jbyte *lparg1=NULL;
+	GTK4_NATIVE_ENTER(env, that, gtk_1editable_1set_1text_FUNC);
+	if (arg1) if ((lparg1 = (*env)->GetByteArrayElements(env, arg1, NULL)) == NULL) goto fail;
+	gtk_editable_set_text((GtkEditable *)arg0, (const gchar *)lparg1);
+fail:
+	if (arg1 && lparg1) (*env)->ReleaseByteArrayElements(env, arg1, lparg1, 0);
+	GTK4_NATIVE_EXIT(env, that, gtk_1editable_1set_1text_FUNC);
+}
+#endif
+
 #ifndef NO_gtk_1entry_1buffer_1get_1text
 JNIEXPORT jlong JNICALL GTK4_NATIVE(gtk_1entry_1buffer_1get_1text)
 	(JNIEnv *env, jclass that, jlong arg0)

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/gtk4_stats.h
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/gtk4_stats.h
@@ -75,6 +75,7 @@ typedef enum {
 	gtk_1editable_1get_1max_1width_1chars_FUNC,
 	gtk_1editable_1get_1text_FUNC,
 	gtk_1editable_1set_1max_1width_1chars_FUNC,
+	gtk_1editable_1set_1text_FUNC,
 	gtk_1entry_1buffer_1get_1text_FUNC,
 	gtk_1entry_1get_1buffer_FUNC,
 	gtk_1entry_1get_1text_1length_FUNC,

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/org/eclipse/swt/internal/gtk4/GTK4.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/org/eclipse/swt/internal/gtk4/GTK4.java
@@ -129,6 +129,11 @@ public class GTK4 {
 	 * @param chars cast=(int)
 	 */
 	public static final native void gtk_editable_set_max_width_chars(long editable, int chars);
+	/**
+	 * @param editable cast=(GtkEditable *)
+	 * @param text cast=(const gchar *)
+	 */
+	public static final native void gtk_editable_set_text(long editable, byte[] text);
 
 	/* GtkPicture */
 	public static final native long gtk_picture_new();

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/DateTime.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/DateTime.java
@@ -1944,7 +1944,12 @@ void setText(String dateTimeText) {
 		byte[] dateTimeConverted = Converter.javaStringToCString(dateTimeText);
 
 		if (GTK.GTK4) {
-			GTK.gtk_entry_buffer_set_text(GTK4.gtk_text_get_buffer(textEntryHandle), dateTimeConverted, dateTimeText.length());
+			if (isDateWithDropDownButton()) {
+				GTK.gtk_entry_buffer_set_text(GTK4.gtk_text_get_buffer(textEntryHandle), dateTimeConverted, dateTimeText.length());
+			} else {
+				GTK4.gtk_editable_set_max_width_chars(handle, dateTimeText.length());
+				GTK4.gtk_editable_set_text(handle, dateTimeConverted);
+			}
 		} else {
 			//note, this is ignored if the control is in a fill-layout.
 			GTK3.gtk_entry_set_width_chars(textEntryHandle, dateTimeText.length());


### PR DESCRIPTION
Before:
<img width="1250" height="596" alt="Screenshot From 2025-07-11 13-51-39" src="https://github.com/user-attachments/assets/e28fc04e-2018-4b1d-8a16-97b6cb6173fd" />

After:
<img width="1346" height="596" alt="Screenshot From 2025-07-11 13-59-22" src="https://github.com/user-attachments/assets/5b0371c2-bc07-4d84-b2e0-316015cbbb4c" />
