### PR TITLE
Fix Cursor hotspot coordinate calculation

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Cursor.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Cursor.java
@@ -429,11 +429,11 @@ public static Long win32_getHandle (Cursor cursor, int zoom) {
 			source = DPIUtil.scaleImageData(cursor.device, cursor.source, zoom, DEFAULT_ZOOM);
 		}
 		if (cursor.isIcon) {
-			Cursor newCursor = new Cursor(cursor.device, source, cursor.hotspotX, cursor.hotspotY);
+			Cursor newCursor = new Cursor(cursor.device, source, Win32DPIUtils.pointToPixel(cursor.hotspotX, zoom), Win32DPIUtils.pointToPixel(cursor.hotspotY, zoom));
 			cursor.setHandleForZoomLevel(newCursor.handle, zoom);
 		} else {
 			ImageData mask = DPIUtil.scaleImageData(cursor.device, cursor.mask, zoom, DEFAULT_ZOOM);
-			Cursor newCursor = new Cursor(cursor.device, source, mask, cursor.hotspotX, cursor.hotspotY);
+			Cursor newCursor = new Cursor(cursor.device, source, mask, Win32DPIUtils.pointToPixel(cursor.hotspotX, zoom), Win32DPIUtils.pointToPixel(cursor.hotspotY, zoom));
 			cursor.setHandleForZoomLevel(newCursor.handle, zoom);
 		}
 	}


### PR DESCRIPTION
While retrieving the handle for the cursor for specific zoom, currently we scale up the cursor source image but not the hotspot coordinates. This commit ensures we have per-zoom coordinates for the cursor.