### PR TITLE
[GTK] Fix gdk_monitor_get_scale_factor on Gtk 4 on X11

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/graphics/Device.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/graphics/Device.java
@@ -1099,8 +1099,12 @@ protected int getDeviceZoom() {
 		monitor = GDK.gdk_display_get_monitor_at_point(display, 0, 0);
 	}
 
-	int scale = GDK.gdk_monitor_get_scale_factor(monitor);
-	dpi = dpi * scale;
+	// GDK can return null monitor in some cases thus play safe
+	// See https://gitlab.gnome.org/GNOME/gtk/-/issues/5075 for details
+	if (monitor != 0) {
+		int scale = GDK.gdk_monitor_get_scale_factor(monitor);
+		dpi = dpi * scale;
+	}
 
 	return DPIUtil.mapDPIToZoom (dpi);
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Display.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Display.java
@@ -2690,7 +2690,7 @@ public Monitor[] getMonitors() {
 				monitor.y = geometry.y;
 				monitor.width = geometry.width;
 				monitor.height = geometry.height;
-				if (!OS.isX11()) {
+				if (!OS.isX11() || GTK.GTK4) {
 					int scaleFactor = (int) GDK.gdk_monitor_get_scale_factor(gdkMonitor);
 					monitor.zoom = scaleFactor * 100;
 				} else {


### PR DESCRIPTION
Fixes a number of "Gdk-CRITICAL **: 14:38:20.208:
gdk_monitor_get_scale_factor: assertion 'GDK_IS_MONITOR (monitor)' failed" warnings in the console.
This doesn't make SWT fail but it's better to play safe. See https://gitlab.gnome.org/GNOME/gtk/-/issues/5075 for some background information.