### PR TITLE
[GTK4] Fix scrollbar warnings when using Breeze theme

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/org/eclipse/swt/internal/gtk/swt_theming_fixes_gtk_4_0_0.css
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/org/eclipse/swt/internal/gtk/swt_theming_fixes_gtk_4_0_0.css
@@ -5,3 +5,8 @@ button {
 	min-height: 0px;
 	min-width: 0px;
 }
+
+scrollbar slider {
+	min-height: 8px;
+	min-width: 8px;
+}


### PR DESCRIPTION
Trying to open e.g. a shell (or any widget with a scrollbar) produces the following warning:
> GtkGizmo (...) (slider) reported min height -2, but sizes must be >= 0

This is a bug with the KDE theme:
https://bugs.kde.org/show_bug.cgi?id=486766

More specifically, the theme is reporting the wrong size for the scroll-bar (6px, as opposed to 8px). To fix this, adjust the CSS theme to define a minimum size for the slider.

To reproduce, run Snippet1 with GTK4 and the Breeze theme.