### PR TITLE
Effectively remove replaced MonitorAwareRectangle/MonitorAwarePoint

### DIFF
--- a/binaries/org.eclipse.swt.cocoa.macosx.aarch64/.settings/.api_filters
+++ b/binaries/org.eclipse.swt.cocoa.macosx.aarch64/.settings/.api_filters
@@ -8,4 +8,20 @@
             </message_arguments>
         </filter>
     </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/graphics/MonitorAwarePoint.java" type="org.eclipse.swt.graphics.MonitorAwarePoint">
+        <filter id="305365105">
+            <message_arguments>
+                <message_argument value="org.eclipse.swt.graphics.MonitorAwarePoint"/>
+                <message_argument value="org.eclipse.swt.cocoa.macosx.aarch64_3.131.0"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/graphics/MonitorAwareRectangle.java" type="org.eclipse.swt.graphics.MonitorAwareRectangle">
+        <filter id="305365105">
+            <message_arguments>
+                <message_argument value="org.eclipse.swt.graphics.MonitorAwareRectangle"/>
+                <message_argument value="org.eclipse.swt.cocoa.macosx.aarch64_3.131.0"/>
+            </message_arguments>
+        </filter>
+    </resource>
 </component>

--- a/binaries/org.eclipse.swt.cocoa.macosx.x86_64/.settings/.api_filters
+++ b/binaries/org.eclipse.swt.cocoa.macosx.x86_64/.settings/.api_filters
@@ -8,4 +8,20 @@
             </message_arguments>
         </filter>
     </resource>
+     <resource path="Eclipse SWT/common/org/eclipse/swt/graphics/MonitorAwarePoint.java" type="org.eclipse.swt.graphics.MonitorAwarePoint">
+        <filter id="305365105">
+            <message_arguments>
+                <message_argument value="org.eclipse.swt.graphics.MonitorAwarePoint"/>
+                <message_argument value="org.eclipse.swt.cocoa.macosx.x86_64_3.131.0"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/graphics/MonitorAwareRectangle.java" type="org.eclipse.swt.graphics.MonitorAwareRectangle">
+        <filter id="305365105">
+            <message_arguments>
+                <message_argument value="org.eclipse.swt.graphics.MonitorAwareRectangle"/>
+                <message_argument value="org.eclipse.swt.cocoa.macosx.x86_64_3.131.0"/>
+            </message_arguments>
+        </filter>
+    </resource>
 </component>

--- a/binaries/org.eclipse.swt.gtk.linux.aarch64/.settings/.api_filters
+++ b/binaries/org.eclipse.swt.gtk.linux.aarch64/.settings/.api_filters
@@ -8,4 +8,20 @@
             </message_arguments>
         </filter>
     </resource>
+     <resource path="Eclipse SWT/common/org/eclipse/swt/graphics/MonitorAwarePoint.java" type="org.eclipse.swt.graphics.MonitorAwarePoint">
+        <filter id="305365105">
+            <message_arguments>
+                <message_argument value="org.eclipse.swt.graphics.MonitorAwarePoint"/>
+                <message_argument value="org.eclipse.swt.gtk.linux.aarch64_3.131.0"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/graphics/MonitorAwareRectangle.java" type="org.eclipse.swt.graphics.MonitorAwareRectangle">
+        <filter id="305365105">
+            <message_arguments>
+                <message_argument value="org.eclipse.swt.graphics.MonitorAwareRectangle"/>
+                <message_argument value="org.eclipse.swt.gtk.linux.aarch64_3.131.0"/>
+            </message_arguments>
+        </filter>
+    </resource>
 </component>

--- a/binaries/org.eclipse.swt.gtk.linux.loongarch64/.settings/.api_filters
+++ b/binaries/org.eclipse.swt.gtk.linux.loongarch64/.settings/.api_filters
@@ -8,4 +8,20 @@
             </message_arguments>
         </filter>
     </resource>
