### PR TITLE
Revert usage of getZoom() when calculating TextExtent

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/GC.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/GC.java
@@ -5725,7 +5725,7 @@ private class SetTransformOperation extends Operation {
  */
 public Point stringExtent (String string) {
 	if (string == null) SWT.error (SWT.ERROR_NULL_ARGUMENT);
-	return Win32DPIUtils.pixelToPoint(drawable, stringExtentInPixels(string), data.font.zoom);
+	return Win32DPIUtils.pixelToPoint(drawable, stringExtentInPixels(string), getZoom());
 }
 
 Point stringExtentInPixels (String string) {
@@ -5805,7 +5805,7 @@ public Point textExtent (String string) {
  * </ul>
  */
 public Point textExtent (String string, int flags) {
-	return Win32DPIUtils.pixelToPoint(drawable, textExtentInPixels(string, flags), data.font.zoom);
+	return Win32DPIUtils.pixelToPoint(drawable, textExtentInPixels(string, flags), getZoom());
 }
 
 Point textExtentInPixels(String string, int flags) {


### PR DESCRIPTION
This issue reverts the behavior of `GC::textExtent` to use `GC::getZoom()` instead of the font’s zoom, as the previous change(#2306) introduced a regression.

I am yet unable to identify the root cause of the regression. From my understanding, With a monitor zoom of 150 even in the case of `Integer200`, the text when drawn with `OS.DrawText`  is drawn according to monitor zoom (e.g., 150), which aligns with `gc.font.zoom`. Based on this, it seemed reasonable to use the font’s zoom to calculate the text extent as `gc.textExtent()` works by drawing text in pixels with `OS.drawText()` and therefore should convert pixels to points using the zoom the text was drawn with.

However, since the change causes a regression which makes eclipse almost unsusable at Integer200, this PR reverts the behavior to its previous state for the M3 release. A more detailed investigation needs to be conducted separately.

Fixes #2361.

Reopens https://github.com/eclipse-platform/eclipse.platform.swt/issues/2311.