### PR TITLE
Win32DPIUtils:pointToPixel shouldn't have residual

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/Win32DPIUtils.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/Win32DPIUtils.java
@@ -205,7 +205,8 @@ public class Win32DPIUtils {
 		float scaleFactor = DPIUtil.getScalingFactor(zoom);
 		float scaledX = fPoint.getX() * scaleFactor;
 		float scaledY = fPoint.getY() * scaleFactor;
-		return new Point.OfFloat(scaledX, scaledY);
+		Point scaledPoint = new Point.OfFloat(scaledX, scaledY);
+		return new Point.OfFloat(scaledPoint.x, scaledPoint.y);
 	}
 
 	public static Point pointToPixel(Drawable drawable, Point point, int zoom) {
@@ -228,7 +229,8 @@ public class Win32DPIUtils {
 	}
 
 	private static Rectangle pointToPixel(Rectangle.OfFloat rect, int zoom) {
-		return scaleBounds(rect, zoom, 100);
+		Rectangle scaledRectangle = scaleBounds(rect, zoom, 100);
+		return new Rectangle.OfFloat(scaledRectangle.x, scaledRectangle.y, scaledRectangle.width, scaledRectangle.height);
 	}
 
 	public static Rectangle pointToPixel(Drawable drawable, Rectangle rect, int zoom) {

--- a/tests/org.eclipse.swt.tests.win32/JUnit Tests/org/eclipse/swt/tests/win32/Win32DPIUtilTests.java
+++ b/tests/org.eclipse.swt.tests.win32/JUnit Tests/org/eclipse/swt/tests/win32/Win32DPIUtilTests.java
@@ -223,14 +223,26 @@ public class Win32DPIUtilTests {
 	@Test
 	public void scaleDownscaleUpRectangleInvertible() {
 		int[] zooms = new int[] {25, 50, 75, 100, 125, 150, 175, 200, 225, 250, 275, 300, 325, 350, 375, 400};
+		for (int zoom : zooms) {
+			for (int i = 1; i <= 10000; i++) {
+				Rectangle rect = new Rectangle.OfFloat(0, 0, i, i);
+				Rectangle scaleDown = Win32DPIUtils.pixelToPoint(rect, zoom);
+				Rectangle scaleUp = Win32DPIUtils.pointToPixel(scaleDown, zoom);
+				assertEquals(rect.width, scaleUp.width);
+				assertEquals(rect.height, scaleUp.height);
+			}
+		}
+	}
+
+	@Test
+	public void scaleBoundsRectangleInvertible() {
+		int[] zooms = new int[] {25, 50, 75, 100, 125, 150, 175, 200, 225, 250, 275, 300, 325, 350, 375, 400};
 		for (int zoom1 : zooms) {
 			for (int zoom2 : zooms) {
 				for (int i = 1; i <= 10000; i++) {
 					Rectangle rect = new Rectangle.OfFloat(0, 0, i, i);
-					Rectangle scaleDown = Win32DPIUtils.pixelToPoint(rect, zoom1);
-					Rectangle scaleUp = Win32DPIUtils.pointToPixel(scaleDown, zoom2);
-					scaleDown = Win32DPIUtils.pixelToPoint(scaleUp, zoom2);
-					scaleUp = Win32DPIUtils.pointToPixel(scaleDown, zoom1);
+					Rectangle scaleDown = Win32DPIUtils.scaleBounds(rect, zoom1, zoom2);
+					Rectangle scaleUp = Win32DPIUtils.scaleBounds(scaleDown, zoom2, zoom1);
 					assertEquals(rect.width, scaleUp.width);
 					assertEquals(rect.height, scaleUp.height);
 				}
@@ -240,18 +252,14 @@ public class Win32DPIUtilTests {
 
 	@Test
 	public void scaleDownscaleUpPointInvertible() {
-		int[] zooms = new int[] {25, 50, 75, 100, 125, 150, 175, 200, 225, 250, 275, 300, 325, 350, 375, 400};
-		for (int zoom1 : zooms) {
-			for (int zoom2 : zooms) {
-				for (int i = 1; i <= 10000; i++) {
-					Point pt = new Point(i, i);
-					Point scaleDown = Win32DPIUtils.pixelToPoint(pt, zoom1);
-					Point scaleUp = Win32DPIUtils.pointToPixel(scaleDown, zoom2);
-					scaleDown = Win32DPIUtils.pixelToPoint(scaleUp, zoom2);
-					scaleUp = Win32DPIUtils.pointToPixel(scaleDown, zoom1);
-					assertEquals(pt.x, scaleUp.x);
-					assertEquals(pt.y, scaleUp.y);
-				}
+		int[] zooms = new int[] {100, 125, 150, 175, 200, 225, 250, 275, 300, 325, 350, 375, 400};
+		for (int zoom : zooms) {
+			for (int i = 1; i <= 10000; i++) {
+				Point pt = new Point(i, i);
+				Point scaleDown = Win32DPIUtils.pixelToPoint(pt, zoom);
+				Point scaleUp = Win32DPIUtils.pointToPixel(scaleDown, zoom);
+				assertEquals(pt.x, scaleUp.x);
+				assertEquals(pt.y, scaleUp.y);
 			}
 		}
 	}


### PR DESCRIPTION
This commit contributes to scaling points and rectangles from point to pixels while making sure they do not have any residuals since the OS doesn't support sub-pixel drawing.

contributes to #62