### PR TITLE
[win32] ImageList#getImageSize should always return value in points

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/ImageList.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/ImageList.java
@@ -359,10 +359,14 @@ private void addPlaceholderImageToImageList(long imageListHandle, int bitmapWidt
 	OS.ReleaseDC(0, hDC);
 }
 
+/**
+ *
+ * {@return size of Images in the ImageList in points}
+ */
 public Point getImageSize() {
 	int [] cx = new int [1], cy = new int [1];
 	OS.ImageList_GetIconSize (handle, cx, cy);
-	return new Point (cx [0], cy [0]);
+	return Win32DPIUtils.pixelToPoint(new Point (cx [0], cy [0]), zoom);
 }
 
 public int indexOf (Image image) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Display.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Display.java
@@ -2062,7 +2062,7 @@ ImageList getImageList (int style, int width, int height, int zoom) {
 		imageList = newList;
 	}
 
-	ImageList list = new ImageList (style, width, height, zoom);
+	ImageList list = new ImageList (style, Win32DPIUtils.pointToPixel(width, zoom), Win32DPIUtils.pointToPixel(height, zoom), zoom);
 	imageList [i] = list;
 	list.addRef();
 	return list;
@@ -2092,7 +2092,7 @@ ImageList getImageListToolBar (int style, int width, int height, int zoom) {
 		toolImageList = newList;
 	}
 
-	ImageList list = new ImageList (style, width, height, zoom);
+	ImageList list = new ImageList (style, Win32DPIUtils.pointToPixel(width, zoom), Win32DPIUtils.pointToPixel(height, zoom), zoom);
 	toolImageList [i] = list;
 	list.addRef();
 	return list;
@@ -2122,7 +2122,7 @@ ImageList getImageListToolBarDisabled (int style, int width, int height, int zoo
 		toolDisabledImageList = newList;
 	}
 
-	ImageList list = new ImageList (style, width, height, zoom);
+	ImageList list = new ImageList (style, Win32DPIUtils.pointToPixel(width, zoom), Win32DPIUtils.pointToPixel(height, zoom), zoom);
 	toolDisabledImageList [i] = list;
 	list.addRef();
 	return list;
@@ -2152,7 +2152,7 @@ ImageList getImageListToolBarHot (int style, int width, int height, int zoom) {
 		toolHotImageList = newList;
 	}
 
