### PR TITLE
[GTK] Implement Display.getHighContrast

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Display.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Display.java
@@ -2519,6 +2519,10 @@ public Control getFocusControl () {
  */
 public boolean getHighContrast () {
 	checkDevice ();
+	String gtkThemeName= OS.getThemeName();
+	if (gtkThemeName.contains("HighContrast") || gtkThemeName.contains("ContrastHigh")) {
+		return true;
+	}
 	return false;
 }
 


### PR DESCRIPTION
Gtk ships with "HighContrast" and "HighContrastInverse" and Mate desktop ships "ContrastHigh*" theme. If the gtk theme is any of these say it's "high contrast" theme.