### PR TITLE
[Win32] Fix wrong line height in StyledText #2405

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/TextLayout.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/TextLayout.java
@@ -2135,7 +2135,7 @@ public FontMetrics getLineMetrics (int lineIndex) {
 	long srcHdc = OS.CreateCompatibleDC(hDC);
 	TEXTMETRIC lptm = new TEXTMETRIC();
 	final int zoom = getZoom();
-	long availableFont = font != null ? SWTFontProvider.getFontHandle(font, zoom) : SWTFontProvider.getSystemFontHandle(device, zoom);
+	long availableFont = font != null ? SWTFontProvider.getFontHandle(font, nativeZoom) : SWTFontProvider.getSystemFontHandle(device, nativeZoom);
 	OS.SelectObject(srcHdc, availableFont);
 	metricsAdapter.GetTextMetrics(srcHdc, lptm);
 	OS.DeleteDC(srcHdc);


### PR DESCRIPTION
The line height in StyledText is currently too large when the auto-scaled device zoom is larger than the native zoom. This for example happens on a 175% primary monitor with `swt.autoScale=int200` or with a fixed `swt.autoScale` value that is higher than the primary monitor zoom. This was caused by a recent change that accidentally used the auto-scaled zoom instead of the native zoom for retrieving a font handle combined with the general usage of the ScalingSWTFontRegistry that, in comparison to the previous fixed-zoom registry, now returns an accordingly scaled handle.

This change adapts the font handle retrieval to properly pass the native zoom instead of the auto-scaled zoom.

Fixes https://github.com/eclipse-platform/eclipse.platform.swt/issues/2405

### Screenshots
Left is before the change, right is after:
<img width="655" height="385" alt="image" src="https://github.com/user-attachments/assets/38540bae-6244-49e7-a3f2-598ff55a0edb" />
