### PR TITLE
Initialization handles without creating a Cursor instance

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Cursor.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Cursor.java
@@ -444,12 +444,12 @@ public static Long win32_getHandle (Cursor cursor, int zoom) {
 			source = DPIUtil.scaleImageData(cursor.device, cursor.source, zoom, DEFAULT_ZOOM);
 		}
 		if (cursor.isIcon) {
-			Cursor newCursor = new Cursor(cursor.device, source, Win32DPIUtils.pointToPixel(cursor.hotspotX, zoom), Win32DPIUtils.pointToPixel(cursor.hotspotY, zoom));
-			cursor.setHandleForZoomLevel(newCursor.handle, zoom);
+			long handle = setupCursorFromImageData(cursor.getDevice(), source, Win32DPIUtils.pointToPixel(cursor.hotspotX, zoom), Win32DPIUtils.pointToPixel(cursor.hotspotY, zoom));
+			cursor.setHandleForZoomLevel(handle, zoom);
 		} else {
-			ImageData mask = DPIUtil.scaleImageData(cursor.device, cursor.mask, zoom, DEFAULT_ZOOM);
-			Cursor newCursor = new Cursor(cursor.device, source, mask, Win32DPIUtils.pointToPixel(cursor.hotspotX, zoom), Win32DPIUtils.pointToPixel(cursor.hotspotY, zoom));
-			cursor.setHandleForZoomLevel(newCursor.handle, zoom);
+			ImageData mask = DPIUtil.scaleImageData(cursor.getDevice(), cursor.mask, zoom, DEFAULT_ZOOM);
+			long handle = setupCursorFromImageData(source, mask, Win32DPIUtils.pointToPixel(cursor.hotspotX, zoom), Win32DPIUtils.pointToPixel(cursor.hotspotY, zoom));
+			cursor.setHandleForZoomLevel(handle, zoom);
 		}
 	}
 	return cursor.zoomLevelToHandle.get(zoom);


### PR DESCRIPTION
In win32_getHandle, a new cursor instance is created to retrieve the OS handle. With this change, we are able to safely retrieve the handle without creating a cursor instance.

### How to Reproduce

To reproduce the issue, run the following snippet with resource tracking turned on:

`-Dorg.eclipse.swt.graphics.Resource.reportNonDisposed=true`


```java
import org.eclipse.swt.graphics.*;
import org.eclipse.swt.widgets.*;

public class Snippet {
	public static void main(String[] args) throws InterruptedException  {
		Cursor cursor = new Cursor(Display.getDefault(), new ImageData(1, 1, 24, new PaletteData(0xFF, 0xFF00, 0xFF0000)), 0, 0);
		Cursor.win32_getHandle(cursor, 200);
		System.gc();
		Thread.sleep(1000);
	}
}
```

You will see the following error:

```
java.lang.Error: SWT Resource was not properly disposed
	at org.eclipse.swt.graphics.Resource.initNonDisposeTracking(Resource.java:191)
	at org.eclipse.swt.graphics.Resource.<init>(Resource.java:124)
	at org.eclipse.swt.graphics.Cursor.<init>(Cursor.java:282)
	at org.eclipse.swt.graphics.Cursor.win32_getHandle(Cursor.java:447)
	at org.eclipse.swt.snippets.Snippet.main(Snippet.java:9)

```

### Expected Result

With this PR, there should be no `NonDisposeResource` error since we are now not creating a new Cursor instance to retrieve the handle.

Fixes: https://github.com/eclipse-platform/eclipse.platform.swt/issues/2355