### PR TITLE
Make fonts use  autoscaled zoom when     swt.autoScale is fixed

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/graphics/TextLayoutWin32Tests.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/graphics/TextLayoutWin32Tests.java
@@ -66,7 +66,7 @@ class TextLayoutWin32Tests {
 		scaledLayout.setText(text);
 		Rectangle scaledBounds = scaledLayout.getBounds();
 
-		assertNotEquals(layout.nativeZoom, scaledLayout.nativeZoom, "The native zoom for the TextLayouts must differ");
+		assertNotEquals(layout.fontZoom, scaledLayout.fontZoom, "The font zooms for the TextLayouts must differ");
 		assertEquals(unscaledBounds.height, scaledBounds.height, 1, "The public API for getBounds with vertical indent > 0 should give a similar result for any zoom level");
 	}
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/GC.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/GC.java
@@ -342,7 +342,7 @@ void checkGC(int mask) {
 			}
 		}
 		if ((state & FONT) != 0) {
-			long fontHandle = SWTFontProvider.getFontHandle(data.font, data.nativeZoom);
+			long fontHandle = SWTFontProvider.getFontHandle(data.font, getFontZoom());
 			OS.SelectObject(handle, fontHandle);
 			long[] hFont = new long[1];
 			long gdipFont = createGdipFont(handle, fontHandle, gdipGraphics, device.fontCollection, null, hFont);
@@ -463,7 +463,7 @@ void checkGC(int mask) {
 		OS.SetTextColor(handle, data.foreground);
 	}
 	if ((state & FONT) != 0) {
-		long fontHandle = SWTFontProvider.getFontHandle(data.font, data.nativeZoom);
+		long fontHandle = SWTFontProvider.getFontHandle(data.font, getFontZoom());
 		OS.SelectObject(handle, fontHandle);
 	}
 }
