### PR TITLE
Migrate SWT Win32 tests to JUnit 5

### DIFF
--- a/tests/org.eclipse.swt.tests.win32/JUnit Tests/org/eclipse/swt/graphics/ImageWin32Tests.java
+++ b/tests/org.eclipse.swt.tests.win32/JUnit Tests/org/eclipse/swt/graphics/ImageWin32Tests.java
@@ -14,13 +14,13 @@
 package org.eclipse.swt.graphics;
 
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 import org.eclipse.swt.internal.DPIUtil;
 import org.eclipse.swt.widgets.Display;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Automated Tests for class org.eclipse.swt.graphics.Image
@@ -32,7 +32,7 @@ import org.junit.Test;
 public class ImageWin32Tests {
 	private Display display;
 
-	@Before
+	@BeforeEach
 	public void setUp() {
 		display = Display.getDefault();
 	}
@@ -45,10 +45,10 @@ public class ImageWin32Tests {
 		int zoom2 = 150;
 		ImageData imageDataAtZoom1 = image.getImageData(zoom1);
 		ImageData imageDataAtZoom2 = image.getImageData(zoom2);
-		assertNotEquals("ImageData::height should not be the same for imageData at different zoom levels",
-				imageDataAtZoom1.height, imageDataAtZoom2.height);
-		assertNotEquals("ImageData::width should not be the same for imageData at different zoom levels",
-				imageDataAtZoom1.width, imageDataAtZoom2.width);
+		assertNotEquals(imageDataAtZoom1.height, imageDataAtZoom2.height,
+				"ImageData::height should not be the same for imageData at different zoom levels");
+		assertNotEquals(imageDataAtZoom1.width, imageDataAtZoom2.width,
+				"ImageData::width should not be the same for imageData at different zoom levels");
 	}
 
 	@Test
@@ -59,11 +59,12 @@ public class ImageWin32Tests {
 		Image image = new Image(display, noOpGcDrawer, 10, 10);
 		try {
 			ImageData baseImageData = image.getImageData(zoom);
-			assertEquals("Width should equal the initial width on the same zoom", 10, baseImageData.width);
+			assertEquals(10, baseImageData.width, "Width should equal the initial width on the same zoom");
 			ImageData scaledImageData = image.getImageData(zoom * scalingFactor);
-			assertEquals("Width should be doubled on doubled zoom", 10*2, scaledImageData.width);
+			assertEquals(10*2, scaledImageData.width, "Width should be doubled on doubled zoom");
 		} finally {
 			image.dispose();
 		}
-}
+	}
+
 }

--- a/tests/org.eclipse.swt.tests.win32/JUnit Tests/org/eclipse/swt/tests/win32/AllWin32Tests.java
+++ b/tests/org.eclipse.swt.tests.win32/JUnit Tests/org/eclipse/swt/tests/win32/AllWin32Tests.java
@@ -17,24 +17,16 @@ package org.eclipse.swt.tests.win32;
 import org.eclipse.swt.graphics.ImageWin32Tests;
 import org.eclipse.swt.tests.win32.widgets.TestTreeColumn;
 import org.eclipse.swt.tests.win32.widgets.Test_org_eclipse_swt_widgets_Display;
-import org.junit.runner.JUnitCore;
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
 
-@RunWith(Suite.class)
-@Suite.SuiteClasses({
-	ImageWin32Tests.class,
-	Test_org_eclipse_swt_dnd_DND.class,
-	Test_org_eclipse_swt_events_KeyEvent.class,
-	Test_org_eclipse_swt_widgets_Display.class,
-	TestTreeColumn.class,
-	Win32DPIUtilTests.class
-})
-
+@Suite
+@SelectClasses({ ImageWin32Tests.class, //
+		Test_org_eclipse_swt_dnd_DND.class, //
+		Test_org_eclipse_swt_events_KeyEvent.class, //
+		Test_org_eclipse_swt_widgets_Display.class, //
+		TestTreeColumn.class, //
+		Win32DPIUtilTests.class })
 public class AllWin32Tests {
-
-	public static void main(String[] args) {
-		JUnitCore.main(AllWin32Tests.class.getName());
-	}
 
 }

