### PR TITLE
Revert Deprecation of DefaultSWTFontRegistry 

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/internal/DefaultSWTFontRegistryTests.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/internal/DefaultSWTFontRegistryTests.java
@@ -23,16 +23,15 @@ import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.*;
 
 @ExtendWith(PlatformSpecificExecutionExtension.class)
-class LegacySWTFontRegistryTests {
+class DefaultSWTFontRegistryTests {
 	private static String TEST_FONT = "Helvetica";
 	private Display display;
 	private SWTFontRegistry fontRegistry;
 
-	@SuppressWarnings("removal")
 	@BeforeEach
 	public void setUp() {
 		this.display = Display.getDefault();
-		this.fontRegistry = new LegacySWTFontRegistry(display);
+		this.fontRegistry = new DefaultSWTFontRegistry(display);
 	}
 
 	@AfterEach

--- a/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/widgets/ControlWin32Tests.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/widgets/ControlWin32Tests.java
@@ -35,7 +35,7 @@ import org.junit.jupiter.params.provider.*;
 class ControlWin32Tests {
 
 	@Test
-	public void testScaleFontCorrectlyInAutoScaleScenario() {
+	public void testScaleFontCorrectlyInAutoScaleSzenario() {
 		DPIUtil.setMonitorSpecificScaling(true);
 		Display display = Display.getDefault();
 
@@ -58,37 +58,15 @@ class ControlWin32Tests {
 	}
 
 	@Test
-	public void testScaleFontCorrectlyInNoAutoScaleScenario() {
+	public void testDoNotScaleFontCorrectlyInNoAutoScaleSzenario() {
 		DPIUtil.setMonitorSpecificScaling(false);
 		Display display = Display.getDefault();
 
 		assertFalse("Autoscale property is not set to false", display.isRescalingAtRuntime());
 		int scalingFactor = 2;
 		FontComparison fontComparison = updateFont(scalingFactor);
-		assertEquals("Font height in pixels is not adjusted according to the scale factor",
-				fontComparison.originalFontHeight * scalingFactor, fontComparison.currentFontHeight);
-	}
-
-	@Test
-	public void testDoNotScaleFontInNoAutoScaleScenarioWithLegacyFontRegistry() {
-		DPIUtil.setMonitorSpecificScaling(false);
-		String originalValue = System.getProperty("swt.fontRegistry");
-		System.setProperty("swt.fontRegistry", "legacy");
-		try {
-			Display display = Display.getDefault();
-
-			assertFalse("Autoscale property is not set to false", display.isRescalingAtRuntime());
-			int scalingFactor = 2;
-			FontComparison fontComparison = updateFont(scalingFactor);
-			assertEquals("Font height in pixels is different when setting the same font again",
-					fontComparison.originalFontHeight, fontComparison.currentFontHeight);
-		} finally {
-			if (originalValue != null) {
-				System.setProperty("swt.fontRegistry", originalValue);
-			} else {
-				System.clearProperty("swt.fontRegistry");
-			}
-		}
+		assertEquals("Font height in pixels is different when setting the same font again",
+				fontComparison.originalFontHeight, fontComparison.currentFontHeight);
 	}
 
 	@Test

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/GC.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/GC.java
@@ -5725,7 +5725,7 @@ private class SetTransformOperation extends Operation {
  */
 public Point stringExtent (String string) {
 	if (string == null) SWT.error (SWT.ERROR_NULL_ARGUMENT);
-	return Win32DPIUtils.pixelToPoint(drawable, stringExtentInPixels(string), data.font.zoom);
+	return Win32DPIUtils.pixelToPoint(drawable, stringExtentInPixels(string), getZoom());
 }
 
 Point stringExtentInPixels (String string) {
@@ -5805,7 +5805,7 @@ public Point textExtent (String string) {
  * </ul>
  */
 public Point textExtent (String string, int flags) {
-	return Win32DPIUtils.pixelToPoint(drawable, textExtentInPixels(string, flags), data.font.zoom);
+	return Win32DPIUtils.pixelToPoint(drawable, textExtentInPixels(string, flags), getZoom());
 }
 
 Point textExtentInPixels(String string, int flags) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/DefaultSWTFontRegistry.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/DefaultSWTFontRegistry.java
@@ -19,25 +19,19 @@ import org.eclipse.swt.graphics.*;
 import org.eclipse.swt.internal.win32.*;
 
 /**
- * <p>
- * Formerly {@code DefaultSWTFontRegistry}, this class is deprecated. Use {@code ScalingSWTFontRegistry} instead.
- * To temporarily fall back to legacy font behavior ({@code LegacySWTFontRegistry})
- * (e.g., if issues arise in existing RCP products), set the system property: {@code
- * -Dswt.fontRegistry=legacy
- * }
- * </p>
+ * This class is used in the win32 implementation only to support
+ * unscaled fonts in multiple DPI zoom levels.
  *
  * As this class is only intended to be used internally via {@code SWTFontProvider},
  * it should neither be instantiated nor referenced in a client application.
  * The behavior can change any time in a future release.
  */
-@Deprecated(forRemoval= true, since= "2025-09")
-final class LegacySWTFontRegistry implements SWTFontRegistry {
+final class DefaultSWTFontRegistry implements SWTFontRegistry {
 	private static FontData KEY_SYSTEM_FONTS = new FontData();
 	private Map<FontData, Font> fontsMap = new HashMap<>();
 	private Device device;
 
-	LegacySWTFontRegistry(Device device) {
+	DefaultSWTFontRegistry(Device device) {
 		this.device = device;
 	}
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/SWTFontProvider.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/SWTFontProvider.java
@@ -108,15 +108,10 @@ public class SWTFontProvider {
 		}
 	}
 
-	private static final String SWT_FONT_REGISTRY = "swt.fontRegistry";
-
-	@SuppressWarnings("removal")
 	private static SWTFontRegistry newFontRegistry(Device device) {
-		if ("legacy".equalsIgnoreCase(System.getProperty(SWT_FONT_REGISTRY)) && device instanceof Display display
-				&& !display.isRescalingAtRuntime()) {
-			return new LegacySWTFontRegistry(device);
+		if (device instanceof Display display && display.isRescalingAtRuntime()) {
+			return new ScalingSWTFontRegistry(device);
 		}
-		return new ScalingSWTFontRegistry(device);
-
+		return new DefaultSWTFontRegistry(device);
 	}
 }


### PR DESCRIPTION
Previously, in LegacySWTFontRegistry (DefaultSWTFontRegistry), fonts were always created using the constructor Font(Device, FontData). However, in ScalingSWTFontRegistry, fonts are now created using the Font(Device, FontData, zoom) constructor.

When fonts are created using Font(Device, FontData), they implicitly use DPIUtil.getNativeDeviceZoom() for scaling. On the other hand, fonts created via the new constructor use the zoom value explicitly passed to SWTFontProvider.getFontHandle(font, zoom)
When DPIUtil.getNativeDeviceZoom() is not equal to passed zoom wrong font sizes occur.

This PR contains two commits.

The first commit is the same as first commit of #2377  
This should be merged only after #2377 

Fixes #2385