### PR TITLE
[GTK] Fix gdk_monitor_get_scale_factor on Gtk 4 on X11

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Shell.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Shell.java
@@ -2527,7 +2527,9 @@ void setInitialBounds() {
 			long display = GDK.gdk_display_get_default();
 			if (display != 0) {
 				long monitor = GDK.gdk_display_get_monitor_at_surface(display, paintSurface());
-				GDK.gdk_monitor_get_geometry(monitor, dest);
+				if (monitor != 0) {
+					GDK.gdk_monitor_get_geometry(monitor, dest);
+				}
 				width = (int) (dest.width * SHELL_TO_MONITOR_RATIO);
 				height = (int) (dest.height * SHELL_TO_MONITOR_RATIO);
 			}


### PR DESCRIPTION
One more case of
https://github.com/eclipse-platform/eclipse.platform.swt/pull/2396