### PR TITLE
 Implements a StyleProcessor class to allow access to a list of set styles for a widget in String format.

### DIFF
--- a/binaries/org.eclipse.swt.win32.win32.x86_64/.settings/.api_filters
+++ b/binaries/org.eclipse.swt.win32.win32.x86_64/.settings/.api_filters
@@ -243,4 +243,11 @@
             </message_arguments>
         </filter>
     </resource>
+    <resource path="Eclipse SWT/win32/org/eclipse/swt/widgets/StyleProcessor.java" type="org.eclipse.swt.widgets.StyleProcessor">
+        <filter comment="Testing" id="1110441988">
+            <message_arguments>
+                <message_argument value="org.eclipse.swt.widgets.StyleProcessor"/>
+            </message_arguments>
+        </filter>
+    </resource>
 </component>

--- a/binaries/org.eclipse.swt.win32.win32.x86_64/.settings/.api_filters
+++ b/binaries/org.eclipse.swt.win32.win32.x86_64/.settings/.api_filters
@@ -243,11 +243,4 @@
             </message_arguments>
         </filter>
     </resource>
-    <resource path="Eclipse SWT/win32/org/eclipse/swt/widgets/StyleProcessor.java" type="org.eclipse.swt.widgets.StyleProcessor">
-        <filter comment="Testing" id="1110441988">
-            <message_arguments>
-                <message_argument value="org.eclipse.swt.widgets.StyleProcessor"/>
-            </message_arguments>
-        </filter>
-    </resource>
 </component>

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Button.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Button.java
@@ -13,8 +13,6 @@
  *     Conrad Groth - Bug 23837 [FEEP] Button, do not respect foreground and background color on Windows
  *******************************************************************************/
 package org.eclipse.swt.widgets;
-
-
 import java.util.List;
 
 import org.eclipse.swt.*;

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Button.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Button.java
@@ -14,6 +14,7 @@
  *******************************************************************************/
 package org.eclipse.swt.widgets;
 import java.util.List;