-	ImageList list = new ImageList (style, width, height, zoom);
+	ImageList list = new ImageList (style, Win32DPIUtils.pointToPixel(width, zoom), Win32DPIUtils.pointToPixel(height, zoom), zoom);
 	toolHotImageList [i] = list;
 	list.addRef();
 	return list;

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TabFolder.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TabFolder.java
@@ -455,8 +455,8 @@ int imageIndex (Image image) {
 	 */
 	if (image == null) return -1;
 	if (imageList == null) {
-		Rectangle bounds = Win32DPIUtils.scaleBounds(image.getBounds(), this.getZoom(), 100);
-		imageList = display.getImageList (style & SWT.RIGHT_TO_LEFT, bounds.width, bounds.height, this.getZoom());
+		Rectangle boundsInPoints = image.getBounds();
+		imageList = display.getImageList (style & SWT.RIGHT_TO_LEFT, boundsInPoints.width, boundsInPoints.height, getZoom());
 		int index = imageList.add (image);
 		long hImageList = imageList.getHandle(getZoom());
 		OS.SendMessage (handle, OS.TCM_SETIMAGELIST, 0, hImageList);
@@ -837,9 +837,9 @@ void updateOrientation () {
 	OS.SetWindowPos (handle, 0, 0, 0, width - 1, height - 1, OS.SWP_NOMOVE | OS.SWP_NOZORDER);
 	OS.SetWindowPos (handle, 0, 0, 0, width, height, OS.SWP_NOMOVE | OS.SWP_NOZORDER);
 	if (imageList != null) {
-		Point size = imageList.getImageSize ();
+		Point sizeInPoints = imageList.getImageSize();
 		display.releaseImageList (imageList);
-		imageList = display.getImageList (style & SWT.RIGHT_TO_LEFT, size.x, size.y, this.getZoom());
+		imageList = display.getImageList (style & SWT.RIGHT_TO_LEFT, sizeInPoints.x, sizeInPoints.y, this.getZoom());
 		long hImageList = imageList.getHandle(getZoom());
 		OS.SendMessage (handle, OS.TCM_SETIMAGELIST, 0, hImageList);
 		TCITEM tcItem = new TCITEM ();

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Table.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Table.java
@@ -2849,8 +2849,8 @@ int imageIndex (Image image, int column) {
 		setSubImagesVisible (true);
 	}
 	if (imageList == null) {
-		Rectangle bounds = Win32DPIUtils.scaleBounds(image.getBounds(), this.getZoom(), 100);
-		imageList = display.getImageList (style & SWT.RIGHT_TO_LEFT, bounds.width, bounds.height, getZoom());
+		Rectangle boundsInPoints = image.getBounds();
+		imageList = display.getImageList (style & SWT.RIGHT_TO_LEFT, boundsInPoints.width, boundsInPoints.height, getZoom());
 		int index = imageList.indexOf (image);
 		if (index == -1) index = imageList.add (image);
 		long hImageList = imageList.getHandle(getZoom());
@@ -2889,8 +2889,8 @@ int imageIndex (Image image, int column) {
 int imageIndexHeader (Image image) {
 	if (image == null) return OS.I_IMAGENONE;
 	if (headerImageList == null) {
-		Rectangle bounds = Win32DPIUtils.scaleBounds(image.getBounds(), this.getZoom(), 100);
-		headerImageList = display.getImageList (style & SWT.RIGHT_TO_LEFT, bounds.width, bounds.height, getZoom());
+		Rectangle boundsInPoints = image.getBounds();
+		headerImageList = display.getImageList (style & SWT.RIGHT_TO_LEFT, boundsInPoints.width, boundsInPoints.height, getZoom());
 		int index = headerImageList.indexOf (image);
 		if (index == -1) index = headerImageList.add (image);
 		long hImageList = headerImageList.getHandle(getZoom());
@@ -5576,9 +5576,9 @@ void updateOrientation () {
 	}
 	if ((style & SWT.CHECK) != 0) fixCheckboxImageListColor (false);
 	if (imageList != null) {
-		Point size = imageList.getImageSize ();
+		Point sizeInPoints = imageList.getImageSize();
 		display.releaseImageList (imageList);
-		imageList = display.getImageList (style & SWT.RIGHT_TO_LEFT, size.x, size.y, getZoom());
+		imageList = display.getImageList (style & SWT.RIGHT_TO_LEFT, sizeInPoints.x, sizeInPoints.y, getZoom());
 		int count = (int)OS.SendMessage (handle, OS.LVM_GETITEMCOUNT, 0, 0);
 		for (int i = 0; i < count; i++) {
 			TableItem item = _getItem (i, false);
@@ -5595,9 +5595,9 @@ void updateOrientation () {
 	}
 	if (hwndHeader != 0) {
 		if (headerImageList != null) {
-			Point size = headerImageList.getImageSize ();
+			Point sizeInPoints = headerImageList.getImageSize();
 			display.releaseImageList (headerImageList);
-			headerImageList = display.getImageList (style & SWT.RIGHT_TO_LEFT, size.x, size.y, getZoom());
+			headerImageList = display.getImageList (style & SWT.RIGHT_TO_LEFT, sizeInPoints.x, sizeInPoints.y, getZoom());
 			if (columns != null) {
 				for (int i = 0; i < columns.length; i++) {
 					TableColumn column = columns [i];
@@ -7297,7 +7297,7 @@ LRESULT wmNotifyToolTip (NMTTCUSTOMDRAW nmcd, long lParam) {
 					if (image != null) {
 						Rectangle rect = Win32DPIUtils.pointToPixel(image.getBounds(), getZoom());
 						RECT imageRect = item.getBounds (pinfo.iItem, pinfo.iSubItem, false, true, false, false, hDC);
-						Point size = imageList == null ? new Point (rect.width, rect.height) : imageList.getImageSize ();
+						Point size = imageList == null ? new Point (rect.width, rect.height) : Win32DPIUtils.pointToPixel(imageList.getImageSize(), getZoom());
 						int y = imageRect.top + Math.max (0, (imageRect.bottom - imageRect.top - size.y) / 2);
 						int zoom = getZoom();
 						rect = Win32DPIUtils.pixelToPoint(rect, zoom);

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ToolBar.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ToolBar.java
@@ -1272,10 +1272,10 @@ String toolTipText (NMTTDISPINFO hdr) {
 void updateOrientation () {
 	super.updateOrientation ();
 	if (imageList != null) {
-		Point size = imageList.getImageSize ();
-		ImageList newImageList = display.getImageListToolBar (style & SWT.RIGHT_TO_LEFT, size.x, size.y, getZoom());
-		ImageList newHotImageList = display.getImageListToolBarHot (style & SWT.RIGHT_TO_LEFT, size.x, size.y, getZoom());
-		ImageList newDisabledImageList = display.getImageListToolBarDisabled (style & SWT.RIGHT_TO_LEFT, size.x, size.y, getZoom());
+		Point sizeInPoints = imageList.getImageSize();
+		ImageList newImageList = display.getImageListToolBar (style & SWT.RIGHT_TO_LEFT, sizeInPoints.x, sizeInPoints.y, getZoom());
+		ImageList newHotImageList = display.getImageListToolBarHot (style & SWT.RIGHT_TO_LEFT, sizeInPoints.x, sizeInPoints.y, getZoom());
+		ImageList newDisabledImageList = display.getImageListToolBarDisabled (style & SWT.RIGHT_TO_LEFT, sizeInPoints.x, sizeInPoints.y, getZoom());
 		TBBUTTONINFO info = new TBBUTTONINFO ();
 		info.cbSize = TBBUTTONINFO.sizeof;
 		info.dwMask = OS.TBIF_IMAGE;

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ToolItem.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ToolItem.java
@@ -1103,16 +1103,16 @@ void updateImages (boolean enabled) {
 	ImageList hotImageList = parent.getHotImageList ();
 	ImageList disabledImageList = parent.getDisabledImageList();
 	if (info.iImage == OS.I_IMAGENONE) {
-		Rectangle bounds = Win32DPIUtils.scaleBounds(image.getBounds(), getParent().getZoom(), 100);
+		Rectangle boundsInPoints = image.getBounds();
 		int listStyle = parent.style & SWT.RIGHT_TO_LEFT;
 		if (imageList == null) {
-			imageList = display.getImageListToolBar (listStyle, bounds.width, bounds.height, getZoom());
+			imageList = display.getImageListToolBar (listStyle, boundsInPoints.width, boundsInPoints.height, getZoom());
 		}
 		if (disabledImageList == null) {
-			disabledImageList = display.getImageListToolBarDisabled (listStyle, bounds.width, bounds.height, getZoom());
+			disabledImageList = display.getImageListToolBarDisabled (listStyle, boundsInPoints.width, boundsInPoints.height, getZoom());
 		}
 		if (hotImageList == null) {
-			hotImageList = display.getImageListToolBarHot (listStyle, bounds.width, bounds.height, getZoom());
+			hotImageList = display.getImageListToolBarHot (listStyle, boundsInPoints.width, boundsInPoints.height, getZoom());
 		}
 		Image disabled = disabledImage;
 		if (disabledImage == null) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Tree.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Tree.java
@@ -3058,7 +3058,7 @@ public boolean getHeaderVisible () {
 }
 
 Point getImageSize () {
-	if (imageList != null) return imageList.getImageSize ();
+	if (imageList != null) return Win32DPIUtils.pointToPixel(imageList.getImageSize(), getZoom());
 	return new Point (0, getItemHeightInPixels ());
 }
 
@@ -3740,8 +3740,8 @@ boolean hitTestSelection (long hItem, int x, int y) {
 int imageIndex (Image image, int index) {
 	if (image == null) return OS.I_IMAGENONE;
 	if (imageList == null) {
-		Rectangle bounds = Win32DPIUtils.scaleBounds(image.getBounds(), this.getZoom(), 100);
-		imageList = display.getImageList (style & SWT.RIGHT_TO_LEFT, bounds.width, bounds.height, getZoom());
+		Rectangle boundsInPoints = image.getBounds();
+		imageList = display.getImageList (style & SWT.RIGHT_TO_LEFT, boundsInPoints.width, boundsInPoints.height, getZoom());
 	}
 	int imageIndex = imageList.indexOf (image);
 	if (imageIndex == -1) imageIndex = imageList.add (image);
@@ -3764,8 +3764,8 @@ int imageIndex (Image image, int index) {
 int imageIndexHeader (Image image) {
 	if (image == null) return OS.I_IMAGENONE;
 	if (headerImageList == null) {
-		Rectangle bounds = Win32DPIUtils.scaleBounds(image.getBounds(), this.getZoom(), 100);
-		headerImageList = display.getImageList (style & SWT.RIGHT_TO_LEFT, bounds.width, bounds.height, getZoom());
+		Rectangle boundsInPoints = image.getBounds();
+		headerImageList = display.getImageList (style & SWT.RIGHT_TO_LEFT, boundsInPoints.width, boundsInPoints.height, getZoom());
 		int index = headerImageList.indexOf (image);
 		if (index == -1) index = headerImageList.add (image);
 		long hImageList = headerImageList.getHandle(getZoom());
@@ -5791,9 +5791,9 @@ void updateOrientation () {
 	}
 	if ((style & SWT.CHECK) != 0) setCheckboxImageList ();
 	if (imageList != null) {
-		Point size = imageList.getImageSize ();
+		Point sizeInPoints = imageList.getImageSize();
 		display.releaseImageList (imageList);
-		imageList = display.getImageList (style & SWT.RIGHT_TO_LEFT, size.x, size.y, getZoom());
+		imageList = display.getImageList (style & SWT.RIGHT_TO_LEFT, sizeInPoints.x, sizeInPoints.y, getZoom());
 		for (TreeItem item : items) {
 			if (item != null) {
 				Image image = item.image;
@@ -5808,9 +5808,9 @@ void updateOrientation () {
 	}
 	if (hwndHeader != 0) {
 		if (headerImageList != null) {
-			Point size = headerImageList.getImageSize ();
+			Point sizeInPoints = headerImageList.getImageSize();
 			display.releaseImageList (headerImageList);
-			headerImageList = display.getImageList (style & SWT.RIGHT_TO_LEFT, size.x, size.y, getZoom());
+			headerImageList = display.getImageList (style & SWT.RIGHT_TO_LEFT, sizeInPoints.x, sizeInPoints.y, getZoom());
 			if (columns != null) {
 				for (int i = 0; i < columns.length; i++) {
 					TreeColumn column = columns[i];


### PR DESCRIPTION
This PR clarifies the contract of ImageList#getImageSize in the windows implementation to always return a value in points. Historically it returned values in pixel. This worked until recent changes in ImageList to support and handle multiple OS image list handles to support monitor specific scaling. Because of the change the ImageList size in pixels depends on the target zoom the ImageList will be used with. Because of this the method is adapted to return a value in points. All callers of this method are adapted accordingly to scale the value to pixels matching the zoom of the Widget if necessary.

### How to reproduce

This is not testable with a Runtime Workspace and must be setup correctly, but can happen easily in real scenarios.

1. Configure monitor setup as: Primary 150%, secondary 100%
2. **Very Important:** Open the File Explorer and move it to the secondary monitor
3. **Start** the latest [I-Build](https://download.eclipse.org/eclipse/downloads/drops4/I20250812-1800/download.php?dropFile=eclipse-SDK-I20250812-1800-win32-x86_64.zip) **from the File Explorer**
4. Some Images will use the 100% image variant, e.g. the _Select Working Set_ dialog
<img width="349" height="290" alt="image" src="https://github.com/user-attachments/assets/9f34a8c5-24e1-43e9-8605-0f2a9708194f" />

The image is smaller than expected
<img width="1014" height="615" alt="image" src="https://github.com/user-attachments/assets/32f9434a-31fc-46e6-af0d-376556f30f72" />


 