### PR TITLE
[GTK] Support popup menu on Gtk 4

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Control.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Control.java
@@ -3421,8 +3421,8 @@ int gtk_gesture_press_event (long gesture, int n_press, double x, double y, long
 		if (!cancelled) {
 			result = GTK4.GTK_EVENT_SEQUENCE_CLAIMED;
 		}
-		if ((state & MENU) != 0) {
-			if (eventButton == 3) {
+		if (eventButton == 3) {
+			if ((state & MENU) != 0 || menu != null) {
 				if (showMenu ((int)x, (int)y)) {
 					result = GTK4.GTK_EVENT_SEQUENCE_CLAIMED;
 				}
@@ -3430,13 +3430,13 @@ int gtk_gesture_press_event (long gesture, int n_press, double x, double y, long
 		}
 	} else if (n_press >= 2) {
 		boolean cancelled = sendMouseEvent(SWT.MouseDoubleClick, eventButton, n_press, 0, false, eventTime, x, y, false, eventState);
-		
-		//Issue 344, DoubleClick event currently unsupported below sendMouseEvent(). Until DoubleClickSupport is 
+
+		//Issue 344, DoubleClick event currently unsupported below sendMouseEvent(). Until DoubleClickSupport is
 		//added this will catch failed events and try MouseDown instead.
 		if (cancelled) {
 			cancelled = sendMouseEvent(SWT.MouseDown, eventButton, n_press, 0, false, eventTime, x, y, false, eventState);
 		}
-		
+
 		if (!cancelled) {
 			result = GTK4.GTK_EVENT_SEQUENCE_CLAIMED;
 		}
@@ -4240,18 +4240,10 @@ long gtk_motion_notify_event (long widget, long event) {
 }
 
 @Override
-long gtk_popup_menu (long widget) {
+long gtk3_popup_menu (long widget) {
 	if (!hasFocus()) return 0;
 	int [] x = new int [1], y = new int [1];
-	if (GTK.GTK4) {
-		/*
-		 * TODO: calling gdk_window_get_device_position() with a 0
-		 * for the GdkWindow uses gdk_get_default_root_window(),
-		 * which doesn't exist on GTK4.
-		 */
-	} else {
-		display.getWindowPointerPosition (0, x, y, null);
-	}
+	display.getWindowPointerPosition (0, x, y, null);
 	return showMenu (x [0], y [0], SWT.MENU_KEYBOARD) ? 1 : 0;
 }
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Widget.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Widget.java
@@ -1061,7 +1061,7 @@ long gtk_populate_popup (long widget, long menu) {
 	return 0;
 }
 
-long gtk_popup_menu (long widget) {
+long gtk3_popup_menu (long widget) {
 	return 0;
 }
 
@@ -2592,7 +2592,7 @@ long windowProc (long handle, long user_data) {
 		case MAP: return gtk_map (handle);
 		case MONTH_CHANGED: return gtk_month_changed (handle);
 		case OUTPUT: return gtk_output (handle);
-		case POPUP_MENU: return gtk_popup_menu (handle);
+		case POPUP_MENU: return gtk3_popup_menu (handle);
 		case PREEDIT_CHANGED: return gtk_preedit_changed (handle);
 		case REALIZE: return gtk_realize (handle);
 		case START_INTERACTIVE_SEARCH: return gtk_start_interactive_search (handle);


### PR DESCRIPTION
Gtk 3 "popup-menu" signal no longer exists on Gtk 4 thus popup menu has to be handled by the generic "gesture-press".
Renamed the Gtk 3 handler to acknowledge the fact it doesn't belong to Gtk 4 port and removed wrong effort to port the popup-menu handler to Gtk 4.