### PR TITLE
Fix label cutoff

### DIFF
--- a/binaries/org.eclipse.swt.cocoa.macosx.aarch64/META-INF/MANIFEST.MF
+++ b/binaries/org.eclipse.swt.cocoa.macosx.aarch64/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Fragment-Host: org.eclipse.swt;bundle-version="[3.128.0,4.0.0)"
 Bundle-Name: %fragmentName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.swt.cocoa.macosx.aarch64; singleton:=true
-Bundle-Version: 3.131.100.qualifier
+Bundle-Version: 3.132.0.qualifier
 Bundle-ManifestVersion: 2
 Bundle-Localization: fragment
 Export-Package: 

--- a/binaries/org.eclipse.swt.cocoa.macosx.x86_64/META-INF/MANIFEST.MF
+++ b/binaries/org.eclipse.swt.cocoa.macosx.x86_64/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Fragment-Host: org.eclipse.swt;bundle-version="[3.128.0,4.0.0)"
 Bundle-Name: %fragmentName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.swt.cocoa.macosx.x86_64; singleton:=true
-Bundle-Version: 3.131.100.qualifier
+Bundle-Version: 3.132.0.qualifier
 Bundle-ManifestVersion: 2
 Bundle-Localization: fragment
 Export-Package: 

--- a/binaries/org.eclipse.swt.gtk.linux.aarch64/META-INF/MANIFEST.MF
+++ b/binaries/org.eclipse.swt.gtk.linux.aarch64/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Fragment-Host: org.eclipse.swt;bundle-version="[3.128.0,4.0.0)"
 Bundle-Name: %fragmentName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.swt.gtk.linux.aarch64; singleton:=true
-Bundle-Version: 3.131.100.qualifier
+Bundle-Version: 3.132.0.qualifier
 Bundle-ManifestVersion: 2
 Bundle-Localization: fragment
 Export-Package: 

--- a/binaries/org.eclipse.swt.gtk.linux.loongarch64/META-INF/MANIFEST.MF
+++ b/binaries/org.eclipse.swt.gtk.linux.loongarch64/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Fragment-Host: org.eclipse.swt;bundle-version="[3.128.0,4.0.0)"
 Bundle-Name: %fragmentName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.swt.gtk.linux.loongarch64; singleton:=true
-Bundle-Version: 3.131.0.qualifier
+Bundle-Version: 3.132.0.qualifier
 Bundle-ManifestVersion: 2
 Bundle-Localization: fragment
 Export-Package: 

--- a/binaries/org.eclipse.swt.gtk.linux.ppc64le/META-INF/MANIFEST.MF
+++ b/binaries/org.eclipse.swt.gtk.linux.ppc64le/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Fragment-Host: org.eclipse.swt;bundle-version="[3.128.0,4.0.0)"
 Bundle-Name: %fragmentName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.swt.gtk.linux.ppc64le;singleton:=true
-Bundle-Version: 3.131.100.qualifier
+Bundle-Version: 3.132.0.qualifier
 Bundle-ManifestVersion: 2
 Bundle-Localization: fragment
 Export-Package: 

--- a/binaries/org.eclipse.swt.gtk.linux.riscv64/META-INF/MANIFEST.MF
+++ b/binaries/org.eclipse.swt.gtk.linux.riscv64/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Fragment-Host: org.eclipse.swt;bundle-version="[3.128.0,4.0.0)"
 Bundle-Name: %fragmentName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.swt.gtk.linux.riscv64; singleton:=true
-Bundle-Version: 3.131.100.qualifier
+Bundle-Version: 3.132.0.qualifier
 Bundle-ManifestVersion: 2
 Bundle-Localization: fragment
 Export-Package: 

--- a/binaries/org.eclipse.swt.gtk.linux.x86_64/META-INF/MANIFEST.MF
+++ b/binaries/org.eclipse.swt.gtk.linux.x86_64/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Fragment-Host: org.eclipse.swt;bundle-version="[3.128.0,4.0.0)"
 Bundle-Name: %fragmentName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.swt.gtk.linux.x86_64; singleton:=true