+     <resource path="Eclipse SWT/common/org/eclipse/swt/graphics/MonitorAwarePoint.java" type="org.eclipse.swt.graphics.MonitorAwarePoint">
+        <filter id="305365105">
+            <message_arguments>
+                <message_argument value="org.eclipse.swt.graphics.MonitorAwarePoint"/>
+                <message_argument value="org.eclipse.swt.gtk.linux.loongarch64_3.131.0"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/graphics/MonitorAwareRectangle.java" type="org.eclipse.swt.graphics.MonitorAwareRectangle">
+        <filter id="305365105">
+            <message_arguments>
+                <message_argument value="org.eclipse.swt.graphics.MonitorAwareRectangle"/>
+                <message_argument value="org.eclipse.swt.gtk.linux.loongarch64_3.131.0"/>
+            </message_arguments>
+        </filter>
+    </resource>
 </component>

--- a/binaries/org.eclipse.swt.gtk.linux.ppc64le/.settings/.api_filters
+++ b/binaries/org.eclipse.swt.gtk.linux.ppc64le/.settings/.api_filters
@@ -8,4 +8,20 @@
             </message_arguments>
         </filter>
     </resource>
+     <resource path="Eclipse SWT/common/org/eclipse/swt/graphics/MonitorAwarePoint.java" type="org.eclipse.swt.graphics.MonitorAwarePoint">
+        <filter id="305365105">
+            <message_arguments>
+                <message_argument value="org.eclipse.swt.graphics.MonitorAwarePoint"/>
+                <message_argument value="org.eclipse.swt.gtk.linux.ppc64le_3.131.0"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/graphics/MonitorAwareRectangle.java" type="org.eclipse.swt.graphics.MonitorAwareRectangle">
+        <filter id="305365105">
+            <message_arguments>
+                <message_argument value="org.eclipse.swt.graphics.MonitorAwareRectangle"/>
+                <message_argument value="org.eclipse.swt.gtk.linux.ppc64le_3.131.0"/>
+            </message_arguments>
+        </filter>
+    </resource>
 </component>

--- a/binaries/org.eclipse.swt.gtk.linux.riscv64/.settings/.api_filters
+++ b/binaries/org.eclipse.swt.gtk.linux.riscv64/.settings/.api_filters
@@ -8,4 +8,20 @@
             </message_arguments>
         </filter>
     </resource>
+     <resource path="Eclipse SWT/common/org/eclipse/swt/graphics/MonitorAwarePoint.java" type="org.eclipse.swt.graphics.MonitorAwarePoint">
+        <filter id="305365105">
+            <message_arguments>
+                <message_argument value="org.eclipse.swt.graphics.MonitorAwarePoint"/>
+                <message_argument value="org.eclipse.swt.gtk.linux.riscv64_3.131.0"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/graphics/MonitorAwareRectangle.java" type="org.eclipse.swt.graphics.MonitorAwareRectangle">
+        <filter id="305365105">
+            <message_arguments>
+                <message_argument value="org.eclipse.swt.graphics.MonitorAwareRectangle"/>
+                <message_argument value="org.eclipse.swt.gtk.linux.riscv64_3.131.0"/>
+            </message_arguments>
+        </filter>
+    </resource>
 </component>

--- a/binaries/org.eclipse.swt.gtk.linux.x86_64/.settings/.api_filters
+++ b/binaries/org.eclipse.swt.gtk.linux.x86_64/.settings/.api_filters
@@ -8,4 +8,20 @@
             </message_arguments>
         </filter>
     </resource>
+     <resource path="Eclipse SWT/common/org/eclipse/swt/graphics/MonitorAwarePoint.java" type="org.eclipse.swt.graphics.MonitorAwarePoint">
+        <filter id="305365105">
+            <message_arguments>
+                <message_argument value="org.eclipse.swt.graphics.MonitorAwarePoint"/>
+                <message_argument value="org.eclipse.swt.gtk.linux.x86_64_3.131.0"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/graphics/MonitorAwareRectangle.java" type="org.eclipse.swt.graphics.MonitorAwareRectangle">
+        <filter id="305365105">
+            <message_arguments>
+                <message_argument value="org.eclipse.swt.graphics.MonitorAwareRectangle"/>
+                <message_argument value="org.eclipse.swt.gtk.linux.x86_64_3.131.0"/>
+            </message_arguments>
+        </filter>
+    </resource>
 </component>

