### PR TITLE
Clarify linear scaling in ImageDataProvider contract

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/ImageDataProvider.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/ImageDataProvider.java
@@ -28,16 +28,31 @@ public interface ImageDataProvider {
 
 	/**
 	 * Returns the image data for the given zoom level.
-	 * <p>
-	 * If no image is available for a particular zoom level, this method should
-	 * return <code>null</code>. For <code>zoom == 100</code>, returning
-	 * <code>null</code> is not allowed, and SWT will throw an exception.
+	 *
+	 * <ul>
+     *   <li>
+     *     If no image is available for a particular zoom level, this method should
+     *     return <code>null</code>. For <code>zoom == 100</code>, returning
+     *     <code>null</code> is not allowed, and SWT will throw an exception.
+     *   </li>
+     *   <li>
+     *     Implementations are expected to return {@link ImageData} that is
+     *     <b>linearly scaled</b> with respect to the zoom level.
+     *     For example, if <code>getImageData(100)</code> returns an image of
+     *     width <code>w</code> and height <code>h</code>, then
+     *     <code>getImageData(200)</code> must return an {@link ImageData}
+     *     of width <code>2 * w</code> and height <code>2 * h</code>,
+     *     if a non-{@code null} result is returned.
+     *   </li>
+     * </ul>
+	 *
 	 *
 	 * @param zoom
 	 *            The zoom level in % of the standard resolution (which is 1
 	 *            physical monitor pixel == 1 SWT logical point). Typically 100,
 	 *            150, or 200.
-	 * @return the image data, or <code>null</code> if <code>zoom != 100</code>
+	 * @return the linearly scaled image data for the given zoom level,
+	 *         or <code>null</code> if <code>zoom != 100</code>
 	 *         and no image is available for the given zoom level.
 	 * @since 3.104
 	 */


### PR DESCRIPTION
This PR extends ImageDataProvider contract  to clarify that implementations need to yield linearly scaled image data. 
<s>This commit also extends the strict checks for verifying linear scaling to GTK and Cocoa implementations.</s>