-Bundle-Version: 3.131.100.qualifier
+Bundle-Version: 3.132.0.qualifier
 Bundle-ManifestVersion: 2
 Bundle-Localization: fragment
 Export-Package: 

--- a/binaries/org.eclipse.swt.win32.win32.aarch64/META-INF/MANIFEST.MF
+++ b/binaries/org.eclipse.swt.win32.win32.aarch64/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Fragment-Host: org.eclipse.swt;bundle-version="[3.128.0,4.0.0)"
 Bundle-Name: %fragmentName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.swt.win32.win32.aarch64; singleton:=true
-Bundle-Version: 3.131.100.qualifier
+Bundle-Version: 3.132.0.qualifier
 Bundle-ManifestVersion: 2
 Bundle-Localization: fragment
 Export-Package: 

--- a/binaries/org.eclipse.swt.win32.win32.x86_64/META-INF/MANIFEST.MF
+++ b/binaries/org.eclipse.swt.win32.win32.x86_64/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Fragment-Host: org.eclipse.swt;bundle-version="[3.128.0,4.0.0)"
 Bundle-Name: %fragmentName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.swt.win32.win32.x86_64; singleton:=true
-Bundle-Version: 3.131.100.qualifier
+Bundle-Version: 3.132.0.qualifier
 Bundle-ManifestVersion: 2
 Bundle-Localization: fragment
 Export-Package: 

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/Point.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/Point.java
@@ -158,6 +158,13 @@ public static sealed class OfFloat extends Point permits Point.WithMonitor {
 		this.y = Math.round(y);
 		this.residualY = y - this.y;
 	}
+
+	public static Point.OfFloat from(Point point) {
+		if (point instanceof Point.OfFloat pointOfFloat) {
+			return new Point.OfFloat(pointOfFloat.getX(), pointOfFloat.getY());
+		}
+		return new Point.OfFloat(point.x, point.y);
+	}
 }
 
 /**

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/Rectangle.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/Rectangle.java
@@ -459,6 +459,13 @@ public static sealed class OfFloat extends Rectangle permits Rectangle.WithMonit
 		this.residualHeight = height - this.height;
 	}
 
+	public static Rectangle.OfFloat from(Rectangle rectangle) {
+		if (rectangle instanceof Rectangle.OfFloat rectangleOfFloat) {
+			return new Rectangle.OfFloat(rectangleOfFloat.getX(), rectangleOfFloat.getY(), rectangleOfFloat.getWidth(), rectangleOfFloat.getHeight());
+		}
+		return new Rectangle.OfFloat(rectangle.x, rectangle.y, rectangle.width, rectangle.height);
+	}
+
 }
 
 /**

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/layout/GridData.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/layout/GridData.java
@@ -398,9 +398,9 @@ public final class GridData {
 	 */
 	public static final int FILL_BOTH = FILL_VERTICAL | FILL_HORIZONTAL;
 
-	int cacheWidth = -1, cacheHeight = -1;
-	int defaultWhint, defaultHhint, defaultWidth = -1, defaultHeight = -1;
-	int currentWhint, currentHhint, currentWidth = -1, currentHeight = -1;
+	float cacheWidth = -1, cacheHeight = -1;
+	int defaultWhint, defaultHhint, currentWhint, currentHhint;
+	float defaultWidth = -1, defaultHeight = -1, currentWidth = -1, currentHeight = -1;
 
 /**
  * Constructs a new instance of GridData using
@@ -493,19 +493,20 @@ void computeSize (Control control, int wHint, int hHint, boolean flushCache) {
 			Point size = control.computeSize (wHint, hHint, flushCache);
 			defaultWhint = wHint;
 			defaultHhint = hHint;
-			defaultWidth = size.x;
-			defaultHeight = size.y;
+			Point.OfFloat defaultSize = Point.OfFloat.from(size);
+			defaultWidth = defaultSize.getX();
+			defaultHeight = defaultSize.getY();
 		}
 		cacheWidth = defaultWidth;
 		cacheHeight = defaultHeight;
 		return;
 	}
 	if (currentWidth == -1 || currentHeight == -1 || wHint != currentWhint || hHint != currentHhint) {
-		Point size = control.computeSize (wHint, hHint, flushCache);
+		Point.OfFloat size = Point.OfFloat.from(control.computeSize (wHint, hHint, flushCache));
 		currentWhint = wHint;
 		currentHhint = hHint;
-		currentWidth = size.x;
-		currentHeight = size.y;
+		currentWidth = size.getX();
+		currentHeight = size.getY();
 	}
 	cacheWidth = currentWidth;
 	cacheHeight = currentHeight;

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/layout/GridLayout.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/layout/GridLayout.java
@@ -292,8 +292,8 @@ Point layout (Composite composite, boolean move, int x, int y, int width, int he
 	/* Column widths */
 	int availableWidth = width - horizontalSpacing * (columnCount - 1) - (marginLeft + marginWidth * 2 + marginRight);
 	int expandCount = 0;