--- a/binaries/org.eclipse.swt.win32.win32.aarch64/.settings/.api_filters
+++ b/binaries/org.eclipse.swt.win32.win32.aarch64/.settings/.api_filters
@@ -144,4 +144,20 @@
             </message_arguments>
         </filter>
     </resource>
+     <resource path="Eclipse SWT/common/org/eclipse/swt/graphics/MonitorAwarePoint.java" type="org.eclipse.swt.graphics.MonitorAwarePoint">
+        <filter id="305365105">
+            <message_arguments>
+                <message_argument value="org.eclipse.swt.graphics.MonitorAwarePoint"/>
+                <message_argument value="org.eclipse.swt.win32.win32.aarch64_3.131.0"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/graphics/MonitorAwareRectangle.java" type="org.eclipse.swt.graphics.MonitorAwareRectangle">
+        <filter id="305365105">
+            <message_arguments>
+                <message_argument value="org.eclipse.swt.graphics.MonitorAwareRectangle"/>
+                <message_argument value="org.eclipse.swt.win32.win32.aarch64_3.131.0"/>
+            </message_arguments>
+        </filter>
+    </resource>
 </component>

--- a/binaries/org.eclipse.swt.win32.win32.x86_64/.settings/.api_filters
+++ b/binaries/org.eclipse.swt.win32.win32.x86_64/.settings/.api_filters
@@ -127,6 +127,22 @@
             </message_arguments>
         </filter>
     </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/graphics/MonitorAwarePoint.java" type="org.eclipse.swt.graphics.MonitorAwarePoint">
+        <filter id="305365105">
+            <message_arguments>
+                <message_argument value="org.eclipse.swt.graphics.MonitorAwarePoint"/>
+                <message_argument value="org.eclipse.swt.win32.win32.x86_64_3.131.0"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="Eclipse SWT/common/org/eclipse/swt/graphics/MonitorAwareRectangle.java" type="org.eclipse.swt.graphics.MonitorAwareRectangle">
+        <filter id="305365105">
+            <message_arguments>
+                <message_argument value="org.eclipse.swt.graphics.MonitorAwareRectangle"/>
+                <message_argument value="org.eclipse.swt.win32.win32.x86_64_3.131.0"/>
+            </message_arguments>
+        </filter>
+    </resource>
     <resource path="Eclipse SWT/win32/org/eclipse/swt/graphics/GCData.java" type="org.eclipse.swt.graphics.GCData">
         <filter id="627060751">
             <message_arguments>

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/MonitorAwarePoint.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/MonitorAwarePoint.java
@@ -13,52 +13,8 @@
  *******************************************************************************/
 package org.eclipse.swt.graphics;
 
-import org.eclipse.swt.widgets.*;
-
 /**
- * Instances of this class represent {@link org.eclipse.swt.graphics.Point}
- * objects along with the context of the monitor in relation to which they are
- * placed on the display. The monitor awareness makes it easy to scale and
- * translate the points between pixels and points.
- *
- * @since 3.129
- * @noreference This class is not intended to be referenced by clients
- * @deprecated
+ * Dummy to make API tooling happy
  */
