### PR TITLE
Copy Region Handle in Region:copy win32 #2346

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Region.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Region.java
@@ -646,6 +646,10 @@ private RegionHandle getRegionHandle(int zoom) {
 
 Region copy() {
 	Region region = new Region();
+	this.zoomToHandle.forEach((zoom, regionHandle) -> {
+		long handleCopy = win32_getHandle(region, zoom);
+		OS.CombineRgn(handleCopy, regionHandle.handle, 0, OS.RGN_COPY);
+	});
 	region.operations.addAll(operations);
 	return region;
 }


### PR DESCRIPTION
This PR fixes the regression in #2346 caused by Region:copy. The copied region handle needs to be in the right state as of the original region handle since GC:getClipping(Region) can modify the original region's handle without storing region operations.

contributes to https://github.com/eclipse-platform/eclipse.platform.swt/issues/2346

**Note: This is a temporary fix and does not cover the effect for multi zoom scenarios for the case GC:getClipping(Region) is called. A proper follow up solution would be to implement operation strategy for the OS calls called in GC:getClipping(Region) for the region.**