--- a/tests/org.eclipse.swt.tests.win32/JUnit Tests/org/eclipse/swt/tests/win32/KeyboardLayoutTest.java
+++ b/tests/org.eclipse.swt.tests.win32/JUnit Tests/org/eclipse/swt/tests/win32/KeyboardLayoutTest.java
@@ -13,7 +13,7 @@
  *******************************************************************************/
 package org.eclipse.swt.tests.win32;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.ArrayList;
 
@@ -25,10 +25,9 @@ import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Listener;
 import org.eclipse.swt.widgets.Shell;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.rules.TestName;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestInfo;
 
 /**
  * Supporting code for testing keyboard layouts
@@ -46,8 +45,7 @@ public class KeyboardLayoutTest {
 	boolean collectKeyErrors;
 	ArrayList<AssertionError> keyErrors;
 
-	@Rule
-	public TestName testName = new TestName();
+	private String testName;
 
 	// Hardware scan codes, with names according to English US layout
 	protected enum UsScan {
@@ -222,8 +220,9 @@ public class KeyboardLayoutTest {
 		A___,
 	};
 
-	@Before
-	public void setUp() {
+	@BeforeEach
+	public void setUp(TestInfo testInfo) {
+		this.testName = testInfo.getDisplayName();
 		display = new Display();
 		shell = new Shell();
 
@@ -253,7 +252,7 @@ public class KeyboardLayoutTest {
 		shell.forceFocus();
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() {
 		if (shell != null) {
 			shell.dispose();
@@ -496,7 +495,7 @@ public class KeyboardLayoutTest {
 			if (keyErrors == null)
 				keyErrors = new ArrayList<>();
 
-			System.out.println(testName.getMethodName() + " : " + error.getMessage());
+			System.out.println(testName + " : " + error.getMessage());
 			keyErrors.add(error);
 		}
 	}

--- a/tests/org.eclipse.swt.tests.win32/JUnit Tests/org/eclipse/swt/tests/win32/Test_org_eclipse_swt_dnd_DND.java
+++ b/tests/org.eclipse.swt.tests.win32/JUnit Tests/org/eclipse/swt/tests/win32/Test_org_eclipse_swt_dnd_DND.java
@@ -13,11 +13,11 @@
  *******************************************************************************/
 package org.eclipse.swt.tests.win32;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -45,9 +45,9 @@ import org.eclipse.swt.layout.RowLayout;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Shell;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Some simple tests for drag and drop.
@@ -64,7 +64,7 @@ public class Test_org_eclipse_swt_dnd_DND {
 
 private Shell shell;
 
-@Before
+@BeforeEach
 public void setUp() {
 	shell = new Shell();
 	shell.setLayout(new RowLayout());
@@ -75,10 +75,10 @@ public void setUp() {
 	} catch (InterruptedException e) {
 		fail("Initialization interrupted");
 	}
-	assertTrue("Shell not visible.", shell.isVisible());
+	assertTrue(shell.isVisible(), "Shell not visible.");
 }
 
-@After
+@AfterEach
 public void tearDown() {
 	Display display = shell.getDisplay();
 	display.dispose();
@@ -108,7 +108,7 @@ public void testByteArrayTransfer() throws InterruptedException {
 			return new int[] { TEST_ID };
 		}
 	}, drag);
