### PR TITLE
[Win32] Avoid disposed image usage in GC operations

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Image.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Image.java
@@ -139,6 +139,8 @@ public final class Image extends Resource implements Drawable {
 
 	private Map<Integer, ImageHandle> zoomLevelToImageHandle = new HashMap<>();
 
+	private List<Consumer<Image>> onDisposeListeners;
+
 private Image (Device device, int type, long handle, int nativeZoom) {
 	super(device);
 	this.type = type;
@@ -995,6 +997,21 @@ long [] createGdipImage(Integer zoom) {
 		default: SWT.error(SWT.ERROR_INVALID_IMAGE);
 	}
 	return null;
+}
+
+void addOnDisposeListener(Consumer<Image> onDisposeListener) {
+	if (onDisposeListeners == null) {
+		onDisposeListeners = new ArrayList<>();
+	}
+	onDisposeListeners.add(onDisposeListener);
+}
+
+@Override
+public void dispose() {
+	if (onDisposeListeners != null) {
+		onDisposeListeners.forEach(listener -> listener.accept(this));
+	}
+	super.dispose();
 }
 
 @Override

--- a/tests/org.eclipse.swt.tests.win32/JUnit Tests/org/eclipse/swt/graphics/ImageWin32Tests.java
+++ b/tests/org.eclipse.swt.tests.win32/JUnit Tests/org/eclipse/swt/graphics/ImageWin32Tests.java
@@ -17,10 +17,13 @@ package org.eclipse.swt.graphics;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
+import org.eclipse.swt.SWT;
 import org.eclipse.swt.internal.DPIUtil;
 import org.eclipse.swt.widgets.Display;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 /**
  * Automated Tests for class org.eclipse.swt.graphics.Image
@@ -64,6 +67,110 @@ public class ImageWin32Tests {
 			assertEquals(10*2, scaledImageData.width, "Width should be doubled on doubled zoom");
 		} finally {
 			image.dispose();
+		}
+	}
+
+	@ParameterizedTest
+	@ValueSource(booleans = { true, false } )
+	public void testRetrieveImageDataAtDifferentZooms(boolean concurrentlyDisposeDrawnImage) {
+		Color imageColor = display.getSystemColor(SWT.COLOR_RED);
+		Image image = new Image (display, 1, 1);
+		GC gc = new GC(image);
+
+		try {
+			Image temporaryImage = createImageOfSizeOne(imageColor);
+			gc.drawImage(temporaryImage, 0,  0);
+
+			if (concurrentlyDisposeDrawnImage) {
+				temporaryImage.dispose();
+			}
+			ImageData resultImageDataAtDifferentZoom = image.getImageData(200);
+
+			assertEquals(imageColor.getRGB(), getRGBAtPixel(resultImageDataAtDifferentZoom, 0, 0));
+
+			if (!concurrentlyDisposeDrawnImage) {
+				temporaryImage.dispose();
+			}
+		} finally {
+			gc.dispose();
+			image.dispose();
+		}
+	}
+
+	private Image createImageOfSizeOne(Color imageColor) {
+		Image imageToDraw = new Image (display, 1, 1);
+		GC imageToDrawGc = new GC(imageToDraw);
+		imageToDrawGc.setBackground(imageColor);
+		imageToDrawGc.fillRectangle(0, 0, 1, 1);
+		imageToDrawGc.dispose();
+		return imageToDraw;
+	}
+
+	private RGB getRGBAtPixel(ImageData resultImageDataAtDifferentZoom, int x, int y) {
+		return resultImageDataAtDifferentZoom.palette.getRGB(resultImageDataAtDifferentZoom.getPixel(x, y));
+	}
+
+	@ParameterizedTest
+	@ValueSource(booleans = { true, false } )
+	public void testDrawImageAtDifferentZooms(boolean concurrentlyDisposeDrawnImage) {
+		Color imageColor = display.getSystemColor(SWT.COLOR_RED);
+		Image image = new Image (display, 1, 1);
+		GC gc = new GC(image);
+		Image temporaryImage = createImageOfSizeOne(imageColor);
+		try {
+			gc.drawImage(temporaryImage, 0,  0);
+		} finally {
+			if (concurrentlyDisposeDrawnImage) {
+				temporaryImage.dispose();
+			}
+		}
+
+		Image targetCanvas = new Image(display, 5, 5);
+		GC targetCanvasGc = new GC(targetCanvas);
+		try {
+			targetCanvasGc.getGCData().nativeZoom = 200;
+			targetCanvasGc.drawImage(image, 0, 0);
+			targetCanvasGc.getGCData().nativeZoom = 100;
+			targetCanvasGc.drawImage(image, 3, 0);
+			ImageData resultImageData = targetCanvas.getImageData(100);
+
+			assertEquals(imageColor.getRGB(), getRGBAtPixel(resultImageData, 0, 0));
+			assertEquals(imageColor.getRGB(), getRGBAtPixel(resultImageData, 1, 0));
+			assertNotEquals(imageColor.getRGB(), getRGBAtPixel(resultImageData, 2, 0));
+			assertEquals(imageColor.getRGB(), getRGBAtPixel(resultImageData, 3, 0));
+			assertNotEquals(imageColor.getRGB(), getRGBAtPixel(resultImageData, 4, 0));
+		} finally {
+			if (!concurrentlyDisposeDrawnImage) {
+				temporaryImage.dispose();
+			}
+			image.dispose();
+			targetCanvasGc.dispose();
+			gc.dispose();
+		}
+	}
+
+	@Test
+	public void testDisposeDrawnImageBeforeRequestingTargetForOtherZoom() {
+		Color imageColor = display.getSystemColor(SWT.COLOR_RED);
+		Image imageToDraw = new Image (display, 1, 1);
+		GC imageToDrawGc = new GC(imageToDraw);
+		imageToDrawGc.setBackground(imageColor);
+		imageToDrawGc.fillRectangle(0, 0, 1, 1);
+
+		Image targetCanvas = new Image(display, 5, 5);
+		GC targetCanvasGc = new GC(targetCanvas);
+		try {
+			targetCanvasGc.drawImage(imageToDraw, 0, 0);
+			imageToDrawGc.dispose();
+			imageToDraw.dispose();
+			ImageData resultImageData = targetCanvas.getImageData(200);
+
+			assertEquals(imageColor.getRGB(), getRGBAtPixel(resultImageData, 0, 0));
+			assertEquals(imageColor.getRGB(), getRGBAtPixel(resultImageData, 1, 0));
+			assertNotEquals(imageColor.getRGB(), getRGBAtPixel(resultImageData, 2, 0));
+		} finally {
+			targetCanvasGc.dispose();
+			targetCanvas.dispose();
 		}
 	}
 

--- a/tests/org.eclipse.swt.tests.win32/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.swt.tests.win32/META-INF/MANIFEST.MF
@@ -9,4 +9,6 @@ Eclipse-BundleShape: dir
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Automatic-Module-Name: org.eclipse.swt.tests.win32
 Import-Package: org.junit.jupiter.api;version="[5.13.0,6.0.0)",
+ org.junit.jupiter.params;version="[5.13.0,6.0.0)",
+ org.junit.jupiter.params.provider;version="[5.13.0,6.0.0)",
  org.junit.platform.suite.api;version="[1.13.0,2.0.0)"


### PR DESCRIPTION
When an image is drawn on a GC, that image may be disposed right afterwards. Since the GC can live much longer and a handle for that GC at a different zoom may be requested later on, such that the operations in the GC are re-applied, the stored image may be disposed by then. This can currently lead to errors because of access to disposed resources.

To avoid that, this change ensures that in case a drawn image becomes disposed, a copy of it is created and stored for the lifetime of the GC.

⚠️ This depends on the GC operation disposal logic of and thus contains those changes and needs to be merged after https://github.com/eclipse-platform/eclipse.platform.swt/pull/2328