-	int [] widths = new int [columnCount];
-	int [] minWidths = new int [columnCount];
+	float [] widths = new float [columnCount];
+	float [] minWidths = new float [columnCount];
 	boolean [] expandColumn = new boolean [columnCount];
 	for (int j=0; j<columnCount; j++) {
 		for (int i=0; i<rowCount; i++) {
@@ -301,7 +301,7 @@ Point layout (Composite composite, boolean move, int x, int y, int width, int he
 			if (data != null) {
 				int hSpan = Math.max (1, Math.min (data.horizontalSpan, columnCount));
 				if (hSpan == 1) {
-					int w = data.cacheWidth + data.horizontalIndent;
+					float w = data.cacheWidth + data.horizontalIndent;
 					widths [j] = Math.max (widths [j], w);
 					if (data.grabExcessHorizontalSpace) {
 						if (!expandColumn [j]) expandCount++;
@@ -330,27 +330,23 @@ Point layout (Composite composite, boolean move, int x, int y, int width, int he
 						expandCount++;
 						expandColumn [j] = true;
 					}
-					int w = data.cacheWidth + data.horizontalIndent - spanWidth - (hSpan - 1) * horizontalSpacing;
+					float w = data.cacheWidth + data.horizontalIndent - spanWidth - (hSpan - 1) * horizontalSpacing;
 					if (w > 0) {
 						if (makeColumnsEqualWidth) {
-							int equalWidth = (w + spanWidth) / hSpan;
-							int remainder = (w + spanWidth) % hSpan, last = -1;
+							float equalWidth = (w + spanWidth) / hSpan;
 							for (int k = 0; k < hSpan; k++) {
-								widths [last=j-k] = Math.max (equalWidth, widths [j-k]);
+								widths [j-k] = Math.max (equalWidth, widths [j-k]);
 							}
-							if (last > -1) widths [last] += remainder;
 						} else {
 							if (spanExpandCount == 0) {
 								widths [j] += w;
 							} else {
-								int delta = w / spanExpandCount;
-								int remainder = w % spanExpandCount, last = -1;
+								float delta = w / spanExpandCount;
 								for (int k = 0; k < hSpan; k++) {
 									if (expandColumn [j-k]) {
-										widths [last=j-k] += delta;
+										widths [j-k] += delta;
 									}
 								}
-								if (last > -1) widths [last] += remainder;
 							}
 						}
 					}
@@ -361,14 +357,12 @@ Point layout (Composite composite, boolean move, int x, int y, int width, int he
 							if (spanExpandCount == 0) {
 								minWidths [j] += w;
 							} else {
-								int delta = w / spanExpandCount;
-								int remainder = w % spanExpandCount, last = -1;
+								float delta = w / spanExpandCount;
 								for (int k = 0; k < hSpan; k++) {
 									if (expandColumn [j-k]) {
-										minWidths [last=j-k] += delta;
+										minWidths [j-k] += delta;
 									}
 								}
-								if (last > -1) minWidths [last] += remainder;
 							}
 						}
 					}
@@ -377,8 +371,8 @@ Point layout (Composite composite, boolean move, int x, int y, int width, int he
 		}
 	}
 	if (makeColumnsEqualWidth) {
-		int minColumnWidth = 0;
-		int columnWidth = 0;
+		float minColumnWidth = 0;
+		float columnWidth = 0;
 		for (int i=0; i<columnCount; i++) {
 			minColumnWidth = Math.max (minColumnWidth, minWidths [i]);
 			columnWidth = Math.max (columnWidth, widths [i]);
@@ -424,20 +418,18 @@ Point layout (Composite composite, boolean move, int x, int y, int width, int he
 										spanWidth += widths [j-k];
 										if (expandColumn [j-k]) spanExpandCount++;
 									}
-									int w = !data.grabExcessHorizontalSpace || data.minimumWidth == SWT.DEFAULT ? data.cacheWidth : data.minimumWidth;
+									float w = !data.grabExcessHorizontalSpace || data.minimumWidth == SWT.DEFAULT ? data.cacheWidth : data.minimumWidth;
 									w += data.horizontalIndent - spanWidth - (hSpan - 1) * horizontalSpacing;
 									if (w > 0) {
 										if (spanExpandCount == 0) {
 											widths [j] += w;
 										} else {
-											int delta2 = w / spanExpandCount;
-											int remainder2 = w % spanExpandCount, last2 = -1;
+											float delta2 = w / spanExpandCount;
 											for (int k = 0; k < hSpan; k++) {
 												if (expandColumn [j-k]) {
-													widths [last2=j-k] += delta2;
+													widths [j-k] += delta2;
 												}
 											}
-											if (last2 > -1) widths [last2] += remainder2;
 										}
 									}
 								}
@@ -499,8 +491,8 @@ Point layout (Composite composite, boolean move, int x, int y, int width, int he
 	/* Row heights */
 	int availableHeight = height - verticalSpacing * (rowCount - 1) - (marginTop + marginHeight * 2 + marginBottom);
 	expandCount = 0;
-	int [] heights = new int [rowCount];
-	int [] minHeights = new int [rowCount];
+	float [] heights = new float [rowCount];
+	float [] minHeights = new float [rowCount];
 	boolean [] expandRow = new boolean [rowCount];
 	for (int i=0; i<rowCount; i++) {
 		for (int j=0; j<columnCount; j++) {
@@ -508,7 +500,7 @@ Point layout (Composite composite, boolean move, int x, int y, int width, int he
 			if (data != null) {
 				int vSpan = Math.max (1, Math.min (data.verticalSpan, rowCount));
 				if (vSpan == 1) {
-					int h = data.cacheHeight + data.verticalIndent;
+					float h = data.cacheHeight + data.verticalIndent;
 					heights [i] = Math.max (heights [i], h);
 					if (data.grabExcessVerticalSpace) {
 						if (!expandRow [i]) expandCount++;
@@ -537,19 +529,17 @@ Point layout (Composite composite, boolean move, int x, int y, int width, int he
 						expandCount++;
 						expandRow [i] = true;
 					}
-					int h = data.cacheHeight + data.verticalIndent - spanHeight - (vSpan - 1) * verticalSpacing;
+					float h = data.cacheHeight + data.verticalIndent - spanHeight - (vSpan - 1) * verticalSpacing;
 					if (h > 0) {
 						if (spanExpandCount == 0) {
 							heights [i] += h;
 						} else {
-							int delta = h / spanExpandCount;
-							int remainder = h % spanExpandCount, last = -1;
+							float delta = h / spanExpandCount;
 							for (int k = 0; k < vSpan; k++) {
 								if (expandRow [i-k]) {
-									heights [last=i-k] += delta;
+									heights [i-k] += delta;
 								}
 							}
-							if (last > -1) heights [last] += remainder;
 						}
 					}
 					if (!data.grabExcessVerticalSpace || data.minimumHeight != 0) {
@@ -559,14 +549,12 @@ Point layout (Composite composite, boolean move, int x, int y, int width, int he
 							if (spanExpandCount == 0) {
 								minHeights [i] += h;
 							} else {
-								int delta = h / spanExpandCount;
-								int remainder = h % spanExpandCount, last = -1;
+								float delta = h / spanExpandCount;
 								for (int k = 0; k < vSpan; k++) {
 									if (expandRow [i-k]) {
-										minHeights [last=i-k] += delta;
+										minHeights [i-k] += delta;
 									}
 								}
-								if (last > -1) minHeights [last] += remainder;
 							}
 						}
 					}
@@ -609,20 +597,18 @@ Point layout (Composite composite, boolean move, int x, int y, int width, int he
 									spanHeight += heights [i-k];
 									if (expandRow [i-k]) spanExpandCount++;
 								}
-								int h = !data.grabExcessVerticalSpace || data.minimumHeight == SWT.DEFAULT ? data.cacheHeight : data.minimumHeight;
+								float h = !data.grabExcessVerticalSpace || data.minimumHeight == SWT.DEFAULT ? data.cacheHeight : data.minimumHeight;
 								h += data.verticalIndent - spanHeight - (vSpan - 1) * verticalSpacing;
 								if (h > 0) {
 									if (spanExpandCount == 0) {
 										heights [i] += h;
 									} else {
-										int delta2 = h / spanExpandCount;
-										int remainder2 = h % spanExpandCount, last2 = -1;
+										float delta2 = h / spanExpandCount;
 										for (int k = 0; k < vSpan; k++) {
 											if (expandRow [i-k]) {
-												heights [last2=i-k] += delta2;
+												heights [i-k] += delta2;
 											}
 										}
-										if (last2 > -1) heights [last2] += remainder2;
 									}
 								}
 							}
@@ -651,7 +637,7 @@ Point layout (Composite composite, boolean move, int x, int y, int width, int he
 				if (data != null) {
 					int hSpan = Math.max (1, Math.min (data.horizontalSpan, columnCount));
 					int vSpan = Math.max (1, data.verticalSpan);
-					int cellWidth = 0, cellHeight = 0;
+					float cellWidth = 0, cellHeight = 0;
 					for (int k=0; k<hSpan; k++) {
 						cellWidth += widths [j+k];
 					}
@@ -660,7 +646,7 @@ Point layout (Composite composite, boolean move, int x, int y, int width, int he
 					}
 					cellWidth += horizontalSpacing * (hSpan - 1);
 					int childX = gridX + data.horizontalIndent;
-					int childWidth = Math.min (data.cacheWidth, cellWidth);
+					float childWidth = Math.min (data.cacheWidth, cellWidth);
 					switch (data.horizontalAlignment) {
 						case SWT.CENTER:
 						case GridData.CENTER:
@@ -677,7 +663,7 @@ Point layout (Composite composite, boolean move, int x, int y, int width, int he
 					}
 					cellHeight += verticalSpacing * (vSpan - 1);
 					int childY = gridY + data.verticalIndent;
-					int childHeight = Math.min (data.cacheHeight, cellHeight);
+					float childHeight = Math.min (data.cacheHeight, cellHeight);
 					switch (data.verticalAlignment) {
 						case SWT.CENTER:
 						case GridData.CENTER:
@@ -694,7 +680,7 @@ Point layout (Composite composite, boolean move, int x, int y, int width, int he
 					}
 					Control child = grid [i][j];
 					if (child != null) {
-						child.setBounds (childX, childY, childWidth, childHeight);
+						child.setBounds (new Rectangle.OfFloat(childX, childY, childWidth, childHeight));
 					}
 				}
 				gridX += widths [j] + horizontalSpacing;
@@ -708,8 +694,8 @@ Point layout (Composite composite, boolean move, int x, int y, int width, int he
 		flush [i].cacheWidth = flush [i].cacheHeight = -1;
 	}
 
-	int totalDefaultWidth = 0;
-	int totalDefaultHeight = 0;
+	float totalDefaultWidth = 0;
+	float totalDefaultHeight = 0;
 	for (int i=0; i<columnCount; i++) {
 		totalDefaultWidth += widths [i];
 	}
@@ -718,7 +704,7 @@ Point layout (Composite composite, boolean move, int x, int y, int width, int he
 	}
 	totalDefaultWidth += horizontalSpacing * (columnCount - 1) + marginLeft + marginWidth * 2 + marginRight;
 	totalDefaultHeight += verticalSpacing * (rowCount - 1) + marginTop + marginHeight * 2 + marginBottom;
-	return new Point (totalDefaultWidth, totalDefaultHeight);
+	return new Point.OfFloat (totalDefaultWidth, totalDefaultHeight);
 }
 
 String getName () {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/Win32DPIUtils.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/Win32DPIUtils.java
@@ -115,7 +115,7 @@ public class Win32DPIUtils {
 
 	public static Point pixelToPoint(Point point, int zoom) {
 		if (zoom == 100 || point == null) return point;
-		Point.OfFloat fPoint = FloatAwareGeometryFactory.createFrom(point);
+		Point.OfFloat fPoint = Point.OfFloat.from(point);
 		float scaleFactor = DPIUtil.getScalingFactor(zoom);
 		float scaledX = fPoint.getX() / scaleFactor;
 		float scaledY = fPoint.getY() / scaleFactor;
@@ -170,7 +170,7 @@ public class Win32DPIUtils {
 	 */
 	private static Rectangle scaleBounds (Rectangle.OfFloat rect, int targetZoom, int currentZoom) {
 		if (rect == null || targetZoom == currentZoom) return rect;
-		Rectangle.OfFloat fRect = FloatAwareGeometryFactory.createFrom(rect);
+		Rectangle.OfFloat fRect = Rectangle.OfFloat.from(rect);
 		float scaleFactor = DPIUtil.getScalingFactor(targetZoom, currentZoom);
 		float scaledX = fRect.getX() * scaleFactor;
 		float scaledY = fRect.getY() * scaleFactor;
@@ -221,7 +221,7 @@ public class Win32DPIUtils {
 
 	public static Point pointToPixel(Point point, int zoom) {
 		if (zoom == 100 || point == null) return point;
-		Point.OfFloat fPoint = FloatAwareGeometryFactory.createFrom(point);
+		Point.OfFloat fPoint = Point.OfFloat.from(point);
 		float scaleFactor = DPIUtil.getScalingFactor(zoom);
 		float scaledX = fPoint.getX() * scaleFactor;
 		float scaledY = fPoint.getY() * scaleFactor;
@@ -328,22 +328,6 @@ public class Win32DPIUtils {
 		@Override
 		public ImageData getImageData(int zoom) {
 			return DPIUtil.scaleImageData(device, imageData, zoom, currentZoom);
-		}
-	}
-
-	private class FloatAwareGeometryFactory {
-		static Rectangle.OfFloat createFrom(Rectangle rectangle) {
-			if (rectangle instanceof Rectangle.OfFloat) {
-				return (Rectangle.OfFloat) rectangle;
-			}
-			return new Rectangle.OfFloat(rectangle.x, rectangle.y, rectangle.width, rectangle.height);
-		}
-
-		static Point.OfFloat createFrom(Point point) {
-			if (point instanceof Point.OfFloat) {
-				return (Point.OfFloat) point;
-			}
-			return new Point.OfFloat(point.x, point.y);
 		}
 	}
 }


### PR DESCRIPTION
This PR contributes to precise scaling of computation of size inside gridLayout by using float precision. This fixes the issue reported in https://github.com/eclipse-platform/eclipse.platform.swt/issues/2166

### Explanation
The issue happens because of the loss of precision while calculating the size of the grid in the GridLayout. The code at first calculates the size of widget in GridData#computeSize. Since the width and height in GridData were stored as integer, the returned Point.OfFloat from Control#computeSize is not fully utilized and the residualX and residualY (the floating pointer values) are lost and only integer is used.

Later this less precision integer value is used to set the bounds of the grid, which leads to wrapping the widget with the wrong size. In case of #2166, that leads to wrapping of the text in the widget while the height of the grid is set thinking that the text doesn't need wrapping.

A simple example for loss of precision:
Let's say a pixel value 223 is set at 150%.
when it is obtained in points by GridData#computeSize, it is 223/1.5 = 148.6667 i.e. 149
When scaled up on GridLayout#layout on child.setBounds, it becomes 149 * 1.5 = 223.5 i.e. 224

Hence, this difference of 1 pixel can have the wrong wrapping effect.
While using float in the layout, the inversibility is maintained. Hence,  223/1.5 = 148.66667 and 148.6666667 * 1.5 = 223


### How to test
```java
package org.eclipse.swt.snippets;

import org.eclipse.swt.*;
import org.eclipse.swt.graphics.*;
import org.eclipse.swt.layout.*;
import org.eclipse.swt.widgets.*;

public class SnippetLabelCutOff {
	public static void main(String[] args) {
		Display display = new Display();


		/* Provide different resolutions for icons to get
		 * high quality rendering wherever the OS needs
		 * large icons. For example, the ALT+TAB window
		 * on certain systems uses a larger icon.
		 */
		Shell shell = new Shell(display);
		PartView partView = new SnippetLabelCutOff.PartView(display);
		partView.postConstruct(shell);
		shell.open();



		while (!shell.isDisposed()) {
			if (!display.readAndDispatch())
				display.sleep();
		}
		partView.preDestroy();
		shell.dispose();
		display.dispose();
	}

	public static class PartView
	{
	   public Display aDisplay;

	   private Composite aMidComposite;

	   private Label aRepairLabel;

	   public Font aNormalFont;

	   public PartView(Display display) {
		aDisplay = display;
	}

	   public void postConstruct(Composite pParent)
	   {
	      FormLayout vLayout = new FormLayout();
	      vLayout.marginHeight = 5;
	      vLayout.marginWidth = 6;
	      pParent.setLayout(vLayout);

	      createResources();

	      createMid(pParent);

	      pParent.pack();
	   }

	   private void createResources()
	   {
	      aNormalFont = new Font(
	            aDisplay,
	            new FontData("Arial", 11, SWT.NORMAL));

	   }

	   private void createMid(Composite pParent)
	   {
	      // MID
	      aMidComposite = new Composite(pParent, SWT.NONE);
	      aMidComposite.setBackground(aDisplay.getSystemColor(SWT.COLOR_WHITE));
	      FormData aFormDataMid = new FormData();
	      aFormDataMid.top = new FormAttachment(0, 0);
	      aFormDataMid.bottom = new FormAttachment(100, 0);
	      aFormDataMid.left = new FormAttachment(0, 0);
	      aFormDataMid.right = new FormAttachment(100, 0);
	      aMidComposite.setLayoutData(aFormDataMid);

	      GridLayout vLayout = new GridLayout();
	      aMidComposite.setLayout(vLayout);

	      aRepairLabel = new Label(aMidComposite, SWT.WRAP);
	      aRepairLabel.setFont(aNormalFont);
	      GridData vRepairLabelGridData = new GridData();
	      vRepairLabelGridData.horizontalAlignment = GridData.BEGINNING;
	      vRepairLabelGridData.verticalAlignment = GridData.CENTER;
	      vRepairLabelGridData.grabExcessHorizontalSpace = true;
	      vRepairLabelGridData.verticalIndent = Math.round(32);
	      aRepairLabel.setLayoutData(vRepairLabelGridData);

	      aRepairLabel
	            .setText(
	                  "Rhe erv fhe eovianae tb orao estnffd rniTaa eultoolte i sssube wreco.");
	   }

	   public void preDestroy()
	   {
	      aNormalFont.dispose();
	   }
	}
}
```

*Before:*
<img width="359" height="88" alt="image" src="https://github.com/user-attachments/assets/a99c165e-6500-48ad-b149-279d9ca0aa0c" />

*After:*
<img width="352" height="81" alt="image" src="https://github.com/user-attachments/assets/c072777a-e672-41e6-81c5-0e14d572b0f5" />

depends on https://github.com/eclipse-platform/eclipse.platform.swt/pull/2486