-	assertArrayEquals("Drop received other data as we dragged.", drag, drop);
+	assertArrayEquals(drag, drop, "Drop received other data as we dragged.");
 }
 
 /**
@@ -120,7 +120,7 @@ public void testFileTransfer() throws InterruptedException {
 	final String[] drop;
 
 	drop = testTransferRoundtrip(FileTransfer.getInstance(), drag);
-	assertArrayEquals("Drop received other data as we dragged.", drag, drop);
+	assertArrayEquals(drag, drop, "Drop received other data as we dragged.");
 }
 
 /**
@@ -132,7 +132,7 @@ public void testHtmlTransfer() throws InterruptedException {
 	final String drop;
 
 	drop = testTransferRoundtrip(HTMLTransfer.getInstance(), drag);
-	assertEquals("Drop received other data as we dragged.", drag, drop);
+	assertEquals(drag, drop, "Drop received other data as we dragged.");
 }
 
 /**
@@ -208,7 +208,7 @@ public void testRtfTransfer() throws InterruptedException {
 	final String drop;
 
 	drop = testTransferRoundtrip(RTFTransfer.getInstance(), drag);
-	assertEquals("Drop received other data as we dragged.", drag, drop);
+	assertEquals(drag, drop, "Drop received other data as we dragged.");
 }
 
 /**
@@ -220,7 +220,7 @@ public void testTextTransfer() throws InterruptedException {
 	final String drop;
 
 	drop = testTransferRoundtrip(TextTransfer.getInstance(), drag);
-	assertEquals("Drop received other data as we dragged.", drag, drop);
+	assertEquals(drag, drop, "Drop received other data as we dragged.");
 }
 
 /**
@@ -232,7 +232,7 @@ public void testUrlTransfer() throws InterruptedException {
 	final String drop;
 
 	drop = testTransferRoundtrip(URLTransfer.getInstance(), drag);
-	assertEquals("Drop received other data as we dragged.", drag, drop);
+	assertEquals(drag, drop, "Drop received other data as we dragged.");
 }
 
 /**
@@ -267,17 +267,17 @@ private Image createTestImage() {
  */
 // This method is necessary because ImageData has no custom equals method and the default one isn't sufficient.
 private void assertImageDataEqualsIgoringAlphaInData(final ImageData expected, final ImageData actual) {
-	assertNotNull("expected data must not be null", expected);
-	assertNotNull("actual data must not be null", actual);
+	assertNotNull(expected, "expected data must not be null");
+	assertNotNull(actual, "actual data must not be null");
 	if (expected == actual) {
 		return;
 	}
-	assertEquals("height of expected image is different from actual image", expected.height, actual.height);
+	assertEquals(expected.height, actual.height, "height of expected image is different from actual image");
 	// Alpha values are taken from alpha data, so ignore whether data depth is 24 or 32 bits
 	int expectedNormalizedDepth = expected.depth == 32 ? 24 : expected.depth;
 	int actualNormalizedDepth = expected.depth == 32 ? 24 : expected.depth;
-	assertEquals("depth of image data to compare must be equal", expectedNormalizedDepth, actualNormalizedDepth);
-	assertEquals("width of expected image is different from actual image", expected.width, actual.width);
+	assertEquals(expectedNormalizedDepth, actualNormalizedDepth, "depth of image data to compare must be equal");
+	assertEquals(expected.width, actual.width, "width of expected image is different from actual image");
 
 	for (int y = 0; y < expected.height; y++) {
 		for (int x = 0; x < expected.width; x++) {
@@ -285,10 +285,10 @@ private void assertImageDataEqualsIgoringAlphaInData(final ImageData expected, f
 			// => alpha stored in ImageData.alphaData
 			String expectedPixel = String.format("0x%08X", expected.getPixel(x, y) >> (expected.depth == 32 ? 8 : 0));
 			String actualPixel = String.format("0x%08X", actual.getPixel(x, y) >> (actual.depth == 32 ? 8 : 0));
-			assertEquals("actual pixel at x=" + x + " y=" + y + " is different from expected pixel", expectedPixel, actualPixel);
+			assertEquals(expectedPixel, actualPixel, "actual pixel at x=" + x + " y=" + y + " is different from expected pixel");
 			int expectedAlpha = expected.getAlpha(x, y);
 			int actualAlpha = actual.getAlpha(x, y);
-			assertEquals("actual pixel alpha at x=" + x + " y=" + y + " is different from expected pixel", expectedAlpha, actualAlpha);
+			assertEquals(expectedAlpha, actualAlpha, "actual pixel alpha at x=" + x + " y=" + y + " is different from expected pixel");
 		}
 	}
 }
@@ -327,8 +327,8 @@ private <T> T testTransferRoundtrip(Transfer transfer, T data) throws Interrupte
 		SwtWin32TestUtil.processEvents(shell.getDisplay(), 2000, dropped::get);
 	} while(!dropped.get() && --maxTries > 0);
 
-	assertTrue("No drop received.", dropped.get());
-	assertNotNull("No data was dropped.", droppedData.get());
+	assertTrue(dropped.get(), "No drop received.");
+	assertNotNull(droppedData.get(), "No data was dropped.");
 
 	return droppedData.get();
 }
