### PR TITLE
Move Windows only functionality to Win32DPIUtil

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/internal/ResetMonitorSpecificScalingExtension.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/internal/ResetMonitorSpecificScalingExtension.java
@@ -25,13 +25,13 @@ public sealed class ResetMonitorSpecificScalingExtension implements BeforeEachCa
 
 	@Override
 	public void beforeEach(ExtensionContext context) throws Exception {
-		wasMonitorSpecificScalingActive = DPIUtil.isMonitorSpecificScalingActive();
+		wasMonitorSpecificScalingActive = Win32DPIUtils.isMonitorSpecificScalingActive();
 		Display.getDefault().dispose();
 	}
 
 	@Override
 	public void afterEach(ExtensionContext context) throws Exception {
-		DPIUtil.setMonitorSpecificScaling(wasMonitorSpecificScalingActive);
+		Win32DPIUtils.setMonitorSpecificScaling(wasMonitorSpecificScalingActive);
 		Display.getDefault().dispose();
 	}
 

--- a/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/internal/WithMonitorSpecificScalingExtension.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/internal/WithMonitorSpecificScalingExtension.java
@@ -24,7 +24,7 @@ public final class WithMonitorSpecificScalingExtension extends ResetMonitorSpeci
 	@Override
 	public void beforeEach(ExtensionContext context) throws Exception {
 		super.beforeEach(context);
-		DPIUtil.setMonitorSpecificScaling(true);
+		Win32DPIUtils.setMonitorSpecificScaling(true);
 	}
 
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/widgets/ControlWin32Tests.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/widgets/ControlWin32Tests.java
@@ -36,7 +36,7 @@ class ControlWin32Tests {
 
 	@Test
 	public void testScaleFontCorrectlyInAutoScaleScenario() {
-		DPIUtil.setMonitorSpecificScaling(true);
+		Win32DPIUtils.setMonitorSpecificScaling(true);
 		Display display = Display.getDefault();
 
 		assertTrue("Autoscale property is not set to true", display.isRescalingAtRuntime());
@@ -48,7 +48,7 @@ class ControlWin32Tests {
 
 	@Test
 	public void testSetFontWithMonitorSpecificScalingEnabled() {
-		DPIUtil.setMonitorSpecificScaling(true);
+		Win32DPIUtils.setMonitorSpecificScaling(true);
 		Display display = Display.getDefault();
 		Image colorImage = new Image(display, 10, 10);
 		GC gc = new GC(colorImage);
@@ -59,7 +59,7 @@ class ControlWin32Tests {
 
 	@Test
 	public void testScaleFontCorrectlyInNoAutoScaleScenario() {
-		DPIUtil.setMonitorSpecificScaling(false);
+		Win32DPIUtils.setMonitorSpecificScaling(false);
 		Display display = Display.getDefault();
 
 		assertFalse("Autoscale property is not set to false", display.isRescalingAtRuntime());
@@ -71,7 +71,7 @@ class ControlWin32Tests {
 
 	@Test
 	public void testDoNotScaleFontInNoAutoScaleScenarioWithLegacyFontRegistry() {
-		DPIUtil.setMonitorSpecificScaling(false);
+		Win32DPIUtils.setMonitorSpecificScaling(false);
 		String originalValue = System.getProperty("swt.fontRegistry");
 		System.setProperty("swt.fontRegistry", "legacy");
 		try {
@@ -93,7 +93,7 @@ class ControlWin32Tests {
 
 	@Test
 	public void testCorrectScaleUpUsingDifferentSetBoundsMethod() {
-		DPIUtil.setMonitorSpecificScaling(true);
+		Win32DPIUtils.setMonitorSpecificScaling(true);
 		Display display = Display.getDefault();
 		Shell shell = new Shell(display);
 		Button button = new Button(shell, SWT.PUSH);
@@ -114,7 +114,7 @@ class ControlWin32Tests {
 	@CsvSource({ "0.5, 100, true", "1.0, 200, true", "2.0, 200, true", "2.0, quarter, true", "0.5, 100, false",
 			"1.0, 200, false", "2.0, 200, false", "2.0, quarter, false", })
 	public void testAutoScaleImageData(float scaleFactor, String autoScale, boolean monitorSpecificScaling) {
-		DPIUtil.setMonitorSpecificScaling(monitorSpecificScaling);
+		Win32DPIUtils.setMonitorSpecificScaling(monitorSpecificScaling);
 		DPIUtil.runWithAutoScaleValue(autoScale, () -> {
 			Display display = new Display();
 			try {

--- a/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/widgets/DisplayWin32Test.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/widgets/DisplayWin32Test.java
@@ -13,7 +13,7 @@ class DisplayWin32Test {
 
 	@Test
 	public void monitorSpecificScaling_activate() {
-		DPIUtil.setMonitorSpecificScaling(true);
+		Win32DPIUtils.setMonitorSpecificScaling(true);
 		Display display = Display.getDefault();
 		assertTrue(display.isRescalingAtRuntime());
 		assertEquals(OS.DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2, OS.GetThreadDpiAwarenessContext());
@@ -21,7 +21,7 @@ class DisplayWin32Test {
 
 	@Test
 	public void monitorSpecificScaling_deactivate() {
-		DPIUtil.setMonitorSpecificScaling(false);
+		Win32DPIUtils.setMonitorSpecificScaling(false);
 		Display display = Display.getDefault();
 		assertFalse(display.isRescalingAtRuntime());
 	}

--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/graphics/Image.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/graphics/Image.java
@@ -1831,22 +1831,5 @@ public static void drawScaled(GC gc, ImageData imageData, int width, int height,
 	imageToDraw.dispose();
 }
 
-private final class CocoaDPIUtil {
-
-	/**
-	 * Auto-scale down int dimensions.
-	 */
-	public static int pixelToPoint(int size) {
-		return DPIUtil.pixelToPoint(size, DPIUtil.getDeviceZoom());
-	}
-
-	/**
-	 * Auto-scale down float dimensions.
-	 */
-	public static float pixelToPoint(float size) {
-		return DPIUtil.pixelToPoint(size, DPIUtil.getDeviceZoom());
-	}
-}
-
 }
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/internal/CocoaDPIUtil.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/internal/CocoaDPIUtil.java
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Yatta Solutions and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Yatta Solutions - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.swt.internal;
+
+public class CocoaDPIUtil {
+
+	/**
+	 * Auto-scale down int dimensions.
+	 */
+	public static int pixelToPoint(int size) {
+		return DPIUtil.pixelToPoint(size, DPIUtil.getDeviceZoom());
+	}
+
+	/**
+	 * Auto-scale down float dimensions.
+	 */
+	public static float pixelToPoint(float size) {
+		return DPIUtil.pixelToPoint(size, DPIUtil.getDeviceZoom());
+	}
+
+}

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/graphics/Image.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/graphics/Image.java
@@ -1592,17 +1592,4 @@ public static void drawScaled(GC gc, ImageData imageData, int width, int height,
 	imageToDraw.dispose();
 }
 
-private final class GtkDPIUtil {
-
-	/**
-	 * Auto-scale up ImageData to device zoom that is at 100%.
-	 */
-	public static ImageData pointToPixel (Device device, final ImageData imageData) {
-		int imageDataZoomFactor = 100;
-		if (DPIUtil.getDeviceZoom() == imageDataZoomFactor || imageData == null || (device != null && !device.isAutoScalable())) return imageData;
-		float scaleFactor = (float) DPIUtil.getDeviceZoom() / imageDataZoomFactor;
-		return DPIUtil.autoScaleImageData(device, imageData, scaleFactor);
-	}
-}
-
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/internal/GtkDPIUtil.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/internal/GtkDPIUtil.java
@@ -1,0 +1,34 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Yatta Solutions and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Yatta Solutions - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.swt.internal;
+
+import org.eclipse.swt.graphics.*;
+
+public class GtkDPIUtil {
+	static {
+	    DPIUtil.setUseSmoothScalingByDefaultProvider(() -> {
+	        return DPIUtil.getDeviceZoom() / 100 * 100 != DPIUtil.getDeviceZoom();
+	    });
+	}
+
+	/**
+	 * Auto-scale up ImageData to device zoom that is at 100%.
+	 */
+	public static ImageData pointToPixel (Device device, final ImageData imageData) {
+		int imageDataZoomFactor = 100;
+		if (DPIUtil.getDeviceZoom() == imageDataZoomFactor || imageData == null || (device != null && !device.isAutoScalable())) return imageData;
+		float scaleFactor = (float) DPIUtil.getDeviceZoom() / imageDataZoomFactor;
+		return DPIUtil.autoScaleImageData(device, imageData, scaleFactor);
+	}
+}

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/Win32DPIUtils.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/Win32DPIUtils.java
@@ -32,6 +32,22 @@ import org.eclipse.swt.internal.win32.version.*;
  * @noreference This class is not intended to be referenced by clients
  */
 public class Win32DPIUtils {
+	/**
+	 * System property to enable to scale the application on runtime
+	 * when a DPI change is detected.
+	 * <ul>
+	 * <li>"true": the application is scaled on DPI changes</li>
+	 * <li>"false": the application will remain in its initial scaling</li>
+	 * </ul>
+	 * <b>Important:</b> This flag is only parsed and used on Win32. Setting it to
+	 * true on GTK or cocoa will be ignored.
+	 */
+	private static final String SWT_AUTOSCALE_UPDATE_ON_RUNTIME = "swt.autoScale.updateOnRuntime";
+
+	static {
+	    DPIUtil.setUseSmoothScalingByDefaultProvider(() -> isMonitorSpecificScalingActive());
+	}
+
 	public static boolean setDPIAwareness(int desiredDpiAwareness) {
 		if (desiredDpiAwareness == OS.GetThreadDpiAwarenessContext()) {
 			return true;
@@ -234,6 +250,56 @@ public class Win32DPIUtils {
 	public static Rectangle pointToPixel(Drawable drawable, Rectangle rect, int zoom) {
 		if (drawable != null && !drawable.isAutoScalable()) return rect;
 		return pointToPixel (rect, zoom);
+	}
+
+	public static void setMonitorSpecificScaling(boolean activate) {
+		System.setProperty(SWT_AUTOSCALE_UPDATE_ON_RUNTIME, Boolean.toString(activate));
+	}
+
+	public static void setAutoScaleForMonitorSpecificScaling() {
+		boolean isDefaultAutoScale = DPIUtil.getAutoScaleValue() == null;
+		if (isDefaultAutoScale) {
+			DPIUtil.setAutoScaleValue("quarter");
+		} else if (!isSupportedAutoScaleForMonitorSpecificScaling()) {
+			throw new SWTError(SWT.ERROR_NOT_IMPLEMENTED,
+					"monitor-specific scaling is only implemented for auto-scale values \"quarter\", \"exact\", \"false\" or a concrete zoom value, but \""
+							+ DPIUtil.getAutoScaleValue() + "\" has been specified");
+		}
+	}
+
+	/**
+	 * Monitor-specific scaling on Windows only supports auto-scale modes in which
+	 * all elements (font, images, control bounds etc.) are scaled equally or almost
+	 * equally. The previously default mode "integer"/"integer200", which rounded
+	 * the scale factor for everything but fonts to multiples of 100, is complex and
+	 * difficult to realize with monitor-specific rescaling of UI elements. Since a
+	 * uniform scale factor for everything should perspectively be used anyway,
+	 * there will be support for complex auto-scale modes for monitor-specific
+	 * scaling.
+	 *
+	 * The supported modes are "quarter" and "exact" or explicit zoom values given
+	 * by the value itself or "false". Every other value will be treated as
+	 * "integer"/"integer200" and is thus not supported.
+	 */
+	private static boolean isSupportedAutoScaleForMonitorSpecificScaling() {
+		if (DPIUtil.getAutoScaleValue() == null) {
+			return false;
+		}
+		switch (DPIUtil.getAutoScaleValue().toLowerCase()) {
+			case "false", "quarter", "exact": return true;
+		}
+		try {
+			Integer.parseInt(DPIUtil.getAutoScaleValue());
+			return true;
+		} catch (NumberFormatException e) {
+			// unsupported value, use default
+		}
+		return false;
+	}
+
+	public static boolean isMonitorSpecificScalingActive() {
+		boolean updateOnRuntimeValue = Boolean.getBoolean (SWT_AUTOSCALE_UPDATE_ON_RUNTIME);
+		return updateOnRuntimeValue;
 	}
 
 	/**

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Display.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Display.java
@@ -954,9 +954,9 @@ public void close () {
 protected void create (DeviceData data) {
 	checkSubclass ();
 	checkDisplay (thread = Thread.currentThread (), true);
-	if (DPIUtil.isMonitorSpecificScalingActive()) {
+	if (Win32DPIUtils.isMonitorSpecificScalingActive()) {
 		setMonitorSpecificScaling(true);
-		DPIUtil.setAutoScaleForMonitorSpecificScaling();
+		Win32DPIUtils.setAutoScaleForMonitorSpecificScaling();
 	}
 	createDisplay (data);
 	register (this);


### PR DESCRIPTION
Moving methods that are consumed only by Windows from DPIUtil to Win32DPIUtil (global state handling for monitor-specific scaling)

**Note: The methods are moved using eclipse refactor tool.**