### PR TITLE
Fix stack overflow in DPIUtil.autoScaleImageData

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/widgets/ControlWin32Tests.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/widgets/ControlWin32Tests.java
@@ -14,12 +14,15 @@
 package org.eclipse.swt.widgets;
 
 import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.eclipse.swt.*;
 import org.eclipse.swt.graphics.*;
 import org.eclipse.swt.internal.*;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.*;
+import org.junit.jupiter.params.*;
+import org.junit.jupiter.params.provider.*;
 
 /**
  * Automated Tests for class org.eclipse.swt.widgets.Control for Windows
@@ -105,6 +108,28 @@ class ControlWin32Tests {
 		button.setBounds(0, 47, 200, 47);
 		assertEquals("Control::setBounds(int, int, int, int) doesn't scale up correctly",
 				new Rectangle(0, 82, 350, 83), button.getBoundsInPixels());
+	}
+
+	@ParameterizedTest
+	@CsvSource({ "0.5, 100, true", "1.0, 200, true", "2.0, 200, true", "2.0, quarter, true", "0.5, 100, false",
+			"1.0, 200, false", "2.0, 200, false", "2.0, quarter, false", })
+	public void testAutoScaleImageData(float scaleFactor, String autoScale, boolean monitorSpecificScaling) {
+		DPIUtil.setMonitorSpecificScaling(monitorSpecificScaling);
+		DPIUtil.runWithAutoScaleValue(autoScale, () -> {
+			Display display = new Display();
+			try {
+				ImageData imageData = new ImageData(100, 100, 1, new PaletteData(new RGB(0, 0, 0)));
+				int width = imageData.width;
+				int height = imageData.height;
+				int scaledWidth = Math.round(width * scaleFactor);
+				int scaledHeight = Math.round(height * scaleFactor);
+				ImageData scaledImageData = DPIUtil.autoScaleImageData(display, imageData, scaleFactor);
+				assertEquals(scaledWidth, scaledImageData.width);
+				assertEquals(scaledHeight, scaledImageData.height);
+			} finally {
+				display.dispose();
+			}
+		});
 	}
 
 	record FontComparison(int originalFontHeight, int currentFontHeight) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/graphics/Image.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/graphics/Image.java
@@ -1811,22 +1811,24 @@ public String toString () {
  * API for Image. It is marked public only so that it
  * can be shared within the packages provided by SWT.
  *
- * Draws a scaled image using the GC by another image.
+ * Draws a scaled image using the GC for a given imageData.
  *
  * @param gc the GC to draw on the resulting image
- * @param original the image which is supposed to be scaled and drawn on the resulting image
+ * @param imageData the imageData which is used to draw the scaled Image
  * @param width the width of the original image
  * @param height the height of the original image
  * @param scaleFactor the factor with which the image is supposed to be scaled
  *
  * @noreference This method is not intended to be referenced by clients.
  */
