### PR TITLE
[Refactor DPIUtil] rename scaleUp/Down

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT AWT/win32/org/eclipse/swt/awt/SWT_AWT.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT AWT/win32/org/eclipse/swt/awt/SWT_AWT.java
@@ -250,7 +250,7 @@ public static Frame new_Frame (final Composite parent) {
 
 	parent.getDisplay().asyncExec(() -> {
 		if (parent.isDisposed()) return;
-		final Rectangle clientArea = Win32DPIUtils.scaleUp(parent.getClientArea(), DPIUtil.getZoomForAutoscaleProperty(parent.nativeZoom)); // To Pixels
+		final Rectangle clientArea = Win32DPIUtils.pointToPixel(parent.getClientArea(), DPIUtil.getZoomForAutoscaleProperty(parent.nativeZoom)); // To Pixels
 		EventQueue.invokeLater(() -> {
 			frame.setSize (clientArea.width, clientArea.height);
 			frame.validate ();
@@ -293,7 +293,7 @@ public static Shell new_Shell (final Display display, final Canvas parent) {
 			display.syncExec (() -> {
 				if (shell.isDisposed()) return;
 				Dimension dim = parent.getSize ();
-				shell.setSize(Win32DPIUtils.scaleDown(new Point(dim.width, dim.height), DPIUtil.getDeviceZoom())); // To Points
+				shell.setSize(Win32DPIUtils.pixelToPoint(new Point(dim.width, dim.height), DPIUtil.getDeviceZoom())); // To Points
 			});
 		}
 	};

--- a/bundles/org.eclipse.swt/Eclipse SWT Browser/win32/org/eclipse/swt/browser/Edge.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Browser/win32/org/eclipse/swt/browser/Edge.java
@@ -1254,14 +1254,14 @@ int handleContextMenuRequested(long pView, long pArgs) {
 	//   to PIXEL coordinates with the real native zoom value
 	//   independent from the swt.autoScale property:
 	Point pt = new Point( //
-			Win32DPIUtils.scaleUp(win32Point.x, DPIUtil.getNativeDeviceZoom()), //
-			Win32DPIUtils.scaleUp(win32Point.y, DPIUtil.getNativeDeviceZoom()));
+			Win32DPIUtils.pointToPixel(win32Point.x, DPIUtil.getNativeDeviceZoom()), //
+			Win32DPIUtils.pointToPixel(win32Point.y, DPIUtil.getNativeDeviceZoom()));
 	// - then, scale back down from PIXEL to DISPLAY coordinates, taking
 	//   swt.autoScale property into account
 	//   which is also later considered in Menu#setLocation()
 	pt = new Point( //
-			DPIUtil.scaleDown(pt.x, DPIUtil.getZoomForAutoscaleProperty(browser.getShell().nativeZoom)), //
-			DPIUtil.scaleDown(pt.y, DPIUtil.getZoomForAutoscaleProperty(browser.getShell().nativeZoom)));
+			DPIUtil.pixelToPoint(pt.x, DPIUtil.getZoomForAutoscaleProperty(browser.getShell().nativeZoom)), //
+			DPIUtil.pixelToPoint(pt.y, DPIUtil.getZoomForAutoscaleProperty(browser.getShell().nativeZoom)));
 	// - finally, translate the POINT from widget-relative
 	//   to DISPLAY-relative coordinates
 	pt = browser.toDisplay(pt.x, pt.y);

--- a/bundles/org.eclipse.swt/Eclipse SWT Browser/win32/org/eclipse/swt/browser/IE.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Browser/win32/org/eclipse/swt/browser/IE.java
@@ -1880,7 +1880,7 @@ void handleDOMEvent (OleEvent e) {
 	int screenY = pVarResult.getInt();
 	pVarResult.dispose();
 
-	Point position = Win32DPIUtils.scaleDown(new Point(screenX, screenY), DPIUtil.getDeviceZoom()); // To Points
+	Point position = Win32DPIUtils.pixelToPoint(new Point(screenX, screenY), DPIUtil.getDeviceZoom()); // To Points
 	position = browser.getDisplay().map(null, browser, position);
 	newEvent.x = position.x; newEvent.y = position.y;
 

--- a/bundles/org.eclipse.swt/Eclipse SWT Browser/win32/org/eclipse/swt/browser/WebSite.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Browser/win32/org/eclipse/swt/browser/WebSite.java
@@ -320,8 +320,8 @@ int ShowContextMenu(int dwID, long ppt, long pcmdtReserved, long pdispReserved) 
 	Event event = new Event();
 	POINT pt = new POINT();
 	OS.MoveMemory(pt, ppt, POINT.sizeof);
-	pt.x = DPIUtil.scaleDown(pt.x, DPIUtil.getDeviceZoom()); // To Points
-	pt.y = DPIUtil.scaleDown(pt.y, DPIUtil.getDeviceZoom()); // To Points
+	pt.x = DPIUtil.pixelToPoint(pt.x, DPIUtil.getDeviceZoom()); // To Points
+	pt.y = DPIUtil.pixelToPoint(pt.y, DPIUtil.getDeviceZoom()); // To Points
 	event.x = pt.x;
 	event.y = pt.y;
 	browser.notifyListeners(SWT.MenuDetect, event);

--- a/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/win32/org/eclipse/swt/dnd/DragSource.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/win32/org/eclipse/swt/dnd/DragSource.java
@@ -510,7 +510,7 @@ private void drag(Event dragEvent) {
 		int offsetX = event.offsetX;
 		hwndDrag = topControl.handle;
 		if ((topControl.getStyle() & SWT.RIGHT_TO_LEFT) != 0) {
-			offsetX = Win32DPIUtils.scaleUp(image.getBounds(), zoom).width - offsetX;
+			offsetX = Win32DPIUtils.pointToPixel(image.getBounds(), zoom).width - offsetX;
 			RECT rect = new RECT ();
 			OS.GetClientRect (topControl.handle, rect);
 			hwndDrag = OS.CreateWindowEx (
@@ -538,8 +538,8 @@ private void drag(Event dragEvent) {
 		int flags = OS.RDW_UPDATENOW | OS.RDW_ALLCHILDREN;
 		OS.RedrawWindow (topControl.handle, null, 0, flags);
 		POINT pt = new POINT ();
-		pt.x = Win32DPIUtils.scaleUp(dragEvent.x, zoom);// To Pixels
-		pt.y = Win32DPIUtils.scaleUp(dragEvent.y, zoom);// To Pixels
+		pt.x = Win32DPIUtils.pointToPixel(dragEvent.x, zoom);// To Pixels
+		pt.y = Win32DPIUtils.pointToPixel(dragEvent.y, zoom);// To Pixels
 		OS.MapWindowPoints (control.handle, 0, pt, 1);
 		RECT rect = new RECT ();
 		OS.GetWindowRect (hwndDrag, rect);

--- a/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/win32/org/eclipse/swt/dnd/DropTarget.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/win32/org/eclipse/swt/dnd/DropTarget.java
@@ -410,7 +410,7 @@ private Point convertPixelToPoint(int xInPixels, int yInPixels) {
 	if (this.control == null) {
 		// If there is no control for context, the behavior remains as before
 		int zoom = DPIUtil.getZoomForAutoscaleProperty(this.nativeZoom);
-		return Win32DPIUtils.scaleDown(new Point(xInPixels, yInPixels), zoom);
+		return Win32DPIUtils.pixelToPoint(new Point(xInPixels, yInPixels), zoom);
 	}
 	int zoom = DPIUtil.getZoomForAutoscaleProperty(this.control.nativeZoom);
 	// There is no API to convert absolute values in pixels to display relative
@@ -419,7 +419,7 @@ private Point convertPixelToPoint(int xInPixels, int yInPixels) {
 	POINT pt = new POINT ();
 	pt.x = xInPixels;  pt.y = yInPixels;
 	OS.ScreenToClient (this.control.handle, pt);
-	Point p = Win32DPIUtils.scaleDown(new Point (pt.x, pt.y), zoom);
+	Point p = Win32DPIUtils.pixelToPoint(new Point (pt.x, pt.y), zoom);
 	return this.control.toDisplay(p);
 }
 

--- a/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/win32/org/eclipse/swt/dnd/TableDropTargetEffect.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/win32/org/eclipse/swt/dnd/TableDropTargetEffect.java
@@ -151,7 +151,7 @@ public class TableDropTargetEffect extends DropTargetEffect {
 		int effect = checkEffect(event.feedback);
 		long handle = table.handle;
 		Point coordinates = new Point(event.x, event.y);
-		coordinates = Win32DPIUtils.scaleUp(table.toControl(coordinates), DPIUtil.getZoomForAutoscaleProperty(table.nativeZoom)); // To Pixels
+		coordinates = Win32DPIUtils.pointToPixel(table.toControl(coordinates), DPIUtil.getZoomForAutoscaleProperty(table.nativeZoom)); // To Pixels
 		LVHITTESTINFO pinfo = new LVHITTESTINFO();
 		pinfo.x = coordinates.x;
 		pinfo.y = coordinates.y;

--- a/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/win32/org/eclipse/swt/dnd/TreeDropTargetEffect.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/win32/org/eclipse/swt/dnd/TreeDropTargetEffect.java
@@ -165,7 +165,7 @@ public class TreeDropTargetEffect extends DropTargetEffect {
 		int effect = checkEffect(event.feedback);
 		long handle = tree.handle;
 		Point coordinates = new Point(event.x, event.y);
-		coordinates = Win32DPIUtils.scaleUp(tree.toControl(coordinates), DPIUtil.getZoomForAutoscaleProperty(tree.nativeZoom)); // To Pixels
+		coordinates = Win32DPIUtils.pointToPixel(tree.toControl(coordinates), DPIUtil.getZoomForAutoscaleProperty(tree.nativeZoom)); // To Pixels
 		TVHITTESTINFO lpht = new TVHITTESTINFO ();
 		lpht.x = coordinates.x;
 		lpht.y = coordinates.y;

--- a/bundles/org.eclipse.swt/Eclipse SWT OLE Win32/win32/org/eclipse/swt/ole/win32/OleClientSite.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT OLE Win32/win32/org/eclipse/swt/ole/win32/OleClientSite.java
@@ -810,7 +810,7 @@ protected int GetWindow(long phwnd) {
 	return COM.S_OK;
 }
 RECT getRect() {
-	Rectangle area = Win32DPIUtils.scaleUp(getClientArea(), DPIUtil.getZoomForAutoscaleProperty(nativeZoom)); // To Pixels
+	Rectangle area = Win32DPIUtils.pointToPixel(getClientArea(), DPIUtil.getZoomForAutoscaleProperty(nativeZoom)); // To Pixels
 	RECT rect = new RECT();
 	rect.left   = area.x;
 	rect.top    = area.y;
@@ -987,14 +987,14 @@ private int OnInPlaceDeactivate() {
 	return COM.S_OK;
 }
 private int OnPosRectChange(long lprcPosRect) {
-	Point size = Win32DPIUtils.scaleUp(getSize(), DPIUtil.getZoomForAutoscaleProperty(nativeZoom)); // To Pixels
+	Point size = Win32DPIUtils.pointToPixel(getSize(), DPIUtil.getZoomForAutoscaleProperty(nativeZoom)); // To Pixels
 	setExtent(size.x, size.y);
 	return COM.S_OK;
 }
 private void onPaint(Event e) {
 	if (state == STATE_RUNNING || state == STATE_INPLACEACTIVE) {
 		SIZE size = getExtent();
-		Rectangle area = Win32DPIUtils.scaleUp(getClientArea(), DPIUtil.getZoomForAutoscaleProperty(nativeZoom)); // To Pixels
+		Rectangle area = Win32DPIUtils.pointToPixel(getClientArea(), DPIUtil.getZoomForAutoscaleProperty(nativeZoom)); // To Pixels
 		RECT rect = new RECT();
 		if (getProgramID().startsWith("Excel.Sheet")) { //$NON-NLS-1$
 			rect.left = area.x; rect.right = area.x + (area.height * size.cx / size.cy);
@@ -1370,11 +1370,11 @@ void setBorderSpace(RECT newBorderwidth) {
 }
 void setBounds() {
 	int zoom = DPIUtil.getZoomForAutoscaleProperty(nativeZoom);
-	Rectangle area = Win32DPIUtils.scaleUp(frame.getClientArea(), zoom); // To Pixels
-	setBounds(DPIUtil.scaleDown(borderWidths.left, zoom),
-			  DPIUtil.scaleDown(borderWidths.top, zoom),
-			  DPIUtil.scaleDown(area.width - borderWidths.left - borderWidths.right, zoom),
-			  DPIUtil.scaleDown(area.height - borderWidths.top - borderWidths.bottom, zoom));
+	Rectangle area = Win32DPIUtils.pointToPixel(frame.getClientArea(), zoom); // To Pixels
+	setBounds(DPIUtil.pixelToPoint(borderWidths.left, zoom),
+			  DPIUtil.pixelToPoint(borderWidths.top, zoom),
+			  DPIUtil.pixelToPoint(area.width - borderWidths.left - borderWidths.right, zoom),
+			  DPIUtil.pixelToPoint(area.height - borderWidths.top - borderWidths.bottom, zoom));
 	setObjectRects();
 }
 private void setExtent(int width, int height){

--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/graphics/Image.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/graphics/Image.java
@@ -1822,11 +1822,11 @@ public String toString () {
  * @noreference This method is not intended to be referenced by clients.
  */
 public static void drawScaled(GC gc, Image original, int width, int height, float scaleFactor) {
-	gc.drawImage (original, 0, 0, CocoaDPIUtil.autoScaleDown (width), CocoaDPIUtil.autoScaleDown (height),
+	gc.drawImage (original, 0, 0, CocoaDPIUtil.pixelToPoint (width), CocoaDPIUtil.pixelToPoint (height),
 			/* E.g. destWidth here is effectively DPIUtil.autoScaleDown (scaledWidth), but avoiding rounding errors.
 			 * Nevertheless, we still have some rounding errors due to the point-based API GC#drawImage(..).
 			 */
-			0, 0, Math.round (CocoaDPIUtil.autoScaleDown (width * scaleFactor)), Math.round (CocoaDPIUtil.autoScaleDown (height * scaleFactor)));
+			0, 0, Math.round (CocoaDPIUtil.pixelToPoint (width * scaleFactor)), Math.round (CocoaDPIUtil.pixelToPoint (height * scaleFactor)));
 }
 
 private final class CocoaDPIUtil {
@@ -1834,15 +1834,15 @@ private final class CocoaDPIUtil {
 	/**
 	 * Auto-scale down int dimensions.
 	 */
-	public static int autoScaleDown(int size) {
-		return DPIUtil.scaleDown(size, DPIUtil.getDeviceZoom());
+	public static int pixelToPoint(int size) {
+		return DPIUtil.pixelToPoint(size, DPIUtil.getDeviceZoom());
 	}
 
 	/**
 	 * Auto-scale down float dimensions.
 	 */
-	public static float autoScaleDown(float size) {
-		return DPIUtil.scaleDown(size, DPIUtil.getDeviceZoom());
+	public static float pixelToPoint(float size) {
+		return DPIUtil.pixelToPoint(size, DPIUtil.getDeviceZoom());
 	}
 }
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/ImageData.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/ImageData.java
@@ -2620,25 +2620,25 @@ static void fillGradientRectangle(GC gc, Device device,
 		fromRGB, toRGB, redBits, greenBits, blueBits);
 	Image image = new Image(device, band);
 	if ((band.width == 1) || (band.height == 1)) {
-			gc.drawImage(image, 0, 0, DPIUtil.scaleDown(band.width, zoom), DPIUtil.scaleDown(band.height, zoom),
-					DPIUtil.scaleDown(x, zoom), DPIUtil.scaleDown(y, zoom), DPIUtil.scaleDown(width, zoom),
-					DPIUtil.scaleDown(height, zoom));
+			gc.drawImage(image, 0, 0, DPIUtil.pixelToPoint(band.width, zoom), DPIUtil.pixelToPoint(band.height, zoom),
+					DPIUtil.pixelToPoint(x, zoom), DPIUtil.pixelToPoint(y, zoom), DPIUtil.pixelToPoint(width, zoom),
+					DPIUtil.pixelToPoint(height, zoom));
 		} else {
 		if (vertical) {
 			for (int dx = 0; dx < width; dx += band.width) {
 				int blitWidth = width - dx;
 				if (blitWidth > band.width) blitWidth = band.width;
-					gc.drawImage(image, 0, 0, DPIUtil.scaleDown(blitWidth, zoom), DPIUtil.scaleDown(band.height, zoom),
-							DPIUtil.scaleDown(dx + x, zoom), DPIUtil.scaleDown(y, zoom), DPIUtil.scaleDown(blitWidth, zoom),
-							DPIUtil.scaleDown(band.height, zoom));
+					gc.drawImage(image, 0, 0, DPIUtil.pixelToPoint(blitWidth, zoom), DPIUtil.pixelToPoint(band.height, zoom),
+							DPIUtil.pixelToPoint(dx + x, zoom), DPIUtil.pixelToPoint(y, zoom), DPIUtil.pixelToPoint(blitWidth, zoom),
+							DPIUtil.pixelToPoint(band.height, zoom));
 				}
 		} else {
 			for (int dy = 0; dy < height; dy += band.height) {
 				int blitHeight = height - dy;
 				if (blitHeight > band.height) blitHeight = band.height;
-					gc.drawImage(image, 0, 0, DPIUtil.scaleDown(band.width, zoom), DPIUtil.scaleDown(blitHeight, zoom),
-							DPIUtil.scaleDown(x, zoom), DPIUtil.scaleDown(dy + y, zoom), DPIUtil.scaleDown(band.width, zoom),
-							DPIUtil.scaleDown(blitHeight, zoom));
+					gc.drawImage(image, 0, 0, DPIUtil.pixelToPoint(band.width, zoom), DPIUtil.pixelToPoint(blitHeight, zoom),
+							DPIUtil.pixelToPoint(x, zoom), DPIUtil.pixelToPoint(dy + y, zoom), DPIUtil.pixelToPoint(band.width, zoom),
+							DPIUtil.pixelToPoint(blitHeight, zoom));
 				}
 		}
 	}

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/DPIUtil.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/DPIUtil.java
@@ -116,14 +116,14 @@ public class DPIUtil {
 	}
 
 
-public static int scaleDown(int size, int zoom) {
+public static int pixelToPoint(int size, int zoom) {
 	if (zoom == 100 || size == SWT.DEFAULT) return size;
 	float scaleFactor = getScalingFactor (zoom);
 	return Math.round (size / scaleFactor);
 }
 
 
-public static float scaleDown(float size, int zoom) {
+public static float pixelToPoint(float size, int zoom) {
 	if (zoom == 100 || size == SWT.DEFAULT) return size;
 	float scaleFactor = getScalingFactor (zoom);
 	return (size / scaleFactor);

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/graphics/Image.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/graphics/Image.java
@@ -439,7 +439,7 @@ public Image(Device device, Rectangle bounds) {
  * @see #dispose()
  */
 public Image(Device device, ImageData data) {
-	this(device, GtkDPIUtil.autoScaleUp(device, data), DPIUtil.getDeviceZoom());
+	this(device, GtkDPIUtil.pointToPixel(device, data), DPIUtil.getDeviceZoom());
 }
 
 private Image(Device device, ImageData data, int zoom) {
@@ -488,8 +488,8 @@ public Image(Device device, ImageData source, ImageData mask) {
 		SWT.error(SWT.ERROR_INVALID_ARGUMENT);
 	}
 	currentDeviceZoom = DPIUtil.getDeviceZoom();
-	source = GtkDPIUtil.autoScaleUp (device, source);
-	mask = GtkDPIUtil.autoScaleUp (device, mask);
+	source = GtkDPIUtil.pointToPixel (device, source);
+	mask = GtkDPIUtil.pointToPixel (device, mask);
 	mask = ImageData.convertMask (mask);
 	ImageData image = new ImageData(source.width, source.height, source.depth, source.palette, source.scanlinePad, source.data);
 	image.maskPad = mask.scanlinePad;
@@ -1597,7 +1597,7 @@ private final class GtkDPIUtil {
 	/**
 	 * Auto-scale up ImageData to device zoom that is at 100%.
 	 */
-	public static ImageData autoScaleUp (Device device, final ImageData imageData) {
+	public static ImageData pointToPixel (Device device, final ImageData imageData) {
 		int imageDataZoomFactor = 100;
 		if (DPIUtil.getDeviceZoom() == imageDataZoomFactor || imageData == null || (device != null && !device.isAutoScalable())) return imageData;
 		float scaleFactor = (float) DPIUtil.getDeviceZoom() / imageDataZoomFactor;

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Device.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Device.java
@@ -420,7 +420,7 @@ long EnumFontFamProc (long lpelfe, long lpntme, long FontType, long lParam) {
  */
 public Rectangle getBounds() {
 	checkDevice ();
-	return Win32DPIUtils.scaleDown(getBoundsInPixels(), getDeviceZoom());
+	return Win32DPIUtils.pixelToPoint(getBoundsInPixels(), getDeviceZoom());
 }
 
 private Rectangle getBoundsInPixels () {
@@ -527,7 +527,7 @@ public Point getDPI () {
 	int dpiX = OS.GetDeviceCaps (hDC, OS.LOGPIXELSX);
 	int dpiY = OS.GetDeviceCaps (hDC, OS.LOGPIXELSY);
 	internal_dispose_GC (hDC, null);
-	return Win32DPIUtils.scaleDown(new Point (dpiX, dpiY), DPIUtil.getZoomForAutoscaleProperty(getDeviceZoom()));
+	return Win32DPIUtils.pixelToPoint(new Point (dpiX, dpiY), DPIUtil.getZoomForAutoscaleProperty(getDeviceZoom()));
 }
 
 /**

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/FontMetrics.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/FontMetrics.java
@@ -97,7 +97,7 @@ public boolean equals (Object object) {
  * @return the ascent of the font
  */
 public int getAscent() {
-	return DPIUtil.scaleDown(handle.tmAscent - handle.tmInternalLeading, getZoom());
+	return DPIUtil.pixelToPoint(handle.tmAscent - handle.tmInternalLeading, getZoom());
 }
 
 /**
@@ -120,7 +120,7 @@ public double getAverageCharacterWidth() {
  */
 @Deprecated
 public int getAverageCharWidth() {
-	return DPIUtil.scaleDown(handle.tmAveCharWidth, getZoom());
+	return DPIUtil.pixelToPoint(handle.tmAveCharWidth, getZoom());
 }
 
 /**
@@ -132,7 +132,7 @@ public int getAverageCharWidth() {
  * @return the descent of the font
  */
 public int getDescent() {
-	return DPIUtil.scaleDown(handle.tmDescent, getZoom());
+	return DPIUtil.pixelToPoint(handle.tmDescent, getZoom());
 }
 
 /**
@@ -147,7 +147,7 @@ public int getDescent() {
  * @see #getLeading
  */
 public int getHeight() {
-	return DPIUtil.scaleDown(handle.tmHeight, getZoom());
+	return DPIUtil.pixelToPoint(handle.tmHeight, getZoom());
 }
 
 /**

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/GC.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/GC.java
@@ -505,8 +505,8 @@ private class CopyAreaToImageOperation extends Operation {
 	@Override
 	void apply() {
 		int zoom = getZoom();
-		int scaledX = Win32DPIUtils.scaleUp(drawable, this.x, zoom);
-		int scaledY = Win32DPIUtils.scaleUp(drawable, this.y, zoom);
+		int scaledX = Win32DPIUtils.pointToPixel(drawable, this.x, zoom);
+		int scaledY = Win32DPIUtils.pointToPixel(drawable, this.y, zoom);
 		copyAreaInPixels(this.image, scaledX, scaledY);
 	}
 }
@@ -579,8 +579,8 @@ private class CopyAreaOperation extends Operation {
 	@Override
 	void apply() {
 		int zoom = getZoom();
-		Rectangle sourceRect = Win32DPIUtils.scaleUp(drawable, source, zoom);
-		Rectangle destRect = Win32DPIUtils.scaleUp(drawable, destination, zoom);
+		Rectangle sourceRect = Win32DPIUtils.pointToPixel(drawable, source, zoom);
+		Rectangle destRect = Win32DPIUtils.pointToPixel(drawable, destination, zoom);
 		copyAreaInPixels(sourceRect.x, sourceRect.y, sourceRect.width, sourceRect.height, destRect.x, destRect.y, paint);
 	}
 }
@@ -839,7 +839,7 @@ private class DrawArcOperation extends Operation {
 	}
 	@Override
 	void apply() {
-		Rectangle rect = Win32DPIUtils.scaleUp(drawable, rectangle, getZoom());
+		Rectangle rect = Win32DPIUtils.pointToPixel(drawable, rectangle, getZoom());
 		drawArcInPixels(rect.x, rect.y, rect.width, rect.height, startAngle, arcAngle);
 	}
 }
@@ -932,7 +932,7 @@ private class DrawFocusOperation extends Operation {
 
 	@Override
 	void apply() {
-		Rectangle rect = Win32DPIUtils.scaleUp(drawable, rectangle, getZoom());
+		Rectangle rect = Win32DPIUtils.pointToPixel(drawable, rectangle, getZoom());
 		drawFocusInPixels(rect.x, rect.y, rect.width, rect.height);
 	}
 }
@@ -1024,7 +1024,7 @@ private class DrawImageOperation extends Operation {
 
 	@Override
 	void apply() {
-		drawImageInPixels(this.image, Win32DPIUtils.scaleUp(drawable, this.location, getZoom()));
+		drawImageInPixels(this.image, Win32DPIUtils.pointToPixel(drawable, this.location, getZoom()));
 	}
 
 	private void drawImageInPixels(Image image, Point location) {
@@ -1132,8 +1132,8 @@ private class DrawScalingImageToImageOperation extends Operation {
 
 private void drawImage(Image image, int srcX, int srcY, int srcWidth, int srcHeight, int destX, int destY,
 		int destWidth, int destHeight, int imageZoom, int scaledImageZoom) {
-	Rectangle src = Win32DPIUtils.scaleUp(drawable, new Rectangle(srcX, srcY, srcWidth, srcHeight), scaledImageZoom);
-	Rectangle dest = Win32DPIUtils.scaleUp(drawable, new Rectangle(destX, destY, destWidth, destHeight), imageZoom);
+	Rectangle src = Win32DPIUtils.pointToPixel(drawable, new Rectangle(srcX, srcY, srcWidth, srcHeight), scaledImageZoom);
+	Rectangle dest = Win32DPIUtils.pointToPixel(drawable, new Rectangle(destX, destY, destWidth, destHeight), imageZoom);
 	if (scaledImageZoom != 100) {
 		/*
 		 * This is a HACK! Due to rounding errors at fractional scale factors,
@@ -1835,8 +1835,8 @@ private class DrawLineOperation extends Operation {
 	@Override
 	void apply() {
 		int deviceZoom = getZoom();
-		Point startInPixels = Win32DPIUtils.scaleUp (drawable, start, deviceZoom);
-		Point endInPixels = Win32DPIUtils.scaleUp (drawable, end, deviceZoom);
+		Point startInPixels = Win32DPIUtils.pointToPixel (drawable, start, deviceZoom);
+		Point endInPixels = Win32DPIUtils.pointToPixel (drawable, end, deviceZoom);
 		drawLineInPixels(startInPixels.x, startInPixels.y, endInPixels.x, endInPixels.y);
 	}
 }
@@ -1898,7 +1898,7 @@ private class DrawOvalOperation extends Operation {
 
 	@Override
 	void apply() {
-		Rectangle boundsInPixels = Win32DPIUtils.scaleUp(drawable, bounds, getZoom());
+		Rectangle boundsInPixels = Win32DPIUtils.pointToPixel(drawable, bounds, getZoom());
 		drawOvalInPixels(boundsInPixels.x, boundsInPixels.y, boundsInPixels.width, boundsInPixels.height);
 	}
 }
@@ -2000,7 +2000,7 @@ private class DrawPointOperation extends Operation {
 
 	@Override
 	void apply() {
-		Point scaleUpLocation = Win32DPIUtils.scaleUp(location, getZoom());
+		Point scaleUpLocation = Win32DPIUtils.pointToPixel(location, getZoom());
 		drawPointInPixels(scaleUpLocation.x, scaleUpLocation.y);
 	}
 }
@@ -2046,7 +2046,7 @@ private class DrawPolygonOperation extends Operation {
 
 	@Override
 	void apply() {
-		drawPolygonInPixels(Win32DPIUtils.scaleUp(drawable, pointArray, getZoom()));
+		drawPolygonInPixels(Win32DPIUtils.pointToPixel(drawable, pointArray, getZoom()));
 	}
 }
 
@@ -2108,7 +2108,7 @@ private class DrawPolylineOperation extends Operation {
 
 	@Override
 	void apply() {
-		drawPolylineInPixels(Win32DPIUtils.scaleUp(drawable, pointArray, getZoom()));
+		drawPolylineInPixels(Win32DPIUtils.pointToPixel(drawable, pointArray, getZoom()));
 	}
 }
 
@@ -2173,7 +2173,7 @@ private class DrawRectangleOperation extends Operation {
 
 	@Override
 	void apply() {
-		Rectangle rect = Win32DPIUtils.scaleUp(drawable, rectangle, getZoom());
+		Rectangle rect = Win32DPIUtils.pointToPixel(drawable, rectangle, getZoom());
 		drawRectangleInPixels(rect.x, rect.y, rect.width, rect.height);
 	}
 }
@@ -2273,9 +2273,9 @@ private class DrawRoundRectangleOperation extends Operation {
 	@Override
 	void apply() {
 		int zoom = getZoom();
-		Rectangle rect = Win32DPIUtils.scaleUp(drawable, rectangle, zoom);
-		int scaledArcWidth = Win32DPIUtils.scaleUp (drawable, arcWidth, zoom);
-		int scaledArcHeight = Win32DPIUtils.scaleUp (drawable, arcHeight, zoom);
+		Rectangle rect = Win32DPIUtils.pointToPixel(drawable, rectangle, zoom);
+		int scaledArcWidth = Win32DPIUtils.pointToPixel (drawable, arcWidth, zoom);
+		int scaledArcHeight = Win32DPIUtils.pointToPixel (drawable, arcHeight, zoom);
 		drawRoundRectangleInPixels(rect.x, rect.y, rect.width, rect.height, scaledArcWidth, scaledArcHeight);
 	}
 }
@@ -2418,7 +2418,7 @@ private class DrawStringOperation extends Operation {
 
 	@Override
 	void apply() {
-		Point scaledLocation = Win32DPIUtils.scaleUp(drawable, location, getZoom());
+		Point scaledLocation = Win32DPIUtils.pointToPixel(drawable, location, getZoom());
 		drawStringInPixels(string, scaledLocation.x, scaledLocation.y, isTransparent);
 	}
 }
@@ -2604,7 +2604,7 @@ private class DrawTextOperation extends Operation {
 
 	@Override
 	void apply() {
-		Point scaledLocation = Win32DPIUtils.scaleUp(drawable, location, getZoom());
+		Point scaledLocation = Win32DPIUtils.pointToPixel(drawable, location, getZoom());
 		drawTextInPixels(string, scaledLocation.x, scaledLocation.y, flags);
 	}
 }
@@ -2997,7 +2997,7 @@ private class FillArcOperation extends Operation {
 
 	@Override
 	void apply() {
-		Rectangle rect = Win32DPIUtils.scaleUp(drawable, bounds, getZoom());
+		Rectangle rect = Win32DPIUtils.pointToPixel(drawable, bounds, getZoom());
 		fillArcInPixels(rect.x, rect.y, rect.width, rect.height, startAngle, arcAngle);
 	}
 }
@@ -3088,7 +3088,7 @@ private class FillGradientRectangleOperation extends FillRectangleOperation {
 
 	@Override
 	void apply() {
-		Rectangle rect = Win32DPIUtils.scaleUp(drawable, rectangle, getZoom());
+		Rectangle rect = Win32DPIUtils.pointToPixel(drawable, rectangle, getZoom());
 		fillGradientRectangleInPixels(rect.x, rect.y, rect.width, rect.height, vertical, getZoom());
 	}
 }
@@ -3216,7 +3216,7 @@ private class FillOvalOperation extends Operation {
 
 	@Override
 	void apply() {
-		Rectangle rect = Win32DPIUtils.scaleUp(drawable, bounds, getZoom());
+		Rectangle rect = Win32DPIUtils.pointToPixel(drawable, bounds, getZoom());
 		fillOvalInPixels(rect.x, rect.y, rect.width, rect.height);
 	}
 }
@@ -3316,7 +3316,7 @@ private class FillPolygonOperation extends Operation {
 
 	@Override
 	void apply() {
-		fillPolygonInPixels(Win32DPIUtils.scaleUp(drawable, pointArray, getZoom()));
+		fillPolygonInPixels(Win32DPIUtils.pointToPixel(drawable, pointArray, getZoom()));
 	}
 }
 
@@ -3378,7 +3378,7 @@ private class FillRectangleOperation extends Operation {
 
 	@Override
 	void apply() {
-		Rectangle scaledBounds = Win32DPIUtils.scaleUp(drawable, rectangle, getZoom());
+		Rectangle scaledBounds = Win32DPIUtils.pointToPixel(drawable, rectangle, getZoom());
 		fillRectangleInPixels(scaledBounds.x, scaledBounds.y, scaledBounds.width, scaledBounds.height);
 	}
 }
@@ -3459,9 +3459,9 @@ private class FillRoundRectangleOperation extends Operation {
 	@Override
 	void apply() {
 		int zoom = getZoom();
-		Rectangle rect = Win32DPIUtils.scaleUp(drawable, rectangle, zoom);
-		int scaledArcWidth = Win32DPIUtils.scaleUp (drawable, arcWidth, zoom);
-		int scaledArcHeight = Win32DPIUtils.scaleUp (drawable, arcHeight, zoom);
+		Rectangle rect = Win32DPIUtils.pointToPixel(drawable, rectangle, zoom);
+		int scaledArcWidth = Win32DPIUtils.pointToPixel (drawable, arcWidth, zoom);
+		int scaledArcHeight = Win32DPIUtils.pointToPixel (drawable, arcHeight, zoom);
 		fillRoundRectangleInPixels(rect.x, rect.y, rect.width, rect.height, scaledArcWidth, scaledArcHeight);
 	}
 }
@@ -3721,7 +3721,7 @@ public int getCharWidth(char ch) {
  * </ul>
  */
 public Rectangle getClipping () {
-	return Win32DPIUtils.scaleDown(drawable, getClippingInPixels(), getZoom());
+	return Win32DPIUtils.pixelToPoint(drawable, getClippingInPixels(), getZoom());
 }
 
 Rectangle getClippingInPixels() {
@@ -3980,9 +3980,9 @@ public int getInterpolation() {
 public LineAttributes getLineAttributes () {
 	LineAttributes attributes = getLineAttributesInPixels();
 	int deviceZoom = getZoom();
-	attributes.width = Win32DPIUtils.scaleDown(drawable, attributes.width, deviceZoom);
+	attributes.width = Win32DPIUtils.pixelToPoint(drawable, attributes.width, deviceZoom);
 	if(attributes.dash != null) {
-		attributes.dash = Win32DPIUtils.scaleDown(drawable, attributes.dash, deviceZoom);
+		attributes.dash = Win32DPIUtils.pixelToPoint(drawable, attributes.dash, deviceZoom);
 	}
 	return attributes;
 }
@@ -4033,7 +4033,7 @@ public int[] getLineDash() {
 	int[] lineDashes = new int[data.lineDashes.length];
 	int deviceZoom = getZoom();
 	for (int i = 0; i < lineDashes.length; i++) {
-		lineDashes[i] = Win32DPIUtils.scaleDown(drawable, (int)data.lineDashes[i], deviceZoom);
+		lineDashes[i] = Win32DPIUtils.pixelToPoint(drawable, (int)data.lineDashes[i], deviceZoom);
 	}
 	return lineDashes;
 }
@@ -4086,7 +4086,7 @@ public int getLineStyle() {
  * </ul>
  */
 public int getLineWidth () {
-	return Win32DPIUtils.scaleDown(drawable, getLineWidthInPixels(), getZoom());
+	return Win32DPIUtils.pixelToPoint(drawable, getLineWidthInPixels(), getZoom());
 }
 
 int getLineWidthInPixels() {
@@ -4762,7 +4762,7 @@ private class SetClippingOperation extends Operation {
 
 	@Override
 	void apply() {
-		Rectangle rect = Win32DPIUtils.scaleUp(drawable, rectangle, getZoom());
+		Rectangle rect = Win32DPIUtils.pointToPixel(drawable, rectangle, getZoom());
 		setClippingInPixels(rect.x, rect.y, rect.width, rect.height);
 	}
 }
@@ -5129,7 +5129,7 @@ private class SetLineAttributesOperation extends Operation {
 
 	@Override
 	void apply() {
-		attributes.width = Win32DPIUtils.scaleUp(drawable, attributes.width, getZoom());
+		attributes.width = Win32DPIUtils.pointToPixel(drawable, attributes.width, getZoom());
 		setLineAttributesInPixels(attributes);
 	}
 }
@@ -5195,7 +5195,7 @@ private void setLineAttributesInPixels (LineAttributes attributes) {
 			float[] newDashes = new float[dashes.length];
 			int deviceZoom = getZoom();
 			for (int i = 0; i < newDashes.length; i++) {
-				newDashes[i] = Win32DPIUtils.scaleUp(drawable, dashes[i], deviceZoom);
+				newDashes[i] = Win32DPIUtils.pointToPixel(drawable, dashes[i], deviceZoom);
 			}
 			dashes = newDashes;
 			mask |= LINE_STYLE;
@@ -5311,7 +5311,7 @@ private class SetLineDashOperation extends Operation {
 			int deviceZoom = getZoom();
 			for (int i = 0; i < dashes.length; i++) {
 				if (dashes[i] <= 0) SWT.error(SWT.ERROR_INVALID_ARGUMENT);
-				newDashes[i] = Win32DPIUtils.scaleUp(drawable, (float) dashes[i], deviceZoom);
+				newDashes[i] = Win32DPIUtils.pointToPixel(drawable, (float) dashes[i], deviceZoom);
 				if (!changed && lineDashes[i] != newDashes[i]) changed = true;
 			}
 			if (!changed) return;
@@ -5453,7 +5453,7 @@ private class SetLineWidthOperation extends Operation {
 
 	@Override
 	void apply() {
-		int lineWidth = Win32DPIUtils.scaleUp (drawable, width, getZoom());
+		int lineWidth = Win32DPIUtils.pointToPixel (drawable, width, getZoom());
 		setLineWidthInPixels(lineWidth);
 	}
 }
@@ -5644,7 +5644,7 @@ private class SetTransformOperation extends Operation {
  */
 public Point stringExtent (String string) {
 	if (string == null) SWT.error (SWT.ERROR_NULL_ARGUMENT);
-	return Win32DPIUtils.scaleDown(drawable, stringExtentInPixels(string), data.font.zoom);
+	return Win32DPIUtils.pixelToPoint(drawable, stringExtentInPixels(string), data.font.zoom);
 }
 
 Point stringExtentInPixels (String string) {
@@ -5689,7 +5689,7 @@ Point stringExtentInPixels (String string) {
  * </ul>
  */
 public Point textExtent (String string) {
-	return Win32DPIUtils.scaleDown(drawable, textExtentInPixels(string, SWT.DRAW_DELIMITER | SWT.DRAW_TAB), getZoom());
+	return Win32DPIUtils.pixelToPoint(drawable, textExtentInPixels(string, SWT.DRAW_DELIMITER | SWT.DRAW_TAB), getZoom());
 }
 
 /**
@@ -5724,7 +5724,7 @@ public Point textExtent (String string) {
  * </ul>
  */
 public Point textExtent (String string, int flags) {
-	return Win32DPIUtils.scaleDown(drawable, textExtentInPixels(string, flags), data.font.zoom);
+	return Win32DPIUtils.pixelToPoint(drawable, textExtentInPixels(string, flags), data.font.zoom);
 }
 
 Point textExtentInPixels(String string, int flags) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Image.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Image.java
@@ -1921,14 +1921,14 @@ private class ExistingImageHandleProviderWrapper extends AbstractImageProviderWr
 		ImageHandle imageHandle = new ImageHandle(handle, zoomForHandle);
 
 		ImageData baseData = imageHandle.getImageData();
-		this.width = DPIUtil.scaleDown(baseData.width, zoomForHandle);
-		this.height = DPIUtil.scaleDown(baseData.height, zoomForHandle);
+		this.width = DPIUtil.pixelToPoint(baseData.width, zoomForHandle);
+		this.height = DPIUtil.pixelToPoint(baseData.height, zoomForHandle);
 	}
 
 	@Override
 	protected Rectangle getBounds(int zoom) {
 		Rectangle rectangle = new Rectangle(0, 0, width, height);
-		return Win32DPIUtils.scaleUp(rectangle, zoom);
+		return Win32DPIUtils.pointToPixel(rectangle, zoom);
 	}
 
 	@Override
@@ -2004,8 +2004,8 @@ private class PlainImageDataProviderWrapper extends ImageFromImageDataProviderWr
 	@Override
 	protected Rectangle getBounds(int zoom) {
 		Rectangle rectangle = new Rectangle(0, 0, imageDataAtBaseZoom.width, imageDataAtBaseZoom.height);
-		rectangle = Win32DPIUtils.scaleDown(rectangle, baseZoom);
-		return Win32DPIUtils.scaleUp(rectangle, zoom);
+		rectangle = Win32DPIUtils.pixelToPoint(rectangle, baseZoom);
+		return Win32DPIUtils.pointToPixel(rectangle, zoom);
 	}
 
 	@Override
@@ -2032,7 +2032,7 @@ private class MaskedImageDataProviderWrapper extends ImageFromImageDataProviderW
 	@Override
 	protected Rectangle getBounds(int zoom) {
 		Rectangle rectangle = new Rectangle(0, 0, srcAt100.width, srcAt100.height);
-		return Win32DPIUtils.scaleUp(rectangle, zoom);
+		return Win32DPIUtils.pointToPixel(rectangle, zoom);
 	}
 
 	@Override
@@ -2110,7 +2110,7 @@ private class PlainImageProviderWrapper extends AbstractImageProviderWrapper {
 	@Override
 	protected Rectangle getBounds(int zoom) {
 		Rectangle rectangle = new Rectangle(0, 0, width, height);
-		return Win32DPIUtils.scaleUp(rectangle, zoom);
+		return Win32DPIUtils.pointToPixel(rectangle, zoom);
 	}
 
 	@Override
@@ -2154,8 +2154,8 @@ private class PlainImageProviderWrapper extends AbstractImageProviderWrapper {
 
 	private long initHandle(int zoom) {
 		if (isDisposed()) SWT.error(SWT.ERROR_GRAPHIC_DISPOSED);
-		int scaledWidth = Win32DPIUtils.scaleUp (width, zoom);
-		int scaledHeight = Win32DPIUtils.scaleUp (height, zoom);
+		int scaledWidth = Win32DPIUtils.pointToPixel (width, zoom);
+		int scaledHeight = Win32DPIUtils.pointToPixel (height, zoom);
 		long hDC = device.internal_new_GC(null);
 		long newHandle = OS.CreateCompatibleBitmap(hDC, scaledWidth, scaledHeight);
 		/*
@@ -2553,8 +2553,8 @@ private class ImageGcDrawerWrapper extends DynamicImageProviderWrapper {
 		int gcStyle = drawer.getGcStyle();
 		Image image;
 		if ((gcStyle & SWT.TRANSPARENT) != 0) {
-			int scaledHeight = Win32DPIUtils.scaleUp(height, zoom);
-			int scaledWidth = Win32DPIUtils.scaleUp(width, zoom);
+			int scaledHeight = Win32DPIUtils.pointToPixel(height, zoom);
+			int scaledWidth = Win32DPIUtils.pointToPixel(width, zoom);
 			/* Create a 24 bit image data with alpha channel */
 			final ImageData resultData = new ImageData (scaledWidth, scaledHeight, 24, new PaletteData (0xFF, 0xFF00, 0xFF0000));
 			resultData.alphaData = new byte [scaledWidth * scaledHeight];

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Path.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Path.java
@@ -516,8 +516,8 @@ private static class PathHandle {
 	}
 
 	boolean contains (float x, float y, GC gc, boolean outline) {
-		float xInPixels = Win32DPIUtils.scaleUp(device, x, zoom);
-		float yInPixels = Win32DPIUtils.scaleUp(device, y, zoom);
+		float xInPixels = Win32DPIUtils.pointToPixel(device, x, zoom);
+		float yInPixels = Win32DPIUtils.pointToPixel(device, y, zoom);
 		return containsInPixels(xInPixels, yInPixels, gc, outline);
 	}
 
@@ -540,7 +540,7 @@ private static class PathHandle {
 
 	void fillBounds (float[] bounds) {
 		getBoundsInPixels(bounds);
-		float[] scaledbounds= Win32DPIUtils.scaleDown(device, bounds, zoom);
+		float[] scaledbounds= Win32DPIUtils.pixelToPoint(device, bounds, zoom);
 		System.arraycopy(scaledbounds, 0, bounds, 0, 4);
 	}
 
@@ -555,7 +555,7 @@ private static class PathHandle {
 
 	void fillCurrentPoint (float[] point) {
 		getCurrentPointInPixels(point);
-		float[] scaledpoint= Win32DPIUtils.scaleDown(device, point, zoom);
+		float[] scaledpoint= Win32DPIUtils.pixelToPoint(device, point, zoom);
 		System.arraycopy(scaledpoint, 0, point, 0, 2);
 	}
 
@@ -566,7 +566,7 @@ private static class PathHandle {
 
 	PathData getPathData() {
 		PathData result = getPathDataInPixels();
-		result.points = Win32DPIUtils.scaleDown(device, result.points, zoom);
+		result.points = Win32DPIUtils.pixelToPoint(device, result.points, zoom);
 		return result;
 	}
 
@@ -643,10 +643,10 @@ private class AddArcOperation implements Operation {
 		if (width == 0 || height == 0 || arcAngle == 0) return;
 		int zoom = pathHandle.zoom;
 		Drawable drawable = getDevice();
-		float xInPixels = Win32DPIUtils.scaleUp(drawable, x, zoom);
-		float yInPixels = Win32DPIUtils.scaleUp(drawable, y, zoom);
-		float widthInPixels = Win32DPIUtils.scaleUp(drawable, width, zoom);
-		float heightInPixels = Win32DPIUtils.scaleUp(drawable, height, zoom);
+		float xInPixels = Win32DPIUtils.pointToPixel(drawable, x, zoom);
+		float yInPixels = Win32DPIUtils.pointToPixel(drawable, y, zoom);
+		float widthInPixels = Win32DPIUtils.pointToPixel(drawable, width, zoom);
+		float heightInPixels = Win32DPIUtils.pointToPixel(drawable, height, zoom);
 		addArcInPixels(pathHandle, xInPixels, yInPixels, widthInPixels, heightInPixels, startAngle, arcAngle);
 	}
 
@@ -695,10 +695,10 @@ private class AddRectangleOperation implements Operation {
 	public void apply(PathHandle pathHandle) {
 		int zoom = pathHandle.zoom;
 		Drawable drawable = getDevice();
-		float xInPixels = Win32DPIUtils.scaleUp(drawable, x, zoom);
-		float yInPixels = Win32DPIUtils.scaleUp(drawable, y, zoom);
-		float widthInPixels = Win32DPIUtils.scaleUp(drawable, width, zoom);
-		float heightInPixels = Win32DPIUtils.scaleUp(drawable, height, zoom);
+		float xInPixels = Win32DPIUtils.pointToPixel(drawable, x, zoom);
+		float yInPixels = Win32DPIUtils.pointToPixel(drawable, y, zoom);
+		float widthInPixels = Win32DPIUtils.pointToPixel(drawable, width, zoom);
+		float heightInPixels = Win32DPIUtils.pointToPixel(drawable, height, zoom);
 		addRectangleInPixels(pathHandle, xInPixels, yInPixels, widthInPixels, heightInPixels);
 	}
 
@@ -751,8 +751,8 @@ private class AddStringOperation implements Operation {
 	public void apply(PathHandle pathHandle) {
 		int zoom = pathHandle.zoom;
 		Drawable drawable = getDevice();
-		float xInPixels = Win32DPIUtils.scaleUp(drawable, x, zoom);
-		float yInPixels = Win32DPIUtils.scaleUp(drawable, y, zoom);
+		float xInPixels = Win32DPIUtils.pointToPixel(drawable, x, zoom);
+		float yInPixels = Win32DPIUtils.pointToPixel(drawable, y, zoom);
 		addStringInPixels(pathHandle, xInPixels, yInPixels);
 	}
 
@@ -825,12 +825,12 @@ private class CubicToOperation implements Operation {
 	public void apply(PathHandle pathHandle) {
 		int zoom = pathHandle.zoom;
 		Drawable drawable = getDevice();
-		float cx1InPixels = Win32DPIUtils.scaleUp(drawable, cx1, zoom);
-		float cy1InPixels = Win32DPIUtils.scaleUp(drawable, cy1, zoom);
-		float cx2InPixels = Win32DPIUtils.scaleUp(drawable, cx2, zoom);
-		float cy2InPixels = Win32DPIUtils.scaleUp(drawable, cy2, zoom);
-		float xInPixels = Win32DPIUtils.scaleUp(drawable, x, zoom);
-		float yInPixels = Win32DPIUtils.scaleUp(drawable, y, zoom);
+		float cx1InPixels = Win32DPIUtils.pointToPixel(drawable, cx1, zoom);
+		float cy1InPixels = Win32DPIUtils.pointToPixel(drawable, cy1, zoom);
+		float cx2InPixels = Win32DPIUtils.pointToPixel(drawable, cx2, zoom);
+		float cy2InPixels = Win32DPIUtils.pointToPixel(drawable, cy2, zoom);
+		float xInPixels = Win32DPIUtils.pointToPixel(drawable, x, zoom);
+		float yInPixels = Win32DPIUtils.pointToPixel(drawable, y, zoom);
 		cubicToInPixels(pathHandle, cx1InPixels, cy1InPixels, cx2InPixels, cy2InPixels, xInPixels, yInPixels);
 	}
 
@@ -855,7 +855,7 @@ private class LineToOperation implements Operation {
 	public void apply(PathHandle pathHandle) {
 		int zoom = pathHandle.zoom;
 		Drawable drawable = getDevice();
-		lineToInPixels(pathHandle, Win32DPIUtils.scaleUp(drawable, x, zoom), Win32DPIUtils.scaleUp(drawable, y, zoom));
+		lineToInPixels(pathHandle, Win32DPIUtils.pointToPixel(drawable, x, zoom), Win32DPIUtils.pointToPixel(drawable, y, zoom));
 	}
 
 	private void lineToInPixels(PathHandle pathHandle, float x, float y) {
@@ -879,7 +879,7 @@ private class MoveToOperation implements Operation {
 	public void apply(PathHandle pathHandle) {
 		int zoom = pathHandle.zoom;
 		Drawable drawable = getDevice();
-		moveToInPixels(pathHandle, Win32DPIUtils.scaleUp(drawable, x, zoom), Win32DPIUtils.scaleUp(drawable, y, zoom));
+		moveToInPixels(pathHandle, Win32DPIUtils.pointToPixel(drawable, x, zoom), Win32DPIUtils.pointToPixel(drawable, y, zoom));
 	}
 
 	void moveToInPixels(PathHandle pathHandle, float x, float y) {
@@ -909,10 +909,10 @@ private class QuadToOperation implements Operation {
 	public void apply(PathHandle pathHandle) {
 		Drawable drawable = getDevice();
 		int zoom = pathHandle.zoom;
-		float cxInPixels = Win32DPIUtils.scaleUp(drawable, cx, zoom);
-		float cyInPixels = Win32DPIUtils.scaleUp(drawable, cy, zoom);
-		float xInPixels = Win32DPIUtils.scaleUp(drawable, x, zoom);
-		float yInPixels = Win32DPIUtils.scaleUp(drawable, y, zoom);
+		float cxInPixels = Win32DPIUtils.pointToPixel(drawable, cx, zoom);
+		float cyInPixels = Win32DPIUtils.pointToPixel(drawable, cy, zoom);
+		float xInPixels = Win32DPIUtils.pointToPixel(drawable, x, zoom);
+		float yInPixels = Win32DPIUtils.pointToPixel(drawable, y, zoom);
 		quadToInPixels(pathHandle, cxInPixels, cyInPixels, xInPixels, yInPixels);
 	}
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Pattern.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Pattern.java
@@ -261,10 +261,10 @@ private class BasePatternHandle extends PatternHandle {
 	@Override
 	long createHandle(int zoom) {
 		long handle;
-		float x1 = Win32DPIUtils.scaleUp(baseX1, zoom);
-		float y1 = Win32DPIUtils.scaleUp(baseY1, zoom);
-		float x2 = Win32DPIUtils.scaleUp(baseX2, zoom);
-		float y2 = Win32DPIUtils.scaleUp(baseY2, zoom);
+		float x1 = Win32DPIUtils.pointToPixel(baseX1, zoom);
+		float y1 = Win32DPIUtils.pointToPixel(baseY1, zoom);
+		float x2 = Win32DPIUtils.pointToPixel(baseX2, zoom);
+		float y2 = Win32DPIUtils.pointToPixel(baseY2, zoom);
 		if (color1 == null) SWT.error(SWT.ERROR_NULL_ARGUMENT);
 		if (color1.isDisposed()) SWT.error(SWT.ERROR_INVALID_ARGUMENT);
 		if (color2 == null) SWT.error(SWT.ERROR_NULL_ARGUMENT);

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Region.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Region.java
@@ -193,8 +193,8 @@ public boolean contains (int x, int y) {
 	if (isDisposed()) SWT.error(SWT.ERROR_GRAPHIC_DISPOSED);
 	return applyUsingAnyHandle(regionHandle -> {
 		int zoom = regionHandle.zoom();
-		int xInPixels = Win32DPIUtils.scaleUp(x, zoom);
-		int yInPixels = Win32DPIUtils.scaleUp(y, zoom);
+		int xInPixels = Win32DPIUtils.pointToPixel(x, zoom);
+		int yInPixels = Win32DPIUtils.pointToPixel(y, zoom);
 		return containsInPixels(regionHandle.handle(), xInPixels, yInPixels);
 	});
 }
@@ -223,7 +223,7 @@ public boolean contains (Point pt) {
 	if (pt == null) SWT.error(SWT.ERROR_NULL_ARGUMENT);
 	return applyUsingAnyHandle(regionHandle -> {
 		int zoom = regionHandle.zoom();
-		Point p = Win32DPIUtils.scaleUp(pt, zoom);
+		Point p = Win32DPIUtils.pointToPixel(pt, zoom);
 		return containsInPixels(regionHandle.handle(), p.x, p.y);
 	});
 }
@@ -280,7 +280,7 @@ public boolean equals (Object object) {
 public Rectangle getBounds () {
 	if (isDisposed()) SWT.error(SWT.ERROR_GRAPHIC_DISPOSED);
 	return applyUsingAnyHandle(regionHandle -> {
-		return Win32DPIUtils.scaleDown(getBoundsInPixels(regionHandle.handle()), regionHandle.zoom());
+		return Win32DPIUtils.pixelToPoint(getBoundsInPixels(regionHandle.handle()), regionHandle.zoom());
 	});
 }
 
@@ -427,7 +427,7 @@ public boolean intersects (Rectangle rect) {
 	if (isDisposed()) SWT.error(SWT.ERROR_GRAPHIC_DISPOSED);
 	if (rect == null) SWT.error(SWT.ERROR_NULL_ARGUMENT);
 	return applyUsingAnyHandle(regionHandle -> {
-		Rectangle r = Win32DPIUtils.scaleUp(rect, regionHandle.zoom());
+		Rectangle r = Win32DPIUtils.pointToPixel(rect, regionHandle.zoom());
 		return intersectsInPixels(regionHandle.handle(), r.x, r.y, r.width, r.height);
 	});
 }
@@ -761,7 +761,7 @@ private static class OperationWithRectangle extends Operation {
 	}
 
 	private Rectangle getScaledRectangle(int zoom) {
-		return Win32DPIUtils.scaleUp(data, zoom);
+		return Win32DPIUtils.pointToPixel(data, zoom);
 	}
 
 }
@@ -809,7 +809,7 @@ private static class OperationWithArray extends Operation {
 	}
 
 	private int[] getScaledPoints(int zoom) {
-		return Win32DPIUtils.scaleUp(data, zoom);
+		return Win32DPIUtils.pointToPixel(data, zoom);
 	}
 }
 
@@ -838,7 +838,7 @@ private static class OperationWithPoint extends Operation {
 
 	@Override
 	void translate(long handle, int zoom) {
-		Point pt = Win32DPIUtils.scaleUp((Point) data, zoom);
+		Point pt = Win32DPIUtils.pointToPixel((Point) data, zoom);
 		OS.OffsetRgn (handle, pt.x, pt.y);
 	}
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/TextLayout.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/TextLayout.java
@@ -379,10 +379,10 @@ void computeRuns (GC gc) {
 	}
 	SCRIPT_LOGATTR logAttr = new SCRIPT_LOGATTR();
 	SCRIPT_PROPERTIES properties = new SCRIPT_PROPERTIES();
-	int wrapIndentInPixels = Win32DPIUtils.scaleUp(wrapIndent, getZoom(gc));
-	int indentInPixels = Win32DPIUtils.scaleUp(indent, getZoom(gc));
-	int wrapWidthInPixels = Win32DPIUtils.scaleUp(wrapWidth, getZoom(gc));
-	int[] tabsInPixels = Win32DPIUtils.scaleUp(tabs, getZoom(gc));
+	int wrapIndentInPixels = Win32DPIUtils.pointToPixel(wrapIndent, getZoom(gc));
+	int indentInPixels = Win32DPIUtils.pointToPixel(indent, getZoom(gc));
+	int wrapWidthInPixels = Win32DPIUtils.pointToPixel(wrapWidth, getZoom(gc));
+	int[] tabsInPixels = Win32DPIUtils.pointToPixel(tabs, getZoom(gc));
 	int lineWidth = indentInPixels, lineStart = 0, lineCount = 1;
 	for (int i=0; i<allRuns.length - 1; i++) {
 		StyleItem run = allRuns[i];
@@ -549,8 +549,8 @@ void computeRuns (GC gc) {
 				TEXTMETRIC lptm = new TEXTMETRIC();
 				OS.SelectObject(srcHdc, getItemFont(run, gc));
 				metricsAdapter.GetTextMetrics(srcHdc, lptm);
-				run.ascentInPoints = Win32DPIUtils.scaleDown(getDevice(), lptm.tmAscent, getZoom(gc));
-				run.descentInPoints = Win32DPIUtils.scaleDown(getDevice(), lptm.tmDescent, getZoom(gc));
+				run.ascentInPoints = Win32DPIUtils.pixelToPoint(getDevice(), lptm.tmAscent, getZoom(gc));
+				run.descentInPoints = Win32DPIUtils.pixelToPoint(getDevice(), lptm.tmDescent, getZoom(gc));
 				ascentInPoints = Math.max(ascentInPoints, run.ascentInPoints);
 				descentInPoints = Math.max(descentInPoints, run.descentInPoints);
 			}
@@ -835,16 +835,16 @@ void drawInPixels (GC gc, int xInPoints, int yInPoints, int selectionStart, int 
 			selectionEnd = translateOffset(Math.min(Math.max(0, selectionEnd), length - 1));
 		}
 	}
-	int x = Win32DPIUtils.scaleUp(getDevice(), xInPoints, getZoom(gc));
+	int x = Win32DPIUtils.pointToPixel(getDevice(), xInPoints, getZoom(gc));
 	RECT rect = new RECT();
 	OS.SetBkMode(hdc, OS.TRANSPARENT);
 	for (int line=0; line<runs.length; line++) {
 		int drawX = x + getLineIndentInPixel(line);
-		int drawY = Win32DPIUtils.scaleUp(getDevice(), yInPoints + lineY[line], getZoom(gc));
+		int drawY = Win32DPIUtils.pointToPixel(getDevice(), yInPoints + lineY[line], getZoom(gc));
 		StyleItem[] lineRuns = runs[line];
-		int drawYWithLineHeight = Win32DPIUtils.scaleUp(getDevice(), yInPoints + lineY[line+1] - lineSpacingInPoints, getZoom(gc));
-		int drawYWithLineHeightWithSpacing = Win32DPIUtils.scaleUp(getDevice(), yInPoints + lineY[line+1], getZoom(gc));
-		int lineHeight = Win32DPIUtils.scaleUp(getDevice(), lineY[line+1] - lineY[line] - lineSpacingInPoints, getZoom(gc));
+		int drawYWithLineHeight = Win32DPIUtils.pointToPixel(getDevice(), yInPoints + lineY[line+1] - lineSpacingInPoints, getZoom(gc));
+		int drawYWithLineHeightWithSpacing = Win32DPIUtils.pointToPixel(getDevice(), yInPoints + lineY[line+1], getZoom(gc));
+		int lineHeight = Win32DPIUtils.pointToPixel(getDevice(), lineY[line+1] - lineY[line] - lineSpacingInPoints, getZoom(gc));
 		int lineHeightWithSpacing = drawYWithLineHeightWithSpacing - drawY;
 		//Draw last line selection
 		boolean extents = false;
@@ -903,10 +903,10 @@ void drawInPixels (GC gc, int xInPoints, int yInPoints, int selectionStart, int 
 		}
 
 		//Draw the text, underline, strikeout, and border of the runs in the line
-		int baselineInPixels = Math.max(0, Win32DPIUtils.scaleUp(getDevice(), ascent, getZoom(gc)));
+		int baselineInPixels = Math.max(0, Win32DPIUtils.pointToPixel(getDevice(), ascent, getZoom(gc)));
 		int lineUnderlinePos = 0;
 		for (StyleItem run : lineRuns) {
-			baselineInPixels = Math.max(baselineInPixels, Win32DPIUtils.scaleUp(getDevice(), run.ascentInPoints, getZoom(gc)));
+			baselineInPixels = Math.max(baselineInPixels, Win32DPIUtils.pointToPixel(getDevice(), run.ascentInPoints, getZoom(gc)));
 			lineUnderlinePos = Math.min(lineUnderlinePos, run.underlinePos);
 		}
 		RECT borderClip = null, underlineClip = null, strikeoutClip = null, pRect = null;
@@ -1186,7 +1186,7 @@ RECT drawRunText(GC gc, long hdc, StyleItem run, RECT rect, int baselineInPixels
 	boolean partialSelection = hasSelection && !fullSelection && !(selectionStart > end || run.start > selectionEnd);
 	int offset = (orientation & SWT.RIGHT_TO_LEFT) != 0 ? -1 : 0;
 	int x = rect.left + offset;
-	int y = rect.top + (baselineInPixels - Win32DPIUtils.scaleUp(getDevice(), run.ascentInPoints, getZoom(gc)));
+	int y = rect.top + (baselineInPixels - Win32DPIUtils.pointToPixel(getDevice(), run.ascentInPoints, getZoom(gc)));
 	long hFont = getItemFont(run, gc);
 	OS.SelectObject(hdc, hFont);
 	if (fullSelection) {
@@ -1217,7 +1217,7 @@ RECT drawRunTextGDIP(GC gc, long graphics, StyleItem run, RECT rect, long gdipFo
 	// rendering (such as ScriptTextOut()) which put top of the character
 	// at requested position.
 	int drawY = rect.top + baselineInPixels;
-	if (run.style != null && run.style.rise != 0) drawY -= Win32DPIUtils.scaleUp(getDevice(), run.style.rise, getZoom(gc));
+	if (run.style != null && run.style.rise != 0) drawY -= Win32DPIUtils.pointToPixel(getDevice(), run.style.rise, getZoom(gc));
 
 	int drawX = rect.left;
 	long brush = color;
@@ -1369,7 +1369,7 @@ RECT drawStrikeout(GC gc, long hdc, int x, int baselineInPixels, StyleItem[] lin
 			}
 		}
 		RECT rect = new RECT();
-		int riseInPixels = Win32DPIUtils.scaleUp(getDevice(), style.rise, getZoom(gc));
+		int riseInPixels = Win32DPIUtils.pointToPixel(getDevice(), style.rise, getZoom(gc));
 		OS.SetRect(rect, x + left, baselineInPixels - run.strikeoutPos - riseInPixels, x + run.x + run.width, baselineInPixels - run.strikeoutPos + run.strikeoutThickness - riseInPixels);
 		long brush = OS.CreateSolidBrush(color);
 		OS.FillRect(hdc, rect, brush);
@@ -1419,7 +1419,7 @@ RECT drawStrikeoutGDIP(GC gc, long graphics, int x, int baselineInPixels, StyleI
 				}
 			}
 		}
-		int riseInPixels = Win32DPIUtils.scaleUp(getDevice(), style.rise, getZoom(gc));
+		int riseInPixels = Win32DPIUtils.pointToPixel(getDevice(), style.rise, getZoom(gc));
 		if (clipRect != null) {
 			int gstate = Gdip.Graphics_Save(graphics);
 			if (clipRect.left == -1) clipRect.left = 0;
@@ -1477,7 +1477,7 @@ RECT drawUnderline(GC gc, long hdc, int x, int baselineInPixels, int lineUnderli
 			}
 		}
 		RECT rect = new RECT();
-		int riseInPixels = Win32DPIUtils.scaleUp(getDevice(), style.rise, getZoom(gc));
+		int riseInPixels = Win32DPIUtils.pointToPixel(getDevice(), style.rise, getZoom(gc));
 		OS.SetRect(rect, x + left, baselineInPixels - lineUnderlinePos - riseInPixels, x + run.x + run.width, baselineInPixels - lineUnderlinePos + run.underlineThickness - riseInPixels);
 		if (clipRect != null) {
 			if (clipRect.left == -1) clipRect.left = 0;
@@ -1553,7 +1553,7 @@ RECT drawUnderline(GC gc, long hdc, int x, int baselineInPixels, int lineUnderli
 				int penStyle = style.underlineStyle == UNDERLINE_IME_DASH ? OS.PS_DASH : OS.PS_DOT;
 				long pen = OS.CreatePen(penStyle, 1, color);
 				long oldPen = OS.SelectObject(hdc, pen);
-				int descentInPixels = Win32DPIUtils.scaleUp(getDevice(), run.descentInPoints, getZoom(gc));
+				int descentInPixels = Win32DPIUtils.pointToPixel(getDevice(), run.descentInPoints, getZoom(gc));
 				OS.SetRect(rect, rect.left, baselineInPixels + descentInPixels, rect.right, baselineInPixels + descentInPixels + run.underlineThickness);
 				OS.MoveToEx(hdc, rect.left, rect.top, 0);
 				OS.LineTo(hdc, rect.right, rect.top);
@@ -1609,7 +1609,7 @@ RECT drawUnderlineGDIP (GC gc, long graphics, int x, int baselineInPixels, int l
 			}
 		}
 		RECT rect = new RECT();
-		int riseInPixels = Win32DPIUtils.scaleUp(getDevice(), style.rise, getZoom(gc));
+		int riseInPixels = Win32DPIUtils.pointToPixel(getDevice(), style.rise, getZoom(gc));
 		OS.SetRect(rect, x + left, baselineInPixels - lineUnderlinePos - riseInPixels, x + run.x + run.width, baselineInPixels - lineUnderlinePos + run.underlineThickness - riseInPixels);
 		Rect gdipRect = null;
 		if (clipRect != null) {
@@ -1705,7 +1705,7 @@ RECT drawUnderlineGDIP (GC gc, long graphics, int x, int baselineInPixels, int l
 					gstate = Gdip.Graphics_Save(graphics);
 					Gdip.Graphics_SetClip(graphics, gdipRect, Gdip.CombineModeExclude);
 				}
-				int descentInPixels = Win32DPIUtils.scaleUp(getDevice(), run.descentInPoints, getZoom(gc));
+				int descentInPixels = Win32DPIUtils.pointToPixel(getDevice(), run.descentInPoints, getZoom(gc));
 				Gdip.Graphics_DrawLine(graphics, pen, rect.left, baselineInPixels + descentInPixels, run.width - run.length, baselineInPixels + descentInPixels);
 				if (gdipRect != null) {
 					Gdip.Graphics_Restore(graphics, gstate);
@@ -1796,7 +1796,7 @@ public Rectangle getBounds () {
 		width = wrapWidth;
 	} else {
 		for (int line=0; line<runs.length; line++) {
-			width = Math.max(width, DPIUtil.scaleDown(lineWidthInPixels[line], getZoom()) + getLineIndent(line));
+			width = Math.max(width, DPIUtil.pixelToPoint(lineWidthInPixels[line], getZoom()) + getLineIndent(line));
 		}
 	}
 	return new Rectangle (0, 0, width, lineY[lineY.length - 1] + getVerticalIndent());
@@ -1818,7 +1818,7 @@ public Rectangle getBounds () {
  */
 public Rectangle getBounds (int start, int end) {
 	checkLayout();
-	return Win32DPIUtils.scaleDown(getDevice(), getBoundsInPixels(start, end), getZoom(null));
+	return Win32DPIUtils.pixelToPoint(getDevice(), getBoundsInPixels(start, end), getZoom(null));
 }
 
 Rectangle getBoundsInPixels (int start, int end) {
@@ -1864,7 +1864,7 @@ Rectangle getBoundsInPixels (int start, int end) {
 			int cx = 0;
 			if (run.style != null && run.style.metrics != null) {
 				GlyphMetrics metrics = run.style.metrics;
-				cx = Win32DPIUtils.scaleUp(getDevice(), metrics.width, getZoom()) * (start - run.start);
+				cx = Win32DPIUtils.pointToPixel(getDevice(), metrics.width, getZoom()) * (start - run.start);
 			} else if (!run.tab) {
 				int iX = ScriptCPtoX(start - run.start, false, run);
 				cx = isRTL ? run.width - iX : iX;
@@ -1879,7 +1879,7 @@ Rectangle getBoundsInPixels (int start, int end) {
 			int cx = run.width;
 			if (run.style != null && run.style.metrics != null) {
 				GlyphMetrics metrics = run.style.metrics;
-				cx = Win32DPIUtils.scaleUp(getDevice(), metrics.width, getZoom()) * (end - run.start + 1);
+				cx = Win32DPIUtils.pointToPixel(getDevice(), metrics.width, getZoom()) * (end - run.start + 1);
 			} else if (!run.tab) {
 				int iX = ScriptCPtoX(end - run.start, true, run);
 				cx = isRTL ? run.width - iX : iX;
@@ -1896,8 +1896,8 @@ Rectangle getBoundsInPixels (int start, int end) {
 		}
 		left = Math.min(left, runLead);
 		right = Math.max(right, runTrail);
-		top = Math.min(top, Win32DPIUtils.scaleUp(lineY[lineIndex], getZoom(null)));
-		bottom = Math.max(bottom, Win32DPIUtils.scaleUp(lineY[lineIndex + 1] - lineSpacingInPoints, getZoom(null)));
+		top = Math.min(top, Win32DPIUtils.pointToPixel(lineY[lineIndex], getZoom(null)));
+		bottom = Math.max(bottom, Win32DPIUtils.pointToPixel(lineY[lineIndex + 1] - lineSpacingInPoints, getZoom(null)));
 	}
 	return new Rectangle(left, top, right - left, bottom - top + getScaledVerticalIndent());
 }
@@ -2023,16 +2023,16 @@ public int getLevel (int offset) {
  */
 public Rectangle getLineBounds (int lineIndex) {
 	checkLayout();
-	return Win32DPIUtils.scaleDown(getDevice(), getLineBoundsInPixels(lineIndex), getZoom());
+	return Win32DPIUtils.pixelToPoint(getDevice(), getLineBoundsInPixels(lineIndex), getZoom());
 }
 
 Rectangle getLineBoundsInPixels(int lineIndex) {
 	computeRuns(null);
 	if (!(0 <= lineIndex && lineIndex < runs.length)) SWT.error(SWT.ERROR_INVALID_RANGE);
 	int x = getLineIndentInPixel(lineIndex);
-	int y = Win32DPIUtils.scaleUp(getDevice(), lineY[lineIndex], getZoom());
+	int y = Win32DPIUtils.pointToPixel(getDevice(), lineY[lineIndex], getZoom());
 	int width = lineWidthInPixels[lineIndex];
-	int height = Win32DPIUtils.scaleUp(getDevice(), lineY[lineIndex + 1] - lineY[lineIndex] - lineSpacingInPoints, getZoom());
+	int height = Win32DPIUtils.pointToPixel(getDevice(), lineY[lineIndex + 1] - lineY[lineIndex] - lineSpacingInPoints, getZoom());
 	return new Rectangle (x, y, width, height);
 }
 
@@ -2053,18 +2053,18 @@ public int getLineCount () {
 }
 
 int getLineIndent(int lineIndex) {
-	return DPIUtil.scaleDown(getLineIndentInPixel(lineIndex), getZoom());
+	return DPIUtil.pixelToPoint(getLineIndentInPixel(lineIndex), getZoom());
 }
 
 int getLineIndentInPixel (int lineIndex) {
-	int lineIndent = Win32DPIUtils.scaleUp(wrapIndent, getZoom());
+	int lineIndent = Win32DPIUtils.pointToPixel(wrapIndent, getZoom());
 	if (lineIndex == 0) {
-		lineIndent = Win32DPIUtils.scaleUp(indent, getZoom());
+		lineIndent = Win32DPIUtils.pointToPixel(indent, getZoom());
 	} else {
 		StyleItem[] previousLine = runs[lineIndex - 1];
 		StyleItem previousRun = previousLine[previousLine.length - 1];
 		if (previousRun.lineBreak && !previousRun.softBreak) {
-			lineIndent = Win32DPIUtils.scaleUp(indent, getZoom());
+			lineIndent = Win32DPIUtils.pointToPixel(indent, getZoom());
 		}
 	}
 	if (wrapWidth != -1) {
@@ -2078,8 +2078,8 @@ int getLineIndentInPixel (int lineIndex) {
 		if (partialLine) {
 			int lineWidth = this.lineWidthInPixels[lineIndex] + lineIndent;
 			switch (alignment) {
-				case SWT.CENTER: lineIndent += (Win32DPIUtils.scaleUp(wrapWidth, getZoom()) - lineWidth) / 2; break;
-				case SWT.RIGHT: lineIndent += Win32DPIUtils.scaleUp(wrapWidth, getZoom()) - lineWidth; break;
+				case SWT.CENTER: lineIndent += (Win32DPIUtils.pointToPixel(wrapWidth, getZoom()) - lineWidth) / 2; break;
+				case SWT.RIGHT: lineIndent += Win32DPIUtils.pointToPixel(wrapWidth, getZoom()) - lineWidth; break;
 			}
 		}
 	}
@@ -2140,9 +2140,9 @@ public FontMetrics getLineMetrics (int lineIndex) {
 	metricsAdapter.GetTextMetrics(srcHdc, lptm);
 	OS.DeleteDC(srcHdc);
 	device.internal_dispose_GC(hDC, null);
-	int ascentInPoints = Math.max(Win32DPIUtils.scaleDown(this.device, lptm.tmAscent, zoom), this.ascent);
-	int descentInPoints = Math.max(Win32DPIUtils.scaleDown(this.device, lptm.tmDescent, zoom), this.descent);
-	int leadingInPoints = Win32DPIUtils.scaleDown(this.device, lptm.tmInternalLeading, zoom);
+	int ascentInPoints = Math.max(Win32DPIUtils.pixelToPoint(this.device, lptm.tmAscent, zoom), this.ascent);
+	int descentInPoints = Math.max(Win32DPIUtils.pixelToPoint(this.device, lptm.tmDescent, zoom), this.descent);
+	int leadingInPoints = Win32DPIUtils.pixelToPoint(this.device, lptm.tmInternalLeading, zoom);
 	if (text.length() != 0) {
 		for (StyleItem run : runs[lineIndex]) {
 			if (run.ascentInPoints > ascentInPoints) {
@@ -2152,10 +2152,10 @@ public FontMetrics getLineMetrics (int lineIndex) {
 			descentInPoints = Math.max(descentInPoints, run.descentInPoints);
 		}
 	}
-	lptm.tmAscent = Win32DPIUtils.scaleUp(this.device, ascentInPoints, zoom);
-	lptm.tmDescent = Win32DPIUtils.scaleUp(this.device, descentInPoints, zoom);
-	lptm.tmHeight = Win32DPIUtils.scaleUp(this.device, ascentInPoints + descentInPoints, zoom);
-	lptm.tmInternalLeading = Win32DPIUtils.scaleUp(this.device, leadingInPoints, zoom);
+	lptm.tmAscent = Win32DPIUtils.pointToPixel(this.device, ascentInPoints, zoom);
+	lptm.tmDescent = Win32DPIUtils.pointToPixel(this.device, descentInPoints, zoom);
+	lptm.tmHeight = Win32DPIUtils.pointToPixel(this.device, ascentInPoints + descentInPoints, zoom);
+	lptm.tmInternalLeading = Win32DPIUtils.pointToPixel(this.device, leadingInPoints, zoom);
 	lptm.tmAveCharWidth = 0;
 	return FontMetrics.win32_new(lptm, nativeZoom);
 }
@@ -2199,7 +2199,7 @@ public int[] getLineOffsets () {
  */
 public Point getLocation (int offset, boolean trailing) {
 	checkLayout();
-	return Win32DPIUtils.scaleDown(getDevice(), getLocationInPixels(offset, trailing), getZoom());
+	return Win32DPIUtils.pixelToPoint(getDevice(), getLocationInPixels(offset, trailing), getZoom());
 }
 
 Point getLocationInPixels (int offset, boolean trailing) {
@@ -2214,7 +2214,7 @@ Point getLocationInPixels (int offset, boolean trailing) {
 	}
 	line = Math.min(line, runs.length - 1);
 	if (offset == length) {
-		return new Point(getLineIndentInPixel(line) + lineWidthInPixels[line], Win32DPIUtils.scaleUp(getDevice(), lineY[line], getZoom()));
+		return new Point(getLineIndentInPixel(line) + lineWidthInPixels[line], Win32DPIUtils.pointToPixel(getDevice(), lineY[line], getZoom()));
 	}
 	/* For trailing use the low surrogate and for lead use the high surrogate */
 	char ch = segmentsText.charAt(offset);
@@ -2250,7 +2250,7 @@ Point getLocationInPixels (int offset, boolean trailing) {
 			int width;
 			if (run.style != null && run.style.metrics != null) {
 				GlyphMetrics metrics = run.style.metrics;
-				width = Win32DPIUtils.scaleUp(getDevice(), metrics.width, getZoom()) * (offset - run.start + (trailing ? 1 : 0));
+				width = Win32DPIUtils.pointToPixel(getDevice(), metrics.width, getZoom()) * (offset - run.start + (trailing ? 1 : 0));
 			} else if (run.tab) {
 				width = (trailing || (offset == length)) ? run.width : 0;
 			} else {
@@ -2258,7 +2258,7 @@ Point getLocationInPixels (int offset, boolean trailing) {
 				final int iX = ScriptCPtoX(runOffset, trailing, run);
 				width = (orientation & SWT.RIGHT_TO_LEFT) != 0 ? run.width - iX : iX;
 			}
-			return new Point(run.x + width, Win32DPIUtils.scaleUp(getDevice(), lineY[line], getZoom()) + getScaledVerticalIndent());
+			return new Point(run.x + width, Win32DPIUtils.pointToPixel(getDevice(), lineY[line], getZoom()) + getScaledVerticalIndent());
 		}
 	}
 	return new Point(0, 0);
@@ -2409,7 +2409,7 @@ int _getOffset(int offset, int movement, boolean forward) {
  */
 public int getOffset (Point point, int[] trailing) {
 	checkLayout();
-	if (point == null) SWT.error (SWT.ERROR_NULL_ARGUMENT);	return getOffsetInPixels(Win32DPIUtils.scaleUp(getDevice(), point, getZoom()), trailing);
+	if (point == null) SWT.error (SWT.ERROR_NULL_ARGUMENT);	return getOffsetInPixels(Win32DPIUtils.pointToPixel(getDevice(), point, getZoom()), trailing);
 }
 
 int getOffsetInPixels (Point point, int[] trailing) {
@@ -2441,7 +2441,7 @@ int getOffsetInPixels (Point point, int[] trailing) {
  */
 public int getOffset (int x, int y, int[] trailing) {
 	checkLayout();
-	return getOffsetInPixels(Win32DPIUtils.scaleUp(getDevice(), x, getZoom()), Win32DPIUtils.scaleUp(getDevice(), y, getZoom()), trailing);
+	return getOffsetInPixels(Win32DPIUtils.pointToPixel(getDevice(), x, getZoom()), Win32DPIUtils.pointToPixel(getDevice(), y, getZoom()), trailing);
 }
 
 int getOffsetInPixels (int x, int y, int[] trailing) {
@@ -2450,7 +2450,7 @@ int getOffsetInPixels (int x, int y, int[] trailing) {
 	int line;
 	int lineCount = runs.length;
 	for (line=0; line<lineCount; line++) {
-		if (Win32DPIUtils.scaleUp(getDevice(), lineY[line + 1], getZoom()) > y) break;
+		if (Win32DPIUtils.pointToPixel(getDevice(), lineY[line + 1], getZoom()) > y) break;
 	}
 	line = Math.min(line, runs.length - 1);
 	StyleItem[] lineRuns = runs[line];
@@ -2472,7 +2472,7 @@ int getOffsetInPixels (int x, int y, int[] trailing) {
 			if (run.style != null && run.style.metrics != null) {
 				GlyphMetrics metrics = run.style.metrics;
 				if (metrics.width > 0) {
-					final int metricsWidthInPixels = Win32DPIUtils.scaleUp(getDevice(), metrics.width, getZoom());
+					final int metricsWidthInPixels = Win32DPIUtils.pointToPixel(getDevice(), metrics.width, getZoom());
 					if (trailing != null) {
 						trailing[0] = (xRun % metricsWidthInPixels < metricsWidthInPixels / 2) ? 0 : 1;
 					}
@@ -2709,7 +2709,7 @@ private int getScaledVerticalIndent() {
 	if (verticalIndentInPoints == 0) {
 		return verticalIndentInPoints;
 	}
-	return Win32DPIUtils.scaleUp(getDevice(), verticalIndentInPoints, getZoom());
+	return Win32DPIUtils.pointToPixel(getDevice(), verticalIndentInPoints, getZoom());
 }
 
 /**
@@ -3918,7 +3918,7 @@ void shape (GC  gc, final long hdc, final StyleItem run) {
 			 *  equals zero for FFFC (possibly other unicode code points), the fix
 			 *  is to make sure the glyph is at least one pixel wide.
 			 */
-			run.width = Win32DPIUtils.scaleUp(getDevice(), metrics.width, getZoom()) * Math.max (1, run.glyphCount);
+			run.width = Win32DPIUtils.pointToPixel(getDevice(), metrics.width, getZoom()) * Math.max (1, run.glyphCount);
 			run.ascentInPoints = metrics.ascent;
 			run.descentInPoints = metrics.descent;
 			run.leadingInPoints = 0;
@@ -3930,9 +3930,9 @@ void shape (GC  gc, final long hdc, final StyleItem run) {
 				lptm = new TEXTMETRIC();
 				metricsAdapter.GetTextMetrics(hdc, lptm);
 			}
-			run.ascentInPoints = Win32DPIUtils.scaleDown(getDevice(), lptm.tmAscent, getZoom(gc));
-			run.descentInPoints = Win32DPIUtils.scaleDown(getDevice(), lptm.tmDescent, getZoom(gc));
-			run.leadingInPoints = Win32DPIUtils.scaleDown(getDevice(), lptm.tmInternalLeading, getZoom(gc));
+			run.ascentInPoints = Win32DPIUtils.pixelToPoint(getDevice(), lptm.tmAscent, getZoom(gc));
+			run.descentInPoints = Win32DPIUtils.pixelToPoint(getDevice(), lptm.tmDescent, getZoom(gc));
+			run.leadingInPoints = Win32DPIUtils.pixelToPoint(getDevice(), lptm.tmInternalLeading, getZoom(gc));
 		}
 		if (lotm != null) {
 			run.underlinePos = lotm.otmsUnderscorePosition;
@@ -3942,7 +3942,7 @@ void shape (GC  gc, final long hdc, final StyleItem run) {
 		} else {
 			run.underlinePos = 1;
 			run.underlineThickness = 1;
-			run.strikeoutPos = Win32DPIUtils.scaleUp(getDevice(), run.ascentInPoints, getZoom(gc)) / 2;
+			run.strikeoutPos = Win32DPIUtils.pointToPixel(getDevice(), run.ascentInPoints, getZoom(gc)) / 2;
 			run.strikeoutThickness = 1;
 		}
 		run.ascentInPoints += style.rise;
@@ -3950,9 +3950,9 @@ void shape (GC  gc, final long hdc, final StyleItem run) {
 	} else {
 		TEXTMETRIC lptm = new TEXTMETRIC();
 		metricsAdapter.GetTextMetrics(hdc, lptm);
-		run.ascentInPoints = Win32DPIUtils.scaleDown(getDevice(), lptm.tmAscent, getZoom(gc));
-		run.descentInPoints = Win32DPIUtils.scaleDown(getDevice(), lptm.tmDescent, getZoom(gc));
-		run.leadingInPoints = Win32DPIUtils.scaleDown(getDevice(), lptm.tmInternalLeading, getZoom(gc));
+		run.ascentInPoints = Win32DPIUtils.pixelToPoint(getDevice(), lptm.tmAscent, getZoom(gc));
+		run.descentInPoints = Win32DPIUtils.pixelToPoint(getDevice(), lptm.tmDescent, getZoom(gc));
+		run.leadingInPoints = Win32DPIUtils.pixelToPoint(getDevice(), lptm.tmInternalLeading, getZoom(gc));
 	}
 }
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Transform.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Transform.java
@@ -190,8 +190,8 @@ public void getElements(float[] elements) {
 		Gdip.Matrix_GetElements(transformHandle.handle, elements);
 		Drawable drawable = getDevice();
 		int zoom = transformHandle.zoom;
-		elements[4] = Win32DPIUtils.scaleDown(drawable, elements[4], zoom);
-		elements[5] = Win32DPIUtils.scaleDown(drawable, elements[5], zoom);
+		elements[4] = Win32DPIUtils.pixelToPoint(drawable, elements[4], zoom);
+		elements[5] = Win32DPIUtils.pixelToPoint(drawable, elements[5], zoom);
 		return true;
 	});
 }
@@ -372,11 +372,11 @@ public void transform(float[] pointArray) {
 	applyUsingAnyHandle(transformHandle -> {
 		int length = pointArray.length;
 		for (int i = 0; i < length; i++) {
-			pointArray[i] = Win32DPIUtils.scaleUp(drawable, pointArray[i], transformHandle.zoom);
+			pointArray[i] = Win32DPIUtils.pointToPixel(drawable, pointArray[i], transformHandle.zoom);
 		}
 		Gdip.Matrix_TransformPoints(transformHandle.handle, pointArray, length / 2);
 		for (int i = 0; i < length; i++) {
-			pointArray[i] = Win32DPIUtils.scaleDown(drawable, pointArray[i], transformHandle.zoom);
+			pointArray[i] = Win32DPIUtils.pixelToPoint(drawable, pointArray[i], transformHandle.zoom);
 		}
 		return pointArray;
 	});
@@ -428,7 +428,7 @@ private class MultiplyOperation implements Operation {
 	public void apply(TransformHandle transformHandle) {
 		long handle = transformHandle.handle;
 		int zoom = transformHandle.zoom;
-		long newHandle = Gdip.Matrix_new(elements[0], elements[1], elements[2], elements[3], Win32DPIUtils.scaleUp(elements[4], zoom), Win32DPIUtils.scaleUp(elements[5], zoom));
+		long newHandle = Gdip.Matrix_new(elements[0], elements[1], elements[2], elements[3], Win32DPIUtils.pointToPixel(elements[4], zoom), Win32DPIUtils.pointToPixel(elements[5], zoom));
 		if (newHandle == 0) SWT.error(SWT.ERROR_NO_HANDLES);
 		try {
 			Gdip.Matrix_Multiply(handle, newHandle, Gdip.MatrixOrderPrepend);
@@ -476,7 +476,7 @@ private class SetElementsOperation implements Operation {
 		Drawable drawable = getDevice();
 		long handle = transformHandle.handle;
 		int zoom = transformHandle.zoom;
-		Gdip.Matrix_SetElements(handle, m11, m12, m21, m22, Win32DPIUtils.scaleUp(drawable, dx, zoom), Win32DPIUtils.scaleUp(drawable, dy, zoom));
+		Gdip.Matrix_SetElements(handle, m11, m12, m21, m22, Win32DPIUtils.pointToPixel(drawable, dx, zoom), Win32DPIUtils.pointToPixel(drawable, dy, zoom));
 	}
 }
 
@@ -502,7 +502,7 @@ private class TranslateOperation implements Operation {
 		Drawable drawable = getDevice();
 		long handle = transformHandle.handle;
 		int zoom = transformHandle.zoom;
-		Gdip.Matrix_Translate(handle, Win32DPIUtils.scaleUp(drawable, offsetX, zoom), Win32DPIUtils.scaleUp(drawable, offsetY, zoom), Gdip.MatrixOrderPrepend);
+		Gdip.Matrix_Translate(handle, Win32DPIUtils.pointToPixel(drawable, offsetX, zoom), Win32DPIUtils.pointToPixel(drawable, offsetY, zoom), Gdip.MatrixOrderPrepend);
 	}
 }
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/ImageList.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/ImageList.java
@@ -332,8 +332,8 @@ public int getStyle () {
 
 public long getHandle(int targetZoom) {
 	if (!zoomToHandle.containsKey(targetZoom)) {
-		int scaledWidth = Win32DPIUtils.scaleUp(DPIUtil.scaleDown(width, this.zoom), targetZoom);
-		int scaledHeight = Win32DPIUtils.scaleUp(DPIUtil.scaleDown(height, this.zoom), targetZoom);
+		int scaledWidth = Win32DPIUtils.pointToPixel(DPIUtil.pixelToPoint(width, this.zoom), targetZoom);
+		int scaledHeight = Win32DPIUtils.pointToPixel(DPIUtil.pixelToPoint(height, this.zoom), targetZoom);
 		long newImageListHandle = OS.ImageList_Create(scaledWidth, scaledHeight, flags, 16, 16);
 		int count = OS.ImageList_GetImageCount (handle);
 		for (int i = 0; i < count; i++) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/Win32DPIUtils.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/Win32DPIUtils.java
@@ -68,7 +68,7 @@ public class Win32DPIUtils {
 		}
 	}
 
-	public static float[] scaleDown(float size[], int zoom) {
+	public static float[] pixelToPoint(float size[], int zoom) {
 		if (zoom == 100 || size == null) return size;
 		float scaleFactor = DPIUtil.getScalingFactor (zoom);
 		float scaledSize[] = new float[size.length];
@@ -78,22 +78,22 @@ public class Win32DPIUtils {
 		return scaledSize;
 	}
 
-	public static float[] scaleDown(Drawable drawable, float size[], int zoom) {
+	public static float[] pixelToPoint(Drawable drawable, float size[], int zoom) {
 		if (drawable != null && !drawable.isAutoScalable()) return size;
-		return scaleDown(size, zoom);
+		return pixelToPoint(size, zoom);
 	}
 
-	public static int scaleDown(Drawable drawable, int size, int zoom) {
+	public static int pixelToPoint(Drawable drawable, int size, int zoom) {
 		if (drawable != null && !drawable.isAutoScalable()) return size;
-		return DPIUtil.scaleDown (size, zoom);
+		return DPIUtil.pixelToPoint (size, zoom);
 	}
 
-	public static float scaleDown(Drawable drawable, float size, int zoom) {
+	public static float pixelToPoint(Drawable drawable, float size, int zoom) {
 		if (drawable != null && !drawable.isAutoScalable()) return size;
-		return DPIUtil.scaleDown (size, zoom);
+		return DPIUtil.pixelToPoint (size, zoom);
 	}
 
-	public static Point scaleDown(Point point, int zoom) {
+	public static Point pixelToPoint(Point point, int zoom) {
 		if (zoom == 100 || point == null) return point;
 		Point.OfFloat fPoint = FloatAwareGeometryFactory.createFrom(point);
 		float scaleFactor = DPIUtil.getScalingFactor(zoom);
@@ -102,18 +102,18 @@ public class Win32DPIUtils {
 		return new Point.OfFloat(scaledX, scaledY);
 	}
 
-	public static Point scaleDown(Drawable drawable, Point point, int zoom) {
+	public static Point pixelToPoint(Drawable drawable, Point point, int zoom) {
 		if (drawable != null && !drawable.isAutoScalable()) return point;
-		return scaleDown (point, zoom);
+		return pixelToPoint (point, zoom);
 	}
 
-	public static Rectangle scaleDown(Rectangle rect, int zoom) {
+	public static Rectangle pixelToPoint(Rectangle rect, int zoom) {
 		return scaleBounds(rect, 100, zoom);
 	}
 
-	public static Rectangle scaleDown(Drawable drawable, Rectangle rect, int zoom) {
+	public static Rectangle pixelToPoint(Drawable drawable, Rectangle rect, int zoom) {
 		if (drawable != null && !drawable.isAutoScalable()) return rect;
-		return scaleDown (rect, zoom);
+		return pixelToPoint (rect, zoom);
 	}
 
 	/**
@@ -130,7 +130,7 @@ public class Win32DPIUtils {
 		return new Rectangle.OfFloat(scaledX, scaledY, scaledWidth, scaledHeight);
 	}
 
-	public static int[] scaleUp(int[] pointArray, int zoom) {
+	public static int[] pointToPixel(int[] pointArray, int zoom) {
 		if (zoom == 100 || pointArray == null) return pointArray;
 		float scaleFactor = DPIUtil.getScalingFactor(zoom);
 		int[] returnArray = new int[pointArray.length];
@@ -140,37 +140,37 @@ public class Win32DPIUtils {
 		return returnArray;
 	}
 
-	public static int[] scaleUp(Drawable drawable, int[] pointArray, int zoom) {
+	public static int[] pointToPixel(Drawable drawable, int[] pointArray, int zoom) {
 		if (drawable != null && !drawable.isAutoScalable()) return pointArray;
-		return scaleUp (pointArray, zoom);
+		return pointToPixel (pointArray, zoom);
 	}
 
 	/**
 	 * Auto-scale up int dimensions to match the given zoom level
 	 */
-	public static int scaleUp(int size, int zoom) {
+	public static int pointToPixel(int size, int zoom) {
 		if (zoom == 100 || size == SWT.DEFAULT) return size;
 		float scaleFactor = DPIUtil.getScalingFactor(zoom);
 		return Math.round (size * scaleFactor);
 	}
 
-	public static int scaleUp(Drawable drawable, int size, int zoom) {
+	public static int pointToPixel(Drawable drawable, int size, int zoom) {
 		if (drawable != null && !drawable.isAutoScalable()) return size;
-		return scaleUp (size, zoom);
+		return pointToPixel (size, zoom);
 	}
 
-	public static float scaleUp(float size, int zoom) {
+	public static float pointToPixel(float size, int zoom) {
 		if (zoom == 100 || size == SWT.DEFAULT) return size;
 		float scaleFactor = DPIUtil.getScalingFactor(zoom);
 		return (size * scaleFactor);
 	}
 
-	public static float scaleUp(Drawable drawable, float size, int zoom) {
+	public static float pointToPixel(Drawable drawable, float size, int zoom) {
 		if (drawable != null && !drawable.isAutoScalable()) return size;
-		return scaleUp (size, zoom);
+		return pointToPixel (size, zoom);
 	}
 
-	public static Point scaleUp(Point point, int zoom) {
+	public static Point pointToPixel(Point point, int zoom) {
 		if (zoom == 100 || point == null) return point;
 		Point.OfFloat fPoint = FloatAwareGeometryFactory.createFrom(point);
 		float scaleFactor = DPIUtil.getScalingFactor(zoom);
@@ -179,18 +179,18 @@ public class Win32DPIUtils {
 		return new Point.OfFloat(scaledX, scaledY);
 	}
 
-	public static Point scaleUp(Drawable drawable, Point point, int zoom) {
+	public static Point pointToPixel(Drawable drawable, Point point, int zoom) {
 		if (drawable != null && !drawable.isAutoScalable()) return point;
-		return scaleUp (point, zoom);
+		return pointToPixel (point, zoom);
 	}
 
-	public static Rectangle scaleUp(Rectangle rect, int zoom) {
+	public static Rectangle pointToPixel(Rectangle rect, int zoom) {
 		return scaleBounds(rect, zoom, 100);
 	}
 
-	public static Rectangle scaleUp(Drawable drawable, Rectangle rect, int zoom) {
+	public static Rectangle pointToPixel(Drawable drawable, Rectangle rect, int zoom) {
 		if (drawable != null && !drawable.isAutoScalable()) return rect;
-		return scaleUp (rect, zoom);
+		return pointToPixel (rect, zoom);
 	}
 
 	/**

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Button.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Button.java
@@ -362,10 +362,10 @@ int computeLeftMargin () {
 					Rectangle rect = Win32DPIUtils.scaleBounds(image.getBounds(), this.getZoom(), 100);
 					width = rect.width;
 					if (hasText && text.length () != 0) {
-						width += Win32DPIUtils.scaleUp(MARGIN * 2, getZoom());;
+						width += Win32DPIUtils.pointToPixel(MARGIN * 2, getZoom());;
 					}
 					height = rect.height;
-					extra = Win32DPIUtils.scaleUp(MARGIN * 2, getZoom());;
+					extra = Win32DPIUtils.pointToPixel(MARGIN * 2, getZoom());;
 				}
 			}
 			if (hasText) {
@@ -379,7 +379,7 @@ int computeLeftMargin () {
 				if (length == 0) {
 					height = Math.max (height, lptm.tmHeight);
 				} else {
-					extra = Math.max (Win32DPIUtils.scaleUp(MARGIN * 2, getZoom()), lptm.tmAveCharWidth);
+					extra = Math.max (Win32DPIUtils.pointToPixel(MARGIN * 2, getZoom()), lptm.tmAveCharWidth);
 					char [] buffer = text.toCharArray ();
 					RECT rect = new RECT ();
 					int flags = OS.DT_CALCRECT | OS.DT_SINGLELINE;
@@ -1315,7 +1315,7 @@ private int getCheckboxTextOffset(long hdc) {
 		OS.GetThemePartSize(display.hButtonTheme(nativeZoom), hdc, OS.BP_CHECKBOX, OS.CBS_UNCHECKEDNORMAL, null, OS.TS_TRUE, size);
 		result += size.cx;
 	} else {
-		result += Win32DPIUtils.scaleUp(13, nativeZoom);
+		result += Win32DPIUtils.pointToPixel(13, nativeZoom);
 	}
 
 	// Windows uses half width of '0' as checkbox-to-text distance.
@@ -1399,7 +1399,7 @@ LRESULT wmNotifyChild (NMHDR hdr, long wParam, long lParam) {
 							int x = margin + (isRadioOrCheck() ? radioOrCheckTextPadding : 3);
 							int y = Math.max (0, (nmcd.bottom - imageBounds.height) / 2);
 							int zoom = getZoom();
-							gc.drawImage (image, DPIUtil.scaleDown(x, zoom), DPIUtil.scaleDown(y, zoom));
+							gc.drawImage (image, DPIUtil.pixelToPoint(x, zoom), DPIUtil.pixelToPoint(y, zoom));
 							gc.dispose ();
 						}
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Canvas.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Canvas.java
@@ -104,7 +104,7 @@ public Canvas (Composite parent, int style) {
  */
 public void drawBackground (GC gc, int x, int y, int width, int height) {
 	int zoom = getZoom();
-	Rectangle rectangle = Win32DPIUtils.scaleUp(new Rectangle(x, y, width, height), zoom);
+	Rectangle rectangle = Win32DPIUtils.pointToPixel(new Rectangle(x, y, width, height), zoom);
 	drawBackgroundInPixels(gc, rectangle.x, rectangle.y, rectangle.width, rectangle.height, 0, 0);
 }
 
@@ -198,9 +198,9 @@ void reskinChildren (int flags) {
 public void scroll (int destX, int destY, int x, int y, int width, int height, boolean all) {
 	checkWidget ();
 	int zoom = getZoom();
-	destX = Win32DPIUtils.scaleUp(destX, zoom);
-	destY = Win32DPIUtils.scaleUp(destY, zoom);
-	Rectangle rectangle = Win32DPIUtils.scaleUp(new Rectangle(x, y, width, height), zoom);
+	destX = Win32DPIUtils.pointToPixel(destX, zoom);
+	destY = Win32DPIUtils.pointToPixel(destY, zoom);
+	Rectangle rectangle = Win32DPIUtils.pointToPixel(new Rectangle(x, y, width, height), zoom);
 	scrollInPixels(destX, destY, rectangle.x, rectangle.y, rectangle.width, rectangle.height, all);
 }
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Caret.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Caret.java
@@ -121,12 +121,12 @@ long defaultFont () {
  */
 public Rectangle getBounds () {
 	checkWidget();
-	return Win32DPIUtils.scaleDown(getBoundsInPixels(), getZoom());
+	return Win32DPIUtils.pixelToPoint(getBoundsInPixels(), getZoom());
 }
 
 Rectangle getBoundsInPixels () {
 	if (image != null) {
-		Rectangle rect = Win32DPIUtils.scaleUp(image.getBounds(), getZoom());
+		Rectangle rect = Win32DPIUtils.pointToPixel(image.getBounds(), getZoom());
 		return new Rectangle (getXInPixels(), getYInPixels(), rect.width, rect.height);
 	}
 	if (width == 0) {
@@ -215,12 +215,12 @@ public Canvas getParent () {
  */
 public Point getSize () {
 	checkWidget();
-	return Win32DPIUtils.scaleDown(getSizeInPixels(), getZoom());
+	return Win32DPIUtils.pixelToPoint(getSizeInPixels(), getZoom());
 }
 
 Point getSizeInPixels () {
 	if (image != null) {
-		Rectangle rect = Win32DPIUtils.scaleUp(image.getBounds(), getZoom());
+		Rectangle rect = Win32DPIUtils.pointToPixel(image.getBounds(), getZoom());
 		return new Point (rect.width, rect.height);
 	}
 	if (width == 0) {
@@ -233,19 +233,19 @@ Point getSizeInPixels () {
 }
 
 private int getWidthInPixels() {
-	return Win32DPIUtils.scaleUp(width, getZoom());
+	return Win32DPIUtils.pointToPixel(width, getZoom());
 }
 
 private int getHeightInPixels() {
-	return Win32DPIUtils.scaleUp(height, getZoom());
+	return Win32DPIUtils.pointToPixel(height, getZoom());
 }
 
 private int getXInPixels() {
-	return Win32DPIUtils.scaleUp(x, getZoom());
+	return Win32DPIUtils.pointToPixel(x, getZoom());
 }
 
 private int getYInPixels() {
-	return Win32DPIUtils.scaleUp(y, getZoom());
+	return Win32DPIUtils.pointToPixel(y, getZoom());
 }
 
 /**

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Combo.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Combo.java
@@ -911,7 +911,7 @@ boolean dragDetect (long hwnd, int x, int y, boolean filter, boolean [] detect, 
  */
 public Point getCaretLocation () {
 	checkWidget ();
-	return Win32DPIUtils.scaleDown(getCaretLocationInPixels(), getZoom());
+	return Win32DPIUtils.pixelToPoint(getCaretLocationInPixels(), getZoom());
 }
 
 Point getCaretLocationInPixels () {
@@ -1079,7 +1079,7 @@ public int getItemCount () {
  */
 public int getItemHeight () {
 	checkWidget ();
-	return DPIUtil.scaleDown(getItemHeightInPixels(), getZoom());
+	return DPIUtil.pixelToPoint(getItemHeightInPixels(), getZoom());
 }
 
 int getItemHeightInPixels () {
@@ -1345,7 +1345,7 @@ public String getText () {
  */
 public int getTextHeight () {
 	checkWidget ();
-	return DPIUtil.scaleDown(getTextHeightInPixels(), getZoom());
+	return DPIUtil.pixelToPoint(getTextHeightInPixels(), getZoom());
 }
 
 int getTextHeightInPixels () {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Composite.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Composite.java
@@ -219,7 +219,7 @@ Point computeSizeInPixels (int wHint, int hHint, boolean changed) {
 			changed |= (state & LAYOUT_CHANGED) != 0;
 			state &= ~LAYOUT_CHANGED;
 			int zoom = getZoom();
-			size = Win32DPIUtils.scaleUp(layout.computeSize (this, DPIUtil.scaleDown(wHint, zoom), DPIUtil.scaleDown(hHint, zoom), changed), zoom);
+			size = Win32DPIUtils.pointToPixel(layout.computeSize (this, DPIUtil.pixelToPoint(wHint, zoom), DPIUtil.pixelToPoint(hHint, zoom), changed), zoom);
 		} else {
 			size = new Point (wHint, hHint);
 		}
@@ -235,7 +235,7 @@ Point computeSizeInPixels (int wHint, int hHint, boolean changed) {
 	 * call computeTrimInPixels directly.
 	 */
 	int zoom = getZoom();
-	Rectangle trim = Win32DPIUtils.scaleUp(computeTrim (0, 0, DPIUtil.scaleDown(size.x, zoom), DPIUtil.scaleDown(size.y, zoom)), zoom);
+	Rectangle trim = Win32DPIUtils.pointToPixel(computeTrim (0, 0, DPIUtil.pixelToPoint(size.x, zoom), DPIUtil.pixelToPoint(size.y, zoom)), zoom);
 	return new Point (trim.width, trim.height);
 }
 
@@ -356,9 +356,9 @@ int applyThemeBackground () {
 public void drawBackground (GC gc, int x, int y, int width, int height, int offsetX, int offsetY) {
 	checkWidget ();
 	int zoom = getZoom();
-	Rectangle rectangle = Win32DPIUtils.scaleUp(new Rectangle(x, y, width, height), zoom);
-	offsetX = Win32DPIUtils.scaleUp(offsetX, zoom);
-	offsetY = Win32DPIUtils.scaleUp(offsetY, zoom);
+	Rectangle rectangle = Win32DPIUtils.pointToPixel(new Rectangle(x, y, width, height), zoom);
+	offsetX = Win32DPIUtils.pointToPixel(offsetX, zoom);
+	offsetY = Win32DPIUtils.pointToPixel(offsetY, zoom);
 	drawBackgroundInPixels(gc, rectangle.x, rectangle.y, rectangle.width, rectangle.height, offsetX, offsetY);
 }
 
@@ -879,10 +879,10 @@ Point minimumSize (int wHint, int hHint, boolean changed) {
 	 * call getClientAreaInPixels directly.
 	 */
 	int zoom = getZoom();
-	Rectangle clientArea = Win32DPIUtils.scaleUp(getClientArea (), zoom);
+	Rectangle clientArea = Win32DPIUtils.pointToPixel(getClientArea (), zoom);
 	int width = 0, height = 0;
 	for (Control element : _getChildren ()) {
-		Rectangle rect = Win32DPIUtils.scaleUp(element.getBounds (), zoom);
+		Rectangle rect = Win32DPIUtils.pointToPixel(element.getBounds (), zoom);
 		width = Math.max (width, rect.x - clientArea.x + rect.width);
 		height = Math.max (height, rect.y - clientArea.y + rect.height);
 	}
@@ -1539,7 +1539,7 @@ LRESULT WM_PAINT (long wParam, long lParam) {
 
 					Event event = new Event ();
 					event.gc = gc;
-					event.setBounds(Win32DPIUtils.scaleDown(new Rectangle(ps.left, ps.top, width, height), getZoom()));
+					event.setBounds(Win32DPIUtils.pixelToPoint(new Rectangle(ps.left, ps.top, width, height), getZoom()));
 					sendEvent (SWT.Paint, event);
 					if (data.focusDrawn && !isDisposed ()) updateUIState ();
 					gc.dispose ();
@@ -1622,7 +1622,7 @@ LRESULT WM_PAINT (long wParam, long lParam) {
 						if ((style & (SWT.DOUBLE_BUFFERED | SWT.NO_BACKGROUND | SWT.TRANSPARENT)) == 0) {
 							drawBackground (gc.handle, rect);
 						}
-						event.setBounds(Win32DPIUtils.scaleDown(new Rectangle(rect.left, rect.top, rect.right - rect.left, rect.bottom - rect.top), zoom));
+						event.setBounds(Win32DPIUtils.pixelToPoint(new Rectangle(rect.left, rect.top, rect.right - rect.left, rect.bottom - rect.top), zoom));
 						event.count = count - 1 - i;
 						sendEvent (SWT.Paint, event);
 					}
@@ -1632,7 +1632,7 @@ LRESULT WM_PAINT (long wParam, long lParam) {
 						OS.SetRect (rect, ps.left, ps.top, ps.right, ps.bottom);
 						drawBackground (gc.handle, rect);
 					}
-					event.setBounds(Win32DPIUtils.scaleDown(new Rectangle(ps.left, ps.top, width, height), zoom));
+					event.setBounds(Win32DPIUtils.pixelToPoint(new Rectangle(ps.left, ps.top, width, height), zoom));
 					sendEvent (SWT.Paint, event);
 				}
 				// widget could be disposed at this point
@@ -1644,7 +1644,7 @@ LRESULT WM_PAINT (long wParam, long lParam) {
 					}
 					gc.dispose();
 					if (!isDisposed ()) {
-						paintGC.drawImage (image, DPIUtil.scaleDown(ps.left, zoom), DPIUtil.scaleDown(ps.top, zoom));
+						paintGC.drawImage (image, DPIUtil.pixelToPoint(ps.left, zoom), DPIUtil.pixelToPoint(ps.top, zoom));
 					}
 					image.dispose ();
 					gc = paintGC;
@@ -1707,7 +1707,7 @@ LRESULT WM_PRINTCLIENT (long wParam, long lParam) {
 			GC gc = createNewGC(wParam, data);
 			Event event = new Event ();
 			event.gc = gc;
-			event.setBounds(Win32DPIUtils.scaleDown(new Rectangle(rect.left, rect.top, rect.right - rect.left, rect.bottom - rect.top), getZoom()));
+			event.setBounds(Win32DPIUtils.pixelToPoint(new Rectangle(rect.left, rect.top, rect.right - rect.left, rect.bottom - rect.top), getZoom()));
 			sendEvent (SWT.Paint, event);
 			event.gc = null;
 			gc.dispose ();

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Control.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Control.java
@@ -618,9 +618,9 @@ public Point computeSize (int wHint, int hHint) {
 public Point computeSize (int wHint, int hHint, boolean changed){
 	checkWidget ();
 	int zoom = getZoom();
-	wHint = (wHint != SWT.DEFAULT ? Win32DPIUtils.scaleUp(wHint, zoom) : wHint);
-	hHint = (hHint != SWT.DEFAULT ? Win32DPIUtils.scaleUp(hHint, zoom) : hHint);
-	return Win32DPIUtils.scaleDown(computeSizeInPixels(wHint, hHint, changed), zoom);
+	wHint = (wHint != SWT.DEFAULT ? Win32DPIUtils.pointToPixel(wHint, zoom) : wHint);
+	hHint = (hHint != SWT.DEFAULT ? Win32DPIUtils.pointToPixel(hHint, zoom) : hHint);
+	return Win32DPIUtils.pixelToPoint(computeSizeInPixels(wHint, hHint, changed), zoom);
 }
 
 Point computeSizeInPixels (int wHint, int hHint, boolean changed) {
@@ -782,7 +782,7 @@ public boolean dragDetect (Event event) {
 	if (event == null) error (SWT.ERROR_NULL_ARGUMENT);
 	Point loc = event.getLocation();
 	int zoom = getZoom();
-	return dragDetect (event.button, event.count, event.stateMask, Win32DPIUtils.scaleUp(loc.x, zoom), Win32DPIUtils.scaleUp(loc.y, zoom));
+	return dragDetect (event.button, event.count, event.stateMask, Win32DPIUtils.pointToPixel(loc.x, zoom), Win32DPIUtils.pointToPixel(loc.y, zoom));
 }
 
 /**
@@ -825,7 +825,7 @@ public boolean dragDetect (MouseEvent event) {
 	checkWidget ();
 	if (event == null) error (SWT.ERROR_NULL_ARGUMENT);
 	int zoom = getZoom();
-	return dragDetect (event.button, event.count, event.stateMask, Win32DPIUtils.scaleUp(event.x, zoom), Win32DPIUtils.scaleUp(event.y, zoom)); // To Pixels
+	return dragDetect (event.button, event.count, event.stateMask, Win32DPIUtils.pointToPixel(event.x, zoom), Win32DPIUtils.pointToPixel(event.y, zoom)); // To Pixels
 }
 
 boolean dragDetect (int button, int count, int stateMask, int x, int y) {
@@ -1159,7 +1159,7 @@ int getBackgroundPixel () {
  */
 public int getBorderWidth () {
 	checkWidget ();
-	return DPIUtil.scaleDown(getBorderWidthInPixels (), getZoom());
+	return DPIUtil.pixelToPoint(getBorderWidthInPixels (), getZoom());
 }
 
 int getBorderWidthInPixels () {
@@ -1199,7 +1199,7 @@ int getBorderWidthInPixels () {
  */
 public Rectangle getBounds (){
 	checkWidget ();
-	return Win32DPIUtils.scaleDown(getBoundsInPixels (), getZoom());
+	return Win32DPIUtils.pixelToPoint(getBoundsInPixels (), getZoom());
 }
 
 Rectangle getBoundsInPixels () {
@@ -1372,7 +1372,7 @@ public Object getLayoutData () {
  */
 public Point getLocation () {
 	checkWidget ();
-	return Win32DPIUtils.scaleDown(getLocationInPixels(), getZoom());
+	return Win32DPIUtils.pixelToPoint(getLocationInPixels(), getZoom());
 }
 
 Point getLocationInPixels () {
@@ -1528,7 +1528,7 @@ public Shell getShell () {
  */
 public Point getSize (){
 	checkWidget ();
-	return Win32DPIUtils.scaleDown(getSizeInPixels (), getZoom());
+	return Win32DPIUtils.pixelToPoint(getSizeInPixels (), getZoom());
 }
 
 Point getSizeInPixels () {
@@ -1987,10 +1987,10 @@ void mapEvent (long hwnd, Event event) {
 		POINT point = new POINT ();
 		Point loc = event.getLocation();
 		int zoom = getZoom();
-		point.x = Win32DPIUtils.scaleUp(loc.x, zoom);
-		point.y = Win32DPIUtils.scaleUp(loc.y, zoom);
+		point.x = Win32DPIUtils.pointToPixel(loc.x, zoom);
+		point.y = Win32DPIUtils.pointToPixel(loc.y, zoom);
 		OS.MapWindowPoints (hwnd, handle, point, 1);
-		event.setLocation(DPIUtil.scaleDown(point.x, zoom), DPIUtil.scaleDown(point.y, zoom));
+		event.setLocation(DPIUtil.pixelToPoint(point.x, zoom), DPIUtil.pixelToPoint(point.y, zoom));
 	}
 }
 
@@ -2450,7 +2450,7 @@ public void redraw (int x, int y, int width, int height, boolean all) {
 	checkWidget ();
 	int zoom = getZoom();
 	if (width <= 0 || height <= 0) return;
-	Rectangle rectangle = Win32DPIUtils.scaleUp(new Rectangle(x, y, width, height), zoom);
+	Rectangle rectangle = Win32DPIUtils.pointToPixel(new Rectangle(x, y, width, height), zoom);
 
 	RECT rect = new RECT ();
 	OS.SetRect (rect, rectangle.x, rectangle.y, rectangle.x + rectangle.width, rectangle.y + rectangle.height);
@@ -2952,7 +2952,7 @@ boolean sendGestureEvent (GESTUREINFO gi) {
 	Point globalPt = new Point(gi.x, gi.y);
 	Point point = toControlInPixels(globalPt.x, globalPt.y);
 	int zoom = getZoom();
-	event.setLocation(DPIUtil.scaleDown(point.x, zoom), DPIUtil.scaleDown(point.y, zoom));
+	event.setLocation(DPIUtil.pixelToPoint(point.x, zoom), DPIUtil.pixelToPoint(point.y, zoom));
 	switch (gi.dwID) {
 		case OS.GID_ZOOM:
 			type = SWT.Gesture;
@@ -3033,7 +3033,7 @@ void sendTouchEvent (TOUCHINPUT touchInput []) {
 	OS.GetCursorPos (pt);
 	OS.ScreenToClient (handle, pt);
 	int zoom = getZoom();
-	event.setLocation(DPIUtil.scaleDown(pt.x, zoom), DPIUtil.scaleDown(pt.y, zoom));
+	event.setLocation(DPIUtil.pixelToPoint(pt.x, zoom), DPIUtil.pixelToPoint(pt.y, zoom));
 	Touch [] touches = new Touch [touchInput.length];
 	Monitor monitor = getMonitor ();
 	for (int i = 0; i < touchInput.length; i++) {
@@ -3264,7 +3264,7 @@ public void setBounds (Rectangle rect) {
 	checkWidget ();
 	if (rect == null) error (SWT.ERROR_NULL_ARGUMENT);
 	int zoom = autoScaleDisabled ? parent.getZoom() : getZoom();
-	setBoundsInPixels(Win32DPIUtils.scaleUp(rect, zoom));
+	setBoundsInPixels(Win32DPIUtils.pointToPixel(rect, zoom));
 }
 
 void setBoundsInPixels (Rectangle rect) {
@@ -3522,8 +3522,8 @@ public void setLayoutData (Object layoutData) {
 public void setLocation (int x, int y) {
 	checkWidget ();
 	int zoom = getZoom();
-	x = Win32DPIUtils.scaleUp(x, zoom);
-	y = Win32DPIUtils.scaleUp(y, zoom);
+	x = Win32DPIUtils.pointToPixel(x, zoom);
+	y = Win32DPIUtils.pointToPixel(y, zoom);
 	setLocationInPixels(x, y);
 }
 
@@ -3552,7 +3552,7 @@ void setLocationInPixels (int x, int y) {
 public void setLocation (Point location) {
 	checkWidget ();
 	if (location == null) error (SWT.ERROR_NULL_ARGUMENT);
-	location = Win32DPIUtils.scaleUp(location, getZoom());
+	location = Win32DPIUtils.pointToPixel(location, getZoom());
 	setLocationInPixels(location.x, location.y);
 }
 
@@ -3779,8 +3779,8 @@ public void setRegion (Region region) {
 public void setSize (int width, int height) {
 	checkWidget ();
 	int zoom = getZoom();
-	width = Win32DPIUtils.scaleUp(width, zoom);
-	height = Win32DPIUtils.scaleUp(height, zoom);
+	width = Win32DPIUtils.pointToPixel(width, zoom);
+	height = Win32DPIUtils.pointToPixel(height, zoom);
 	setSizeInPixels(width, height);
 }
 
@@ -3815,7 +3815,7 @@ void setSizeInPixels (int width, int height) {
 public void setSize (Point size) {
 	checkWidget ();
 	if (size == null) error (SWT.ERROR_NULL_ARGUMENT);
-	size = Win32DPIUtils.scaleUp(size, getZoom());
+	size = Win32DPIUtils.pointToPixel(size, getZoom());
 	setSizeInPixels(size.x, size.y);
 }
 
@@ -4031,7 +4031,7 @@ public Point toControl (int x, int y) {
 	int zoom = getZoom();
 	Point displayPointInPixels = getDisplay().translateToDisplayCoordinates(new Point(x, y), zoom);
 	final Point controlPointInPixels = toControlInPixels(displayPointInPixels.x, displayPointInPixels.y);
-	return Win32DPIUtils.scaleDown(controlPointInPixels, zoom);
+	return Win32DPIUtils.pixelToPoint(controlPointInPixels, zoom);
 }
 
 Point toControlInPixels (int x, int y) {
@@ -4090,7 +4090,7 @@ public Point toControl (Point point) {
 public Point toDisplay (int x, int y) {
 	checkWidget ();
 	int zoom = getZoom();
-	Point displayPointInPixels = toDisplayInPixels(Win32DPIUtils.scaleUp(x, zoom), Win32DPIUtils.scaleUp(y, zoom));
+	Point displayPointInPixels = toDisplayInPixels(Win32DPIUtils.pointToPixel(x, zoom), Win32DPIUtils.pointToPixel(y, zoom));
 	return getDisplay().translateFromDisplayCoordinates(displayPointInPixels, zoom);
 }
 
@@ -5684,7 +5684,7 @@ LRESULT WM_TABLET_FLICK (long wParam, long lParam) {
 			break;
 	}
 	int zoom = getZoom();
-	event.setLocation(DPIUtil.scaleDown(fPoint.x, zoom), DPIUtil.scaleDown(fPoint.y, zoom));
+	event.setLocation(DPIUtil.pixelToPoint(fPoint.x, zoom), DPIUtil.pixelToPoint(fPoint.y, zoom));
 	event.type = SWT.Gesture;
 	event.detail = SWT.GESTURE_SWIPE;
 	setInputState (event, SWT.Gesture);

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/CoolBar.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/CoolBar.java
@@ -412,7 +412,7 @@ int getMargin (int index) {
 	}
 	if ((style & SWT.FLAT) == 0) {
 		if (!isLastItemOfRow (index)) {
-			margin += Win32DPIUtils.scaleUp(SEPARATOR_WIDTH, getZoom());
+			margin += Win32DPIUtils.pointToPixel(SEPARATOR_WIDTH, getZoom());
 		}
 	}
 	return margin;
@@ -549,7 +549,7 @@ public Point [] getItemSizes () {
 	Point [] sizes = getItemSizesInPixels();
 	if (sizes != null) {
 		for (int i = 0; i < sizes.length; i++) {
-			sizes[i] = Win32DPIUtils.scaleDown(sizes[i], getZoom());
+			sizes[i] = Win32DPIUtils.pixelToPoint(sizes[i], getZoom());
 		}
 	}
 	return sizes;
@@ -809,7 +809,7 @@ public void setItemLayout (int [] itemOrder, int [] wrapIndices, Point [] sizes)
 	if (sizes == null) error (SWT.ERROR_NULL_ARGUMENT);
 	Point [] sizesInPoints = new Point [sizes.length];
 	for (int i = 0; i < sizes.length; i++) {
-		sizesInPoints[i] = Win32DPIUtils.scaleUp(sizes[i], getZoom());
+		sizesInPoints[i] = Win32DPIUtils.pointToPixel(sizes[i], getZoom());
 	}
 	setItemLayoutInPixels (itemOrder, wrapIndices, sizesInPoints);
 }
@@ -1175,9 +1175,9 @@ LRESULT wmNotifyChild (NMHDR hdr, long wParam, long lParam) {
 				event.detail = SWT.ARROW;
 				int zoom = getZoom();
 				if ((style & SWT.VERTICAL) != 0) {
-					event.setLocation(DPIUtil.scaleDown(lpnm.right, zoom), DPIUtil.scaleDown(lpnm.top, zoom));
+					event.setLocation(DPIUtil.pixelToPoint(lpnm.right, zoom), DPIUtil.pixelToPoint(lpnm.top, zoom));
 				} else {
-					event.setLocation(DPIUtil.scaleDown(lpnm.left, zoom), DPIUtil.scaleDown(lpnm.bottom, zoom));
+					event.setLocation(DPIUtil.pixelToPoint(lpnm.left, zoom), DPIUtil.pixelToPoint(lpnm.bottom, zoom));
 				}
 				item.sendSelectionEvent(SWT.Selection, event, false);
 			}

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/CoolItem.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/CoolItem.java
@@ -186,9 +186,9 @@ protected void checkSubclass () {
 public Point computeSize (int wHint, int hHint) {
 	checkWidget ();
 	int zoom = getZoom();
-	wHint = (wHint != SWT.DEFAULT ? Win32DPIUtils.scaleUp(wHint, zoom) : wHint);
-	hHint = (hHint != SWT.DEFAULT ? Win32DPIUtils.scaleUp(hHint, zoom) : hHint);
-	return Win32DPIUtils.scaleDown(computeSizeInPixels(wHint, hHint), zoom);
+	wHint = (wHint != SWT.DEFAULT ? Win32DPIUtils.pointToPixel(wHint, zoom) : wHint);
+	hHint = (hHint != SWT.DEFAULT ? Win32DPIUtils.pointToPixel(hHint, zoom) : hHint);
+	return Win32DPIUtils.pixelToPoint(computeSizeInPixels(wHint, hHint), zoom);
 }
 Point computeSizeInPixels (int wHint, int hHint) {
 	int index = parent.indexOf (this);
@@ -223,7 +223,7 @@ void destroyWidget () {
  */
 public Rectangle getBounds () {
 	checkWidget ();
-	return Win32DPIUtils.scaleDown(getBoundsInPixels(), getZoom());
+	return Win32DPIUtils.pixelToPoint(getBoundsInPixels(), getZoom());
 }
 
 Rectangle getBoundsInPixels () {
@@ -383,7 +383,7 @@ public void setControl (Control control) {
  */
 public Point getPreferredSize () {
 	checkWidget ();
-	return Win32DPIUtils.scaleDown(getPreferredSizeInPixels(), getZoom());
+	return Win32DPIUtils.pixelToPoint(getPreferredSizeInPixels(), getZoom());
 }
 
 Point getPreferredSizeInPixels () {
@@ -415,7 +415,7 @@ Point getPreferredSizeInPixels () {
 public void setPreferredSize (int width, int height) {
 	checkWidget ();
 	int zoom = getZoom();
-	setPreferredSizeInPixels(Win32DPIUtils.scaleUp(width, zoom), Win32DPIUtils.scaleUp(height, zoom));
+	setPreferredSizeInPixels(Win32DPIUtils.pointToPixel(width, zoom), Win32DPIUtils.pointToPixel(height, zoom));
 }
 
 void setPreferredSizeInPixels (int width, int height) {
@@ -464,7 +464,7 @@ void setPreferredSizeInPixels (int width, int height) {
 public void setPreferredSize (Point size) {
 	checkWidget ();
 	if (size == null) error(SWT.ERROR_NULL_ARGUMENT);
-	size = Win32DPIUtils.scaleUp(size, getZoom());
+	size = Win32DPIUtils.pointToPixel(size, getZoom());
 	setPreferredSizeInPixels(size.x, size.y);
 }
 
@@ -483,7 +483,7 @@ public void setPreferredSize (Point size) {
  */
 public Point getSize () {
 	checkWidget ();
-	return Win32DPIUtils.scaleDown(getSizeInPixels(), getZoom());
+	return Win32DPIUtils.pixelToPoint(getSizeInPixels(), getZoom());
 }
 
 Point getSizeInPixels() {
@@ -526,7 +526,7 @@ Point getSizeInPixels() {
 public void setSize (int width, int height) {
 	checkWidget ();
 	int zoom = getZoom();
-	setSizeInPixels(Win32DPIUtils.scaleUp(width, zoom), Win32DPIUtils.scaleUp(height, zoom));
+	setSizeInPixels(Win32DPIUtils.pointToPixel(width, zoom), Win32DPIUtils.pointToPixel(height, zoom));
 }
 
 void setSizeInPixels (int width, int height) {
@@ -592,7 +592,7 @@ void setSizeInPixels (int width, int height) {
 public void setSize (Point size) {
 	checkWidget ();
 	if (size == null) error(SWT.ERROR_NULL_ARGUMENT);
-	size = Win32DPIUtils.scaleUp(size, getZoom());
+	size = Win32DPIUtils.pointToPixel(size, getZoom());
 	setSizeInPixels(size.x, size.y);
 }
 
@@ -611,7 +611,7 @@ public void setSize (Point size) {
  */
 public Point getMinimumSize () {
 	checkWidget ();
-	return Win32DPIUtils.scaleDown(getMinimumSizeInPixels(), getZoom());
+	return Win32DPIUtils.pixelToPoint(getMinimumSizeInPixels(), getZoom());
 }
 
 Point getMinimumSizeInPixels () {
@@ -645,7 +645,7 @@ Point getMinimumSizeInPixels () {
 public void setMinimumSize (int width, int height) {
 	checkWidget ();
 	int zoom = getZoom();
-	setMinimumSizeInPixels(Win32DPIUtils.scaleUp(width, zoom), Win32DPIUtils.scaleUp(height, zoom));
+	setMinimumSizeInPixels(Win32DPIUtils.pointToPixel(width, zoom), Win32DPIUtils.pointToPixel(height, zoom));
 }
 
 void setMinimumSizeInPixels (int width, int height) {
@@ -695,7 +695,7 @@ void setMinimumSizeInPixels (int width, int height) {
 public void setMinimumSize (Point size) {
 	checkWidget ();
 	if (size == null) error (SWT.ERROR_NULL_ARGUMENT);
-	size = Win32DPIUtils.scaleUp(size, getZoom());
+	size = Win32DPIUtils.pointToPixel(size, getZoom());
 	setMinimumSizeInPixels(size.x, size.y);
 }
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Display.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Display.java
@@ -1592,7 +1592,7 @@ public Menu getMenuBar () {
 @Override
 public Rectangle getBounds() {
 	checkDevice ();
-	return Win32DPIUtils.scaleDown(getBoundsInPixels(), DPIUtil.getDeviceZoom());
+	return Win32DPIUtils.pixelToPoint(getBoundsInPixels(), DPIUtil.getDeviceZoom());
 }
 
 Rectangle getBoundsInPixels () {
@@ -1665,7 +1665,7 @@ int getClickCount (int type, int button, long hwnd, long lParam) {
 @Override
 public Rectangle getClientArea () {
 	checkDevice ();
-	return Win32DPIUtils.scaleDown(getClientAreaInPixels(), DPIUtil.getDeviceZoom());
+	return Win32DPIUtils.pixelToPoint(getClientAreaInPixels(), DPIUtil.getDeviceZoom());
 }
 
 Rectangle getClientAreaInPixels () {
@@ -2608,7 +2608,7 @@ public Image getSystemImage (int id) {
 
 private ImageDataProvider getImageDataProviderForIcon(int iconName) {
 	return zoom -> {
-		int scaledIconSize = Win32DPIUtils.scaleUp(ICON_SIZE_AT_100, zoom);
+		int scaledIconSize = Win32DPIUtils.pointToPixel(ICON_SIZE_AT_100, zoom);
 		long [] hIcon = new long [1];
 		OS.LoadIconWithScaleDown(0, iconName, scaledIconSize, scaledIconSize, hIcon);
 		Image image = Image.win32_new (this, SWT.ICON, hIcon[0], zoom);
@@ -3639,7 +3639,7 @@ public boolean post (Event event) {
 					int y = OS.GetSystemMetrics (OS.SM_YVIRTUALSCREEN);
 					int width = OS.GetSystemMetrics (OS.SM_CXVIRTUALSCREEN);
 					int height = OS.GetSystemMetrics (OS.SM_CYVIRTUALSCREEN);
-					Point loc = Win32DPIUtils.scaleUp(event.getLocation(), getDeviceZoom());
+					Point loc = Win32DPIUtils.pointToPixel(event.getLocation(), getDeviceZoom());
 					inputs.dx = ((loc.x - x) * 65535 + width - 2) / (width - 1);
 					inputs.dy = ((loc.y - y) * 65535 + height - 2) / (height - 1);
 				} else {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ExpandBar.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ExpandBar.java
@@ -391,7 +391,7 @@ public ExpandItem [] getItems () {
  */
 public int getSpacing () {
 	checkWidget ();
-	return DPIUtil.scaleDown(getSpacingInPixels (), getZoom());
+	return DPIUtil.pixelToPoint(getSpacingInPixels (), getZoom());
 }
 
 int getSpacingInPixels () {
@@ -561,7 +561,7 @@ void setScrollbar () {
  */
 public void setSpacing (int spacing) {
 	checkWidget ();
-	setSpacingInPixels(Win32DPIUtils.scaleUp(spacing, getZoom()));
+	setSpacingInPixels(Win32DPIUtils.pointToPixel(spacing, getZoom()));
 }
 
 void setSpacingInPixels (int spacing) {
@@ -789,7 +789,7 @@ LRESULT WM_PAINT (long wParam, long lParam) {
 			if (hooks (SWT.Paint) || filters (SWT.Paint)) {
 				Event event = new Event ();
 				event.gc = gc;
-				event.setBounds(Win32DPIUtils.scaleDown(new Rectangle(rect.left, rect.top, width, height), getZoom()));
+				event.setBounds(Win32DPIUtils.pixelToPoint(new Rectangle(rect.left, rect.top, width, height), getZoom()));
 				sendEvent (SWT.Paint, event);
 				event.gc = null;
 			}

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ExpandItem.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ExpandItem.java
@@ -186,8 +186,8 @@ void drawItem (GC gc, long hTheme, RECT clipRect, boolean drawFocus) {
 	long hDC = gc.handle;
 	int headerHeightinPixels = getHeaderHeightInPixels();
 	int zoom = getZoom();
-	int imageHeightInPixels = Win32DPIUtils.scaleUp(imageHeight, zoom);
-	int imageWidthInPixels = Win32DPIUtils.scaleUp(imageWidth, zoom);
+	int imageHeightInPixels = Win32DPIUtils.pointToPixel(imageHeight, zoom);
+	int imageWidthInPixels = Win32DPIUtils.pointToPixel(imageWidth, zoom);
 
 	RECT rect = new RECT ();
 	OS.SetRect (rect, x, y, x + width, y + headerHeightinPixels);
@@ -200,8 +200,8 @@ void drawItem (GC gc, long hTheme, RECT clipRect, boolean drawFocus) {
 	}
 	if (image != null) {
 		rect.left += ExpandItem.TEXT_INSET;
-		int yInPoints = DPIUtil.scaleDown(rect.top + ((headerHeightinPixels - imageHeightInPixels) / 2), zoom);
-		gc.drawImage (image, DPIUtil.scaleDown(rect.left, zoom), yInPoints);
+		int yInPoints = DPIUtil.pixelToPoint(rect.top + ((headerHeightinPixels - imageHeightInPixels) / 2), zoom);
+		gc.drawImage (image, DPIUtil.pixelToPoint(rect.left, zoom), yInPoints);
 		rect.left += imageWidthInPixels;
 	}
 	if (text.length () > 0) {
@@ -306,12 +306,12 @@ public boolean getExpanded () {
  */
 public int getHeaderHeight () {
 	checkWidget ();
-	return DPIUtil.scaleDown(getHeaderHeightInPixels(), getZoom());
+	return DPIUtil.pixelToPoint(getHeaderHeightInPixels(), getZoom());
 }
 
 int getHeaderHeightInPixels () {
 	int headerHeightInPixels = parent.getBandHeight();
-	int imageHeightInPixels = Win32DPIUtils.scaleUp(imageHeight, getZoom());
+	int imageHeightInPixels = Win32DPIUtils.pointToPixel(imageHeight, getZoom());
 	int imageHeaderDiff = headerHeightInPixels - imageHeightInPixels;
 	if (imageHeaderDiff < IMAGE_MARGIN) {
 		headerHeightInPixels = imageHeightInPixels + IMAGE_MARGIN;
@@ -331,7 +331,7 @@ int getHeaderHeightInPixels () {
  */
 public int getHeight () {
 	checkWidget ();
-	return DPIUtil.scaleDown(getHeightInPixels(), getZoom());
+	return DPIUtil.pixelToPoint(getHeightInPixels(), getZoom());
 }
 
 int getHeightInPixels () {
@@ -380,8 +380,8 @@ void redraw (boolean all) {
 	long parentHandle = parent.handle;
 	int headerHeightInPixels = getHeaderHeightInPixels();
 	int zoom = getZoom();
-	int imageHeightInPixels = Win32DPIUtils.scaleUp(imageHeight, zoom);
-	int imageWidthInPixels = Win32DPIUtils.scaleUp(imageWidth, zoom);
+	int imageHeightInPixels = Win32DPIUtils.pointToPixel(imageHeight, zoom);
+	int imageWidthInPixels = Win32DPIUtils.pointToPixel(imageWidth, zoom);
 	RECT rect = new RECT ();
 	int left = all ? x : x + width - headerHeightInPixels;
 	OS.SetRect (rect, left, y, x + width, y + headerHeightInPixels);
@@ -496,7 +496,7 @@ public void setExpanded (boolean expanded) {
  */
 public void setHeight (int height) {
 	checkWidget ();
-	setHeightInPixels(Win32DPIUtils.scaleUp(height, getZoom()));
+	setHeightInPixels(Win32DPIUtils.pointToPixel(height, getZoom()));
 }
 
 void setHeightInPixels (int height) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/IME.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/IME.java
@@ -568,7 +568,7 @@ LRESULT WM_LBUTTONDOWN (long wParam, long lParam) {
 				Event event = new Event ();
 				event.detail = SWT.COMPOSITION_OFFSET;
 				int zoom = getZoom();
-				event.setLocation(DPIUtil.scaleDown(OS.GET_X_LPARAM (lParam), zoom), DPIUtil.scaleDown(OS.GET_Y_LPARAM (lParam), zoom));
+				event.setLocation(DPIUtil.pixelToPoint(OS.GET_X_LPARAM (lParam), zoom), DPIUtil.pixelToPoint(OS.GET_Y_LPARAM (lParam), zoom));
 				sendEvent (SWT.ImeComposition, event);
 				int offset = event.index;
 				int length = text.length();

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Label.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Label.java
@@ -567,7 +567,7 @@ void wmDrawChildImage(DRAWITEMSTRUCT struct) {
 	data.device = display;
 	GC gc = createNewGC(struct.hDC, data);
 	Image image = getEnabled () ? this.image : new Image (display, this.image, SWT.IMAGE_DISABLE);
-	gc.drawImage (image, DPIUtil.scaleDown(x, zoom), DPIUtil.scaleDown(Math.max (0, (height - imageRect.height) / 2), zoom));
+	gc.drawImage (image, DPIUtil.pixelToPoint(x, zoom), DPIUtil.pixelToPoint(Math.max (0, (height - imageRect.height) / 2), zoom));
 	if (image != this.image) image.dispose ();
 	gc.dispose ();
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/List.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/List.java
@@ -473,7 +473,7 @@ public int getItemCount () {
  */
 public int getItemHeight () {
 	checkWidget ();
-	return DPIUtil.scaleDown(getItemHeightInPixels(), getZoom());
+	return DPIUtil.pixelToPoint(getItemHeightInPixels(), getZoom());
 }
 
 int getItemHeightInPixels () {
@@ -1564,7 +1564,7 @@ void updateMenuLocation (Event event) {
 	}
 	Point pt = toDisplayInPixels (x, y);
 	int zoom = getZoom();
-	event.setLocation(DPIUtil.scaleDown(pt.x, zoom), DPIUtil.scaleDown(pt.y, zoom));
+	event.setLocation(DPIUtil.pixelToPoint(pt.x, zoom), DPIUtil.pixelToPoint(pt.y, zoom));
 }
 
 @Override

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/MenuItem.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/MenuItem.java
@@ -1216,22 +1216,22 @@ LRESULT wmDrawChild(long wParam, long lParam) {
 			}
 			Rectangle menuItemBounds = this.getBounds();
 
-			int fillMenuWidth =  DPIUtil.scaleDown(menuItemBounds.width, zoom);
-			int fillMenuHeight = DPIUtil.scaleDown(menuItemBounds.height, zoom);
-			menuItemArea = new Rectangle(DPIUtil.scaleDown(x, zoom), DPIUtil.scaleDown(struct.top, zoom), fillMenuWidth, fillMenuHeight);
+			int fillMenuWidth =  DPIUtil.pixelToPoint(menuItemBounds.width, zoom);
+			int fillMenuHeight = DPIUtil.pixelToPoint(menuItemBounds.height, zoom);
+			menuItemArea = new Rectangle(DPIUtil.pixelToPoint(x, zoom), DPIUtil.pixelToPoint(struct.top, zoom), fillMenuWidth, fillMenuHeight);
 
 			gc.setForeground(isInactive ? display.getSystemColor(SWT.COLOR_GRAY) : display.getSystemColor(SWT.COLOR_WHITE));
 			gc.setBackground(isSelected ? display.getSystemColor(SWT.COLOR_DARK_GRAY) : parent.getBackground());
 			gc.fillRectangle(menuItemArea);
 
-			int xPositionText = LEFT_TEXT_MARGIN + DPIUtil.scaleDown(x, zoom) + (this.image != null ? this.image.getBounds().width + IMAGE_TEXT_GAP : 0);
-			int yPositionText = DPIUtil.scaleDown(struct.top, zoom) + MARGIN_HEIGHT;
+			int xPositionText = LEFT_TEXT_MARGIN + DPIUtil.pixelToPoint(x, zoom) + (this.image != null ? this.image.getBounds().width + IMAGE_TEXT_GAP : 0);
+			int yPositionText = DPIUtil.pixelToPoint(struct.top, zoom) + MARGIN_HEIGHT;
 			gc.drawText(drawnText, xPositionText, yPositionText, flags);
 		}
 		if (image != null) {
 			Image image = getEnabled() ? this.image : new Image(display, this.image, SWT.IMAGE_DISABLE);
 			int gap = (menuItemArea.height - image.getBounds().height) / 2;
-			gc.drawImage(image, LEFT_TEXT_MARGIN + DPIUtil.scaleDown(x, zoom), gap + DPIUtil.scaleDown(struct.top, zoom));
+			gc.drawImage(image, LEFT_TEXT_MARGIN + DPIUtil.pixelToPoint(x, zoom), gap + DPIUtil.pixelToPoint(struct.top, zoom));
 			if (this.image != image) {
 				image.dispose();
 			}
@@ -1252,7 +1252,7 @@ LRESULT wmMeasureChild (long wParam, long lParam) {
 		if (parent.needsMenuCallback()) {
 			Point point = calculateRenderedTextSize();
 			int menuZoom = getDisplay().isRescalingAtRuntime() ? super.getZoom() : getMonitorZoom();
-			struct.itemHeight = Win32DPIUtils.scaleUp(point.y, menuZoom);
+			struct.itemHeight = Win32DPIUtils.pointToPixel(point.y, menuZoom);
 			/*
 			 * Weirdness in Windows. Setting `HBMMENU_CALLBACK` causes
 			 * item sizes to mean something else. It seems that it is
@@ -1262,7 +1262,7 @@ LRESULT wmMeasureChild (long wParam, long lParam) {
 			 * that value of 5 works well in matching text to mnemonic.
 			 */
 			int horizontalSpaceImage = this.image != null ? this.image.getBounds().width + IMAGE_TEXT_GAP: 0;
-			struct.itemWidth = Win32DPIUtils.scaleUp(LEFT_TEXT_MARGIN + point.x - WINDOWS_OVERHEAD + horizontalSpaceImage, menuZoom);
+			struct.itemWidth = Win32DPIUtils.pointToPixel(LEFT_TEXT_MARGIN + point.x - WINDOWS_OVERHEAD + horizontalSpaceImage, menuZoom);
 			OS.MoveMemory (lParam, struct, MEASUREITEMSTRUCT.sizeof);
 			return null;
 		}
@@ -1270,7 +1270,7 @@ LRESULT wmMeasureChild (long wParam, long lParam) {
 
 	int width = 0, height = 0;
 	if (image != null) {
-		Rectangle rect = Win32DPIUtils.scaleUp(image.getBounds(), getZoom());
+		Rectangle rect = Win32DPIUtils.pointToPixel(image.getBounds(), getZoom());
 		width = rect.width;
 		height = rect.height;
 	} else {
@@ -1292,7 +1292,7 @@ LRESULT wmMeasureChild (long wParam, long lParam) {
 		if ((lpcmi.dwStyle & OS.MNS_CHECKORBMP) == 0) {
 			for (MenuItem item : parent.getItems ()) {
 				if (item.image != null) {
-					Rectangle rect = Win32DPIUtils.scaleUp(item.image.getBounds(), getZoom());
+					Rectangle rect = Win32DPIUtils.pointToPixel(item.image.getBounds(), getZoom());
 					width = Math.max (width, rect.width);
 				}
 			}
@@ -1326,7 +1326,7 @@ private Point calculateRenderedTextSize() {
 			// GC calculated height of 15px, scales down with adjusted zoom of 100% and returns 15pt -> should be 10pt
 			// this calculation is corrected by the following line
 			// This is the only place, where the GC needs to use the native zoom to do that, therefore it is fixed only here
-			points = Win32DPIUtils.scaleDown(Win32DPIUtils.scaleUp(points, adjustedPrimaryMonitorZoom), primaryMonitorZoom);
+			points = Win32DPIUtils.pixelToPoint(Win32DPIUtils.pointToPixel(points, adjustedPrimaryMonitorZoom), primaryMonitorZoom);
 		}
 	}
 	return points;

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/MultiZoomCoordinateSystemMapper.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/MultiZoomCoordinateSystemMapper.java
@@ -49,14 +49,14 @@ class MultiZoomCoordinateSystemMapper implements CoordinateSystemMapper {
 		if (from == null) {
 			Point mappedPointInpixels = display.mapInPixels(from, to,
 					getPixelsFromPoint(to.getShell().getMonitor(), x, y));
-			mappedPointInPoints = Win32DPIUtils.scaleDown(mappedPointInpixels, to.getZoom());
+			mappedPointInPoints = Win32DPIUtils.pixelToPoint(mappedPointInpixels, to.getZoom());
 		} else if (to == null) {
-			Point mappedPointInpixels = display.mapInPixels(from, to, Win32DPIUtils.scaleUp(new Point(x, y), from.getZoom()));
+			Point mappedPointInpixels = display.mapInPixels(from, to, Win32DPIUtils.pointToPixel(new Point(x, y), from.getZoom()));
 			mappedPointInPoints = getPointFromPixels(from.getShell().getMonitor(), mappedPointInpixels.x,
 					mappedPointInpixels.y);
 		} else {
-			Point mappedPointInpixels = display.mapInPixels(from, to, Win32DPIUtils.scaleUp(new Point(x, y), from.getZoom()));
-			mappedPointInPoints = Win32DPIUtils.scaleDown(mappedPointInpixels, to.getZoom());
+			Point mappedPointInpixels = display.mapInPixels(from, to, Win32DPIUtils.pointToPixel(new Point(x, y), from.getZoom()));
+			mappedPointInPoints = Win32DPIUtils.pixelToPoint(mappedPointInpixels, to.getZoom());
 		}
 		return mappedPointInPoints;
 	}
@@ -68,24 +68,24 @@ class MultiZoomCoordinateSystemMapper implements CoordinateSystemMapper {
 			Rectangle mappedRectangleInPixels = display.mapInPixels(from, to,
 					translateRectangleInPointsToPixels(x, y, width, height,
 							to.getShell().getMonitor()));
-			mappedRectangleInPoints = Win32DPIUtils.scaleDown(mappedRectangleInPixels, to.getZoom());
+			mappedRectangleInPoints = Win32DPIUtils.pixelToPoint(mappedRectangleInPixels, to.getZoom());
 		} else if (to == null) {
 			Rectangle mappedRectangleInPixels = display.mapInPixels(from, to,
-					Win32DPIUtils.scaleUp(new Rectangle(x, y, width, height), from.getZoom()));
+					Win32DPIUtils.pointToPixel(new Rectangle(x, y, width, height), from.getZoom()));
 			mappedRectangleInPoints = translateRectangleInPixelsToPoints(mappedRectangleInPixels.x,
 					mappedRectangleInPixels.y, mappedRectangleInPixels.width, mappedRectangleInPixels.height,
 					from.getShell().getMonitor());
 		} else {
 			Rectangle mappedRectangleInPixels = display.mapInPixels(from, to,
-					Win32DPIUtils.scaleUp(new Rectangle(x, y, width, height), from.getZoom()));
-			mappedRectangleInPoints = Win32DPIUtils.scaleDown(mappedRectangleInPixels, to.getZoom());
+					Win32DPIUtils.pointToPixel(new Rectangle(x, y, width, height), from.getZoom()));
+			mappedRectangleInPoints = Win32DPIUtils.pixelToPoint(mappedRectangleInPixels, to.getZoom());
 		}
 		return mappedRectangleInPoints;
 	}
 
 	@Override
 	public Rectangle mapMonitorBounds(Rectangle rect, int zoom) {
-		Rectangle bounds = Win32DPIUtils.scaleDown(rect, zoom);
+		Rectangle bounds = Win32DPIUtils.pixelToPoint(rect, zoom);
 		bounds.x = rect.x;
 		bounds.y = rect.y;
 		return bounds;
@@ -140,8 +140,8 @@ class MultiZoomCoordinateSystemMapper implements CoordinateSystemMapper {
 		monitor = getValidMonitorIfApplicable(x, y, width, height, monitor);
 		Point topLeft = getPixelsFromPoint(monitor, x, y);
 		int zoom = getApplicableMonitorZoom(monitor);
-		int widthInPixels = Win32DPIUtils.scaleUp(width, zoom);
-		int heightInPixels = Win32DPIUtils.scaleUp(height, zoom);
+		int widthInPixels = Win32DPIUtils.pointToPixel(width, zoom);
+		int heightInPixels = Win32DPIUtils.pointToPixel(height, zoom);
 		return new Rectangle(topLeft.x, topLeft.y, widthInPixels, heightInPixels);
 	}
 
@@ -150,8 +150,8 @@ class MultiZoomCoordinateSystemMapper implements CoordinateSystemMapper {
 			monitor = getContainingMonitorForPixels(x, y, widthInPixels, heightInPixels);
 		int zoom = getApplicableMonitorZoom(monitor);
 		Point topLeft = getPointFromPixels(monitor, x, y);
-		int width = DPIUtil.scaleDown(widthInPixels, zoom);
-		int height = DPIUtil.scaleDown(heightInPixels, zoom);
+		int width = DPIUtil.pixelToPoint(widthInPixels, zoom);
+		int height = DPIUtil.pixelToPoint(heightInPixels, zoom);
 		Rectangle.WithMonitor rect = new Rectangle.WithMonitor(topLeft.x, topLeft.y, width, height, monitor);
 		return rect;
 	}
@@ -201,8 +201,8 @@ class MultiZoomCoordinateSystemMapper implements CoordinateSystemMapper {
 		for (Monitor currentMonitor : monitors) {
 			// Obtain the rectangle in pixels per monitor for absolute comparison
 			Point topLeftOfRectangle = getPixelsFromPoint(currentMonitor, x, y);
-			int widthInPixels = Win32DPIUtils.scaleUp(width, getApplicableMonitorZoom(currentMonitor));
-			int heightInPixels = Win32DPIUtils.scaleUp(height, getApplicableMonitorZoom(currentMonitor));
+			int widthInPixels = Win32DPIUtils.pointToPixel(width, getApplicableMonitorZoom(currentMonitor));
+			int heightInPixels = Win32DPIUtils.pointToPixel(height, getApplicableMonitorZoom(currentMonitor));
 			Rectangle boundsInPixel = new Rectangle(topLeftOfRectangle.x, topLeftOfRectangle.y, widthInPixels, heightInPixels);
 			Rectangle clientArea = getMonitorClientAreaInPixels(currentMonitor);
 			Rectangle intersection = clientArea.intersection(boundsInPixel);
@@ -248,22 +248,22 @@ class MultiZoomCoordinateSystemMapper implements CoordinateSystemMapper {
 
 	private Rectangle getMonitorClientAreaInPixels(Monitor monitor) {
 		int zoom = getApplicableMonitorZoom(monitor);
-		int widthInPixels = Win32DPIUtils.scaleUp(monitor.clientWidth, zoom);
-		int heightInPixels = Win32DPIUtils.scaleUp(monitor.clientHeight, zoom);
+		int widthInPixels = Win32DPIUtils.pointToPixel(monitor.clientWidth, zoom);
+		int heightInPixels = Win32DPIUtils.pointToPixel(monitor.clientHeight, zoom);
 		return new Rectangle(monitor.clientX, monitor.clientY, widthInPixels, heightInPixels);
 	}
 
 	private Point getPixelsFromPoint(Monitor monitor, int x, int y) {
 		int zoom = getApplicableMonitorZoom(monitor);
-		int mappedX = Win32DPIUtils.scaleUp(x - monitor.clientX, zoom) + monitor.clientX;
-		int mappedY = Win32DPIUtils.scaleUp(y - monitor.clientY, zoom) + monitor.clientY;
+		int mappedX = Win32DPIUtils.pointToPixel(x - monitor.clientX, zoom) + monitor.clientX;
+		int mappedY = Win32DPIUtils.pointToPixel(y - monitor.clientY, zoom) + monitor.clientY;
 		return new Point(mappedX, mappedY);
 	}
 
 	private Point getPointFromPixels(Monitor monitor, int x, int y) {
 		int zoom = getApplicableMonitorZoom(monitor);
-		int mappedX = DPIUtil.scaleDown(x - monitor.clientX, zoom) + monitor.clientX;
-		int mappedY = DPIUtil.scaleDown(y - monitor.clientY, zoom) + monitor.clientY;
+		int mappedX = DPIUtil.pixelToPoint(x - monitor.clientX, zoom) + monitor.clientX;
+		int mappedY = DPIUtil.pixelToPoint(y - monitor.clientY, zoom) + monitor.clientY;
 		return new Point.WithMonitor(mappedX, mappedY, monitor);
 	}
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Sash.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Sash.java
@@ -244,7 +244,7 @@ LRESULT WM_KEYDOWN (long wParam, long lParam) {
 			OS.SetCursorPos (cursorPt.x, cursorPt.y);
 
 			Event event = new Event ();
-			event.setBounds(Win32DPIUtils.scaleDown(new Rectangle(newX, newY, width, height), getZoom()));
+			event.setBounds(Win32DPIUtils.pixelToPoint(new Rectangle(newX, newY, width, height), getZoom()));
 			sendSelectionEvent  (SWT.Selection, event, true);
 			if (isDisposed ()) return LRESULT.ZERO;
 			if (event.doit) {
@@ -284,7 +284,7 @@ LRESULT WM_LBUTTONDOWN (long wParam, long lParam) {
 
 	/* The event must be sent because doit flag is used */
 	Event event = new Event ();
-	event.setBounds(Win32DPIUtils.scaleDown(new Rectangle(lastX, lastY, width, height), getZoom()));
+	event.setBounds(Win32DPIUtils.pixelToPoint(new Rectangle(lastX, lastY, width, height), getZoom()));
 	if ((style & SWT.SMOOTH) == 0) {
 		event.detail = SWT.DRAG;
 	}
@@ -292,7 +292,7 @@ LRESULT WM_LBUTTONDOWN (long wParam, long lParam) {
 	if (isDisposed ()) return LRESULT.ZERO;
 
 	/* Draw the banding rectangle */
-	Rectangle boundsInPixels = Win32DPIUtils.scaleUp(event.getBounds(), getZoom());
+	Rectangle boundsInPixels = Win32DPIUtils.pointToPixel(event.getBounds(), getZoom());
 	if (event.doit) {
 		dragging = true;
 		lastX = boundsInPixels.x;
@@ -325,7 +325,7 @@ LRESULT WM_LBUTTONUP (long wParam, long lParam) {
 
 	/* The event must be sent because doit flag is used */
 	Event event = new Event ();
-	event.setBounds(Win32DPIUtils.scaleDown(new Rectangle(lastX, lastY, width, height), getZoom()));
+	event.setBounds(Win32DPIUtils.pixelToPoint(new Rectangle(lastX, lastY, width, height), getZoom()));
 	drawBand (lastX, lastY, width, height);
 	sendSelectionEvent (SWT.Selection, event, true);
 	if (isDisposed ()) return result;
@@ -369,7 +369,7 @@ LRESULT WM_MOUSEMOVE (long wParam, long lParam) {
 	int zoom = getZoom();
 	/* The event must be sent because doit flag is used */
 	Event event = new Event ();
-	event.setBounds(Win32DPIUtils.scaleDown(new Rectangle(newX, newY, width, height), zoom));
+	event.setBounds(Win32DPIUtils.pixelToPoint(new Rectangle(newX, newY, width, height), zoom));
 	if ((style & SWT.SMOOTH) == 0) {
 		event.detail = SWT.DRAG;
 	}
@@ -377,8 +377,8 @@ LRESULT WM_MOUSEMOVE (long wParam, long lParam) {
 	if (isDisposed ()) return LRESULT.ZERO;
 	if (event.doit) {
 		Rectangle bounds = event.getBounds();
-		lastX = Win32DPIUtils.scaleUp(bounds.x, zoom);
-		lastY = Win32DPIUtils.scaleUp(bounds.y, zoom);
+		lastX = Win32DPIUtils.pointToPixel(bounds.x, zoom);
+		lastY = Win32DPIUtils.pointToPixel(bounds.y, zoom);
 	}
 	int flags = OS.RDW_UPDATENOW | OS.RDW_ALLCHILDREN;
 	OS.RedrawWindow (hwndTrack, null, 0, flags);

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ScrollBar.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ScrollBar.java
@@ -355,7 +355,7 @@ public int getSelection () {
  */
 public Point getSize () {
 	checkWidget();
-	return Win32DPIUtils.scaleDown(getSizeInPixels(), getZoom());
+	return Win32DPIUtils.pixelToPoint(getSizeInPixels(), getZoom());
 }
 
 Point getSizeInPixels () {
@@ -412,7 +412,7 @@ public int getThumb () {
  */
 public Rectangle getThumbBounds () {
 	checkWidget();
-	return Win32DPIUtils.scaleDown(getThumbBoundsInPixels(), getZoom());
+	return Win32DPIUtils.pixelToPoint(getThumbBoundsInPixels(), getZoom());
 }
 
 Rectangle getThumbBoundsInPixels () {
@@ -458,7 +458,7 @@ Rectangle getThumbBoundsInPixels () {
  */
 public Rectangle getThumbTrackBounds () {
 	checkWidget();
-	return Win32DPIUtils.scaleDown(getThumbTrackBoundsInPixels(), getZoom());
+	return Win32DPIUtils.pixelToPoint(getThumbTrackBoundsInPixels(), getZoom());
 }
 
 Rectangle getThumbTrackBoundsInPixels () {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Scrollable.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Scrollable.java
@@ -121,8 +121,8 @@ long callWindowProc (long hwnd, int msg, long wParam, long lParam) {
 public Rectangle computeTrim (int x, int y, int width, int height) {
 	checkWidget ();
 	int zoom = getZoom();
-	Rectangle rectangle = Win32DPIUtils.scaleUp(new Rectangle(x, y, width, height), zoom);
-	return Win32DPIUtils.scaleDown(computeTrimInPixels(rectangle.x, rectangle.y, rectangle.width, rectangle.height), zoom);
+	Rectangle rectangle = Win32DPIUtils.pointToPixel(new Rectangle(x, y, width, height), zoom);
+	return Win32DPIUtils.pixelToPoint(computeTrimInPixels(rectangle.x, rectangle.y, rectangle.width, rectangle.height), zoom);
 }
 
 Rectangle computeTrimInPixels (int x, int y, int width, int height) {
@@ -210,7 +210,7 @@ void destroyScrollBar (int type) {
  */
 public Rectangle getClientArea () {
 	checkWidget ();
-	return Win32DPIUtils.scaleDown(getClientAreaInPixels(), getZoom());
+	return Win32DPIUtils.pixelToPoint(getClientAreaInPixels(), getZoom());
 }
 
 Rectangle getClientAreaInPixels () {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Shell.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Shell.java
@@ -1043,7 +1043,7 @@ public boolean getMaximized () {
  */
 public Point getMaximumSize () {
 	checkWidget ();
-	return Win32DPIUtils.scaleDown(getMaximumSizeInPixels(), getZoom());
+	return Win32DPIUtils.pixelToPoint(getMaximumSizeInPixels(), getZoom());
 }
 
 Point getMaximumSizeInPixels () {
@@ -1084,7 +1084,7 @@ Point getMaximumSizeInPixels () {
  */
 public Point getMinimumSize () {
 	checkWidget ();
-	return Win32DPIUtils.scaleDown(getMinimumSizeInPixels(), getZoom());
+	return Win32DPIUtils.pixelToPoint(getMinimumSizeInPixels(), getZoom());
 }
 
 Point getMinimumSizeInPixels () {
@@ -1592,8 +1592,8 @@ public void setBounds(Rectangle rect) {
 	// the WM_DPICHANGED event processing. So to avoid duplicate scaling, we always
 	// have to scale width and height with the zoom of the original monitor (still
 	// returned by getZoom()) here.
-	setBoundsInPixels(boundsInPixels.x, boundsInPixels.y, Win32DPIUtils.scaleUp(rect.width, getZoom()),
-			Win32DPIUtils.scaleUp(rect.height, getZoom()));
+	setBoundsInPixels(boundsInPixels.x, boundsInPixels.y, Win32DPIUtils.pointToPixel(rect.width, getZoom()),
+			Win32DPIUtils.pointToPixel(rect.height, getZoom()));
 }
 
 @Override
@@ -1769,7 +1769,7 @@ public void setImeInputMode (int mode) {
 public void setMaximumSize (int width, int height) {
 	checkWidget ();
 	int zoom = getZoom();
-	setMaximumSizeInPixels(Win32DPIUtils.scaleUp(width, zoom), Win32DPIUtils.scaleUp(height, zoom));
+	setMaximumSizeInPixels(Win32DPIUtils.pointToPixel(width, zoom), Win32DPIUtils.pointToPixel(height, zoom));
 }
 
 /**
@@ -1797,7 +1797,7 @@ public void setMaximumSize (int width, int height) {
 public void setMaximumSize (Point size) {
 	checkWidget ();
 	if (size == null) error (SWT.ERROR_NULL_ARGUMENT);
-	size = Win32DPIUtils.scaleUp(size, getZoom());
+	size = Win32DPIUtils.pointToPixel(size, getZoom());
 	setMaximumSizeInPixels(size.x, size.y);
 }
 
@@ -1844,7 +1844,7 @@ void setMaximumSizeInPixels (int width, int height) {
 public void setMinimumSize (int width, int height) {
 	checkWidget ();
 	int zoom = getZoom();
-	setMinimumSizeInPixels(Win32DPIUtils.scaleUp(width, zoom), Win32DPIUtils.scaleUp(height, zoom));
+	setMinimumSizeInPixels(Win32DPIUtils.pointToPixel(width, zoom), Win32DPIUtils.pointToPixel(height, zoom));
 }
 
 void setMinimumSizeInPixels (int width, int height) {
@@ -1892,7 +1892,7 @@ void setMinimumSizeInPixels (int width, int height) {
 public void setMinimumSize (Point size) {
 	checkWidget ();
 	if (size == null) error (SWT.ERROR_NULL_ARGUMENT);
-	size = Win32DPIUtils.scaleUp(size, getZoom());
+	size = Win32DPIUtils.pointToPixel(size, getZoom());
 	setMinimumSizeInPixels(size.x, size.y);
 }
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/SingleZoomCoordinateSystemMapper.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/SingleZoomCoordinateSystemMapper.java
@@ -41,79 +41,79 @@ class SingleZoomCoordinateSystemMapper implements CoordinateSystemMapper {
 	@Override
 	public Point map(Control from, Control to, Point point) {
 		int zoom = getZoomLevelForMapping(from, to);
-		point = Win32DPIUtils.scaleUp(point, zoom);
-		return Win32DPIUtils.scaleDown(display.mapInPixels(from, to, point), zoom);
+		point = Win32DPIUtils.pointToPixel(point, zoom);
+		return Win32DPIUtils.pixelToPoint(display.mapInPixels(from, to, point), zoom);
 	}
 
 	@Override
 	public Rectangle map(Control from, Control to, Rectangle rectangle) {
 		int zoom = getZoomLevelForMapping(from, to);
-		rectangle = Win32DPIUtils.scaleUp(rectangle, zoom);
-		return Win32DPIUtils.scaleDown(display.mapInPixels(from, to, rectangle), zoom);
+		rectangle = Win32DPIUtils.pointToPixel(rectangle, zoom);
+		return Win32DPIUtils.pixelToPoint(display.mapInPixels(from, to, rectangle), zoom);
 	}
 
 	@Override
 	public Point map(Control from, Control to, int x, int y) {
 		int zoom = getZoomLevelForMapping(from, to);
-		x = Win32DPIUtils.scaleUp(x, zoom);
-		y = Win32DPIUtils.scaleUp(y, zoom);
-		return Win32DPIUtils.scaleDown(display.mapInPixels(from, to, x, y), zoom);
+		x = Win32DPIUtils.pointToPixel(x, zoom);
+		y = Win32DPIUtils.pointToPixel(y, zoom);
+		return Win32DPIUtils.pixelToPoint(display.mapInPixels(from, to, x, y), zoom);
 	}
 
 	@Override
 	public Rectangle map(Control from, Control to, int x, int y, int width, int height) {
 		int zoom = getZoomLevelForMapping(from, to);
-		x = Win32DPIUtils.scaleUp(x, zoom);
-		y = Win32DPIUtils.scaleUp(y, zoom);
-		width = Win32DPIUtils.scaleUp(width, zoom);
-		height = Win32DPIUtils.scaleUp(height, zoom);
-		return Win32DPIUtils.scaleDown(display.mapInPixels(from, to, x, y, width, height), zoom);
+		x = Win32DPIUtils.pointToPixel(x, zoom);
+		y = Win32DPIUtils.pointToPixel(y, zoom);
+		width = Win32DPIUtils.pointToPixel(width, zoom);
+		height = Win32DPIUtils.pointToPixel(height, zoom);
+		return Win32DPIUtils.pixelToPoint(display.mapInPixels(from, to, x, y, width, height), zoom);
 	}
 
 	@Override
 	public Rectangle mapMonitorBounds(Rectangle rect, int zoom) {
-		return Win32DPIUtils.scaleDown(rect, zoom);
+		return Win32DPIUtils.pixelToPoint(rect, zoom);
 	}
 
 	@Override
 	public Point translateFromDisplayCoordinates(Point point, int zoom) {
-		return Win32DPIUtils.scaleDown(point, zoom);
+		return Win32DPIUtils.pixelToPoint(point, zoom);
 	}
 
 	@Override
 	public Point translateToDisplayCoordinates(Point point, int zoom) {
-		return Win32DPIUtils.scaleUp(point, zoom);
+		return Win32DPIUtils.pointToPixel(point, zoom);
 	}
 
 	@Override
 	public Rectangle translateFromDisplayCoordinates(Rectangle rect, int zoom) {
-		return Win32DPIUtils.scaleDown(rect, zoom);
+		return Win32DPIUtils.pixelToPoint(rect, zoom);
 	}
 
 	@Override
 	public Rectangle translateToDisplayCoordinates(Rectangle rect, int zoom) {
-		return Win32DPIUtils.scaleUp(rect, zoom);
+		return Win32DPIUtils.pointToPixel(rect, zoom);
 	}
 
 	@Override
 	public Point getCursorLocation() {
 		int zoom = DPIUtil.getDeviceZoom();
 		Point cursorLocationInPixels = display.getCursorLocationInPixels();
-		return Win32DPIUtils.scaleDown(cursorLocationInPixels, zoom);
+		return Win32DPIUtils.pixelToPoint(cursorLocationInPixels, zoom);
 	}
 
 	@Override
 	public void setCursorLocation(int x, int y) {
 		int zoom = DPIUtil.getDeviceZoom();
-		display.setCursorLocationInPixels(Win32DPIUtils.scaleUp(x, zoom), Win32DPIUtils.scaleUp(y, zoom));
+		display.setCursorLocationInPixels(Win32DPIUtils.pointToPixel(x, zoom), Win32DPIUtils.pointToPixel(y, zoom));
 	}
 
 	@Override
 	public Rectangle getContainingMonitorBoundsInPixels(Point point) {
 		int zoom = DPIUtil.getDeviceZoom();
-		point = Win32DPIUtils.scaleUp(point, zoom);
+		point = Win32DPIUtils.pointToPixel(point, zoom);
 		for (Monitor monitor : display.getMonitors()) {
-			Rectangle monitorBounds = Win32DPIUtils.scaleUp(monitor.getBounds(), zoom);
+			Rectangle monitorBounds = Win32DPIUtils.pointToPixel(monitor.getBounds(), zoom);
 			if (monitorBounds.contains(point)) {
 				return monitorBounds;
 			}

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TabFolder.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TabFolder.java
@@ -510,7 +510,7 @@ Point minimumSize (int wHint, int hHint, boolean flushCache) {
 		}
 		int zoom = getZoom();
 		if (index == count) {
-			Rectangle rect = Win32DPIUtils.scaleUp(child.getBounds (), zoom);
+			Rectangle rect = Win32DPIUtils.pointToPixel(child.getBounds (), zoom);
 			width = Math.max (width, rect.x + rect.width);
 			height = Math.max (height, rect.y + rect.height);
 		} else {
@@ -518,7 +518,7 @@ Point minimumSize (int wHint, int hHint, boolean flushCache) {
 			 * Since computeSize can be overridden by subclasses, we cannot
 			 * call computeSizeInPixels directly.
 			 */
-			Point size = Win32DPIUtils.scaleUp(child.computeSize (DPIUtil.scaleDown(wHint, zoom), DPIUtil.scaleDown(hHint, zoom), flushCache), zoom);
+			Point size = Win32DPIUtils.pointToPixel(child.computeSize (DPIUtil.pixelToPoint(wHint, zoom), DPIUtil.pixelToPoint(hHint, zoom), flushCache), zoom);
 			width = Math.max (width, size.x);
 			height = Math.max (height, size.y);
 		}

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TabItem.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TabItem.java
@@ -191,7 +191,7 @@ public Control getControl () {
  */
 public Rectangle getBounds () {
 	checkWidget();
-	return Win32DPIUtils.scaleDown(getBoundsInPixels(), getZoom());
+	return Win32DPIUtils.pixelToPoint(getBoundsInPixels(), getZoom());
 }
 
 Rectangle getBoundsInPixels() {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Table.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Table.java
@@ -2334,7 +2334,7 @@ int getFocusIndex () {
  */
 public int getGridLineWidth () {
 	checkWidget ();
-	return DPIUtil.scaleDown(getGridLineWidthInPixels(), getZoom());
+	return DPIUtil.pixelToPoint(getGridLineWidthInPixels(), getZoom());
 }
 
 int getGridLineWidthInPixels () {
@@ -2395,7 +2395,7 @@ private int getHeaderForegroundPixel() {
  */
 public int getHeaderHeight () {
 	checkWidget ();
-	return DPIUtil.scaleDown(getHeaderHeightInPixels (), getZoom());
+	return DPIUtil.pixelToPoint(getHeaderHeightInPixels (), getZoom());
 }
 
 int getHeaderHeightInPixels () {
@@ -2476,7 +2476,7 @@ public TableItem getItem (int index) {
 public TableItem getItem (Point point) {
 	checkWidget ();
 	if (point == null) error (SWT.ERROR_NULL_ARGUMENT);
-	return getItemInPixels (Win32DPIUtils.scaleUp(point, getZoom()));
+	return getItemInPixels (Win32DPIUtils.pointToPixel(point, getZoom()));
 }
 
 TableItem getItemInPixels (Point point) {
@@ -2576,7 +2576,7 @@ public int getItemCount () {
  */
 public int getItemHeight () {
 	checkWidget ();
-	return DPIUtil.scaleDown(getItemHeightInPixels(), getZoom());
+	return DPIUtil.pixelToPoint(getItemHeightInPixels(), getZoom());
 }
 
 int getItemHeightInPixels () {
@@ -2832,7 +2832,7 @@ boolean hitTestSelection (int index, int x, int y) {
 		long hFont = item.fontHandle (0);
 		if (hFont != -1) hFont = OS.SelectObject (hDC, hFont);
 		Event event = sendMeasureItemEvent (item, index, 0, hDC);
-		if (Win32DPIUtils.scaleUp(event.getBounds(), getZoom()).contains (x, y)) result = true;
+		if (Win32DPIUtils.pointToPixel(event.getBounds(), getZoom()).contains (x, y)) result = true;
 		if (hFont != -1) hFont = OS.SelectObject (hDC, hFont);
 		if (newFont != 0) OS.SelectObject (hDC, oldFont);
 		OS.ReleaseDC (handle, hDC);
@@ -3484,7 +3484,7 @@ void sendEraseItemEvent (TableItem item, NMLVCUSTOMDRAW nmcd, long lParam, Event
 	if (drawHot) event.detail |= SWT.HOT;
 	if (drawSelected) event.detail |= SWT.SELECTED;
 	if (drawBackground) event.detail |= SWT.BACKGROUND;
-	Rectangle bounds = Win32DPIUtils.scaleDown(new Rectangle (cellRect.left, cellRect.top, cellRect.right - cellRect.left, cellRect.bottom - cellRect.top), getZoom());
+	Rectangle bounds = Win32DPIUtils.pixelToPoint(new Rectangle (cellRect.left, cellRect.top, cellRect.right - cellRect.left, cellRect.bottom - cellRect.top), getZoom());
 	event.setBounds (bounds);
 	gc.setClipping (bounds);
 	sendEvent (SWT.EraseItem, event);
@@ -3530,7 +3530,7 @@ void sendEraseItemEvent (TableItem item, NMLVCUSTOMDRAW nmcd, long lParam, Event
 		RECT textRect = item.getBounds ((int)nmcd.dwItemSpec, nmcd.iSubItem, true, false, fullText, false, hDC);
 		if ((style & SWT.FULL_SELECTION) == 0) {
 			if (measureEvent != null) {
-				Rectangle boundsInPixels = Win32DPIUtils.scaleUp(measureEvent.getBounds(), getZoom());
+				Rectangle boundsInPixels = Win32DPIUtils.pointToPixel(measureEvent.getBounds(), getZoom());
 				textRect.right = Math.min (cellRect.right, boundsInPixels.x + boundsInPixels.width);
 			}
 			if (!ignoreDrawFocus) {
@@ -3605,7 +3605,7 @@ Event sendEraseItemEvent (TableItem item, NMTTCUSTOMDRAW nmcd, int column, RECT 
 	event.index = column;
 	event.gc = gc;
 	event.detail |= SWT.FOREGROUND;
-	event.setBounds(Win32DPIUtils.scaleDown(new Rectangle(cellRect.left, cellRect.top, cellRect.right - cellRect.left, cellRect.bottom - cellRect.top), getZoom()));
+	event.setBounds(Win32DPIUtils.pixelToPoint(new Rectangle(cellRect.left, cellRect.top, cellRect.right - cellRect.left, cellRect.bottom - cellRect.top), getZoom()));
 	//gc.setClipping (event.x, event.y, event.width, event.height);
 	sendEvent (SWT.EraseItem, event);
 	event.gc = null;
@@ -3626,7 +3626,7 @@ Event sendMeasureItemEvent (TableItem item, int row, int column, long hDC) {
 	event.item = item;
 	event.gc = gc;
 	event.index = column;
-	event.setBounds(Win32DPIUtils.scaleDown(new Rectangle(itemRect.left, itemRect.top, itemRect.right - itemRect.left, itemRect.bottom - itemRect.top), getZoom()));
+	event.setBounds(Win32DPIUtils.pixelToPoint(new Rectangle(itemRect.left, itemRect.top, itemRect.right - itemRect.left, itemRect.bottom - itemRect.top), getZoom()));
 	boolean drawSelected = false;
 	if (OS.IsWindowEnabled (handle)) {
 		LVITEM lvItem = new LVITEM ();
@@ -3649,7 +3649,7 @@ Event sendMeasureItemEvent (TableItem item, int row, int column, long hDC) {
 	gc.dispose ();
 	OS.RestoreDC (hDC, nSavedDC);
 	if (!isDisposed () && !item.isDisposed ()) {
-		Rectangle boundsInPixels = Win32DPIUtils.scaleUp(event.getBounds(), getZoom());
+		Rectangle boundsInPixels = Win32DPIUtils.pointToPixel(event.getBounds(), getZoom());
 		if (columnCount == 0) {
 			int width = (int)OS.SendMessage (handle, OS.LVM_GETCOLUMNWIDTH, 0, 0);
 			if (boundsInPixels.x + boundsInPixels.width > width) setScrollWidth (boundsInPixels.x + boundsInPixels.width);
@@ -3926,11 +3926,11 @@ void sendPaintItemEvent (TableItem item, NMLVCUSTOMDRAW nmcd) {
 	if (drawHot) event.detail |= SWT.HOT;
 	if (drawSelected) event.detail |= SWT.SELECTED;
 	if (drawBackground) event.detail |= SWT.BACKGROUND;
-	event.setBounds(Win32DPIUtils.scaleDown(new Rectangle(itemRect.left, itemRect.top, itemRect.right - itemRect.left, itemRect.bottom - itemRect.top), getZoom()));
+	event.setBounds(Win32DPIUtils.pixelToPoint(new Rectangle(itemRect.left, itemRect.top, itemRect.right - itemRect.left, itemRect.bottom - itemRect.top), getZoom()));
 	RECT cellRect = item.getBounds ((int)nmcd.dwItemSpec, nmcd.iSubItem, true, true, true, true, hDC);
 	int cellWidth = cellRect.right - cellRect.left;
 	int cellHeight = cellRect.bottom - cellRect.top;
-	gc.setClipping (Win32DPIUtils.scaleDown(new Rectangle (cellRect.left, cellRect.top, cellWidth, cellHeight), getZoom()));
+	gc.setClipping (Win32DPIUtils.pixelToPoint(new Rectangle (cellRect.left, cellRect.top, cellWidth, cellHeight), getZoom()));
 	sendEvent (SWT.PaintItem, event);
 	if (data.focusDrawn) focusRect = null;
 	event.gc = null;
@@ -3954,7 +3954,7 @@ Event sendPaintItemEvent (TableItem item, NMTTCUSTOMDRAW nmcd, int column, RECT 
 	event.index = column;
 	event.gc = gc;
 	event.detail |= SWT.FOREGROUND;
-	event.setBounds(Win32DPIUtils.scaleDown(new Rectangle(itemRect.left, itemRect.top, itemRect.right - itemRect.left, itemRect.bottom - itemRect.top), getZoom()));
+	event.setBounds(Win32DPIUtils.pixelToPoint(new Rectangle(itemRect.left, itemRect.top, itemRect.right - itemRect.left, itemRect.bottom - itemRect.top), getZoom()));
 	//gc.setClipping (cellRect.left, cellRect.top, cellWidth, cellHeight);
 	sendEvent (SWT.PaintItem, event);
 	event.gc = null;
@@ -5541,7 +5541,7 @@ void updateMenuLocation (Event event) {
 	}
 	Point pt = toDisplayInPixels (x, y);
 	int zoom = getZoom();
-	event.setLocation(DPIUtil.scaleDown(pt.x, zoom), DPIUtil.scaleDown(pt.y, zoom));
+	event.setLocation(DPIUtil.pixelToPoint(pt.x, zoom), DPIUtil.pixelToPoint(pt.y, zoom));
 }
 
 void updateMoveable () {
@@ -6915,7 +6915,7 @@ LRESULT wmNotifyHeader (NMHDR hdr, long wParam, long lParam) {
 							 * Sort indicator size needs to scale as per the Native Windows OS DPI level
 							 * when header is custom drawn. For more details refer bug 537097.
 							 */
-							int leg = Win32DPIUtils.scaleUp(3, nativeZoom);
+							int leg = Win32DPIUtils.pointToPixel(3, nativeZoom);
 							if (sortDirection == SWT.UP) {
 								OS.Polyline(nmcd.hdc, new int[] {center-leg, 1+leg, center+1, 0}, 2);
 								OS.Polyline(nmcd.hdc, new int[] {center+leg, 1+leg, center-1, 0}, 2);
@@ -6966,10 +6966,10 @@ LRESULT wmNotifyHeader (NMHDR hdr, long wParam, long lParam) {
 							GCData data = new GCData();
 							data.device = display;
 							GC gc = createNewGC(nmcd.hdc, data);
-							int y = Math.max (0, (nmcd.bottom - Win32DPIUtils.scaleUp(columns[i].image.getBounds(), getZoom()).height) / 2);
+							int y = Math.max (0, (nmcd.bottom - Win32DPIUtils.pointToPixel(columns[i].image.getBounds(), getZoom()).height) / 2);
 							int zoom = getZoom();
-							gc.drawImage (columns[i].image, DPIUtil.scaleDown(x, zoom), DPIUtil.scaleDown(y, zoom));
-							x += Win32DPIUtils.scaleUp(columns[i].image.getBounds(), getZoom()).width + 12;
+							gc.drawImage (columns[i].image, DPIUtil.pixelToPoint(x, zoom), DPIUtil.pixelToPoint(y, zoom));
+							x += Win32DPIUtils.pointToPixel(columns[i].image.getBounds(), getZoom()).width + 12;
 							gc.dispose ();
 						}
 
@@ -7191,7 +7191,7 @@ private LRESULT positionTooltip(NMHDR hdr, long lParam) {
 		Event event = sendMeasureItemEvent (item, pinfo.iItem, pinfo.iSubItem, hDC);
 		if (!isDisposed () && !item.isDisposed ()) {
 			RECT itemRect = new RECT ();
-			Rectangle boundsInPixels = Win32DPIUtils.scaleUp(event.getBounds(), getZoom());
+			Rectangle boundsInPixels = Win32DPIUtils.pointToPixel(event.getBounds(), getZoom());
 			OS.SetRect (itemRect, boundsInPixels.x, boundsInPixels.y, boundsInPixels.x + boundsInPixels.width, boundsInPixels.y + boundsInPixels.height);
 			if (hdr.code == OS.TTN_SHOW) {
 				RECT toolRect = isCustomToolTip() ? toolTipRect (itemRect) : itemRect;
@@ -7288,13 +7288,13 @@ LRESULT wmNotifyToolTip (NMTTCUSTOMDRAW nmcd, long lParam) {
 					if (pinfo.iSubItem != 0) x -= gridWidth;
 					Image image = item.getImage (pinfo.iSubItem);
 					if (image != null) {
-						Rectangle rect = Win32DPIUtils.scaleUp(image.getBounds(), getZoom());
+						Rectangle rect = Win32DPIUtils.pointToPixel(image.getBounds(), getZoom());
 						RECT imageRect = item.getBounds (pinfo.iItem, pinfo.iSubItem, false, true, false, false, hDC);
 						Point size = imageList == null ? new Point (rect.width, rect.height) : imageList.getImageSize ();
 						int y = imageRect.top + Math.max (0, (imageRect.bottom - imageRect.top - size.y) / 2);
 						int zoom = getZoom();
-						rect = Win32DPIUtils.scaleDown(rect, zoom);
-						gc.drawImage (image, rect.x, rect.y, rect.width, rect.height, DPIUtil.scaleDown(x, zoom), DPIUtil.scaleDown(y, zoom), DPIUtil.scaleDown(size.x, zoom), DPIUtil.scaleDown(size.y, zoom));
+						rect = Win32DPIUtils.pixelToPoint(rect, zoom);
+						gc.drawImage (image, rect.x, rect.y, rect.width, rect.height, DPIUtil.pixelToPoint(x, zoom), DPIUtil.pixelToPoint(y, zoom), DPIUtil.pixelToPoint(size.x, zoom), DPIUtil.pixelToPoint(size.y, zoom));
 						x += size.x + INSET + (pinfo.iSubItem == 0 ? -2 : 4);
 					} else {
 						x += INSET + 2;

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TableColumn.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TableColumn.java
@@ -309,7 +309,7 @@ public String getToolTipText () {
  */
 public int getWidth () {
 	checkWidget ();
-	return DPIUtil.scaleDown(getWidthInPixels(), getZoom());
+	return DPIUtil.pixelToPoint(getWidthInPixels(), getZoom());
 }
 
 int getWidthInPixels () {
@@ -413,7 +413,7 @@ public void pack () {
 		if (parent.sortColumn == this && parent.sortDirection != SWT.NONE) {
 			headerWidth += Table.SORT_WIDTH;
 		} else if (image != null) {
-			Rectangle bounds = Win32DPIUtils.scaleUp(image.getBounds(), getZoom());
+			Rectangle bounds = Win32DPIUtils.pointToPixel(image.getBounds(), getZoom());
 			headerWidth += bounds.width;
 		}
 		long hwndHeader = OS.SendMessage (hwnd, OS.LVM_GETHEADER, 0, 0);
@@ -440,7 +440,7 @@ public void pack () {
 				if (hFont != -1) hFont = OS.SelectObject (hDC, hFont);
 				if (isDisposed () || parent.isDisposed ()) break;
 				Rectangle bounds = event.getBounds();
-				columnWidth = Math.max (columnWidth, Win32DPIUtils.scaleUp(bounds.x + bounds.width, getZoom()) - headerRect.left);
+				columnWidth = Math.max (columnWidth, Win32DPIUtils.pointToPixel(bounds.x + bounds.width, getZoom()) - headerRect.left);
 			}
 		}
 		if (newFont != 0) OS.SelectObject (hDC, oldFont);
@@ -854,7 +854,7 @@ public void setToolTipText (String string) {
  */
 public void setWidth (int width) {
 	checkWidget ();
-	setWidthInPixels(Win32DPIUtils.scaleUp(width, getZoom()));
+	setWidthInPixels(Win32DPIUtils.pointToPixel(width, getZoom()));
 }
 
 void setWidthInPixels (int width) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TableItem.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TableItem.java
@@ -218,7 +218,7 @@ public Color getBackground (int index) {
  */
 public Rectangle getBounds () {
 	checkWidget();
-	return Win32DPIUtils.scaleDown(getBoundsInPixels(), getZoom());
+	return Win32DPIUtils.pixelToPoint(getBoundsInPixels(), getZoom());
 }
 
 Rectangle getBoundsInPixels () {
@@ -244,7 +244,7 @@ Rectangle getBoundsInPixels () {
  */
 public Rectangle getBounds (int index) {
 	checkWidget();
-	return Win32DPIUtils.scaleDown(getBoundsInPixels(index), getZoom());
+	return Win32DPIUtils.pixelToPoint(getBoundsInPixels(index), getZoom());
 }
 
 Rectangle getBoundsInPixels (int index) {
@@ -590,7 +590,7 @@ public Image getImage (int index) {
  */
 public Rectangle getImageBounds (int index) {
 	checkWidget();
-	return Win32DPIUtils.scaleDown(getImageBoundsInPixels(index), getZoom());
+	return Win32DPIUtils.pixelToPoint(getImageBoundsInPixels(index), getZoom());
 }
 
 Rectangle getImageBoundsInPixels (int index) {
@@ -691,7 +691,7 @@ public String getText (int index) {
  */
 public Rectangle getTextBounds (int index) {
 	checkWidget();
-	return Win32DPIUtils.scaleDown(getTextBoundsInPixels(index), getZoom());
+	return Win32DPIUtils.pixelToPoint(getTextBoundsInPixels(index), getZoom());
 }
 
 Rectangle getTextBoundsInPixels (int index) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Text.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Text.java
@@ -986,7 +986,7 @@ public int getCaretLineNumber () {
  */
 public Point getCaretLocation () {
 	checkWidget ();
-	return Win32DPIUtils.scaleDown(getCaretLocationInPixels(), getZoom());
+	return Win32DPIUtils.pixelToPoint(getCaretLocationInPixels(), getZoom());
 }
 
 Point getCaretLocationInPixels () {
@@ -1211,7 +1211,7 @@ public String getLineDelimiter () {
  */
 public int getLineHeight () {
 	checkWidget ();
-	return DPIUtil.scaleDown(getLineHeightInPixels (), getZoom());
+	return DPIUtil.pixelToPoint(getLineHeightInPixels (), getZoom());
 }
 
 int getLineHeightInPixels () {
@@ -1554,7 +1554,7 @@ public int getTopIndex () {
  */
 public int getTopPixel () {
 	checkWidget ();
-	return DPIUtil.scaleDown(getTopPixelInPixels(), getZoom());
+	return DPIUtil.pixelToPoint(getTopPixelInPixels(), getZoom());
 }
 
 int getTopPixelInPixels () {
@@ -2489,7 +2489,7 @@ int untranslateOffset (int offset) {
 void updateMenuLocation (Event event) {
 	Point pointInPixels = display.mapInPixels (this, null, getCaretLocationInPixels ());
 	int zoom = getZoom();
-	event.setLocation(DPIUtil.scaleDown(pointInPixels.x, zoom), DPIUtil.scaleDown(pointInPixels.y + getLineHeightInPixels (), zoom));
+	event.setLocation(DPIUtil.pixelToPoint(pointInPixels.x, zoom), DPIUtil.pixelToPoint(pointInPixels.y + getLineHeightInPixels (), zoom));
 }
 
 @Override

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ToolBar.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ToolBar.java
@@ -570,7 +570,7 @@ public ToolItem getItem (int index) {
 public ToolItem getItem (Point point) {
 	checkWidget ();
 	if (point == null) error (SWT.ERROR_NULL_ARGUMENT);
-	return getItemInPixels(Win32DPIUtils.scaleUp(point, getZoom()));
+	return getItemInPixels(Win32DPIUtils.pointToPixel(point, getZoom()));
 }
 
 ToolItem getItemInPixels (Point point) {
@@ -1651,7 +1651,7 @@ LRESULT wmNotifyChild (NMHDR hdr, long wParam, long lParam) {
 				RECT rect = new RECT ();
 				OS.SendMessage (handle, OS.TB_GETITEMRECT, index, rect);
 				int zoom = getZoom();
-				event.setLocation(DPIUtil.scaleDown(rect.left, zoom), DPIUtil.scaleDown(rect.bottom, zoom));
+				event.setLocation(DPIUtil.pixelToPoint(rect.left, zoom), DPIUtil.pixelToPoint(rect.bottom, zoom));
 				child.sendSelectionEvent (SWT.Selection, event, false);
 			}
 			break;

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ToolItem.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ToolItem.java
@@ -235,7 +235,7 @@ void destroyWidget () {
  */
 public Rectangle getBounds () {
 	checkWidget();
-	return Win32DPIUtils.scaleDown(getBoundsInPixels(), getZoom());
+	return Win32DPIUtils.pixelToPoint(getBoundsInPixels(), getZoom());
 }
 
 Rectangle getBoundsInPixels () {
@@ -448,7 +448,7 @@ public String getToolTipText () {
  */
 public int getWidth () {
 	checkWidget();
-	return DPIUtil.scaleDown(getWidthInPixels(), getZoom());
+	return DPIUtil.pixelToPoint(getWidthInPixels(), getZoom());
 }
 
 int getWidthInPixels () {
@@ -1076,7 +1076,7 @@ public void setToolTipText (String string) {
  */
 public void setWidth (int width) {
 	checkWidget();
-	setWidthInPixels(Win32DPIUtils.scaleUp(width, getZoom()));
+	setWidthInPixels(Win32DPIUtils.pointToPixel(width, getZoom()));
 }
 
 void setWidthInPixels (int width) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ToolTip.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ToolTip.java
@@ -358,7 +358,7 @@ public void setAutoHide (boolean autoHide) {
 public void setLocation (int x, int y) {
 	checkWidget ();
 	int zoom = getZoom();
-	setLocationInPixels(Win32DPIUtils.scaleUp(x, zoom), Win32DPIUtils.scaleUp(y, zoom));
+	setLocationInPixels(Win32DPIUtils.pointToPixel(x, zoom), Win32DPIUtils.pointToPixel(y, zoom));
 }
 
 void setLocationInPixels (int x, int y) {
@@ -393,7 +393,7 @@ void setLocationInPixels (int x, int y) {
 public void setLocation (Point location) {
 	checkWidget ();
 	if (location == null) error (SWT.ERROR_NULL_ARGUMENT);
-	location = Win32DPIUtils.scaleUp(location, getZoom());
+	location = Win32DPIUtils.pointToPixel(location, getZoom());
 	setLocationInPixels(location.x, location.y);
 }
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Tracker.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Tracker.java
@@ -405,7 +405,7 @@ public Rectangle [] getRectangles () {
 	checkWidget();
 	Rectangle [] result = getRectanglesInPixels();
 	for (int i = 0; i < result.length; i++) {
-		result[i] = Win32DPIUtils.scaleDown(result[i], getZoom());
+		result[i] = Win32DPIUtils.pixelToPoint(result[i], getZoom());
 	}
 	return result;
 }
@@ -846,7 +846,7 @@ public void setRectangles (Rectangle [] rectangles) {
 	if (rectangles == null) error (SWT.ERROR_NULL_ARGUMENT);
 	Rectangle [] rectanglesInPixels = new Rectangle [rectangles.length];
 	for (int i = 0; i < rectangles.length; i++) {
-		rectanglesInPixels [i] = Win32DPIUtils.scaleUp (rectangles [i], getZoom());
+		rectanglesInPixels [i] = Win32DPIUtils.pointToPixel (rectangles [i], getZoom());
 	}
 	setRectanglesInPixels (rectanglesInPixels);
 }
@@ -999,7 +999,7 @@ LRESULT wmKeyDown (long hwnd, long wParam, long lParam) {
 			rectsToErase [i] = new Rectangle (current.x, current.y, current.width, current.height);
 		}
 		Event event = new Event ();
-		event.setLocation(DPIUtil.scaleDown(oldX + xChange, getZoom()), DPIUtil.scaleDown(oldY + yChange, getZoom()));
+		event.setLocation(DPIUtil.pixelToPoint(oldX + xChange, getZoom()), DPIUtil.pixelToPoint(oldY + yChange, getZoom()));
 		Point cursorPos;
 		if ((style & SWT.RESIZE) != 0) {
 			resizeRectangles (xChange, yChange);
@@ -1120,7 +1120,7 @@ LRESULT wmMouse (int message, long wParam, long lParam) {
 		}
 		Event event = new Event ();
 		int zoom = getZoom();
-		event.setLocation(DPIUtil.scaleDown(newX, zoom), DPIUtil.scaleDown(newY, zoom));
+		event.setLocation(DPIUtil.pixelToPoint(newX, zoom), DPIUtil.pixelToPoint(newY, zoom));
 		if ((style & SWT.RESIZE) != 0) {
 			if (isMirrored) {
 				resizeRectangles (oldX - newX, newY - oldY);

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Tree.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Tree.java
@@ -524,14 +524,14 @@ LRESULT CDDS_ITEMPOSTPAINT (NMTVCUSTOMDRAW nmcd, long wParam, long lParam) {
 							}
 							if (image != null) {
 								Rectangle bounds = image.getBounds (); // Points
-								if (size == null) size = Win32DPIUtils.scaleDown (getImageSize (), zoom); // To Points
+								if (size == null) size = Win32DPIUtils.pixelToPoint (getImageSize (), zoom); // To Points
 								if (!ignoreDrawForeground) {
 									GCData data = new GCData();
 									data.device = display;
 									GC gc = createNewGC(hDC, data);
 									RECT iconRect = item.getBounds (index, false, true, false, false, true, hDC); // Pixels
-									gc.setClipping (Win32DPIUtils.scaleDown(new Rectangle(iconRect.left, iconRect.top, iconRect.right - iconRect.left, iconRect.bottom - iconRect.top), zoom));
-									gc.drawImage (image, 0, 0, bounds.width, bounds.height, DPIUtil.scaleDown(iconRect.left, zoom), DPIUtil.scaleDown(iconRect.top, zoom), size.x, size.y);
+									gc.setClipping (Win32DPIUtils.pixelToPoint(new Rectangle(iconRect.left, iconRect.top, iconRect.right - iconRect.left, iconRect.bottom - iconRect.top), zoom));
+									gc.drawImage (image, 0, 0, bounds.width, bounds.height, DPIUtil.pixelToPoint(iconRect.left, zoom), DPIUtil.pixelToPoint(iconRect.top, zoom), size.x, size.y);
 									OS.SelectClipRgn (hDC, 0);
 									gc.dispose ();
 								}
@@ -646,7 +646,7 @@ LRESULT CDDS_ITEMPOSTPAINT (NMTVCUSTOMDRAW nmcd, long wParam, long lParam) {
 								}
 							}
 						}
-						Rectangle bounds = Win32DPIUtils.scaleDown(new Rectangle (cellRect.left, cellRect.top, cellRect.right - cellRect.left, cellRect.bottom - cellRect.top), getZoom());
+						Rectangle bounds = Win32DPIUtils.pixelToPoint(new Rectangle (cellRect.left, cellRect.top, cellRect.right - cellRect.left, cellRect.bottom - cellRect.top), getZoom());
 						event.setBounds (bounds);
 						gc.setClipping (bounds);
 						sendEvent (SWT.EraseItem, event);
@@ -762,20 +762,20 @@ LRESULT CDDS_ITEMPOSTPAINT (NMTVCUSTOMDRAW nmcd, long wParam, long lParam) {
 					int offset = i != 0 ? INSET : INSET + 2;
 					if (image != null) {
 						Rectangle bounds = image.getBounds (); // Points
-						if (size == null) size = Win32DPIUtils.scaleDown (getImageSize (), zoom); // To Points
+						if (size == null) size = Win32DPIUtils.pixelToPoint (getImageSize (), zoom); // To Points
 						if (!ignoreDrawForeground) {
 							//int y1 = rect.top + (index == 0 ? (getItemHeight () - size.y) / 2 : 0);
-							int y1 = rect.top + Win32DPIUtils.scaleUp((getItemHeight () - size.y) / 2, zoom);
+							int y1 = rect.top + Win32DPIUtils.pointToPixel((getItemHeight () - size.y) / 2, zoom);
 							int x1 = Math.max (rect.left, rect.left - inset + 1);
 							GCData data = new GCData();
 							data.device = display;
 							GC gc = createNewGC(hDC, data);
-							gc.setClipping (Win32DPIUtils.scaleDown(new Rectangle(x1, rect.top, rect.right - x1, rect.bottom - rect.top), zoom));
-							gc.drawImage (image, 0, 0, bounds.width, bounds.height, DPIUtil.scaleDown(x1, zoom), DPIUtil.scaleDown(y1, zoom), size.x, size.y);
+							gc.setClipping (Win32DPIUtils.pixelToPoint(new Rectangle(x1, rect.top, rect.right - x1, rect.bottom - rect.top), zoom));
+							gc.drawImage (image, 0, 0, bounds.width, bounds.height, DPIUtil.pixelToPoint(x1, zoom), DPIUtil.pixelToPoint(y1, zoom), size.x, size.y);
 							OS.SelectClipRgn (hDC, 0);
 							gc.dispose ();
 						}
-						OS.SetRect (rect, rect.left + Win32DPIUtils.scaleUp(size.x, zoom) + offset, rect.top, rect.right - inset, rect.bottom);
+						OS.SetRect (rect, rect.left + Win32DPIUtils.pointToPixel(size.x, zoom) + offset, rect.top, rect.right - inset, rect.bottom);
 					} else {
 						if (i == 0) {
 							if (OS.SendMessage (handle, OS.TVM_GETIMAGELIST, OS.TVSIL_NORMAL, 0) != 0) {
@@ -864,11 +864,11 @@ LRESULT CDDS_ITEMPOSTPAINT (NMTVCUSTOMDRAW nmcd, long wParam, long lParam) {
 						}
 					}
 				}
-				event.setBounds(Win32DPIUtils.scaleDown(new Rectangle(itemRect.left, itemRect.top, itemRect.right - itemRect.left, itemRect.bottom - itemRect.top), getZoom()));
+				event.setBounds(Win32DPIUtils.pixelToPoint(new Rectangle(itemRect.left, itemRect.top, itemRect.right - itemRect.left, itemRect.bottom - itemRect.top), getZoom()));
 				RECT cellRect = item.getBounds (index, true, true, true, true, true, hDC);
 				int cellWidth = cellRect.right - cellRect.left;
 				int cellHeight = cellRect.bottom - cellRect.top;
-				gc.setClipping (Win32DPIUtils.scaleDown(new Rectangle(cellRect.left, cellRect.top, cellWidth, cellHeight), zoom));
+				gc.setClipping (Win32DPIUtils.pixelToPoint(new Rectangle(cellRect.left, cellRect.top, cellWidth, cellHeight), zoom));
 				sendEvent (SWT.PaintItem, event);
 				if (data.focusDrawn) focusRect = null;
 				event.gc = null;
@@ -1031,7 +1031,7 @@ LRESULT CDDS_ITEMPREPAINT (NMTVCUSTOMDRAW nmcd, long wParam, long lParam) {
 		Rectangle boundsInPixels = null;
 		if (hooks (SWT.MeasureItem)) {
 			measureEvent = sendMeasureItemEvent (item, index, hDC, selected ? SWT.SELECTED : 0);
-			boundsInPixels = Win32DPIUtils.scaleUp(measureEvent.getBounds(), getZoom());
+			boundsInPixels = Win32DPIUtils.pointToPixel(measureEvent.getBounds(), getZoom());
 			if (isDisposed () || item.isDisposed ()) return null;
 		}
 		selectionForeground = -1;
@@ -1085,7 +1085,7 @@ LRESULT CDDS_ITEMPREPAINT (NMTVCUSTOMDRAW nmcd, long wParam, long lParam) {
 					}
 				}
 			}
-			Rectangle bounds = Win32DPIUtils.scaleDown(new Rectangle (cellRect.left, cellRect.top, cellRect.right - cellRect.left, cellRect.bottom - cellRect.top), getZoom());
+			Rectangle bounds = Win32DPIUtils.pixelToPoint(new Rectangle (cellRect.left, cellRect.top, cellRect.right - cellRect.left, cellRect.bottom - cellRect.top), getZoom());
 			event.setBounds (bounds);
 			gc.setClipping (bounds);
 			sendEvent (SWT.EraseItem, event);
@@ -2804,7 +2804,7 @@ boolean findCell (int x, int y, TreeItem [] item, int [] index, RECT [] cellRect
 						int detail = (state & OS.TVIS_SELECTED) != 0 ? SWT.SELECTED : 0;
 						Event event = sendMeasureItemEvent (item [0], order [index [0]], hDC, detail);
 						if (isDisposed () || item [0].isDisposed ()) break;
-						Rectangle boundsInPixels = Win32DPIUtils.scaleUp(event.getBounds(), getZoom());
+						Rectangle boundsInPixels = Win32DPIUtils.pointToPixel(event.getBounds(), getZoom());
 						itemRect [0] = new RECT ();
 						itemRect [0].left = boundsInPixels.x;
 						itemRect [0].right = boundsInPixels.x + boundsInPixels.width;
@@ -2960,7 +2960,7 @@ TreeItem getFocusItem () {
  */
 public int getGridLineWidth () {
 	checkWidget ();
-	return DPIUtil.scaleDown(getGridLineWidthInPixels (), getZoom());
+	return DPIUtil.pixelToPoint(getGridLineWidthInPixels (), getZoom());
 }
 
 int getGridLineWidthInPixels () {
@@ -3021,7 +3021,7 @@ private int getHeaderForegroundPixel() {
  */
 public int getHeaderHeight () {
 	checkWidget ();
-	return DPIUtil.scaleDown(getHeaderHeightInPixels (), getZoom());
+	return DPIUtil.pixelToPoint(getHeaderHeightInPixels (), getZoom());
 }
 
 int getHeaderHeightInPixels () {
@@ -3287,7 +3287,7 @@ TreeItem getItem (NMTVCUSTOMDRAW nmcd) {
 public TreeItem getItem (Point point) {
 	checkWidget ();
 	if (point == null) error (SWT.ERROR_NULL_ARGUMENT);
-	return getItemInPixels(Win32DPIUtils.scaleUp(point, getZoom()));
+	return getItemInPixels(Win32DPIUtils.pointToPixel(point, getZoom()));
 }
 
 TreeItem getItemInPixels (Point point) {
@@ -3361,7 +3361,7 @@ int getItemCount (long hItem) {
  */
 public int getItemHeight () {
 	checkWidget ();
-	return DPIUtil.scaleDown(getItemHeightInPixels(), getZoom());
+	return DPIUtil.pixelToPoint(getItemHeightInPixels(), getZoom());
 }
 
 int getItemHeightInPixels () {
@@ -3730,7 +3730,7 @@ boolean hitTestSelection (long hItem, int x, int y) {
 	int state = (int)OS.SendMessage (handle, OS.TVM_GETITEMSTATE, hItem, OS.TVIS_SELECTED);
 	int detail = (state & OS.TVIS_SELECTED) != 0 ? SWT.SELECTED : 0;
 	Event event = sendMeasureItemEvent (item, order [index [0]], hDC, detail);
-	if (Win32DPIUtils.scaleUp(event.getBounds(), getZoom()).contains (x, y)) result = true;
+	if (Win32DPIUtils.pointToPixel(event.getBounds(), getZoom()).contains (x, y)) result = true;
 	if (newFont != 0) OS.SelectObject (hDC, oldFont);
 	OS.ReleaseDC (handle, hDC);
 //	if (isDisposed () || item.isDisposed ()) return false;
@@ -4530,7 +4530,7 @@ Event sendEraseItemEvent (TreeItem item, NMTTCUSTOMDRAW nmcd, int column, RECT c
 	event.index = column;
 	event.gc = gc;
 	event.detail |= SWT.FOREGROUND;
-	event.setBounds(Win32DPIUtils.scaleDown(new Rectangle(cellRect.left, cellRect.top, cellRect.right - cellRect.left, cellRect.bottom - cellRect.top), getZoom()));
+	event.setBounds(Win32DPIUtils.pixelToPoint(new Rectangle(cellRect.left, cellRect.top, cellRect.right - cellRect.left, cellRect.bottom - cellRect.top), getZoom()));
 	//gc.setClipping (event.x, event.y, event.width, event.height);
 	sendEvent (SWT.EraseItem, event);
 	event.gc = null;
@@ -4551,14 +4551,14 @@ Event sendMeasureItemEvent (TreeItem item, int index, long hDC, int detail) {
 	event.item = item;
 	event.gc = gc;
 	event.index = index;
-	event.setBounds(Win32DPIUtils.scaleDown(new Rectangle(itemRect.left, itemRect.top, itemRect.right - itemRect.left, itemRect.bottom - itemRect.top), getZoom()));
+	event.setBounds(Win32DPIUtils.pixelToPoint(new Rectangle(itemRect.left, itemRect.top, itemRect.right - itemRect.left, itemRect.bottom - itemRect.top), getZoom()));
 	event.detail = detail;
 	sendEvent (SWT.MeasureItem, event);
 	event.gc = null;
 	gc.dispose ();
 	OS.RestoreDC (hDC, nSavedDC);
 	if (isDisposed () || item.isDisposed ()) return null;
-	Rectangle rect = Win32DPIUtils.scaleUp(event.getBounds(), getZoom());
+	Rectangle rect = Win32DPIUtils.pointToPixel(event.getBounds(), getZoom());
 	if (hwndHeader != 0) {
 		if (columnCount == 0) {
 			if (rect.x + rect.width > scrollWidth) {
@@ -4586,7 +4586,7 @@ Event sendPaintItemEvent (TreeItem item, NMTTCUSTOMDRAW nmcd, int column, RECT i
 	event.index = column;
 	event.gc = gc;
 	event.detail |= SWT.FOREGROUND;
-	event.setBounds(Win32DPIUtils.scaleDown(new Rectangle(itemRect.left, itemRect.top, itemRect.right - itemRect.left, itemRect.bottom - itemRect.top), getZoom()));
+	event.setBounds(Win32DPIUtils.pixelToPoint(new Rectangle(itemRect.left, itemRect.top, itemRect.right - itemRect.left, itemRect.bottom - itemRect.top), getZoom()));
 	//gc.setClipping (cellRect.left, cellRect.top, cellWidth, cellHeight);
 	sendEvent (SWT.PaintItem, event);
 	event.gc = null;
@@ -5371,7 +5371,7 @@ public void setTopItem (TreeItem item) {
  * In a Tree without imageList, the indent also controls the chevron (glyph) size.
  */
 private void calculateAndApplyIndentSize() {
-	int indent = Win32DPIUtils.scaleUp(DEFAULT_INDENT, nativeZoom);
+	int indent = Win32DPIUtils.pointToPixel(DEFAULT_INDENT, nativeZoom);
 	OS.SendMessage(handle, OS.TVM_SETINDENT, indent, 0);
 }
 
@@ -5753,7 +5753,7 @@ void updateMenuLocation (Event event) {
 	}
 	Point pt = toDisplayInPixels (x, y);
 	int zoom = getZoom();
-	event.setLocation(DPIUtil.scaleDown(pt.x, zoom), DPIUtil.scaleDown(pt.y, zoom));
+	event.setLocation(DPIUtil.pixelToPoint(pt.x, zoom), DPIUtil.pixelToPoint(pt.y, zoom));
 }
 
 @Override
@@ -7152,7 +7152,7 @@ LRESULT WM_PAINT (long wParam, long lParam) {
 				if (hooksPaint) {
 					Event event = new Event ();
 					event.gc = gc;
-					event.setBounds(Win32DPIUtils.scaleDown(new Rectangle(ps.left, ps.top, ps.right - ps.left, ps.bottom - ps.top), getZoom()));
+					event.setBounds(Win32DPIUtils.pixelToPoint(new Rectangle(ps.left, ps.top, ps.right - ps.left, ps.bottom - ps.top), getZoom()));
 					sendEvent (SWT.Paint, event);
 					// widget could be disposed at this point
 					event.gc = null;
@@ -7886,7 +7886,7 @@ LRESULT wmNotifyHeader (NMHDR hdr, long wParam, long lParam) {
 							 * Sort indicator size needs to scale as per the Native Windows OS DPI level
 							 * when header is custom drawn. For more details refer bug 537097.
 							 */
-							int leg = Win32DPIUtils.scaleUp(3, nativeZoom);
+							int leg = Win32DPIUtils.pointToPixel(3, nativeZoom);
 							if (sortDirection == SWT.UP) {
 								OS.Polyline(nmcd.hdc, new int[] {center-leg, 1+leg, center+1, 0}, 2);
 								OS.Polyline(nmcd.hdc, new int[] {center+leg, 1+leg, center-1, 0}, 2);
@@ -7933,7 +7933,7 @@ LRESULT wmNotifyHeader (NMHDR hdr, long wParam, long lParam) {
 							int zoom = getZoom();
 							Rectangle imageBounds = Win32DPIUtils.scaleBounds(columns[i].image.getBounds(), zoom, 100);
 							int y = Math.max (0, (nmcd.bottom - imageBounds.height) / 2);
-							gc.drawImage (columns[i].image, DPIUtil.scaleDown(x, zoom), DPIUtil.scaleDown(y, zoom));
+							gc.drawImage (columns[i].image, DPIUtil.pixelToPoint(x, zoom), DPIUtil.pixelToPoint(y, zoom));
 							x += imageBounds.width + 12;
 							gc.dispose ();
 						}
@@ -8253,7 +8253,7 @@ LRESULT wmNotifyToolTip (NMTTCUSTOMDRAW nmcd, long lParam) {
 								if (image != null) {
 									Rectangle rect = image.getBounds (); // Points
 									int zoom = getZoom();
-									gc.drawImage (image, rect.x, rect.y, rect.width, rect.height, DPIUtil.scaleDown(x, zoom), DPIUtil.scaleDown(imageRect.top, zoom), DPIUtil.scaleDown(size.x, zoom), DPIUtil.scaleDown(size.y, zoom));
+									gc.drawImage (image, rect.x, rect.y, rect.width, rect.height, DPIUtil.pixelToPoint(x, zoom), DPIUtil.pixelToPoint(imageRect.top, zoom), DPIUtil.pixelToPoint(size.x, zoom), DPIUtil.pixelToPoint(size.y, zoom));
 									x += INSET + (index [0] == 0 ? 1 : 0);
 								}
 								x += size.x;

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TreeColumn.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TreeColumn.java
@@ -311,7 +311,7 @@ public String getToolTipText () {
  */
 public int getWidth () {
 	checkWidget ();
-	return DPIUtil.scaleDown(getWidthInPixels(), getZoom());
+	return DPIUtil.pixelToPoint(getWidthInPixels(), getZoom());
 }
 
 int getWidthInPixels () {
@@ -359,7 +359,7 @@ public void pack () {
 				Event event = parent.sendMeasureItemEvent (item, index, hDC, detail);
 				if (isDisposed () || parent.isDisposed ()) break;
 				Rectangle bounds = event.getBounds();
-				itemRight = Win32DPIUtils.scaleUp(bounds.x + bounds.width, getZoom());
+				itemRight = Win32DPIUtils.pointToPixel(bounds.x + bounds.width, getZoom());
 			} else {
 				long hFont = item.fontHandle (index);
 				if (hFont != -1) hFont = OS.SelectObject (hDC, hFont);
@@ -385,7 +385,7 @@ public void pack () {
 			headerImage = image;
 		}
 		if (headerImage != null) {
-			Rectangle bounds = Win32DPIUtils.scaleUp(headerImage.getBounds(), getZoom());
+			Rectangle bounds = Win32DPIUtils.pointToPixel(headerImage.getBounds(), getZoom());
 			headerWidth += bounds.width;
 		}
 		int margin = 0;
@@ -717,7 +717,7 @@ public void setToolTipText (String string) {
  */
 public void setWidth (int width) {
 	checkWidget ();
-	setWidthInPixels(Win32DPIUtils.scaleUp(width, getZoom()));
+	setWidthInPixels(Win32DPIUtils.pointToPixel(width, getZoom()));
 }
 
 void setWidthInPixels (int width) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TreeItem.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TreeItem.java
@@ -375,7 +375,7 @@ public Color getBackground (int index) {
  */
 public Rectangle getBounds () {
 	checkWidget ();
-	return Win32DPIUtils.scaleDown(getBoundsInPixels(), getZoom());
+	return Win32DPIUtils.pixelToPoint(getBoundsInPixels(), getZoom());
 }
 
 Rectangle getBoundsInPixels () {
@@ -401,7 +401,7 @@ Rectangle getBoundsInPixels () {
  */
 public Rectangle getBounds (int index) {
 	checkWidget();
-	return Win32DPIUtils.scaleDown(getBoundsInPixels(index), getZoom());
+	return Win32DPIUtils.pixelToPoint(getBoundsInPixels(index), getZoom());
 }
 
 Rectangle getBoundsInPixels (int index) {
@@ -817,7 +817,7 @@ public Image getImage (int index) {
  */
 public Rectangle getImageBounds (int index) {
 	checkWidget();
-	return Win32DPIUtils.scaleDown(getImageBoundsInPixels(index), getZoom());
+	return Win32DPIUtils.pixelToPoint(getImageBoundsInPixels(index), getZoom());
 }
 
 Rectangle getImageBoundsInPixels (int index) {
@@ -912,7 +912,7 @@ public String getText (int index) {
  */
 public Rectangle getTextBounds (int index) {
 	checkWidget();
-	return Win32DPIUtils.scaleDown(getTextBoundsInPixels(index), getZoom());
+	return Win32DPIUtils.pixelToPoint(getTextBoundsInPixels(index), getZoom());
 }
 
 Rectangle getTextBoundsInPixels (int index) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Widget.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Widget.java
@@ -1190,7 +1190,7 @@ boolean sendDragEvent (int button, int x, int y) {
 	Event event = new Event ();
 	event.button = button;
 	int zoom = getZoom();
-	event.setLocation(DPIUtil.scaleDown(x, zoom), DPIUtil.scaleDown(y, zoom));
+	event.setLocation(DPIUtil.pixelToPoint(x, zoom), DPIUtil.pixelToPoint(y, zoom));
 	setInputState (event, SWT.DragDetect);
 	postEvent (SWT.DragDetect, event);
 	if (isDisposed ()) return false;
@@ -1201,7 +1201,7 @@ boolean sendDragEvent (int button, int stateMask, int x, int y) {
 	Event event = new Event ();
 	event.button = button;
 	int zoom = getZoom();
-	event.setLocation(DPIUtil.scaleDown(x, zoom), DPIUtil.scaleDown(y, zoom));
+	event.setLocation(DPIUtil.pixelToPoint(x, zoom), DPIUtil.pixelToPoint(y, zoom));
 	event.stateMask = stateMask;
 	postEvent (SWT.DragDetect, event);
 	if (isDisposed ()) return false;
@@ -1278,7 +1278,7 @@ boolean sendMouseEvent (int type, int button, int count, int detail, boolean sen
 	event.detail = detail;
 	event.count = count;
 	int zoom = getZoom();
-	event.setLocation(DPIUtil.scaleDown(OS.GET_X_LPARAM (lParam), zoom), DPIUtil.scaleDown(OS.GET_Y_LPARAM (lParam), zoom));
+	event.setLocation(DPIUtil.pixelToPoint(OS.GET_X_LPARAM (lParam), zoom), DPIUtil.pixelToPoint(OS.GET_Y_LPARAM (lParam), zoom));
 	setInputState (event, type);
 	mapEvent (hwnd, event);
 	if (send) {
@@ -1708,7 +1708,7 @@ boolean showMenu (int x, int y, int detail) {
 	if (!event.doit) return true;
 	Menu menu = getMenu ();
 	if (menu != null && !menu.isDisposed ()) {
-		Point locInPixels = Win32DPIUtils.scaleUp(event.getLocation(), getZoom()); // In Pixels
+		Point locInPixels = Win32DPIUtils.pointToPixel(event.getLocation(), getZoom()); // In Pixels
 		if (x != locInPixels.x || y != locInPixels.y) {
 			menu.setLocation (event.getLocation());
 		}
@@ -2362,7 +2362,7 @@ LRESULT wmPaint (long hwnd, long wParam, long lParam) {
 			OS.SetMetaRgn (hDC);
 			Event event = new Event ();
 			event.gc = gc;
-			event.setBounds(Win32DPIUtils.scaleDown(new Rectangle(rect.left, rect.top, width, height), getZoom()));
+			event.setBounds(Win32DPIUtils.pixelToPoint(new Rectangle(rect.left, rect.top, width, height), getZoom()));
 			sendEvent (SWT.Paint, event);
 			// widget could be disposed at this point
 			event.gc = null;

--- a/tests/org.eclipse.swt.tests.win32/JUnit Tests/org/eclipse/swt/tests/win32/Win32DPIUtilTests.java
+++ b/tests/org.eclipse.swt.tests.win32/JUnit Tests/org/eclipse/swt/tests/win32/Win32DPIUtilTests.java
@@ -37,17 +37,17 @@ public class Win32DPIUtilTests {
 		float[] valueAt150 = new float[] { 1.5f, 2.25f, 3 };
 		float[] valueAt100 = new float[] { 1, 1.5f, 2 };
 
-		float[] scaledValue = Win32DPIUtils.scaleDown(valueAt200, 200);
+		float[] scaledValue = Win32DPIUtils.pixelToPoint(valueAt200, 200);
 		assertArrayEquals(valueAt100, scaledValue, .001f, "Scaling down float array from 200 failed");
-		scaledValue = Win32DPIUtils.scaleDown((Device) null, valueAt200, 200);
+		scaledValue = Win32DPIUtils.pixelToPoint((Device) null, valueAt200, 200);
 		assertArrayEquals(valueAt100, scaledValue, .001f, "Scaling down float array from 200 with device failed");
-		scaledValue = Win32DPIUtils.scaleDown(valueAt150, 150);
+		scaledValue = Win32DPIUtils.pixelToPoint(valueAt150, 150);
 		assertArrayEquals(valueAt100, scaledValue, .001f, "Scaling down float array from 150 failed");
-		scaledValue = Win32DPIUtils.scaleDown((Device) null, valueAt150, 150);
+		scaledValue = Win32DPIUtils.pixelToPoint((Device) null, valueAt150, 150);
 		assertArrayEquals(valueAt100, scaledValue, .001f, "Scaling down float array from 150 with device failed");
-		scaledValue = Win32DPIUtils.scaleDown(valueAt100, 100);
+		scaledValue = Win32DPIUtils.pixelToPoint(valueAt100, 100);
 		assertSame(valueAt100, scaledValue, "Scaling down float array without zoom change failed");
-		scaledValue = Win32DPIUtils.scaleDown((Device) null, valueAt100, 100);
+		scaledValue = Win32DPIUtils.pixelToPoint((Device) null, valueAt100, 100);
 		assertSame(valueAt100, scaledValue, "Scaling down float array without zoom change with device failed");
 	}
 
@@ -57,11 +57,11 @@ public class Win32DPIUtilTests {
 		int valueAt150 = 7;
 		int valueAt100 = 5;
 
-		int scaledValue = Win32DPIUtils.scaleDown((Device) null, valueAt200, 200);
+		int scaledValue = Win32DPIUtils.pixelToPoint((Device) null, valueAt200, 200);
 		assertEquals(valueAt100, scaledValue, "Scaling down integer from 200 with device failed");
-		scaledValue = Win32DPIUtils.scaleDown((Device) null, valueAt150, 150);
+		scaledValue = Win32DPIUtils.pixelToPoint((Device) null, valueAt150, 150);
 		assertEquals(valueAt100, scaledValue, "Scaling down integer from 150 with device failed");
-		scaledValue = Win32DPIUtils.scaleDown((Device) null, valueAt100, 100);
+		scaledValue = Win32DPIUtils.pixelToPoint((Device) null, valueAt100, 100);
 		assertSame(valueAt100, scaledValue, "Scaling down integer without zoom change with device failed");
 	}
 
@@ -71,11 +71,11 @@ public class Win32DPIUtilTests {
 		float valueAt150 = 7.5f;
 		float valueAt100 = 5f;
 
-		float scaledValue = Win32DPIUtils.scaleDown((Device) null, valueAt200, 200);
+		float scaledValue = Win32DPIUtils.pixelToPoint((Device) null, valueAt200, 200);
 		assertEquals(valueAt100, scaledValue, .001f, "Scaling down float from 200 with device failed");
-		scaledValue = Win32DPIUtils.scaleDown((Device) null, valueAt150, 150);
+		scaledValue = Win32DPIUtils.pixelToPoint((Device) null, valueAt150, 150);
 		assertEquals(valueAt100, scaledValue, .001f, "Scaling down float without zoom change failed");
-		scaledValue = Win32DPIUtils.scaleDown((Device) null, valueAt100, 100);
+		scaledValue = Win32DPIUtils.pixelToPoint((Device) null, valueAt100, 100);
 		assertEquals(valueAt100, scaledValue, .001f, "Scaling down float without zoom change with device failed");
 	}
 
@@ -85,17 +85,17 @@ public class Win32DPIUtilTests {
 		Point valueAt150 = new Point(7, 10);
 		Point valueAt100 = new Point(5, 7);
 
-		Point scaledValue = Win32DPIUtils.scaleDown(valueAt200, 200);
+		Point scaledValue = Win32DPIUtils.pixelToPoint(valueAt200, 200);
 		assertEquals(valueAt100, scaledValue, "Scaling down Point from 200 failed");
-		scaledValue = Win32DPIUtils.scaleDown((Device) null, valueAt200, 200);
+		scaledValue = Win32DPIUtils.pixelToPoint((Device) null, valueAt200, 200);
 		assertEquals(valueAt100, scaledValue, "Scaling down Point from 200 with device failed");
-		scaledValue = Win32DPIUtils.scaleDown(valueAt150, 150);
+		scaledValue = Win32DPIUtils.pixelToPoint(valueAt150, 150);
 		assertEquals(valueAt100, scaledValue, "Scaling down Point from 150 failed");
-		scaledValue = Win32DPIUtils.scaleDown((Device) null, valueAt150, 150);
+		scaledValue = Win32DPIUtils.pixelToPoint((Device) null, valueAt150, 150);
 		assertEquals(valueAt100, scaledValue, "Scaling down Point from 150 with device failed");
-		scaledValue = Win32DPIUtils.scaleDown(valueAt100, 100);
+		scaledValue = Win32DPIUtils.pixelToPoint(valueAt100, 100);
 		assertSame(valueAt100, scaledValue, "Scaling down Point without zoom change failed");
-		scaledValue = Win32DPIUtils.scaleDown((Device) null, valueAt100, 100);
+		scaledValue = Win32DPIUtils.pixelToPoint((Device) null, valueAt100, 100);
 		assertSame(valueAt100, scaledValue, "Scaling down Point without zoom change with device failed");
 	}
 
@@ -105,17 +105,17 @@ public class Win32DPIUtilTests {
 		Rectangle valueAt150 = new Rectangle(75, 113, 7, 10);
 		Rectangle valueAt100 = new Rectangle(50, 75, 5, 7);
 
-		Rectangle scaledValue = Win32DPIUtils.scaleDown(valueAt200, 200);
+		Rectangle scaledValue = Win32DPIUtils.pixelToPoint(valueAt200, 200);
 		assertEquals(valueAt100, scaledValue, "Scaling down Rectangle from 200 failed");
-		scaledValue = Win32DPIUtils.scaleDown((Device) null, valueAt200, 200);
+		scaledValue = Win32DPIUtils.pixelToPoint((Device) null, valueAt200, 200);
 		assertEquals(valueAt100, scaledValue, "Scaling down Rectangle from 200 with device failed");
-		scaledValue = Win32DPIUtils.scaleDown(valueAt150, 150);
+		scaledValue = Win32DPIUtils.pixelToPoint(valueAt150, 150);
 		assertEquals(valueAt100, scaledValue, "Scaling down Rectangle from 150 failed");
-		scaledValue = Win32DPIUtils.scaleDown((Device) null, valueAt150, 150);
+		scaledValue = Win32DPIUtils.pixelToPoint((Device) null, valueAt150, 150);
 		assertEquals(valueAt100, scaledValue, "Scaling down Rectangle from 150 with device failed");
-		scaledValue = Win32DPIUtils.scaleDown(valueAt100, 100);
+		scaledValue = Win32DPIUtils.pixelToPoint(valueAt100, 100);
 		assertSame(valueAt100, scaledValue, "Scaling down Rectangle without zoom change failed");
-		scaledValue = Win32DPIUtils.scaleDown((Device) null, valueAt100, 100);
+		scaledValue = Win32DPIUtils.pixelToPoint((Device) null, valueAt100, 100);
 		assertSame(valueAt100, scaledValue, "Scaling down Rectangle without zoom change with device failed");
 	}
 
@@ -125,17 +125,17 @@ public class Win32DPIUtilTests {
 		int[] valueAt150 = new int[] { 8, 9, 11 };
 		int[] valueAt100 = new int[] { 5, 6, 7 };
 
-		int[] scaledValue = Win32DPIUtils.scaleUp(valueAt100, 200);
+		int[] scaledValue = Win32DPIUtils.pointToPixel(valueAt100, 200);
 		assertArrayEquals(valueAt200, scaledValue, "Scaling up int array to 200 failed");
-		scaledValue = Win32DPIUtils.scaleUp((Device) null, valueAt100, 200);
+		scaledValue = Win32DPIUtils.pointToPixel((Device) null, valueAt100, 200);
 		assertArrayEquals(valueAt200, scaledValue, "Scaling up int array to 200 with device failed");
-		scaledValue = Win32DPIUtils.scaleUp(valueAt100, 150);
+		scaledValue = Win32DPIUtils.pointToPixel(valueAt100, 150);
 		assertArrayEquals(valueAt150, scaledValue, "Scaling up int array to 150 failed");
-		scaledValue = Win32DPIUtils.scaleUp((Device) null, valueAt100, 150);
+		scaledValue = Win32DPIUtils.pointToPixel((Device) null, valueAt100, 150);
 		assertArrayEquals(valueAt150, scaledValue, "Scaling up int array to 150 with device failed");
-		scaledValue = Win32DPIUtils.scaleUp(valueAt100, 100);
+		scaledValue = Win32DPIUtils.pointToPixel(valueAt100, 100);
 		assertSame(valueAt100, scaledValue, "Scaling up int array without zoom change failed");
-		scaledValue = Win32DPIUtils.scaleUp((Device) null, valueAt100, 100);
+		scaledValue = Win32DPIUtils.pointToPixel((Device) null, valueAt100, 100);
 		assertSame(valueAt100, scaledValue, "Scaling up int array without zoom change with device failed");
 	}
 
@@ -145,17 +145,17 @@ public class Win32DPIUtilTests {
 		int valueAt150 = 8;
 		int valueAt100 = 5;
 
-		int scaledValue = Win32DPIUtils.scaleUp(valueAt100, 200);
+		int scaledValue = Win32DPIUtils.pointToPixel(valueAt100, 200);
 		assertEquals(valueAt200, scaledValue, "Scaling up integer to 200 failed");
-		scaledValue = Win32DPIUtils.scaleUp((Device) null, valueAt100, 200);
+		scaledValue = Win32DPIUtils.pointToPixel((Device) null, valueAt100, 200);
 		assertEquals(valueAt200, scaledValue, "Scaling up integer to 200 with device failed");
-		scaledValue = Win32DPIUtils.scaleUp(valueAt100, 150);
+		scaledValue = Win32DPIUtils.pointToPixel(valueAt100, 150);
 		assertEquals(valueAt150, scaledValue, "Scaling up integer to 150 failed");
-		scaledValue = Win32DPIUtils.scaleUp((Device) null, valueAt100, 150);
+		scaledValue = Win32DPIUtils.pointToPixel((Device) null, valueAt100, 150);
 		assertEquals(valueAt150, scaledValue, "Scaling up integer to 150 with device failed");
-		scaledValue = Win32DPIUtils.scaleUp(valueAt100, 100);
+		scaledValue = Win32DPIUtils.pointToPixel(valueAt100, 100);
 		assertSame(valueAt100, scaledValue, "Scaling up integer without zoom change failed");
-		scaledValue = Win32DPIUtils.scaleUp((Device) null, valueAt100, 100);
+		scaledValue = Win32DPIUtils.pointToPixel((Device) null, valueAt100, 100);
 		assertSame(valueAt100, scaledValue,"Scaling up integer without zoom change with device failed");
 	}
 
@@ -165,17 +165,17 @@ public class Win32DPIUtilTests {
 		float valueAt150 = 7.5f;
 		float valueAt100 = 5;
 
-		float scaledValue = Win32DPIUtils.scaleUp(valueAt100, 200);
+		float scaledValue = Win32DPIUtils.pointToPixel(valueAt100, 200);
 		assertEquals(valueAt200, scaledValue, 0.001f, "Scaling up integer to 200 failed");
-		scaledValue = Win32DPIUtils.scaleUp((Device) null, valueAt100, 200);
+		scaledValue = Win32DPIUtils.pointToPixel((Device) null, valueAt100, 200);
 		assertEquals(valueAt200, scaledValue, 0.001f, "Scaling up integer to 200 with device failed");
-		scaledValue = Win32DPIUtils.scaleUp(valueAt100, 150);
+		scaledValue = Win32DPIUtils.pointToPixel(valueAt100, 150);
 		assertEquals(valueAt150, scaledValue, 0.001f, "Scaling up integer to 150 failed");
-		scaledValue = Win32DPIUtils.scaleUp((Device) null, valueAt100, 150);
+		scaledValue = Win32DPIUtils.pointToPixel((Device) null, valueAt100, 150);
 		assertEquals(valueAt150, scaledValue, 0.001f, "Scaling up integer to 150 with device failed");
-		scaledValue = Win32DPIUtils.scaleUp(valueAt100, 100);
+		scaledValue = Win32DPIUtils.pointToPixel(valueAt100, 100);
 		assertEquals(valueAt100, scaledValue, 0.001f, "Scaling up integer without zoom change failed");
-		scaledValue = Win32DPIUtils.scaleUp((Device) null, valueAt100, 100);
+		scaledValue = Win32DPIUtils.pointToPixel((Device) null, valueAt100, 100);
 		assertEquals(valueAt100, scaledValue, 0.001f, "Scaling up integer without zoom change with device failed");
 	}
 
@@ -185,17 +185,17 @@ public class Win32DPIUtilTests {
 		Point valueAt150 = new Point(8, 11);
 		Point valueAt100 = new Point(5, 7);
 
-		Point scaledValue = Win32DPIUtils.scaleUp(valueAt100, 200);
+		Point scaledValue = Win32DPIUtils.pointToPixel(valueAt100, 200);
 		assertEquals(valueAt200, scaledValue, "Scaling up Point to 200 failed");
-		scaledValue = Win32DPIUtils.scaleUp((Device) null, valueAt100, 200);
+		scaledValue = Win32DPIUtils.pointToPixel((Device) null, valueAt100, 200);
 		assertEquals(valueAt200, scaledValue, "Scaling up Point to 200 with device failed");
-		scaledValue = Win32DPIUtils.scaleUp(valueAt100, 150);
+		scaledValue = Win32DPIUtils.pointToPixel(valueAt100, 150);
 		assertEquals(valueAt150, scaledValue, "Scaling up Point to 150 failed");
-		scaledValue = Win32DPIUtils.scaleUp((Device) null, valueAt100, 150);
+		scaledValue = Win32DPIUtils.pointToPixel((Device) null, valueAt100, 150);
 		assertEquals(valueAt150, scaledValue, "Scaling up Point to 150 with device failed");
-		scaledValue = Win32DPIUtils.scaleUp(valueAt100, 100);
+		scaledValue = Win32DPIUtils.pointToPixel(valueAt100, 100);
 		assertSame(valueAt100, scaledValue, "Scaling up Point without zoom change failed");
-		scaledValue = Win32DPIUtils.scaleUp((Device) null, valueAt100, 100);
+		scaledValue = Win32DPIUtils.pointToPixel((Device) null, valueAt100, 100);
 		assertSame(valueAt100, scaledValue, "Scaling up Point without zoom change with device failed");
 	}
 
@@ -205,17 +205,17 @@ public class Win32DPIUtilTests {
 		Rectangle valueAt150 = new Rectangle(75, 113, 8, 11);
 		Rectangle valueAt100 = new Rectangle(50, 75, 5, 7);
 
-		Rectangle scaledValue = Win32DPIUtils.scaleUp(valueAt100, 200);
+		Rectangle scaledValue = Win32DPIUtils.pointToPixel(valueAt100, 200);
 		assertEquals(valueAt200, scaledValue, "Scaling up Rectangle to 200 failed");
-		scaledValue = Win32DPIUtils.scaleUp((Device) null, valueAt100, 200);
+		scaledValue = Win32DPIUtils.pointToPixel((Device) null, valueAt100, 200);
 		assertEquals(valueAt200, scaledValue, "Scaling up Rectangle to 200 with device failed");
-		scaledValue = Win32DPIUtils.scaleUp(valueAt100, 150);
+		scaledValue = Win32DPIUtils.pointToPixel(valueAt100, 150);
 		assertEquals(valueAt150, scaledValue, "Scaling up Rectangle to 150 failed");
-		scaledValue = Win32DPIUtils.scaleUp((Device) null, valueAt100, 150);
+		scaledValue = Win32DPIUtils.pointToPixel((Device) null, valueAt100, 150);
 		assertEquals(valueAt150, scaledValue, "Scaling up Rectangle to 150 with device failed");
-		scaledValue = Win32DPIUtils.scaleUp(valueAt100, 100);
+		scaledValue = Win32DPIUtils.pointToPixel(valueAt100, 100);
 		assertSame(valueAt100, scaledValue, "Scaling up Rectangle without zoom change failed");
-		scaledValue = Win32DPIUtils.scaleUp((Device) null, valueAt100, 100);
+		scaledValue = Win32DPIUtils.pointToPixel((Device) null, valueAt100, 100);
 		assertSame(valueAt100, scaledValue, "Scaling up Rectangle without zoom change with device failed");
 	}
 
@@ -226,10 +226,10 @@ public class Win32DPIUtilTests {
 			for (int zoom2 : zooms) {
 				for (int i = 1; i <= 10000; i++) {
 					Rectangle rect = new Rectangle(0, 0, i, i);
-					Rectangle scaleDown = Win32DPIUtils.scaleDown(rect, zoom1);
-					Rectangle scaleUp = Win32DPIUtils.scaleUp(scaleDown, zoom2);
-					scaleDown = Win32DPIUtils.scaleDown(scaleUp, zoom2);
-					scaleUp = Win32DPIUtils.scaleUp(scaleDown, zoom1);
+					Rectangle scaleDown = Win32DPIUtils.pixelToPoint(rect, zoom1);
+					Rectangle scaleUp = Win32DPIUtils.pointToPixel(scaleDown, zoom2);
+					scaleDown = Win32DPIUtils.pixelToPoint(scaleUp, zoom2);
+					scaleUp = Win32DPIUtils.pointToPixel(scaleDown, zoom1);
 					assertEquals(rect.width, scaleUp.width);
 					assertEquals(rect.height, scaleUp.height);
 				}
@@ -244,10 +244,10 @@ public class Win32DPIUtilTests {
 			for (int zoom2 : zooms) {
 				for (int i = 1; i <= 10000; i++) {
 					Point pt = new Point(i, i);
-					Point scaleDown = Win32DPIUtils.scaleDown(pt, zoom1);
-					Point scaleUp = Win32DPIUtils.scaleUp(scaleDown, zoom2);
-					scaleDown = Win32DPIUtils.scaleDown(scaleUp, zoom2);
-					scaleUp = Win32DPIUtils.scaleUp(scaleDown, zoom1);
+					Point scaleDown = Win32DPIUtils.pixelToPoint(pt, zoom1);
+					Point scaleUp = Win32DPIUtils.pointToPixel(scaleDown, zoom2);
+					scaleDown = Win32DPIUtils.pixelToPoint(scaleUp, zoom2);
+					scaleUp = Win32DPIUtils.pointToPixel(scaleDown, zoom1);
 					assertEquals(pt.x, scaleUp.x);
 					assertEquals(pt.y, scaleUp.y);
 				}

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/DPIUtilTests.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/DPIUtilTests.java
@@ -34,11 +34,11 @@ public class DPIUtilTests {
 		int valueAt200 = 10;
 		int valueAt150 = 7;
 		int valueAt100 = 5;
-		int scaledValue = DPIUtil.scaleDown(valueAt200, 200);
+		int scaledValue = DPIUtil.pixelToPoint(valueAt200, 200);
 		assertEquals(valueAt100, scaledValue, "Scaling down integer from 200 failed");
-		scaledValue = DPIUtil.scaleDown(valueAt150, 150);
+		scaledValue = DPIUtil.pixelToPoint(valueAt150, 150);
 		assertEquals(valueAt100, scaledValue, "Scaling down integer from 150 failed");
-		scaledValue = DPIUtil.scaleDown(valueAt100, 100);
+		scaledValue = DPIUtil.pixelToPoint(valueAt100, 100);
 		assertSame(valueAt100, scaledValue, "Scaling down integer without zoom change failed");
 	}
 
@@ -47,11 +47,11 @@ public class DPIUtilTests {
 		float valueAt200 = 10f;
 		float valueAt150 = 7.5f;
 		float valueAt100 = 5f;
-		float scaledValue = DPIUtil.scaleDown(valueAt200, 200);
+		float scaledValue = DPIUtil.pixelToPoint(valueAt200, 200);
 		assertEquals(valueAt100, scaledValue, .001f, "Scaling down float from 200 failed");
-		scaledValue = DPIUtil.scaleDown(valueAt150, 150);
+		scaledValue = DPIUtil.pixelToPoint(valueAt150, 150);
 		assertEquals(valueAt100, scaledValue, .001f, "Scaling down float from 150 failed");
-		scaledValue = DPIUtil.scaleDown(valueAt100, 100);
+		scaledValue = DPIUtil.pixelToPoint(valueAt100, 100);
 		assertEquals(valueAt100, scaledValue, .001f, "Scaling down float without zoom change failed");
 	}
 


### PR DESCRIPTION
Renaming scaleDown and ScaleUp methods to pixelToPoint and pointToPixel respectively. The implementation detail (using a scale factor in body) doesn't clearly convey the intent of the method from its name. When someone (me) reads scaleDown(x) or scaleUp(x), the natural question is:

**“Scaling relative to what? What coordinate system or unit is this about?”**

That’s ambiguous without diving into the implementation.
In contrast, renaming to pixelToPoint(x) and pointToPixel(x) makes it immediately clear. We’re converting between pixel units (physical/screen space) and point units (logical/UI space). The direction of conversion is unambiguous.

The changes are done with **Eclipse Refactoring tool**. There are no manual changes.