+import java.util.*;
 
 import org.eclipse.swt.*;
 import org.eclipse.swt.events.*;

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Button.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Button.java
@@ -262,7 +262,7 @@ static {
 	StyleProcessor processor = new StyleProcessor();
 
 	if (COMMAND_LINK) {
-		processor.oneOf("PUSH, ARROW, CHECK, RADIO, TOGGLE, SWT.COMMAND");
+		processor.someOf("COMMAND");
 	} else {
 		processor.oneOf("PUSH, ARROW, CHECK, RADIO, TOGGLE");
 	}

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Button.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Button.java
@@ -289,8 +289,6 @@ static int checkStyle (int style) {
 
 }
 
-
-@SuppressWarnings("unused")
 List<String> getStyles() {
 	return STYLE_PROCESSOR.process(this.style);
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Button.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Button.java
@@ -22,6 +22,7 @@ import org.eclipse.swt.internal.*;
 import org.eclipse.swt.internal.win32.*;
 import org.eclipse.swt.internal.win32.version.*;
 
+
 /**
  * Instances of this class represent a selectable user interface object that
  * issues notification when pressed and released.
@@ -252,8 +253,16 @@ long callWindowProc (long hwnd, int msg, long wParam, long lParam) {
 	if (handle == 0) return 0;
 	return OS.CallWindowProc (ButtonProc, hwnd, msg, wParam, lParam);
 }
+//COMMAND_LINK ? SWT.COMMAND : 0
+private static final StyleProcessor STYLE_PROCESSOR = new StyleProcessor()
+.oneOf("PUSH, ARROW, CHECK, RADIO, TOGGLE")
+.ifOneOf("PUSH, TOGGLE").thenOneOf("CENTER, LEFT, RIGHT")
+.ifOneOf("CHECK, RADIO").thenOneOf("LEFT, RIGHT, CENTER")
+.ifOneOf("ARROW").thenOneOf("UP, DOWN, LEFT, RIGHT");
 
 static int checkStyle (int style) {
+	System.out.println("Testing the Style Processor");
+	System.out.println(STYLE_PROCESSOR.process(style));
 	style = checkBits (style, SWT.PUSH, SWT.ARROW, SWT.CHECK, SWT.RADIO, SWT.TOGGLE, COMMAND_LINK ? SWT.COMMAND : 0);
 	if ((style & (SWT.PUSH | SWT.TOGGLE)) != 0) {
 		return checkBits (style, SWT.CENTER, SWT.LEFT, SWT.RIGHT, 0, 0, 0);
@@ -266,6 +275,8 @@ static int checkStyle (int style) {
 		return checkBits (style, SWT.UP, SWT.DOWN, SWT.LEFT, SWT.RIGHT, 0, 0);
 	}
 	return style;
+
+
 }
 
 void click () {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Button.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Button.java
@@ -15,7 +15,7 @@
 package org.eclipse.swt.widgets;
 
 
-import java.util.*;
+import java.util.List;
 
 import org.eclipse.swt.*;
 import org.eclipse.swt.events.*;
@@ -288,12 +288,10 @@ static int checkStyle (int style) {
 	return style;
 
 }
-/**
- * test
- * @return ArrayList<String> styles
- * @since 3.131
- */
-public ArrayList<String> getStyles() {
+
+
+@SuppressWarnings("unused")
+List<String> getStyles() {
 	return STYLE_PROCESSOR.process(this.style);
 }
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Button.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Button.java
@@ -15,6 +15,8 @@
 package org.eclipse.swt.widgets;
 
 
+import java.util.*;
+
 import org.eclipse.swt.*;
 import org.eclipse.swt.events.*;
 import org.eclipse.swt.graphics.*;
@@ -253,16 +255,25 @@ long callWindowProc (long hwnd, int msg, long wParam, long lParam) {
 	if (handle == 0) return 0;
 	return OS.CallWindowProc (ButtonProc, hwnd, msg, wParam, lParam);
 }
-//COMMAND_LINK ? SWT.COMMAND : 0
-private static final StyleProcessor STYLE_PROCESSOR = new StyleProcessor()
-.oneOf("PUSH, ARROW, CHECK, RADIO, TOGGLE")
-.ifOneOf("PUSH, TOGGLE").thenOneOf("CENTER, LEFT, RIGHT")
-.ifOneOf("CHECK, RADIO").thenOneOf("LEFT, RIGHT, CENTER")
-.ifOneOf("ARROW").thenOneOf("UP, DOWN, LEFT, RIGHT");
+
+private static StyleProcessor STYLE_PROCESSOR = new StyleProcessor();
+
+static {
+	StyleProcessor processor = new StyleProcessor();
+
+	if (COMMAND_LINK) {
+		processor.oneOf("PUSH, ARROW, CHECK, RADIO, TOGGLE, SWT.COMMAND");
+	} else {
+		processor.oneOf("PUSH, ARROW, CHECK, RADIO, TOGGLE");
+	}
+	processor.ifOneOf("PUSH, TOGGLE").thenOneOf("CENTER, LEFT, RIGHT")
+	.ifOneOf("CHECK, RADIO").thenOneOf("LEFT, RIGHT, CENTER")
+	.ifOneOf("ARROW").thenOneOf("UP, DOWN, LEFT, RIGHT");
+
+	STYLE_PROCESSOR = processor;
+}
 
 static int checkStyle (int style) {
-	System.out.println("Testing the Style Processor");
-	System.out.println(STYLE_PROCESSOR.process(style));
 	style = checkBits (style, SWT.PUSH, SWT.ARROW, SWT.CHECK, SWT.RADIO, SWT.TOGGLE, COMMAND_LINK ? SWT.COMMAND : 0);
 	if ((style & (SWT.PUSH | SWT.TOGGLE)) != 0) {
 		return checkBits (style, SWT.CENTER, SWT.LEFT, SWT.RIGHT, 0, 0, 0);
@@ -276,7 +287,14 @@ static int checkStyle (int style) {
 	}
 	return style;
 
-
+}
+/**
+ * test
+ * @return ArrayList<String> styles
+ * @since 3.131
+ */
+public ArrayList<String> getStyles() {
+	return STYLE_PROCESSOR.process(this.style);
 }
 
 void click () {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/StyleProcessor.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/StyleProcessor.java
@@ -4,7 +4,7 @@ import java.util.*;
 
 import org.eclipse.swt.*;
 
-public class StyleProcessor {
+class StyleProcessor {
 
 
 	private static class Rule {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/StyleProcessor.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/StyleProcessor.java
@@ -21,12 +21,21 @@ public class StyleProcessor {
 
 	private ArrayList<Rule> rules = new ArrayList<>();
 	private ArrayList<String> oneOfArr = new ArrayList<>();
+	private ArrayList<String> someOfArr = new ArrayList<>();
 	private Rule currentRule = null;
 
 	public StyleProcessor oneOf(String styles) {
 		String[] tempHolder = styles.split(", ");
 
 		oneOfArr.addAll(Arrays.asList(tempHolder));
+
+		return this;
+	}
+
+	public StyleProcessor someOf(String styles) {
+		String[] tempHolder = styles.split(", ");
+
+		someOfArr.addAll(Arrays.asList(tempHolder));
 
 		return this;
 	}
@@ -67,6 +76,17 @@ public class StyleProcessor {
 	            if ((style & SWT.class.getField(s).getInt(null)) != 0) {
 	                finalList.add(s);
 	                break;
+	            }
+	        } catch (NoSuchFieldException | IllegalAccessException e) {
+	            System.out.println("Invalid Style: " + s);
+	            e.printStackTrace();
+	        }
+	    }
+
+	    for (String s : someOfArr) {
+	        try {
+	            if ((style & SWT.class.getField(s).getInt(null)) != 0) {
+	                finalList.add(s);
 	            }
 	        } catch (NoSuchFieldException | IllegalAccessException e) {
 	            System.out.println("Invalid Style: " + s);

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/StyleProcessor.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/StyleProcessor.java
@@ -5,11 +5,24 @@ import java.util.*;
 import org.eclipse.swt.*;
 
 public class StyleProcessor {
-	private ArrayList<String> oneOfArr = new ArrayList<>();
-	private ArrayList<ArrayList<String>> ifOneArr = new ArrayList<>();
-	private ArrayList<ArrayList<String>> thenOneArr = new ArrayList<>();
 
-	// Just add styles you want to detect — no validation
+
+	private static class Rule {
+	    ArrayList<String> ifOneOf;
+	    ArrayList<String> thenOneOf;
+	    ArrayList<String> thenSomeOf;
+
+	    Rule(ArrayList<String> ifOneOf) {
+	        this.ifOneOf = ifOneOf;
+	        this.thenOneOf = new ArrayList<>();
+	        this.thenSomeOf = new ArrayList<>();
+	    }
+	}
+
+	private ArrayList<Rule> rules = new ArrayList<>();
+	private ArrayList<String> oneOfArr = new ArrayList<>();
+	private Rule currentRule = null;
+
 	public StyleProcessor oneOf(String styles) {
 		String[] tempHolder = styles.split(", ");
 
@@ -19,77 +32,94 @@ public class StyleProcessor {
 	}
 
 	public StyleProcessor ifOneOf(String styles) {
-		String[] tempHolder = styles.split(", ");
-		ArrayList<String> tempList = new ArrayList<>(Arrays.asList(tempHolder));
-
-		ifOneArr.add(tempList);
-
-		return this;
+	    String[] tempHolder = styles.split(", ");
+	    ArrayList<String> tempList = new ArrayList<>(Arrays.asList(tempHolder));
+	    currentRule = new Rule(tempList);
+	    rules.add(currentRule);
+	    return this;
 	}
+
 
 	public StyleProcessor thenOneOf(String styles) {
-		if (ifOneArr.isEmpty()) {
-			throw new IllegalStateException("No 'ifOneOf' condition defined before 'thenOneOf'");
-		}
-
-		String[] tempHolder = styles.split(", ");
-		ArrayList<String> tempList = new ArrayList<>(Arrays.asList(tempHolder));
-
-		thenOneArr.add(tempList);
-
-		return this;
+	    if (currentRule == null) {
+	        throw new IllegalStateException("No 'ifOneOf' defined before 'thenOneOf'");
+	    }
+	    currentRule.thenOneOf.addAll(Arrays.asList(styles.split(", ")));
+	    return this;
 	}
+
+
+	public StyleProcessor thenSomeOf(String styles) {
+	    if (currentRule == null) {
+	        throw new IllegalStateException("No 'ifOneOf' defined before 'thenSomeOf'");
+	    }
+	    currentRule.thenSomeOf.addAll(Arrays.asList(styles.split(", ")));
+	    return this;
+	}
+
 
 
 	public ArrayList<String> process(int style) {
-//		System.out.println("Int Style" + style);
-		ArrayList<String> finalList = new ArrayList<>();
+	    ArrayList<String> finalList = new ArrayList<>();
 
-		for (String s: oneOfArr) {
-			try {
-				if ((style & SWT.class.getField(s).getInt(null)) != 0) {
-					finalList.add(s);
-					break;
-				}
-			} catch (NoSuchFieldException | IllegalAccessException e) {
-				System.out.println("Invalid Style: " + s);
-				e.printStackTrace(); // or handle gracefully
-			}
-		}
+	    for (String s : oneOfArr) {
+	        try {
+	            if ((style & SWT.class.getField(s).getInt(null)) != 0) {
+	                finalList.add(s);
+	                break;
+	            }
+	        } catch (NoSuchFieldException | IllegalAccessException e) {
+	            System.out.println("Invalid Style: " + s);
+	            e.printStackTrace();
+	        }
+	    }
 
-		for (int i = 0; i < ifOneArr.size(); i++) {
+	    for (Rule rule : rules) {
+	        boolean matched = false;
 
-			for (String s2: ifOneArr.get(i)) {
-				try {
-					//Made it into a variable to make the it easy to read
-					int flag = SWT.class.getField(s2).getInt(null);
-					
-					if ((style & flag)  != 0 ) {
-						//Checks if the s2 (String) is inside the oneOfArr 
-						if (oneOfArr.contains(s2)) {
-						
-							for (String s3: thenOneArr.get(i)) {
-								if ((style & SWT.class.getField(s3).getInt(null)) != 0) {
-									finalList.add(s3);
-									break;
-								}
-							}
-							break;
-						} else {
-							System.out.println("Not inside the oneArr: " + s2);
-						}
-					}
-				} catch (NoSuchFieldException | IllegalAccessException e) {
-					System.out.println("Invalid Style: " + s2);
-					e.printStackTrace();
-				}
-			}
+	        for (String condition : rule.ifOneOf) {
+	            try {
+	                int flag = SWT.class.getField(condition).getInt(null);
+	                if ((style & flag) != 0) {
+	                    matched = true;
+	                    break;
+	                }
+	            } catch (NoSuchFieldException | IllegalAccessException e) {
+	                System.out.println("Invalid condition: " + condition);
+	                e.printStackTrace();
+	            }
+	        }
 
-		}
-		
-		
-		return finalList;
+	        if (matched) {
+	            for (String s : rule.thenOneOf) {
+	                try {
+	                    int flag = SWT.class.getField(s).getInt(null);
+	                    if ((style & flag) != 0) {
+	                        finalList.add(s);
+	                        break;
+	                    }
+	                } catch (NoSuchFieldException | IllegalAccessException e) {
+	                    System.out.println("Invalid thenOneOf: " + s);
+	                    e.printStackTrace();
+	                }
+	            }
 
+	            for (String s : rule.thenSomeOf) {
+	                try {
+	                    int flag = SWT.class.getField(s).getInt(null);
+	                    if ((style & flag) != 0) {
+	                        finalList.add(s);
+	                    }
+	                } catch (NoSuchFieldException | IllegalAccessException e) {
+	                    System.out.println("Invalid thenSomeOf: " + s);
+	                    e.printStackTrace();
+	                }
+	            }
+	        }
+	    }
+
+	    return finalList;
 	}
+
 
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/StyleProcessor.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/StyleProcessor.java
@@ -9,7 +9,6 @@ public class StyleProcessor {
 	private ArrayList<ArrayList<String>> ifOneArr = new ArrayList<>();
 	private ArrayList<ArrayList<String>> thenOneArr = new ArrayList<>();
 
-
 	// Just add styles you want to detect — no validation
 	public StyleProcessor oneOf(String styles) {
 		String[] tempHolder = styles.split(", ");
@@ -41,9 +40,9 @@ public class StyleProcessor {
 		return this;
 	}
 
-//	 Given a style bitmask, return or print the styles that are set
+
 	public ArrayList<String> process(int style) {
-		System.out.println("Int Style" + style);
+//		System.out.println("Int Style" + style);
 		ArrayList<String> finalList = new ArrayList<>();
 
 		for (String s: oneOfArr) {
@@ -53,6 +52,7 @@ public class StyleProcessor {
 					break;
 				}
 			} catch (NoSuchFieldException | IllegalAccessException e) {
+				System.out.println("Invalid Style: " + s);
 				e.printStackTrace(); // or handle gracefully
 			}
 		}
@@ -61,16 +61,26 @@ public class StyleProcessor {
 
 			for (String s2: ifOneArr.get(i)) {
 				try {
-					if ((style & SWT.class.getField(s2).getInt(null)) != 0) {
-						for (String s3: thenOneArr.get(i)) {
-							if ((style & SWT.class.getField(s3).getInt(null)) != 0) {
-								finalList.add(s3);
-								break;
+					//Made it into a variable to make the it easy to read
+					int flag = SWT.class.getField(s2).getInt(null);
+					
+					if ((style & flag)  != 0 ) {
+						//Checks if the s2 (String) is inside the oneOfArr 
+						if (oneOfArr.contains(s2)) {
+						
+							for (String s3: thenOneArr.get(i)) {
+								if ((style & SWT.class.getField(s3).getInt(null)) != 0) {
+									finalList.add(s3);
+									break;
+								}
 							}
+							break;
+						} else {
+							System.out.println("Not inside the oneArr: " + s2);
 						}
-						break;
 					}
 				} catch (NoSuchFieldException | IllegalAccessException e) {
+					System.out.println("Invalid Style: " + s2);
 					e.printStackTrace();
 				}
 			}

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/StyleProcessor.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/StyleProcessor.java
@@ -1,0 +1,85 @@
+package org.eclipse.swt.widgets;
+
+import java.util.*;
+
+import org.eclipse.swt.*;
+
+public class StyleProcessor {
+	private ArrayList<String> oneOfArr = new ArrayList<>();
+	private ArrayList<ArrayList<String>> ifOneArr = new ArrayList<>();
+	private ArrayList<ArrayList<String>> thenOneArr = new ArrayList<>();
+
+
+	// Just add styles you want to detect — no validation
+	public StyleProcessor oneOf(String styles) {
+		String[] tempHolder = styles.split(", ");
+
+		oneOfArr.addAll(Arrays.asList(tempHolder));
+
+		return this;
+	}
+
+	public StyleProcessor ifOneOf(String styles) {
+		String[] tempHolder = styles.split(", ");
+		ArrayList<String> tempList = new ArrayList<>(Arrays.asList(tempHolder));
+
+		ifOneArr.add(tempList);
+
+		return this;
+	}
+
+	public StyleProcessor thenOneOf(String styles) {
+		if (ifOneArr.isEmpty()) {
+			throw new IllegalStateException("No 'ifOneOf' condition defined before 'thenOneOf'");
+		}
+
+		String[] tempHolder = styles.split(", ");
+		ArrayList<String> tempList = new ArrayList<>(Arrays.asList(tempHolder));
+
+		thenOneArr.add(tempList);
+
+		return this;
+	}
+
+//	 Given a style bitmask, return or print the styles that are set
+	public ArrayList<String> process(int style) {
+		System.out.println("Int Style" + style);
+		ArrayList<String> finalList = new ArrayList<>();
+
+		for (String s: oneOfArr) {
+			try {
+				if ((style & SWT.class.getField(s).getInt(null)) != 0) {
+					finalList.add(s);
+					break;
+				}
+			} catch (NoSuchFieldException | IllegalAccessException e) {
+				e.printStackTrace(); // or handle gracefully
+			}
+		}
+
+		for (int i = 0; i < ifOneArr.size(); i++) {
+
+			for (String s2: ifOneArr.get(i)) {
+				try {
+					if ((style & SWT.class.getField(s2).getInt(null)) != 0) {
+						for (String s3: thenOneArr.get(i)) {
+							if ((style & SWT.class.getField(s3).getInt(null)) != 0) {
+								finalList.add(s3);
+								break;
+							}
+						}
+						break;
+					}
+				} catch (NoSuchFieldException | IllegalAccessException e) {
+					e.printStackTrace();
+				}
+			}
+
+		}
+		
+		
+		return finalList;
+
+	}
+
+}

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/StyleProcessor.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/StyleProcessor.java
@@ -20,14 +20,14 @@ public class StyleProcessor {
 	}
 
 	private ArrayList<Rule> rules = new ArrayList<>();
-	private ArrayList<String> oneOfArr = new ArrayList<>();
+	private ArrayList<ArrayList<String>> oneOfArr = new ArrayList<>();
 	private ArrayList<String> someOfArr = new ArrayList<>();
 	private Rule currentRule = null;
 
 	public StyleProcessor oneOf(String styles) {
 		String[] tempHolder = styles.split(", ");
 
-		oneOfArr.addAll(Arrays.asList(tempHolder));
+		oneOfArr.add(new ArrayList<>(Arrays.asList(tempHolder)));
 
 		return this;
 	}
@@ -70,17 +70,18 @@ public class StyleProcessor {
 
 	public ArrayList<String> process(int style) {
 	    ArrayList<String> finalList = new ArrayList<>();
-
-	    for (String s : oneOfArr) {
-	        try {
-	            if ((style & SWT.class.getField(s).getInt(null)) != 0) {
-	                finalList.add(s);
-	                break;
-	            }
-	        } catch (NoSuchFieldException | IllegalAccessException e) {
-	            System.out.println("Invalid Style: " + s);
-	            e.printStackTrace();
-	        }
+	    for (ArrayList<String> a: oneOfArr) {
+		    for (String s: a) {
+		        try {
+		            if ((style & SWT.class.getField(s).getInt(null)) != 0) {
+		                finalList.add(s);
+		                break;
+		            }
+		        } catch (NoSuchFieldException | IllegalAccessException e) {
+		            System.out.println("Invalid Style: " + s);
+		            e.printStackTrace();
+		        }
+		    }
 	    }
 
 	    for (String s : someOfArr) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/StyleProcessor.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/StyleProcessor.java
@@ -79,7 +79,6 @@ public class StyleProcessor {
 		            }
 		        } catch (NoSuchFieldException | IllegalAccessException e) {
 		            System.out.println("Invalid Style: " + s);
-		            e.printStackTrace();
 		        }
 		    }
 	    }
@@ -91,7 +90,6 @@ public class StyleProcessor {
 	            }
 	        } catch (NoSuchFieldException | IllegalAccessException e) {
 	            System.out.println("Invalid Style: " + s);
-	            e.printStackTrace();
 	        }
 	    }
 
@@ -107,7 +105,6 @@ public class StyleProcessor {
 	                }
 	            } catch (NoSuchFieldException | IllegalAccessException e) {
 	                System.out.println("Invalid condition: " + condition);
-	                e.printStackTrace();
 	            }
 	        }
 
@@ -121,7 +118,6 @@ public class StyleProcessor {
 	                    }
 	                } catch (NoSuchFieldException | IllegalAccessException e) {
 	                    System.out.println("Invalid thenOneOf: " + s);
-	                    e.printStackTrace();
 	                }
 	            }
 
@@ -132,8 +128,7 @@ public class StyleProcessor {
 	                        finalList.add(s);
 	                    }
 	                } catch (NoSuchFieldException | IllegalAccessException e) {
-	                    System.out.println("Invalid thenSomeOf: " + s);
-	                    e.printStackTrace();
+	                    System.out.println("Invalid thenSomeOf: " + s);;
 	                }
 	            }
 	        }

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Text.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Text.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.swt.widgets;
 import java.util.List;
+import java.util.*;
 
 import org.eclipse.swt.*;
 import org.eclipse.swt.events.*;

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Text.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Text.java
@@ -664,11 +664,7 @@ static int checkStyle (int style) {
 	return style | SWT.SINGLE;
 }
 
-/**
- * test
- * @return ArrayList<String> styles
- * @since 3.131
- */
+
 List<String> getStyles() {
 	return STYLE_PROCESSOR.process(this.style);
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Text.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Text.java
@@ -14,7 +14,7 @@
 package org.eclipse.swt.widgets;
 
 
-import java.util.*;
+import java.util.List;
 
 import org.eclipse.swt.*;
 import org.eclipse.swt.events.*;
@@ -669,7 +669,7 @@ static int checkStyle (int style) {
  * @return ArrayList<String> styles
  * @since 3.131
  */
-public ArrayList<String> getStyles() {
+List<String> getStyles() {
 	return STYLE_PROCESSOR.process(this.style);
 }
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Text.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Text.java
@@ -630,8 +630,8 @@ private static StyleProcessor STYLE_PROCESSOR = new StyleProcessor();
 static {
 	StyleProcessor processor = new StyleProcessor();
 	
-	processor.oneof("SINGLE, MULTI").oneof("LEFT, CENTER, RIGHT").ifOneOf("SEARCH")
-	.thenSomeOf("SINGLE, BORDER").ifOneOf("MULTI").thenSomeOf("H_SCROLL, V_SCROLL, WRAP")
+	processor.oneof("SINGLE, MULTI").oneof("LEFT, CENTER, RIGHT")
+	.someOf("BORDER, SEARCH").ifOneOf("MULTI").thenSomeOf("H_SCROLL, V_SCROLL, WRAP")
 	.ifOneOf("SINGLE").thenSomeOf("PASSWORD");
 
 	STYLE_PROCESSOR = processor;

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Text.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Text.java
@@ -625,7 +625,20 @@ void applySegments () {
 	ignoreVerify = oldIgnoreVerify;
 }
 
+private static StyleProcessor STYLE_PROCESSOR = new StyleProcessor();
+
+static {
+	StyleProcessor processor = new StyleProcessor();
+	
+	processor.oneof("SINGLE, MULTI").oneof("LEFT, CENTER, RIGHT").ifOneOf("SEARCH")
+	.thenSomeOf("SINGLE, BORDER").ifOneOf("MULTI").thenSomeOf("H_SCROLL, V_SCROLL, WRAP")
+	.ifOneOf("SINGLE").thenSomeOf("PASSWORD");
+
+	STYLE_PROCESSOR = processor;
+}
+
 static int checkStyle (int style) {
+	System.out.println(STYLE_PROCESSOR.process(style));
 	if ((style & SWT.SINGLE) != 0 && (style & SWT.MULTI) != 0) {
 		style &= ~SWT.MULTI;
 	}

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Text.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Text.java
@@ -12,8 +12,6 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package org.eclipse.swt.widgets;
-
-
 import java.util.List;
 
 import org.eclipse.swt.*;
@@ -629,12 +627,12 @@ private static StyleProcessor STYLE_PROCESSOR = new StyleProcessor();
 
 static {
 	StyleProcessor processor = new StyleProcessor();
-	
+
 	processor.oneOf("SINGLE, MULTI")
 	.oneOf("LEFT, CENTER, RIGHT")
 	.someOf("BORDER, SEARCH").ifOneOf("MULTI").thenSomeOf("H_SCROLL, V_SCROLL, WRAP")
 	.ifOneOf("SINGLE").thenSomeOf("PASSWORD");
-	
+
 	STYLE_PROCESSOR = processor;
 }
 
@@ -663,7 +661,6 @@ static int checkStyle (int style) {
 	if ((style & (SWT.H_SCROLL | SWT.V_SCROLL)) != 0) return style | SWT.MULTI;
 	return style | SWT.SINGLE;
 }
-
 
 List<String> getStyles() {
 	return STYLE_PROCESSOR.process(this.style);

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Text.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Text.java
@@ -630,10 +630,11 @@ private static StyleProcessor STYLE_PROCESSOR = new StyleProcessor();
 static {
 	StyleProcessor processor = new StyleProcessor();
 	
-	processor.oneof("SINGLE, MULTI").oneof("LEFT, CENTER, RIGHT")
+	processor.oneOf("SINGLE, MULTI")
+	.oneOf("LEFT, CENTER, RIGHT")
 	.someOf("BORDER, SEARCH").ifOneOf("MULTI").thenSomeOf("H_SCROLL, V_SCROLL, WRAP")
 	.ifOneOf("SINGLE").thenSomeOf("PASSWORD");
-
+	
 	STYLE_PROCESSOR = processor;
 }
 
@@ -661,6 +662,15 @@ static int checkStyle (int style) {
 	if ((style & (SWT.SINGLE | SWT.MULTI)) != 0) return style;
 	if ((style & (SWT.H_SCROLL | SWT.V_SCROLL)) != 0) return style | SWT.MULTI;
 	return style | SWT.SINGLE;
+}
+
+/**
+ * test
+ * @return ArrayList<String> styles
+ * @since 3.131
+ */
+public ArrayList<String> getStyles() {
+	return STYLE_PROCESSOR.process(this.style);
 }
 
 void clearSegments (boolean applyText) {


### PR DESCRIPTION
This PR allows us to fix issues with the CSS Spy in Eclipse PDE, detailed in [Issue #611](https://github.com/eclipse-pde/eclipse.pde/issues/611) Completed with @WillPeltz

**Changes**
-StyleProcessor class
Parses styles that can be set based on context, checks relevant styles against integer bitmask to see which are actually set, and converts them into String list

-getStyles method in Text and Button classes
Returns a list of styles currently set for a given widget in String format, allowing for style inspection at runtime

-Static function using instance of StyleProcessor in Text and Button classes 
Clearly defines which styles can be set for a widget based on context, in a human-readable way.

**Motivation**

Currently, there is no built-in way to view a widget’s set styles in a human-readable format, leading to projects like Eclipse PDE implementing complex and limited parsers for UI elements like the CSS Spy tool. This PR makes this process much simpler and easier, without requiring much upkeep. It should be quite simple to add support for and update widget classes.

**Notes**
-Since this implementation only focuses on Text and Button classes, other widget classes should be revised incrementally to use the StyleProcessor class.

-Backwards compatible; existing behavior is unchanged. 
Having both getStyles and checkStyle is a bit redundant, so merging them at some point in the future might be a good idea if it can be done without breaking existing behavior too much in downstream projects.