### PR TITLE
[Win32] Fix drag and drop on secondary monitor without monitor-specific scaling

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/win32/org/eclipse/swt/dnd/DropTarget.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/win32/org/eclipse/swt/dnd/DropTarget.java
@@ -242,7 +242,7 @@ void createCOMInterfaces() {
 		public long method2(long[] args) {return Release();}
 		@Override
 		public long method3(long[] args) {
-			return Win32DPIUtils.runWithProperDPIAwareness(() -> {
+			return Win32DPIUtils.runWithProperDPIAwareness(getDisplay(), () -> {
 				if (args.length == 5) {
 					return DragEnter(args[0], (int)args[1], (int)args[2], (int)args[3], args[4]);
 				} else {
@@ -252,7 +252,7 @@ void createCOMInterfaces() {
 		}
 		@Override
 		public long method4(long[] args) {
-			return Win32DPIUtils.runWithProperDPIAwareness(() -> {
+			return Win32DPIUtils.runWithProperDPIAwareness(getDisplay(), () -> {
 				if (args.length == 4) {
 					return DragOver((int)args[0], (int)args[1], (int)args[2], args[3]);
 				} else {
@@ -264,7 +264,7 @@ void createCOMInterfaces() {
 		public long method5(long[] args) {return DragLeave();}
 		@Override
 		public long method6(long[] args) {
-			return Win32DPIUtils.runWithProperDPIAwareness(() -> {
+			return Win32DPIUtils.runWithProperDPIAwareness(getDisplay(), () -> {
 				if (args.length == 5) {
 					return Drop(args[0], (int)args[1], (int)args[2], (int)args[3], args[4]);
 				} else {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/Win32DPIUtils.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/Win32DPIUtils.java
@@ -19,6 +19,7 @@ import org.eclipse.swt.*;
 import org.eclipse.swt.graphics.*;
 import org.eclipse.swt.internal.win32.*;
 import org.eclipse.swt.internal.win32.version.*;
+import org.eclipse.swt.widgets.*;
 
 /**
  * This class is used in the win32 implementation only to provide
@@ -68,8 +69,11 @@ public class Win32DPIUtils {
 		return true;
 	}
 
-	public static <T> T runWithProperDPIAwareness(Supplier<T> operation) {
-		// refreshing is only necessary, when monitor specific scaling is active
+	public static <T> T runWithProperDPIAwareness(Display display, Supplier<T> operation) {
+		// only with monitor-specific scaling enabled, the main thread's DPI awareness may be adapted
+		if (!display.isRescalingAtRuntime()) {
+			return operation.get();
+		}
 		long previousDPIAwareness = OS.GetThreadDpiAwarenessContext();
 		try {
 			if (!setDPIAwareness(OS.DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2)) {


### PR DESCRIPTION
To fix drag and drop behavior on multiple monitors with different zooms when using monitor-specific scaling, a recent change adapted the OS callbacks for drop operations to run with the required DPI awareness (PerMonitorV2) in that case. This change did not consider that without monitor-specific scaling (and particularly when DPI awareness "System" is used), running with that modified DPI awareness is not correct.

This change adapts the drop callback to only adapt the DPI awareness if appropriate (i.e., if monitor-specific scaling is enabled).

Fixes https://github.com/eclipse-platform/eclipse.platform.swt/issues/2394

For reproduction see the original issue. Here is how it looks on 125% secondary monitor (with 100% primary monitor):

### Before
![dragdrop_nonmonitoraware_issue](https://github.com/user-attachments/assets/adbd84c9-e91c-438a-b21b-bc3d42e88699)

### After
![dragdrop_nonmonitoraware_fix](https://github.com/user-attachments/assets/08aef353-ab8f-409c-a321-330c244b06b1)
