### PR TITLE
[win32] Fix inconsistency when an Image with GC is drawn on a GC

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/GC.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/GC.java
@@ -1253,7 +1253,7 @@ private void drawImage(Image srcImage, int srcX, int srcY, int srcWidth, int src
 		}
 		return;
 	}
-	long imageHandle = Image.win32_getHandle(srcImage, imageZoom);
+	long imageHandle = srcImage.getHandle(imageZoom, data.nativeZoom);
 	switch (srcImage.type) {
 		case SWT.BITMAP:
 			drawBitmap(srcImage, imageHandle, srcX, srcY, srcWidth, srcHeight, destX, destY, destWidth, destHeight, simple);
@@ -4384,7 +4384,7 @@ private void init(Drawable drawable, GCData data, long hDC) {
 	}
 	Image image = data.image;
 	if (image != null) {
-		data.hNullBitmap = OS.SelectObject(hDC, Image.win32_getHandle(image, data.nativeZoom));
+		data.hNullBitmap = OS.SelectObject(hDC, image.getHandle(data.imageZoom, data.nativeZoom));
 		image.memGC = this;
 	}
 	int layout = data.layout;

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/GCData.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/GCData.java
@@ -48,6 +48,7 @@ public final class GCData {
 	public float lineMiterLimit = 10;
 	public int alpha = 0xFF;
 	public int nativeZoom;
+	int imageZoom;
 
 	public Image image;
 	public PAINTSTRUCT ps;
@@ -67,6 +68,7 @@ public final class GCData {
 		originalData.font = font;
 		originalData.nativeZoom = nativeZoom;
 		originalData.image = image;
+		originalData.imageZoom = imageZoom;
 		originalData.ps = ps;
 		originalData.layout = layout;
 		originalData.hwnd = hwnd;


### PR DESCRIPTION
This PR adapts the logic when a bitmap or icon is drawn with the GC in the windows implementation. As of now, the autoscale zoom was used to identify the image handle to use. If the image is itself drawn with a ImageGCDrawer, information about the original native zoom was lost, which led to inconsistencies in fonts depending on the auto scale mode. This PR forwards the native zoom in this case to enable the Image to initialize the GC accordingly. This was e.g. an issue with auto scale mode integer200 as described in #2385.
