### PR TITLE
[Win32] Properly handle setting null font to GC #2350

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/GC.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/GC.java
@@ -5015,8 +5015,7 @@ private class SetFontOperation extends Operation {
 	private final Font font;
 
 	SetFontOperation(Font font) {
-		this.font = new Font(font.getDevice(), font.getFontData());
-		registerForDisposal(this.font);
+		this.font = font != null ? SWTFontProvider.getFont(font.getDevice(), font.getFontData()[0], data.nativeZoom) : null;
 	}
 
 	@Override

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_GC.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_GC.java
@@ -605,6 +605,9 @@ public void test_setClippingLorg_eclipse_swt_graphics_Rectangle() {
 
 @Test
 public void test_setFontLorg_eclipse_swt_graphics_Font() {
+	gc.setFont(null);
+	assertEquals(shell.getDisplay().getSystemFont(), gc.getFont());
+
 	gc.setFont(shell.getDisplay().getSystemFont());
 	Font font = gc.getFont();
 	assertEquals(shell.getDisplay().getSystemFont(), font);


### PR DESCRIPTION
When calling GC#setFont(), a copy of the given font is created. However, the font may be null, leading to an exception. In addition, a font should be retrieved from the font provider instead of creating a new font that is manually disposed later on.

This change ensures that null fonts are properly handled and that the stored font is retrieved from the provider.

Fixes https://github.com/eclipse-platform/eclipse.platform.swt/issues/2350