@@ -341,7 +341,7 @@ private <T> T testTransferRoundtrip(Transfer transfer, T data) throws Interrupte
  */
 private void postDragAndDropEvents() {
 	shell.forceActive();
-	assertTrue("Test shell requires input focus.", shell.forceFocus());
+	assertTrue(shell.forceFocus(), "Test shell requires input focus.");
 	Event event = new Event();
 	Point pt = shell.toDisplay(50, 50);
 	event.x = pt.x;

--- a/tests/org.eclipse.swt.tests.win32/JUnit Tests/org/eclipse/swt/tests/win32/Test_org_eclipse_swt_events_KeyEvent.java
+++ b/tests/org.eclipse.swt.tests.win32/JUnit Tests/org/eclipse/swt/tests/win32/Test_org_eclipse_swt_events_KeyEvent.java
@@ -16,8 +16,8 @@ package org.eclipse.swt.tests.win32;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.internal.win32.OS;
 import org.eclipse.swt.widgets.Event;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 /**
  * Automated Test Suite for class org.eclipse.swt.events.KeyEvent
@@ -166,7 +166,7 @@ public class Test_org_eclipse_swt_events_KeyEvent extends KeyboardLayoutTest {
 	/**
 	 * Extensive test for English US layout
 	 */
-	@Test
+	@org.junit.jupiter.api.Test
 	public void testEnglishUs_stdKeys() {
 		// This table intentionally provides "naive" expected values. Actual
 		// expected values have some discrepancies from that, see code below.
@@ -921,7 +921,7 @@ public class Test_org_eclipse_swt_events_KeyEvent extends KeyboardLayoutTest {
 	 * release that isn't paired with key press (due to RegisterHotKey()
 	 * or hook or pressing in other app and releasing in SWT).
 	 */
-	@Ignore("Have been broken for ages, maybe not worth fixing")
+	@Disabled("Have been broken for ages, maybe not worth fixing")
 	@Test
 	public void testEnglishUs_unpairedKeyUp() {
 		runWithLayout(LAYOUT_ENGLISH_US, () -> {
@@ -959,7 +959,7 @@ public class Test_org_eclipse_swt_events_KeyEvent extends KeyboardLayoutTest {
 	 * released first. Specifically, it didn't produce SWT.KeyUp for 'C' at all,
 	 * and also produced SWT.KeyUp for 'Ctrl' with incorrect 'character = 0x03'.
 	 */
-	@Ignore("Have been broken for ages, maybe not worth fixing")
+	@Disabled("Have been broken for ages, maybe not worth fixing")
 	@Test
 	public void testEnglishUs_unorderedCtrlC() {
 		runWithLayout(LAYOUT_ENGLISH_US, () -> {
@@ -981,7 +981,7 @@ public class Test_org_eclipse_swt_events_KeyEvent extends KeyboardLayoutTest {
 	 * Not yet fixed: SWT doesn't report second SWT.KeyUp when two letters
 	 * were pressed and released out of order
 	 */
-	@Ignore("Have been broken for ages, maybe not worth fixing")
+	@Disabled("Have been broken for ages, maybe not worth fixing")
 	@Test
 	public void testEnglishUs_multipleLetters() {
 		runWithLayout(LAYOUT_ENGLISH_US, () -> {

--- a/tests/org.eclipse.swt.tests.win32/JUnit Tests/org/eclipse/swt/tests/win32/Win32DPIUtilTests.java
+++ b/tests/org.eclipse.swt.tests.win32/JUnit Tests/org/eclipse/swt/tests/win32/Win32DPIUtilTests.java
@@ -22,7 +22,8 @@ import org.eclipse.swt.graphics.Device;
 import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.graphics.Rectangle;
 import org.eclipse.swt.internal.Win32DPIUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
 /**
  * Automated Test Suite for class org.eclipse.swt.internal.Win32DPIUtils
  *

--- a/tests/org.eclipse.swt.tests.win32/JUnit Tests/org/eclipse/swt/tests/win32/widgets/TestTreeColumn.java
+++ b/tests/org.eclipse.swt.tests.win32/JUnit Tests/org/eclipse/swt/tests/win32/widgets/TestTreeColumn.java
@@ -13,7 +13,7 @@
  *******************************************************************************/
 package org.eclipse.swt.tests.win32.widgets;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -24,7 +24,7 @@ import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.Tree;
 import org.eclipse.swt.widgets.TreeColumn;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestTreeColumn {
 

--- a/tests/org.eclipse.swt.tests.win32/JUnit Tests/org/eclipse/swt/tests/win32/widgets/Test_org_eclipse_swt_widgets_Display.java
+++ b/tests/org.eclipse.swt.tests.win32/JUnit Tests/org/eclipse/swt/tests/win32/widgets/Test_org_eclipse_swt_widgets_Display.java
@@ -13,7 +13,7 @@
  *******************************************************************************/
 package org.eclipse.swt.tests.win32.widgets;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -22,22 +22,22 @@ import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.Text;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class Test_org_eclipse_swt_widgets_Display {
 
 	private Display display;
 	private Shell shell;
 
-	@Before
+	@BeforeEach
 	public void setup() {
 		display = new Display();
 		shell = new Shell(display);
 	}
 
-	@After
+	@AfterEach
 	public void teardown() {
 		shell.dispose();
 		display.dispose();

--- a/tests/org.eclipse.swt.tests.win32/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.swt.tests.win32/META-INF/MANIFEST.MF
@@ -4,9 +4,9 @@ Bundle-Name: Eclipse SWT Tests Windows/win32
 Bundle-SymbolicName: org.eclipse.swt.tests.win32
 Bundle-Version: 3.108.200.qualifier
 Bundle-Vendor: Eclipse.org
-Require-Bundle: org.junit;bundle-version="4.12.0",
- org.eclipse.swt
+Require-Bundle: org.eclipse.swt
 Eclipse-BundleShape: dir
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Automatic-Module-Name: org.eclipse.swt.tests.win32
-Import-Package: org.junit.jupiter.api;version="[5.13.0,6.0.0)"
+Import-Package: org.junit.jupiter.api;version="[5.13.0,6.0.0)",
+ org.junit.platform.suite.api;version="[1.13.0,2.0.0)"

--- a/tests/org.eclipse.swt.tests.win32/ManualTests/org/eclipse/swt/tests/win32/snippets/Bug512629_test_fullscreen_before_open.java
+++ b/tests/org.eclipse.swt.tests.win32/ManualTests/org/eclipse/swt/tests/win32/snippets/Bug512629_test_fullscreen_before_open.java
@@ -13,8 +13,8 @@
  *******************************************************************************/
 package org.eclipse.swt.tests.win32.snippets;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.function.Function;
 
@@ -23,9 +23,9 @@ import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.graphics.Rectangle;
 import org.eclipse.swt.layout.FillLayout;
 import org.eclipse.swt.widgets.Shell;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Manual test to check a bunch of uncommon combinations of shell open/hide and
@@ -37,12 +37,12 @@ public class Bug512629_test_fullscreen_before_open {
 	Shell shell;
 	Shell testShell;
 
-	@Before
+	@BeforeEach
 	public void setUp() {
 		shell = new Shell();
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() {
 		shell.getDisplay().dispose();
 	}
@@ -116,12 +116,12 @@ public class Bug512629_test_fullscreen_before_open {
 			for (int shellStyle : new int[] { SWT.SHELL_TRIM, SWT.DIALOG_TRIM, SWT.NO_TRIM, SWT.BORDER }) {
 				createShell(shellStyle);
 				setFullscreenAndOpen.run();
-				assertTrue("Not fullscreen.", looksLikeFullscreen.apply(testShell));
-				assertFalse("Not fullscreen.", hasTrimming.apply(testShell));
+				assertTrue(looksLikeFullscreen.apply(testShell), "Not fullscreen.");
+				assertFalse(hasTrimming.apply(testShell), "Not fullscreen.");
 				assertTrue(testShell.getFullScreen());
 				assertFalse(testShell.getMaximized());
 				testShell.setFullScreen(false);
-				assertTrue("Window not restored.", looksLikeNormalWindow.apply(testShell));
+				assertTrue(looksLikeNormalWindow.apply(testShell), "Window not restored.");
 				assertTrue(hasTrimming.apply(testShell) == ((shellStyle & SWT.TITLE) != 0));
 				assertFalse(testShell.getFullScreen());
 				assertFalse(testShell.getMaximized());
@@ -130,12 +130,12 @@ public class Bug512629_test_fullscreen_before_open {
 				testShell.setMaximized(true);
 				assertTrue(testShell.getMaximized());
 				setFullscreenAndOpen.run();
-				assertTrue("Not fullscreen.", looksLikeFullscreen.apply(testShell));
-				assertFalse("Not fullscreen.", hasTrimming.apply(testShell));
+				assertTrue(looksLikeFullscreen.apply(testShell), "Not fullscreen.");
+				assertFalse(hasTrimming.apply(testShell), "Not fullscreen.");
 				assertTrue(testShell.getFullScreen());
 				assertFalse(testShell.getMaximized());
 				testShell.setFullScreen(false);
-				assertTrue("Not maximized.", looksLikeMaximizedWindow.apply(testShell));
+				assertTrue(looksLikeMaximizedWindow.apply(testShell), "Not maximized.");
 				assertTrue(hasTrimming.apply(testShell) == ((shellStyle & SWT.TITLE) != 0));
 				assertFalse(testShell.getFullScreen());
 				assertTrue(testShell.getMaximized());
@@ -145,8 +145,8 @@ public class Bug512629_test_fullscreen_before_open {
 		createShell(SWT.SHELL_TRIM);
 		testShell.setFullScreen(false);
 		testShell.open();
-		assertTrue("Window not restored.", looksLikeNormalWindow.apply(testShell));
-		assertTrue("Lost trimming.", hasTrimming.apply(testShell));
+		assertTrue(looksLikeNormalWindow.apply(testShell), "Window not restored.");
+		assertTrue(hasTrimming.apply(testShell), "Lost trimming.");
 		assertFalse(testShell.getFullScreen());
 		assertFalse(testShell.getMaximized());
 	}

--- a/tests/org.eclipse.swt.tests.win32/ManualTests/org/eclipse/swt/tests/win32/snippets/Bug567422_DNDCrash.java
+++ b/tests/org.eclipse.swt.tests.win32/ManualTests/org/eclipse/swt/tests/win32/snippets/Bug567422_DNDCrash.java
@@ -13,9 +13,9 @@
  *******************************************************************************/
 package org.eclipse.swt.tests.win32.snippets;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -37,9 +37,9 @@ import org.eclipse.swt.tests.win32.SwtWin32TestUtil;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Shell;
-import org.junit.FixMethodOrder;
-import org.junit.Test;
-import org.junit.runners.MethodSorters;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
 
 /**
  * This one is primary a manual test because it is platform dependent, kind of
@@ -47,7 +47,7 @@ import org.junit.runners.MethodSorters;
  * grabs the mouse while testing. Apart from that the test runs automatically.
  * Just start and see if the JVM crashes.
  */
-@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+@TestMethodOrder(MethodOrderer.MethodName.class)
 @SuppressWarnings("restriction")
 public class Bug567422_DNDCrash {
 
@@ -114,7 +114,7 @@ public class Bug567422_DNDCrash {
 			} catch (InterruptedException e) {
 				fail("Initialization interrupted");
 			}
-			assertTrue("Shell not visible.", shell.isVisible());
+			assertTrue(shell.isVisible(), "Shell not visible.");
 
 			Transfer transfer = TextTransfer.getInstance();
 			AtomicBoolean dropped = new AtomicBoolean(false);
@@ -182,8 +182,8 @@ public class Bug567422_DNDCrash {
 					postDragAndDropEvents(shell);
 					SwtWin32TestUtil.processEvents(shell.getDisplay(), 1000, dropped::get);
 				} while (!dropped.get() && --dragDropTries > 0);
-				assertTrue("No drop received.", dropped.get());
-				assertNotNull("No data was dropped.", droppedData.get());
+				assertTrue(dropped.get(), "No drop received.");
+				assertNotNull(droppedData.get(), "No data was dropped.");
 
 				if (mode == TestMode.UNCOMMON && (i % testBatchSize) == 0) {
 					for (IDataObject dataObject : dataObjects) {
@@ -214,7 +214,7 @@ public class Bug567422_DNDCrash {
 	 */
 	private static void postDragAndDropEvents(Shell shell) {
 		shell.forceActive();
-		assertTrue("Test shell requires input focus.", shell.forceFocus());
+		assertTrue(shell.forceFocus(), "Test shell requires input focus.");
 		Event event = new Event();
 		Point pt = shell.toDisplay(50, 50);
 		event.x = pt.x;


### PR DESCRIPTION
This migrates the Win32 tests for SWT to JUnit5, including the usage of JUnit 5 test annotations, assertions and test suite.