### PR TITLE
[Edge] Improve dialog when WebView2 engine is not available #2035

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Browser/common/org/eclipse/swt/browser/Browser.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Browser/common/org/eclipse/swt/browser/Browser.java
@@ -56,6 +56,8 @@ public class Browser extends Composite {
 	static final String PACKAGE_PREFIX = "org.eclipse.swt.browser."; //$NON-NLS-1$
 	static final String PROPERTY_DEFAULTTYPE = "org.eclipse.swt.browser.DefaultType"; //$NON-NLS-1$
 
+	static final String WEBIEW_UNAVAILABLE_DISABLED = "org.eclipse.swt.browser.DisableWebViewUnavailableDialog"; //$NON-NLS-1$
+
 /**
  * Constructs a new instance of this class given its parent
  * and a style value describing its behavior and appearance.
@@ -144,7 +146,7 @@ private class WebViewUnavailableDialog {
 	private static final DialogOption CANCEL_OPTION = new DialogOption(SWT.CANCEL, "Cancel");
 
 	private static final String DIALOG_TITLE = "Default browser engine not available";
-	private static final String DIALOG_MESSAGE = "Microsoft Edge (WebView2) is not available. Do you want to use the legacy Internet Explorer?\n\nNote: It is necessary to reopen browsers for the change to take effect.";
+	private static final String DIALOG_MESSAGE = "Microsoft Edge (WebView2) is not available. Do you want to use the legacy Internet Explorer?\n\nNote: It is necessary to reopen browsers for the change to take effect and the effect will be lost at next application start. For information on how to permanently switch to Internet Explorer, press the \"Information\" button.";
 	private static final String FAQ_URL = "https://github.com/eclipse-platform/eclipse.platform/tree/master/docs/FAQ/FAQ_How_do_I_use_Edge-IE_as_the_Browser's_underlying_renderer.md";
 
 	private static final int DIALOG_OPTION_FLAGS = USE_IE_OPTION.index | MORE_INFORMATION_OPTION.index | CANCEL_OPTION.index;
@@ -156,7 +158,8 @@ private class WebViewUnavailableDialog {
 	private static boolean shownOnce;
 
 	static void showAsync(Shell parentShell) {
-		if (shownOnce) {
+		if (shownOnce || Boolean.getBoolean(WEBIEW_UNAVAILABLE_DISABLED)) {
+			shownOnce = true;
 			return;
 		}
 		shownOnce = true;


### PR DESCRIPTION
When a browser is opened and the WebView2 engine used as default is not available, a dialog pops up with additional information and the ability to switch back to the Internet Explorer for the current application session. By now, the dialog lacked the information that the switch to the Internet Explorer is not permanent. In addition, it was not possible to disable that dialog, e.g., for scenarios in which an application is executed in some automation and such a popup blocks automated processes.

This change adapts the dialog message to clarify that the switch to Internet Explorer will lose its effect on next application start and refers to the information link which gives more insights on how to permanently switch back to Internet Explorer. In addition, it adds a system property to disable that dialog.

Contributes to https://github.com/eclipse-platform/eclipse.platform.swt/issues/2035

This is how the dialog now looks like (ignore the large title bars, that's a Windows scaling issue not specific to Eclipse):
<img width="418" height="220" alt="image" src="https://github.com/user-attachments/assets/3c73919d-b459-4f22-b4b0-b38833fe24a2" />

@BeckerWdf since you were heavily involved in refining the original dialog, what do you think about the change?

@Bestsoft101 would the changed dialog text have been clearer to you to understand that the effect is temporary and how a permanent switch to IE is done?