### PR TITLE
[win32] Use deviceZoom in single zoom mapper

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/SingleZoomCoordinateSystemMapper.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/SingleZoomCoordinateSystemMapper.java
@@ -77,22 +77,22 @@ class SingleZoomCoordinateSystemMapper implements CoordinateSystemMapper {
 
 	@Override
 	public Point translateFromDisplayCoordinates(Point point, int zoom) {
-		return Win32DPIUtils.pixelToPoint(point, zoom);
+		return Win32DPIUtils.pixelToPoint(point, DPIUtil.getDeviceZoom());
 	}
 
 	@Override
 	public Point translateToDisplayCoordinates(Point point, int zoom) {
-		return Win32DPIUtils.pointToPixel(point, zoom);
+		return Win32DPIUtils.pointToPixel(point, DPIUtil.getDeviceZoom());
 	}
 
 	@Override
 	public Rectangle translateFromDisplayCoordinates(Rectangle rect, int zoom) {
-		return Win32DPIUtils.pixelToPoint(rect, zoom);
+		return Win32DPIUtils.pixelToPoint(rect, DPIUtil.getDeviceZoom());
 	}
 
 	@Override
 	public Rectangle translateToDisplayCoordinates(Rectangle rect, int zoom) {
-		return Win32DPIUtils.pointToPixel(rect, zoom);
+		return Win32DPIUtils.pointToPixel(rect, DPIUtil.getDeviceZoom());
 	}
 
 	@Override


### PR DESCRIPTION
This PR replaces the usage of the zoom attribute in methods in the `SingleZoomCoordinateMapper` that translate `Point` and `Rectangle` from and to display coordinates to use `DPIUtil.getDeviceZoom()` instead. As each widget inherits its zoom from  `DPIUtil.getDeviceZoom()` when the `SingleZoomCoordinateMapper` is involved, the behavior is not changed in most scenarios. but this PR fixes the scenarios, if a widget is scaled to a different zoom, e.g. by utilizing `widget.setData("AUTOSCALE_DISABLED", true)` the current implementation will break all conversions. One important factor in the CoordinateMapper implementation is to have a consistent translation from and to display coordinates. In the `MultiZoomCoordinateSystemMapper` this is achieved by extracting the Monitor (zoom) out of the coordinate to translate. In `SingleZoomCoordinateMapper`, the implementation was not consistent yet, as e.g. in `SingleZoomCoordinateMapper#getCursorLocation` or `SingleZoomCoordinateMapper#setCursorLocation` `DPIUtil.getDeviceZoom()` is already used.