### PR TITLE
Unify strict checks and extend ImageDataProvider checks to GTK and Cocoa

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/graphics/Image.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/graphics/Image.java
@@ -850,6 +850,9 @@ public Image(Device device, ImageDataProvider imageDataProvider) {
 	try {
 		init (data, 100);
 		init ();
+		StrictChecks.runIfStrictChecksEnabled(() -> {
+			DPIUtil.validateLinearScaling(imageDataProvider);
+		});
 		ImageData data2x = imageDataProvider.getImageData (200);
 		if (data2x != null) {
 			alphaInfo_200 = new AlphaInfo();
@@ -1822,13 +1825,18 @@ public String toString () {
  * @noreference This method is not intended to be referenced by clients.
  */
 public static void drawScaled(GC gc, ImageData imageData, int width, int height, float scaleFactor) {
-	Image imageToDraw = new Image(gc.device, (ImageDataProvider) zoom ->  imageData);
-	gc.drawImage (imageToDraw, 0, 0, CocoaDPIUtil.pixelToPoint (width), CocoaDPIUtil.pixelToPoint (height),
-			/* E.g. destWidth here is effectively DPIUtil.autoScaleDown (scaledWidth), but avoiding rounding errors.
-			 * Nevertheless, we still have some rounding errors due to the point-based API GC#drawImage(..).
-			 */
-			0, 0, Math.round (CocoaDPIUtil.pixelToPoint (width * scaleFactor)), Math.round (CocoaDPIUtil.pixelToPoint (height * scaleFactor)));
-	imageToDraw.dispose();
+	StrictChecks.runWithStrictChecksDisabled(() -> {
+		Image imageToDraw = new Image(gc.device, (ImageDataProvider) zoom -> imageData);
+		gc.drawImage(imageToDraw, 0, 0, CocoaDPIUtil.pixelToPoint(width), CocoaDPIUtil.pixelToPoint(height),
+				/*
+				 * E.g. destWidth here is effectively DPIUtil.autoScaleDown (scaledWidth), but
+				 * avoiding rounding errors. Nevertheless, we still have some rounding errors
+				 * due to the point-based API GC#drawImage(..).
+				 */
+				0, 0, Math.round(CocoaDPIUtil.pixelToPoint(width * scaleFactor)),
+				Math.round(CocoaDPIUtil.pixelToPoint(height * scaleFactor)));
+		imageToDraw.dispose();
+	});
 }
 
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/DPIUtil.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/DPIUtil.java
@@ -223,6 +223,26 @@ public static int mapZoomToDPI (int zoom) {
 	return roundedDpi;
 }
 
+public static void validateLinearScaling(ImageDataProvider provider) {
+	final int baseZoom = 100;
+	final int scaledZoom = 200;
+	final int scaleFactor = scaledZoom / baseZoom;
+	ImageData baseImageData = provider.getImageData(baseZoom);
+	ImageData scaledImageData = provider.getImageData(scaledZoom);
+
+	if (scaledImageData == null) {
+		return;
+	}
+
+	if (scaledImageData.width != scaleFactor * baseImageData.width
+			|| scaledImageData.height != scaleFactor * baseImageData.height) {
+		System.err.println(String.format(
+				"***WARNING: ImageData should be linearly scaled across zooms but size is (%d, %d) at 100%% and (%d, %d) at 200%%.",
+				baseImageData.width, baseImageData.height, scaledImageData.width, scaledImageData.height));
+		new Error().printStackTrace(System.err);
+	}
+}
+
 /**
  * Represents an element, such as some image data, at a specific zoom level.
  *

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/StrictChecks.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/StrictChecks.java
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Yatta Solutions
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Yatta Solutions - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.swt.internal;
+
+public final class StrictChecks {
+
+	private static final boolean STRICT_CHECKS_ENABLED = System
+			.getProperty("org.eclipse.swt.internal.enableStrictChecks") != null;
+
+	private static boolean temporarilyDisabled = false;
+
+	private StrictChecks() {
+	}
+
+	public static void runIfStrictChecksEnabled(Runnable runnable) {
+		if (STRICT_CHECKS_ENABLED && !temporarilyDisabled) {
+			runnable.run();
+		}
+	}
+
+	public static void runWithStrictChecksDisabled(Runnable runnable) {
+		temporarilyDisabled = true;
+		try {
+			runnable.run();
+		} finally {
+			temporarilyDisabled = false;
+		}
+	}
+}

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/graphics/Image.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/graphics/Image.java
@@ -672,6 +672,9 @@ public Image(Device device, ImageDataProvider imageDataProvider) {
 	currentDeviceZoom = DPIUtil.getDeviceZoom();
 	initFromImageDataProvider(currentDeviceZoom);
 	init ();
+	StrictChecks.runIfStrictChecksEnabled(() -> {
+		DPIUtil.validateLinearScaling(imageDataProvider);
+	});
 }
 
 /**
@@ -1583,13 +1586,17 @@ public String toString () {
  * @noreference This method is not intended to be referenced by clients.
  */
 public static void drawScaled(GC gc, ImageData imageData, int width, int height, float scaleFactor) {
-	Image imageToDraw = new Image(gc.device, (ImageDataProvider) zoom -> imageData);
-	gc.drawImage (imageToDraw, 0, 0, width, height,
-			/* E.g. destWidth here is effectively DPIUtil.autoScaleDown (scaledWidth), but avoiding rounding errors.
-			 * Nevertheless, we still have some rounding errors due to the point-based API GC#drawImage(..).
-			 */
-			0, 0, Math.round (width * scaleFactor), Math.round (height * scaleFactor));
-	imageToDraw.dispose();
+	StrictChecks.runWithStrictChecksDisabled(() -> {
+		Image imageToDraw = new Image(gc.device, (ImageDataProvider) zoom -> imageData);
+		gc.drawImage(imageToDraw, 0, 0, width, height,
+				/*
+				 * E.g. destWidth here is effectively DPIUtil.autoScaleDown (scaledWidth), but
+				 * avoiding rounding errors. Nevertheless, we still have some rounding errors
+				 * due to the point-based API GC#drawImage(..).
+				 */
+				0, 0, Math.round(width * scaleFactor), Math.round(height * scaleFactor));
+		imageToDraw.dispose();
+	});
 }
 
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Display.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Display.java
@@ -116,8 +116,6 @@ import org.eclipse.swt.internal.gtk4.*;
  */
 public class Display extends Device implements Executor {
 
-	static boolean strictChecks = System.getProperty("org.eclipse.swt.internal.enableStrictChecks") != null;
-
 	private static final int SLOT_IN_USE = -2;
 	private static final int LAST_TABLE_INDEX = -1;
 
@@ -880,12 +878,12 @@ void addWidget (long handle, Widget widget) {
 		widgetTable = newWidgetTable;
 	}
 	int index = freeSlot + 1;
-	if(strictChecks) {
+	StrictChecks.runIfStrictChecksEnabled(() -> {
 		long data = OS.g_object_get_qdata (handle, SWT_OBJECT_INDEX);
 		if(data > 0 && data != index) {
 			SWT.error(SWT.ERROR_INVALID_ARGUMENT, null, ". Potential leak of " + widget + debugInfoForIndex(data - 1));
 		}
-	}
+	});
 	OS.g_object_set_qdata (handle, SWT_OBJECT_INDEX, index);
 	int oldSlot = freeSlot;
 	freeSlot = indexTable[oldSlot];

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Shell.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Shell.java
@@ -3258,14 +3258,14 @@ void deregister () {
 	if(shellHandle != 0 && !(disposed instanceof Shell)) {
 		SWT.error(SWT.ERROR_INVALID_RETURN_VALUE, null, ". Wrong widgetTable entry: " + disposed + " removed for shell: " + this + display.dumpWidgetTableInfo());
 	}
-	if(Display.strictChecks) {
+	StrictChecks.runIfStrictChecksEnabled(() -> {
 		Shell[] shells = display.getShells();
 		for (Shell shell : shells) {
 			if(shell == this) {
 				SWT.error(SWT.ERROR_INVALID_RETURN_VALUE, null, ". Disposed shell still in the widgetTable: " + this + display.dumpWidgetTableInfo());
 			}
 		}
-	}
+	});
 }
 
 boolean requiresUngrab () {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Device.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Device.java
@@ -34,8 +34,6 @@ import org.eclipse.swt.widgets.*;
  */
 public abstract class Device implements Drawable {
 
-	static boolean strictChecks = System.getProperty("org.eclipse.swt.internal.enableStrictChecks") != null;
-
 	/* Debugging */
 	public static boolean DEBUG;
 	boolean debug = DEBUG;

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/GC.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/GC.java
@@ -210,9 +210,9 @@ private void validateGCState() {
 }
 
 void checkGC(int mask) {
-	if (Device.strictChecks) {
+	StrictChecks.runIfStrictChecksEnabled(() -> {
 		validateGCState();
-	}
+	});
 	int state = data.state;
 	if ((state & mask) == mask) return;
 	state = (state ^ mask) & mask;
@@ -4402,10 +4402,10 @@ private void init(Drawable drawable, GCData data, long hDC) {
 }
 
 private static int extractZoom(long hDC) {
-	if (Device.strictChecks) {
+	StrictChecks.runIfStrictChecksEnabled(() -> {
 		System.err.println("***WARNING: GC is initialized with a missing zoom. This indicates an "
 				+ "incompatible custom Drawable implementation.");
-	}
+	});
 	long hwnd = OS.WindowFromDC(hDC);
 	long parentWindow = OS.GetAncestor(hwnd, OS.GA_ROOT);
 	long monitorParent = OS.MonitorFromWindow(parentWindow, OS.MONITOR_DEFAULTTONEAREST);


### PR DESCRIPTION
- Move strict checks into a separate class.
- Extend strict check to verify if imageData is linearly scaled by the imageDataProvider in GTK and COCOA implementations.