### PR TITLE
[GTK] Remove duplicate device-zoom initialization in Image

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/graphics/Image.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/graphics/Image.java
@@ -215,7 +215,6 @@ Image(Device device) {
 public Image(Device device, int width, int height) {
 	super(device);
 	Point size = new Point(width, height);
-	currentDeviceZoom = DPIUtil.getDeviceZoom();
 	init(size.x, size.y);
 	init();
 }
@@ -410,7 +409,6 @@ public Image(Device device, Image srcImage, int flag) {
 public Image(Device device, Rectangle bounds) {
 	super(device);
 	if (bounds == null) SWT.error(SWT.ERROR_NULL_ARGUMENT);
-	currentDeviceZoom = DPIUtil.getDeviceZoom();
 	init(bounds.width, bounds.height);
 	init();
 }


### PR DESCRIPTION
The device zoom is hard-coded to 100% when creating blank images. Setting it to the current device zoom in the constructor is both wrong and unnecessary, given that the value will be immediately overwritten.