### PR TITLE
[Win32] Lazy load Cursor handles

### DIFF
--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_Cursor.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_Cursor.java
@@ -28,6 +28,8 @@ import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.graphics.ImageData;
 import org.eclipse.swt.graphics.ImageDataProvider;
 import org.eclipse.swt.graphics.ImageLoader;
+import org.eclipse.swt.graphics.PaletteData;
+import org.eclipse.swt.graphics.RGB;
 import org.eclipse.swt.widgets.Display;
 import org.junit.Before;
 import org.junit.Test;
@@ -160,6 +162,66 @@ public void test_ConstructorWithImageDataProvider() {
 
 	assertThrows("No exception thrown when ImageDataProvider is null",
 			IllegalArgumentException.class, () -> new Cursor(display, (ImageDataProvider) null, 0, 0));
+}
+
+@Test
+public void test_InvalidArgumentsForAllConstructors() {
+	ImageData source = new ImageData(16, 16, 1, new PaletteData(new RGB[] { new RGB(0, 0, 0) }));
+	ImageData mask = new ImageData(16, 16, 1, new PaletteData(new RGB[] { new RGB(0, 0, 0) }));
+
+	assertThrows("When wrong style was provided", IllegalArgumentException.class,
+			() -> {
+				Cursor cursor = new Cursor(Display.getDefault(), -99);
+				cursor.dispose();
+			});
+
+	assertThrows("When source is null", IllegalArgumentException.class, () -> {
+		Cursor cursorFromImageAndMask = new Cursor(Display.getDefault(), null, mask, 0, 0);
+		cursorFromImageAndMask.dispose();
+	});
+
+	assertThrows("When mask is null and source doesn't heve a mask",
+			IllegalArgumentException.class, () -> {
+				Cursor cursorFromImageAndMask = new Cursor(Display.getDefault(), source, null, 0, 0);
+				cursorFromImageAndMask.dispose();
+			});
+
+	assertThrows("When source and the mask are not the same size",
+			IllegalArgumentException.class, () -> {
+				ImageData source32 = new ImageData(32, 32, 1, new PaletteData(new RGB[] { new RGB(0, 0, 0) }));
+				ImageData mask16 = new ImageData(16, 16, 1, new PaletteData(new RGB[] { new RGB(0, 0, 0) }));
+
+				Cursor cursorFromImageAndMask = new Cursor(Display.getDefault(), source32, mask16, 0, 0);
+				cursorFromImageAndMask.dispose();
+			});
+
+	assertThrows("When hotspot is outside the bounds of the image",
+			IllegalArgumentException.class, () -> {
+				Cursor cursorFromImageAndMask = new Cursor(Display.getDefault(), source, mask, 18, 18);
+				cursorFromImageAndMask.dispose();
+			});
+
+	assertThrows("When source image data is null", IllegalArgumentException.class,
+			() -> {
+				ImageData nullImageData = null;
+				Cursor cursorFromSourceOnly = new Cursor(Display.getDefault(), nullImageData, 0, 0);
+				cursorFromSourceOnly.dispose();
+			});
+
+	assertThrows("When ImageDataProvider is null", IllegalArgumentException.class,
+			() -> {
+				ImageDataProvider provider = null;
+				Cursor cursorFromProvider = new Cursor(Display.getDefault(), provider, 0, 0);
+				cursorFromProvider.dispose();
+			});
+
+	assertThrows("When source in ImageDataProvider is null",
+			IllegalArgumentException.class, () -> {
+				ImageData nullSource = null;
+				ImageDataProvider provider = zoom -> nullSource;
+				Cursor cursorFromProvider = new Cursor(Display.getDefault(), provider, 0, 0);
+				cursorFromProvider.dispose();
+			});
 }
 
 @Test


### PR DESCRIPTION
### Problem

Currently, we have a logic to always initialize the first **handle** in a `handle` field. Instead of using it, we could switch to lazy loading via using `zoomLevelToHandle` map. The handle will only created when `win32_getHandle` is called. 

---

