### PR TITLE
[GTK] Fire settings event on Gtk theme change

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/org/eclipse/swt/internal/gtk/OS.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/org/eclipse/swt/internal/gtk/OS.java
@@ -338,6 +338,7 @@ public class OS extends C {
 	public static final byte[] mnemonic_activate = ascii("mnemonic-activate");
 	public static final byte[] month_changed = ascii("month-changed");
 	public static final byte[] next_month = ascii("next-month");
+	public static final byte[] notify_gtk_theme = ascii("notify::gtk-theme-name");
 	public static final byte[] prev_month = ascii("prev-month");
 	public static final byte[] next_year = ascii("next-year");
 	public static final byte[] prev_year = ascii("prev-year");


### PR DESCRIPTION
Listen for notify::gtk-theme-name signal and fire SWT.Settings even in this case. Fixes https://github.com/eclipse-platform/eclipse.platform.swt/issues/2374