### PR TITLE
Store Region in GC.SetClippingRegionOperation #62

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/GC.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/GC.java
@@ -4730,19 +4730,21 @@ private class SetBackgroundPatternOperation extends Operation {
 
 private void setClipping(long clipRgn) {
 	checkNonDisposed();
-	storeAndApplyOperationForExistingHandle(new SetClippingRegionOperation(clipRgn));
+	setClippingRegion(clipRgn);
 }
 
 private class SetClippingRegionOperation extends Operation {
-	private final long clipRgn;
+	private final Region clipRgn;
 
-	SetClippingRegionOperation(long clipRgn) {
-		this.clipRgn = clipRgn;
+	SetClippingRegionOperation(Region clipRgn) {
+		this.clipRgn = clipRgn != null ? clipRgn.copy() : null;
+		registerForDisposal(this.clipRgn);
 	}
 
 	@Override
 	void apply() {
-		setClippingRegion(clipRgn);
+		// Reset clipping if clipRgn is null.
+		setClippingRegion(clipRgn != null ? Region.win32_getHandle(clipRgn, getZoom()) : 0);
 	}
 }
 
@@ -4880,7 +4882,7 @@ private class SetClippingPathOperation extends Operation {
 public void setClipping (Rectangle rect) {
 	checkNonDisposed();
 	if (rect == null) {
-		setClipping(0);
+		storeAndApplyOperationForExistingHandle(new SetClippingRegionOperation(null));
 	} else {
 		storeAndApplyOperationForExistingHandle(new SetClippingOperation(rect));
 	}
@@ -4905,7 +4907,7 @@ public void setClipping (Rectangle rect) {
 public void setClipping (Region region) {
 	checkNonDisposed();
 	if (region != null && region.isDisposed()) SWT.error(SWT.ERROR_INVALID_ARGUMENT);
-	setClipping(region != null ? Region.win32_getHandle(region, getZoom()) : 0);
+	storeAndApplyOperationForExistingHandle(new SetClippingRegionOperation(region));
 }
 
 /**

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Region.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Region.java
@@ -644,6 +644,12 @@ private RegionHandle getRegionHandle(int zoom) {
 	return zoomToHandle.get(zoom);
 }
 
+Region copy() {
+	Region region = new Region();
+	region.operations.addAll(operations);
+	return region;
+}
+
 /**
  * <b>IMPORTANT:</b> This method is not part of the public
  * API for Image. It is marked public only so that it


### PR DESCRIPTION
This PR refactors GC.SetClippingRegionOperation to store Region and hence refactors GC:setClipping(Region) to call the Operation instead of GC:setClipping(long) for a better behaviour on a GC refresh. Additionally this PR also makes Region operations compatible with GC Operation Strategy by following:
1. Copy Resource on Operation Creation
2. Register the region object as a disposable

Contributes to
https://github.com/eclipse-platform/eclipse.platform.swt/issues/62 and https://github.com/eclipse-platform/eclipse.platform.swt/issues/128