### PR TITLE
Correct GC tests to properly execute at non-default device zoom

### DIFF
--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_GC.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_GC.java
@@ -638,13 +638,15 @@ public void test_setLineAttributes$I() {
 	float[] dashes = new float[] { 1.2f, 3.3f };
 	float dashOffset = 3.3f;
 	float miterLimit = 2.6f;
-	gc.setLineAttributes(new LineAttributes(width, cap, join, style, dashes, dashOffset, miterLimit));
+	LineAttributes passedLineAttributes = new LineAttributes(width, cap, join, style, dashes, dashOffset, miterLimit);
+	gc.setLineAttributes(passedLineAttributes);
 	assertEquals("unexpected line width", width, gc.getLineWidth());
 	assertEquals("unexpected line cap", cap, gc.getLineCap());
 	assertEquals("unexpected line join", join, gc.getLineJoin());
 	assertEquals("unexpected line style", style, gc.getLineStyle());
 	assertEquals("actual line attributes differ from the ones that have been set",
 			new LineAttributes(width, cap, join, style, dashes, dashOffset, miterLimit), gc.getLineAttributes());
+	assertEquals("setter call changed line width", width, passedLineAttributes.width, 0.0f);
 
 	gc.setLineAttributes(new LineAttributes(1));
 	assertEquals(new LineAttributes(1), gc.getLineAttributes());
@@ -853,7 +855,9 @@ RGB getRealRGB(Color color) {
 
 private void executeWithNonDefaultDeviceZoom(Runnable executable) {
 	int previousDeviceZoom = DPIUtil.getDeviceZoom();
-	DPIUtil.setDeviceZoom(150);
+	DPIUtil.setDeviceZoom(200);
+	gc.dispose();
+	gc = new GC(image);
 	try {
 		executable.run();
 	} finally {


### PR DESCRIPTION
Some GC tests are explicitly executed on a non-default device zoom. However, most of them use a GC as subject to test that is  created in a setup method that is thus using the original device zoom instead of the non-default one set by the test afterwards.

This change ensures that when executing a test with a non-default device zoom, the GC used as subject to test is recreated to rely on that modified device zoom.

Contributes to https://github.com/eclipse-platform/eclipse.platform.swt/issues/2334