### Proposed Solution

To fix this, the `Cursor` class should be refactored to manage zoom-level-specific handles more robustly and safely. The following changes are needed:

1. **Remove `handle` Field**
   Eliminate the dedicated `handle` field from the class. All handle accesses should go through the `zoomLevelToHandle` map, which now acts as the single source of truth for all zoom levels.

2. **Update All Related Methods**
   Refactor all methods that previously relied on the `handle` field to instead use `zoomLevelToHandle`. This includes:

   * `hashCode()`
   * `equals(Object obj)`
   * `isDisposed()`
   * `destroy()`

---

### Benefits

* Enables safe, lazy creation of per-zoom handles when needed.
* Simplifies and centralizes handle management logic for better maintainability.

### Example

```java
import org.eclipse.swt.*;
import org.eclipse.swt.graphics.*;
import org.eclipse.swt.widgets.*;

public class CursorZoomTest {
    public static void main(String[] args) {
        Display display = new Display();
        Shell shell = new Shell(display);

        // 1. Constructor: Cursor(Device, int style)
        Cursor cursorFromStyle = new Cursor(display, SWT.CURSOR_HAND);

        // 2. Constructor: Cursor(Device, ImageData source, ImageData mask, int hotspotX, int hotspotY)
        ImageData source = new ImageData(16, 16, 1, new PaletteData(new RGB[]{new RGB(0, 0, 0)}));
        ImageData mask = new ImageData(16, 16, 1, new PaletteData(new RGB[]{new RGB(0, 0, 0)}));
        Cursor cursorFromImageAndMask = new Cursor(display, source, mask, 0, 0);

        // 3. Constructor: Cursor(Device, ImageData source, int hotspotX, int hotspotY)
        Cursor cursorFromImageOnly = new Cursor(display, source, 0, 0);

        // 4. Constructor: Cursor(Device, ImageDataProvider imageDataProvider, int hotspotX, int hotspotY)
        ImageDataProvider provider = zoom -> source;
        Cursor cursorFromProvider = new Cursor(display, provider, 0, 0);

        Cursor[] cursors = {
            cursorFromStyle,
            cursorFromImageAndMask,
            cursorFromImageOnly,
            cursorFromProvider
        };

        int[] zoomLevels = {100, 125, 150, 175, 200, 250};

        for (int i = 0; i < cursors.length; i++) {
            System.out.println("Cursor #" + (i + 1));
            for (int zoom : zoomLevels) {
                long handle = Cursor.win32_getHandle(cursors[i], zoom);
                System.out.println("  Zoom " + zoom + ": handle = " + handle);
            }
        }

        // Dispose resources
        for (Cursor cursor : cursors) {
            cursor.dispose();
        }

        shell.dispose();
        display.dispose();
    }
}
```

**Output**
```
Cursor #1
  Zoom 100: handle = 65567
  Zoom 125: handle = 65567
  Zoom 150: handle = 65567
  Zoom 175: handle = 65567
  Zoom 200: handle = 65567
  Zoom 250: handle = 65567
Cursor #2
  Zoom 100: handle = 75434631
  Zoom 125: handle = 53612289
  Zoom 150: handle = 43651639
  Zoom 175: handle = 61083667
  Zoom 200: handle = 30212277
  Zoom 250: handle = 141363963
Cursor #3
  Zoom 100: handle = 33559507
  Zoom 125: handle = 263197751
  Zoom 150: handle = 84413253
  Zoom 175: handle = 21237883
  Zoom 200: handle = 56361347
  Zoom 250: handle = 46928295
Cursor #4
  Zoom 100: handle = 20124285
  Zoom 125: handle = 63705063
  Zoom 150: handle = 46729749
  Zoom 175: handle = 68358127
  Zoom 200: handle = 79891305
  Zoom 250: handle = 14290407

```

**Note that for the Cursor 1, we always get the same handle from OS but it's scaled correctly for all zoom levels.**

Fixes: https://github.com/eclipse-platform/eclipse.platform.swt/issues/2355