### PR TITLE
[Win32] Remove obsolete zoom parameter for refreshing GC handle

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/GC.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/GC.java
@@ -5833,15 +5833,12 @@ Point textExtentInPixels(String string, int flags) {
 	return new Point(rect.right, rect.bottom);
 }
 
-void refreshFor(Drawable drawable, int zoom) {
+void refreshFor(Drawable drawable) {
 	if (drawable == null) SWT.error(SWT.ERROR_NULL_ARGUMENT);
-	if (zoom == getZoom()) {
-		return;
-	}
 	destroy();
 	GCData newData = new GCData();
 	originalData.copyTo(newData);
-	createGcHandle(drawable, newData, zoom);
+	createGcHandle(drawable, newData);
 }
 
 /**
@@ -5947,8 +5944,7 @@ private void storeAndApplyOperationForExistingHandle(Operation operation) {
 	operation.apply();
 }
 
-private void createGcHandle(Drawable drawable, GCData newData, int nativeZoom) {
-	newData.nativeZoom = nativeZoom;
+private void createGcHandle(Drawable drawable, GCData newData) {
 	long newHandle = drawable.internal_new_GC(newData);
 	if (newHandle == 0) SWT.error(SWT.ERROR_NO_HANDLES);
 	init(drawable, newData, newHandle);

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Image.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Image.java
@@ -2177,10 +2177,12 @@ private class PlainImageProviderWrapper extends AbstractImageProviderWrapper {
 			return createBaseHandle(zoom);
 		}
 		if (memGC != null) {
-			GC currentGC = memGC;
-			memGC = null;
-			createHandle(zoom);
-			currentGC.refreshFor(new DrawableWrapper(Image.this, zoom), zoom);
+			if (memGC.getZoom() != zoom) {
+				GC currentGC = memGC;
+				memGC = null;
+				createHandle(zoom);
+				currentGC.refreshFor(new DrawableWrapper(Image.this, zoom));
+			}
 			return zoomLevelToImageHandle.get(zoom);
 		}
 		return super.newImageHandle(zoom);


### PR DESCRIPTION
When refreshing a GC with another zoom, that zoom is unnecessarily duplicated in the DrawableWrapper of the Image and as a parameter of the refresh method of the GC. This refresh method than unnecessarily uses that zoom to initialize the GCData's native zoom with it, even though that's overwritten with the proper zoom by initializing the GC with the DrawableWrapper afterwards.

This change removes the zoom duplication by removing the parameter in the refresh method of the GC. It removes the unnecessary assignment of the GCData's native zoom and moves the check for whether a refresh is necessary because of a zoom change from the GC to the image. In addition, it ensures that the memGC of an image is not accidentally set to null in case the memGC's zoom does already fit to the requested zoom.