### PR TITLE
Release Edge callbacks after registering

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Browser/win32/org/eclipse/swt/browser/Edge.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Browser/win32/org/eclipse/swt/browser/Edge.java
@@ -662,7 +662,9 @@ private void createInstance(int previousAttempts) {
 	int hr = containingEnvironment.environment().QueryInterface(COM.IID_ICoreWebView2Environment2, ppv);
 	if (hr == COM.S_OK) environment2 = new ICoreWebView2Environment2(ppv[0]);
 	// The webview calls are queued to be executed when it is done executing the current task.
-	containingEnvironment.environment().CreateCoreWebView2Controller(browser.handle, createControllerInitializationCallback(previousAttempts));
+	IUnknown controllerInitializationHandler = createControllerInitializationCallback(previousAttempts);
+	containingEnvironment.environment().CreateCoreWebView2Controller(browser.handle, controllerInitializationHandler);
+	controllerInitializationHandler.Release();
 }
 
 private IUnknown createControllerInitializationCallback(int previousAttempts) {


### PR DESCRIPTION
This PR releases the HandleCoreWebView2SwtCallback resource created by Edge browser in createControllerInitializationCallback after it has been registered by CreateCoreWebView2Controller method as otherwise the HandleCoreWebView2SwtCallback object can cause memory leaks if left unreleased.

fixes https://github.com/eclipse-platform/eclipse.platform.swt/issues/2339

*How to test:*
1. On master, test this snippet:
```java
package org.eclipse.swt.snippets;

import org.eclipse.swt.*;
import org.eclipse.swt.browser.*;
import org.eclipse.swt.layout.*;
import org.eclipse.swt.widgets.*;

public class Snippet138 {
	public static void main(String[] args) {
		Display display = new Display();
		Shell parentShell = new Shell(display);
		long allocatedMemory =  (Runtime.getRuntime().totalMemory()-Runtime.getRuntime().freeMemory());
		long presumableFreeMemory = Runtime.getRuntime().maxMemory() - allocatedMemory;
		long blockSize = Math.min(Integer.MAX_VALUE / 2, presumableFreeMemory/10);
		int block = Math.toIntExact(blockSize);

		for(int i = 0; i < 100; i++) { // should not fail after 5 rounds

		    Shell shell = new Shell(parentShell);
		    Browser browser = new Browser(shell, SWT.BORDER);
		    shell.setLayout(new RowLayout());
		    browser.setUrl("http://example.com");
		    browser.setSize(500, 500);

		    shell.open();

		    browser.addTitleListener(new TitleListener() {

		        byte[] payload = new byte[block];

		        @Override
		        public void changed(TitleEvent event) {
		            System.out.println(payload[0]); // reference payload
		        }
		    });

		    shell.close();
		    browser.dispose();
		    browser = null;
		    shell=null;

		}
	}
}

``` 
It should throw an out of memory exception.
2. Run the snippet on this branch. The code should execute without any exception.