### PR TITLE
Move Windows only functionality to Win32DPIUtil

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/widgets/ControlWin32Tests.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/widgets/ControlWin32Tests.java
@@ -123,7 +123,7 @@ class ControlWin32Tests {
 				int height = imageData.height;
 				int scaledWidth = Math.round(width * scaleFactor);
 				int scaledHeight = Math.round(height * scaleFactor);
-				ImageData scaledImageData = DPIUtil.autoScaleImageData(display, imageData, scaleFactor);
+				ImageData scaledImageData = Win32DPIUtils.autoScaleImageData(display, imageData, scaleFactor);
 				assertEquals(scaledWidth, scaledImageData.width);
 				assertEquals(scaledHeight, scaledImageData.height);
 			} finally {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Cursor.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Cursor.java
@@ -441,13 +441,13 @@ public static Long win32_getHandle (Cursor cursor, int zoom) {
 			tempImage.dispose();
 		}
 		else {
-			source = DPIUtil.scaleImageData(cursor.device, cursor.source, zoom, DEFAULT_ZOOM);
+			source = Win32DPIUtils.scaleImageData(cursor.device, cursor.source, zoom, DEFAULT_ZOOM);
 		}
 		if (cursor.isIcon) {
 			Cursor newCursor = new Cursor(cursor.device, source, Win32DPIUtils.pointToPixel(cursor.hotspotX, zoom), Win32DPIUtils.pointToPixel(cursor.hotspotY, zoom));
 			cursor.setHandleForZoomLevel(newCursor.handle, zoom);
 		} else {
-			ImageData mask = DPIUtil.scaleImageData(cursor.device, cursor.mask, zoom, DEFAULT_ZOOM);
+			ImageData mask = Win32DPIUtils.scaleImageData(cursor.device, cursor.mask, zoom, DEFAULT_ZOOM);
 			Cursor newCursor = new Cursor(cursor.device, source, mask, Win32DPIUtils.pointToPixel(cursor.hotspotX, zoom), Win32DPIUtils.pointToPixel(cursor.hotspotY, zoom));
 			cursor.setHandleForZoomLevel(newCursor.handle, zoom);
 		}

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Image.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Image.java
@@ -1932,7 +1932,7 @@ private abstract class AbstractImageProviderWrapper {
 	ImageData getScaledImageData (int zoom) {
 		TreeSet<Integer> availableZooms = new TreeSet<>(zoomLevelToImageHandle.keySet());
 		int closestZoom = Optional.ofNullable(availableZooms.higher(zoom)).orElse(availableZooms.lower(zoom));
-		return DPIUtil.scaleImageData(device, getImageMetadata(closestZoom).getImageData(), zoom, closestZoom);
+		return Win32DPIUtils.scaleImageData(device, getImageMetadata(closestZoom).getImageData(), zoom, closestZoom);
 	}
 
 	protected ImageHandle newImageHandle(int zoom) {
@@ -2025,7 +2025,7 @@ private abstract class ImageFromImageDataProviderWrapper extends AbstractImagePr
 
 	private ImageHandle initializeHandleFromSource(int zoom) {
 		ElementAtZoom<ImageData> imageDataAtZoom = loadImageData(zoom);
-		ImageData imageData = DPIUtil.scaleImageData(device, imageDataAtZoom.element(), zoom, imageDataAtZoom.zoom());
+		ImageData imageData = Win32DPIUtils.scaleImageData(device, imageDataAtZoom.element(), zoom, imageDataAtZoom.zoom());
 		imageData = adaptImageDataIfDisabledOrGray(imageData);
 		return newImageHandle(imageData, zoom);
 	}
@@ -2082,8 +2082,8 @@ private class MaskedImageDataProviderWrapper extends ImageFromImageDataProviderW
 
 	@Override
 	protected ElementAtZoom<ImageData> loadImageData(int zoom) {
-		ImageData scaledSource = DPIUtil.scaleImageData(device, srcAt100, zoom, 100);
-		ImageData scaledMask = DPIUtil.scaleImageData(device, maskAt100, zoom, 100);
+		ImageData scaledSource = Win32DPIUtils.scaleImageData(device, srcAt100, zoom, 100);
+		ImageData scaledMask = Win32DPIUtils.scaleImageData(device, maskAt100, zoom, 100);
 		scaledMask = ImageData.convertMask(scaledMask);
 		ImageData mergedData = applyMask(scaledSource, scaledMask);
 		return new ElementAtZoom<>(mergedData, zoom);
@@ -2294,7 +2294,7 @@ private abstract class BaseImageProviderWrapper<T> extends DynamicImageProviderW
 
 	private ImageHandle initializeHandleFromSource(int zoom) {
 		ElementAtZoom<ImageData> imageDataAtZoom = loadImageData(zoom);
-		ImageData imageData = DPIUtil.scaleImageData (device,imageDataAtZoom.element(), zoom, imageDataAtZoom.zoom());
+		ImageData imageData = Win32DPIUtils.scaleImageData (device,imageDataAtZoom.element(), zoom, imageDataAtZoom.zoom());
 		imageData = adaptImageDataIfDisabledOrGray(imageData);
 		return init(imageData, zoom);
 	}
@@ -2318,7 +2318,7 @@ private class ImageFileNameProviderWrapper extends BaseImageProviderWrapper<Imag
 
 	@Override
 	protected ElementAtZoom<ImageData> loadImageData(int zoom) {
-		ElementAtZoom<String> fileForZoom = DPIUtil.validateAndGetImagePathAtZoom(provider, zoom);
+		ElementAtZoom<String> fileForZoom = Win32DPIUtils.validateAndGetImagePathAtZoom(provider, zoom);
 
 		// Load at appropriate zoom via loader
 		if (fileForZoom.zoom() != zoom && ImageDataLoader.canLoadAtZoom(fileForZoom.element(), fileForZoom.zoom(), zoom)) {
@@ -2554,7 +2554,7 @@ private class ImageDataProviderWrapper extends BaseImageProviderWrapper<ImageDat
 
 	@Override
 	protected ElementAtZoom<ImageData> loadImageData(int zoom) {
-		return DPIUtil.validateAndGetImageDataAtZoom (provider, zoom);
+		return Win32DPIUtils.validateAndGetImageDataAtZoom (provider, zoom);
 	}
 
 	@Override


### PR DESCRIPTION
Moving methods that are consumed only by Windows from DPIUtil to Win32DPIUtil. 

**Note:** The methods are moved using eclipse refactor tool. 