-public static void drawScaled(GC gc, Image original, int width, int height, float scaleFactor) {
-	gc.drawImage (original, 0, 0, CocoaDPIUtil.pixelToPoint (width), CocoaDPIUtil.pixelToPoint (height),
+public static void drawScaled(GC gc, ImageData imageData, int width, int height, float scaleFactor) {
+	Image imageToDraw = new Image(gc.device, (ImageDataProvider) zoom ->  imageData);
+	gc.drawImage (imageToDraw, 0, 0, CocoaDPIUtil.pixelToPoint (width), CocoaDPIUtil.pixelToPoint (height),
 			/* E.g. destWidth here is effectively DPIUtil.autoScaleDown (scaledWidth), but avoiding rounding errors.
 			 * Nevertheless, we still have some rounding errors due to the point-based API GC#drawImage(..).
 			 */
 			0, 0, Math.round (CocoaDPIUtil.pixelToPoint (width * scaleFactor)), Math.round (CocoaDPIUtil.pixelToPoint (height * scaleFactor)));
+	imageToDraw.dispose();
 }
 
 private final class CocoaDPIUtil {

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/DPIUtil.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/DPIUtil.java
@@ -153,12 +153,11 @@ public static ImageData autoScaleImageData (Device device, final ImageData image
 	int defaultZoomLevel = 100;
 	boolean useSmoothScaling = isSmoothScalingEnabled() && imageData.getTransparencyType() != SWT.TRANSPARENCY_MASK;
 	if (useSmoothScaling) {
-		Image original = new Image(device, (ImageDataProvider) zoom -> (zoom == defaultZoomLevel) ? imageData : null);
 		ImageGcDrawer drawer =  new ImageGcDrawer() {
 			@Override
 			public void drawOn(GC gc, int imageWidth, int imageHeight) {
 				gc.setAntialias (SWT.ON);
-				Image.drawScaled(gc, original, width, height, scaleFactor);
+				Image.drawScaled(gc, imageData, width, height, scaleFactor);
 			};
 
 			@Override
@@ -168,7 +167,6 @@ public static ImageData autoScaleImageData (Device device, final ImageData image
 		};
 		Image resultImage = new Image (device, drawer, scaledWidth, scaledHeight);
 		ImageData result = resultImage.getImageData (defaultZoomLevel);
-		original.dispose ();
 		resultImage.dispose ();
 		return result;
 	} else {

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/graphics/Image.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/graphics/Image.java
@@ -1572,22 +1572,24 @@ public String toString () {
  * API for Image. It is marked public only so that it
  * can be shared within the packages provided by SWT.
  *
- * Draws a scaled image using the GC by another image.
+ * Draws a scaled image using the GC for a given imageData.
  *
  * @param gc the GC to draw on the resulting image
- * @param original the image which is supposed to be scaled and drawn on the resulting image
+ * @param imageData the imageData which is used to draw the scaled Image
  * @param width the width of the original image
  * @param height the height of the original image
  * @param scaleFactor the factor with which the image is supposed to be scaled
  *
  * @noreference This method is not intended to be referenced by clients.
  */
-public static void drawScaled(GC gc, Image original, int width, int height, float scaleFactor) {
-	gc.drawImage (original, 0, 0, width, height,
+public static void drawScaled(GC gc, ImageData imageData, int width, int height, float scaleFactor) {
+	Image imageToDraw = new Image(gc.device, (ImageDataProvider) zoom -> imageData);
+	gc.drawImage (imageToDraw, 0, 0, width, height,
 			/* E.g. destWidth here is effectively DPIUtil.autoScaleDown (scaledWidth), but avoiding rounding errors.
 			 * Nevertheless, we still have some rounding errors due to the point-based API GC#drawImage(..).
 			 */
 			0, 0, Math.round (width * scaleFactor), Math.round (height * scaleFactor));
+	imageToDraw.dispose();
 }
 
 private final class GtkDPIUtil {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Image.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Image.java
@@ -839,19 +839,24 @@ public static long win32_getHandle (Image image, int zoom) {
  * API for Image. It is marked public only so that it
  * can be shared within the packages provided by SWT.
  *
- * Draws a scaled image using the GC by another image.
+ * Draws a scaled image using the GC for a given imageData.
  *
  * @param gc the GC to draw on the resulting image
- * @param original the image which is supposed to be scaled and drawn on the resulting image
+ * @param imageData the imageData which is used to draw the scaled Image
  * @param width the width of the original image
  * @param height the height of the original image
  * @param scaleFactor the factor with which the image is supposed to be scaled
  *
  * @noreference This method is not intended to be referenced by clients.
  */
-public static void drawScaled(GC gc, Image original, int width, int height, float scaleFactor) {
-	gc.drawImage (original, 0, 0, width, height,
+public static void drawScaled(GC gc, ImageData imageData, int width, int height, float scaleFactor) {
+	boolean originalStrictChecks = Device.strictChecks;
+	Device.strictChecks = false;
+	Image imageToDraw = new Image(gc.device, (ImageDataProvider) zoom ->  imageData);
+	gc.drawImage (imageToDraw, 0, 0, width, height,
 			0, 0, Math.round (width * scaleFactor), Math.round (height * scaleFactor), false);
+	Device.strictChecks = originalStrictChecks;
+	imageToDraw.dispose();
 }
 
 long [] createGdipImage(Integer zoom) {


### PR DESCRIPTION
Fixes #2353 

In PR #2249, a strict check was introduced  that `ImageData` should be linearly scaled for 
zoom levels. And imageDataProviders in SWT repo not following this strict checks were modified (eg to return only imageData at 100%).

However, this change broke `DPIUtil.autoScaleImageData`. That function creates an Image using the system zoom level, draws it on a GC at scaled dimensions, and then requests ImageData at 100% zoom from the image. Since the `ImageDataProvider` was now restricted to 100% zoom only, requesting imageData at other zoom levels during creation of  image at system zoom level triggered recursive calls,  causing a stack overflow error.

The current commit reverts the behavior of the `ImageDataProvider` used in` DPIUtil.autoScaleImageData` to return the same `ImageData` at all zoom levels.
We also Disable the strict zoom check in this specific case, because the scaling is done by `GC.drawImage()` and the `ImageData` used to create the image at system zoom level is expected to be same as the passed `imageData`.


**Steps to reproduce**

Execute Issue0445_HiDPISmoothScaling when your device zoom is something other than 200%. This would give stackoverflow error without this change