-@Deprecated(forRemoval = true, since = "2025-09")
-public final class MonitorAwarePoint extends Point {
-
-	private static final long serialVersionUID = 6077427420686999194L;
-
-	private final Monitor monitor;
-
-	/**
-	 * Constructs a new MonitorAwarePoint
-	 *
-	 * @param x       the x coordinate of the point
-	 * @param y       the y coordinate of the point
-	 * @param monitor the monitor with whose context the point is created
-	 */
-	public MonitorAwarePoint(int x, int y, Monitor monitor) {
-		super(x, y);
-		this.monitor = monitor;
-	}
-
-	/**
-	 * {@return the monitor with whose context the instance is created}
-	 */
-	public Monitor getMonitor() {
-		return monitor;
-	}
-
-	@Override
-	public boolean equals(Object object) {
-		return super.equals(object);
-	}
-
-	@Override
-	public int hashCode() {
-		return super.hashCode();
-	}
-
+final class MonitorAwarePoint {
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/MonitorAwareRectangle.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/MonitorAwareRectangle.java
@@ -13,59 +13,9 @@
  *******************************************************************************/
 package org.eclipse.swt.graphics;
 
-import org.eclipse.swt.widgets.*;
-
 /**
- * Instances of this class represent {@link org.eclipse.swt.graphics.Rectangle}
- * objects along with the context of the monitor in relation to which they are
- * placed on the display. The monitor awareness makes it easy to scale and
- * translate the rectangles between pixels and points.
- *
- * @since 3.129
- * @noreference This class is not intended to be referenced by clients
- * @deprecated
+ * Dummy to make API tooling happy
  */
-@Deprecated(forRemoval = true, since = "2025-09")
-public final class MonitorAwareRectangle extends Rectangle {
-
-	private static final long serialVersionUID = 5041911840525116925L;
-
-	private final Monitor monitor;
-
-	/**
-	 * Constructs a new MonitorAwareRectangle
-	 *
-	 * @param x the x coordinate of the top left corner of the rectangle
-	 * @param y the y coordinate of the top left corner of the rectangle
-	 * @param width the width of the rectangle
-	 * @param height the height of the rectangle
-	 * @param monitor the monitor with whose context the rectangle is created
-	 */
-	public MonitorAwareRectangle(int x, int y, int width, int height, Monitor monitor) {
-		super(x, y, width, height);
-		this.monitor = monitor;
-	}
-
-	/**
-	 * {@return the monitor with whose context the instance is created}
-	 */
-	public Monitor getMonitor() {
-		return monitor;
-	}
-
-	@Override
-	public boolean equals(Object object) {
-		return super.equals(object);
-	}
-
-	@Override
-	public int hashCode() {
-		return super.hashCode();
-	}
-
-	@Override
-	public MonitorAwareRectangle clone() {
-		return new MonitorAwareRectangle(x, y, width, height, monitor);
-	}
+final class MonitorAwareRectangle {
 
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/Point.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/Point.java
@@ -43,8 +43,7 @@ import org.eclipse.swt.widgets.*;
  * @see <a href="http://www.eclipse.org/swt/">Sample code and further information</a>
  */
 
-@SuppressWarnings("removal")
-public sealed class Point implements Serializable permits MonitorAwarePoint, Point.OfFloat {
+public sealed class Point implements Serializable permits Point.OfFloat {
 
 	/**
 	 * the x coordinate of the point

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/Rectangle.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/Rectangle.java
@@ -46,8 +46,7 @@ import org.eclipse.swt.widgets.*;
  * @see <a href="http://www.eclipse.org/swt/">Sample code and further information</a>
  */
 
-@SuppressWarnings("removal")
-public sealed class Rectangle implements Serializable, Cloneable permits MonitorAwareRectangle, Rectangle.OfFloat {
+public sealed class Rectangle implements Serializable, Cloneable permits Rectangle.OfFloat {
 
 	/**
 	 * the x coordinate of the rectangle


### PR DESCRIPTION
The MonitorAwareRectangle/MonitorAwarePoint classes have been replaced by Rectangle.WithMonitor and Point.WithMonitor. They have been marked as deprecated but not removed because of issues with API tooling, however they were marked as non-API so they may be removed without any deprecation period.

This change effectively removes the classes, only keeping package-internal stubs of them as otherwise API tooling currently fails.

This is not the cleanest solution as it is driven by tooling limitations, but I don't think we should unnecessarily keep those classes and I am currently stuck in debugging the tooling issue:
- https://github.com/eclipse-tycho/tycho/issues/5148

Since API tooling treats this change as a breaking API change despite the `@noreference` Javadoc tag, according API filters are required. This also means that any dependent bundle that reexports SWT and uses API tooling (such as `org.eclipse.jface` and `org.eclipse.ui`) need to be extended with API filters as well if we merge this:
<img width="952" height="126" alt="image" src="https://github.com/user-attachments/assets/c5439341-4154-4c74-a33e-ef365d19d456" />