@@ -2712,7 +2712,7 @@ void drawText(long gdipGraphics, String string, int x, int y, int flags, Point s
 	char[] chars = string.toCharArray();
 	long hdc = Gdip.Graphics_GetHDC(gdipGraphics);
 	long hFont = data.hGDIFont;
-	if (hFont == 0 && data.font != null) hFont = SWTFontProvider.getFontHandle(data.font, data.nativeZoom);
+	if (hFont == 0 && data.font != null) hFont = SWTFontProvider.getFontHandle(data.font, getFontZoom());
 	long oldFont = 0;
 	if (hFont != 0) oldFont = OS.SelectObject(hdc, hFont);
 	TEXTMETRIC lptm = new TEXTMETRIC();
@@ -2802,7 +2802,7 @@ private RectF drawText(long gdipGraphics, char[] buffer, int start, int length, 
 	}
 	long hdc = Gdip.Graphics_GetHDC(gdipGraphics);
 	long hFont = data.hGDIFont;
-	if (hFont == 0 && data.font != null) hFont = SWTFontProvider.getFontHandle(data.font, data.nativeZoom);
+	if (hFont == 0 && data.font != null) hFont = SWTFontProvider.getFontHandle(data.font, getFontZoom());
 	long oldFont = 0;
 	if (hFont != 0) oldFont = OS.SelectObject(hdc, hFont);
 	if (start != 0) {
@@ -3945,7 +3945,7 @@ public FontMetrics getFontMetrics() {
 	checkGC(FONT);
 	TEXTMETRIC lptm = new TEXTMETRIC();
 	OS.GetTextMetrics(handle, lptm);
-	return FontMetrics.win32_new(lptm, data.nativeZoom);
+	return FontMetrics.win32_new(lptm, getFontZoom());
 }
 
 /**
@@ -4378,9 +4378,9 @@ private void init(Drawable drawable, GCData data, long hDC) {
 	}
 	if (data.font != null) {
 		data.state &= ~FONT;
-		data.font = Font.win32_new(data.font, data.nativeZoom);
+		data.font = Font.win32_new(data.font, DPIUtil.getFontZoomForAutoscaleProperty(data.nativeZoom));
 	} else {
-		data.font = SWTFontProvider.getFont(device, OS.GetCurrentObject(hDC, OS.OBJ_FONT), data.nativeZoom);
+		data.font = SWTFontProvider.getFont(device, OS.GetCurrentObject(hDC, OS.OBJ_FONT), DPIUtil.getFontZoomForAutoscaleProperty(data.nativeZoom));
 	}
 	Image image = data.image;
 	if (image != null) {
@@ -5015,12 +5015,12 @@ private class SetFontOperation extends Operation {
 	private final Font font;
 
 	SetFontOperation(Font font) {
-		this.font = font != null ? SWTFontProvider.getFont(font.getDevice(), font.getFontData()[0], data.nativeZoom) : null;
+		this.font = font != null ? SWTFontProvider.getFont(font.getDevice(), font.getFontData()[0], getFontZoom()) : null;
 	}
 
 	@Override
 	void apply() {
-		data.font = font != null ? SWTFontProvider.getFont(font.getDevice(), font.getFontData()[0], data.nativeZoom) : SWTFontProvider.getSystemFont(device, data.nativeZoom);
+		data.font = font != null ? SWTFontProvider.getFont(font.getDevice(), font.getFontData()[0], getFontZoom()) : SWTFontProvider.getSystemFont(device, getFontZoom());
 		data.state &= ~FONT;
 	}
 }
@@ -5940,6 +5940,10 @@ private static int sin(int angle, int length) {
 
 int getZoom() {
 	return DPIUtil.getZoomForAutoscaleProperty(data.nativeZoom);
+}
+
+int getFontZoom() {
+	return DPIUtil.getFontZoomForAutoscaleProperty(data.nativeZoom);
 }
 
 private void storeAndApplyOperationForExistingHandle(Operation operation) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/TextLayout.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/TextLayout.java
@@ -67,7 +67,7 @@ public final class TextLayout extends Resource {
 
 	private MetricsAdapter metricsAdapter = new MetricsAdapter();
 
-	int nativeZoom = DPIUtil.getNativeDeviceZoom();
+	int fontZoom = DPIUtil.getFontZoomForAutoscaleProperty(DPIUtil.getNativeDeviceZoom());
 
 	static final char LTR_MARK = '\u200E', RTL_MARK = '\u200F';
 	static final int SCRIPT_VISATTR_SIZEOF = 2;
@@ -363,9 +363,9 @@ void checkLayout () {
 * 	Break paragraphs into lines, wraps the text, and initialize caches.
 */
 void computeRuns (GC gc) {
-	int newNativeZoom = getNativeZoom(gc);
-	if (nativeZoom != newNativeZoom) {
-		nativeZoom = newNativeZoom;
+	int newFontZoom = getFontZoom(gc);
+	if (fontZoom != newFontZoom) {
+		fontZoom = newFontZoom;
 		freeRuns();
 	}
 	if (runs != null) return;
@@ -768,19 +768,19 @@ public void draw (GC gc, int x, int y, int selectionStart, int selectionEnd, Col
 	drawInPixels(gc, x, y, selectionStart, selectionEnd, selectionForeground, selectionBackground, flags);
 }
 
-private int getNativeZoom(GC gc) {
+private int getFontZoom(GC gc) {
 	if (gc != null) {
-		return gc.data.nativeZoom;
+		return DPIUtil.getFontZoomForAutoscaleProperty(gc.data.nativeZoom);
 	}
-	return nativeZoom;
+	return fontZoom;
 }
 
 private int getZoom(GC gc){
-	return DPIUtil.getZoomForAutoscaleProperty(getNativeZoom(gc));
+	return DPIUtil.getZoomForAutoscaleProperty(getFontZoom(gc));
 }
 
 private int getZoom() {
-	return DPIUtil.getZoomForAutoscaleProperty(nativeZoom);
+	return DPIUtil.getZoomForAutoscaleProperty(fontZoom);
 }
 
 void drawInPixels (GC gc, int xInPoints, int yInPoints) {
@@ -1970,7 +1970,7 @@ public boolean getJustify () {
 
 long getItemFont (StyleItem item, GC gc) {
 	if (item.fallbackFont != 0) return item.fallbackFont;
-	final int zoom = getNativeZoom(gc);
+	final int zoom = getFontZoom(gc);
 	if (item.style != null && item.style.font != null) {
 		return SWTFontProvider.getFontHandle(item.style.font, zoom);
 	}
@@ -2157,7 +2157,7 @@ public FontMetrics getLineMetrics (int lineIndex) {
 	lptm.tmHeight = Win32DPIUtils.pointToPixel(this.device, ascentInPoints + descentInPoints, zoom);
 	lptm.tmInternalLeading = Win32DPIUtils.pointToPixel(this.device, leadingInPoints, zoom);
 	lptm.tmAveCharWidth = 0;
-	return FontMetrics.win32_new(lptm, nativeZoom);
+	return FontMetrics.win32_new(lptm, fontZoom);
 }
 
 /**
@@ -3258,7 +3258,7 @@ public void setFont (Font font) {
 	Font oldFont = this.font;
 	if (oldFont == font) return;
 	this.font = font;
-	this.nativeZoom = this.font == null ? nativeZoom : this.font.zoom;
+	this.fontZoom = this.font == null ? fontZoom : this.font.zoom;
 	if (oldFont != null && oldFont.equals(font)) return;
 	freeRuns();
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Control.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Control.java
@@ -1763,7 +1763,7 @@ public long internal_new_GC (GCData data) {
 		if (font != null) {
 			data.font = font;
 		} else {
-			data.font = SWTFontProvider.getFont(display, OS.SendMessage (hwnd, OS.WM_GETFONT, 0, 0), data.nativeZoom);
+			data.font = SWTFontProvider.getFont(display, OS.SendMessage (hwnd, OS.WM_GETFONT, 0, 0), DPIUtil.getFontZoomForAutoscaleProperty(data.nativeZoom));
 		}
 		data.uiState = (int)OS.SendMessage (hwnd, OS.WM_QUERYUISTATE, 0, 0);
 	}


### PR DESCRIPTION
This change ensures that images and fonts share the same zoom level when  a fixed autoscale value is used.

Previously, when different GCs were created for images and widgets, their native zoom(GC.data.nativeZoom) levels could differ, causing inconsistencies.

For example, in `LineNumberRuler`, one GC is created from an image (used for rendering), and another is created from a widget (used for text measurement). The differing native zoom levels between these GCs led to incorrect text width calculations. Specifically, one GC was used to measure the text extent, while the other used those measurements to calculate the width of the columns where the text would be drawn and this resulted in #2311


### Steps to reproduce
1)Checkout the first commit.  Run steps in https://github.com/eclipse-platform/eclipse.platform.swt/pull/2306
2)Checkout the second commit, this solves the issue with lineNumberRuler

First commit which reverts changes from #2306  Fixes #2361 
Second commit fixes the original issue in #2311