### PR TITLE
[GTK] Support background image on GTK 4 in Table

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Table.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Table.java
@@ -839,7 +839,12 @@ void createRenderers (long columnHandle, int modelIndex, boolean check, int colu
 			GTK.gtk_tree_view_column_add_attribute (columnHandle, checkRenderer, OS.cell_background_rgba, BACKGROUND_COLUMN);
 		}
 	}
-	long pixbufRenderer = ownerDraw ? OS.g_object_new (display.gtk_cell_renderer_pixbuf_get_type (), 0) : GTK.gtk_cell_renderer_pixbuf_new ();
+	long pixbufRenderer ;
+	if (GTK.GTK4) {
+		pixbufRenderer = GTK.gtk_cell_renderer_pixbuf_new ();
+	} else {
+		pixbufRenderer = ownerDraw ? OS.g_object_new (display.gtk_cell_renderer_pixbuf_get_type (), 0) : GTK.gtk_cell_renderer_pixbuf_new ();
+	}
 	if (pixbufRenderer == 0) {
 		error (SWT.ERROR_NO_HANDLES);
 	} else {


### PR DESCRIPTION
Without the patch it crashes with no more handles as GtkCellRendererPixbuf if final struct on Gtk4 and thus SWT can't create it's own.