### PR TITLE
Win32: Use native monitor zoom for menu item image scaling

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/MenuItem.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/MenuItem.java
@@ -896,7 +896,7 @@ private long getMenuItemIconBitmapHandle(Image image) {
 		return 0;
 	}
 	if (hBitmap != 0) OS.DeleteObject (hBitmap);
-	int zoom = adaptZoomForMenuItem(getZoom(), image);
+	int zoom = adaptZoomForMenuItem(nativeZoom, image);
 	return Display.create32bitDIB (image, zoom);
 }
 
@@ -906,7 +906,7 @@ private long getMenuItemIconSelectedBitmapHandle() {
 		return 0;
 	}
 	if (hBitmapSelected != 0) OS.DeleteObject (hBitmapSelected);
-	int zoom = adaptZoomForMenuItem(getZoom(), image);
+	int zoom = adaptZoomForMenuItem(nativeZoom, image);
 	return hBitmapSelected = Display.create32bitDIB (image, zoom);
 }
 


### PR DESCRIPTION
On Win32, the OS paints MenuItem images using sizes defined by SM_CXMENUCHECK / SM_CYMENUCHECK. If images are not provided at these metrics-specific sizes, Windows rescales them, causing unexpected sizes and alpha channel issues.

In getMenuItemIconSelectedBitmapHandle, adaptZoomForMenuItem was called which returns a fixed scaled value from getZoom() when fix autoScale value is provided e.g. 250 instead of the current
monitor's native zoom (150). This caused the OS to perform additional scaling.

Updated code to call adaptZoomForMenuItem(nativeZoom, image) so that the image is prepared for the actual monitor zoom, avoiding unnecessary OS scaling and preserving alpha channel integrity.

### How to Reproduce

The issue can be reproduced when autoScale value is provided. e.g. `-Dswt.autoScale=x`

**Issue Case 1** 
Primary monitor is Quarter (125, 175, 225 ..) and AutoScale > Primary

Primary monitor at 175%
Secondary monitor at 100, 125, 150, 300, 350
VM-Arg: -Dswt.autoScale=275


**Issue Case 2**
Primary is Half Zoom (150, 250, 350) and AutoScale is also Half Zoom and AutoScale > Primary

VM-Arg: -Dswt.autoScale=250, Primary = 150
Secondary = 100, 125, 300, 350

at Secondary 150, 175, 200, 225, 250 -> no Issue
Any Value between Primary and AutoScale is ok