### PR TITLE
[Win32] Ensure Image#getImageData() returns no internal data

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Image.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Image.java
@@ -2017,7 +2017,7 @@ private abstract class ImageFromImageDataProviderWrapper extends AbstractImagePr
 			handle.destroy();
 			return data;
 		};
-		return cachedImageData.computeIfAbsent(zoomContext.targetZoom(), imageDataRetrieval);
+		return (ImageData) cachedImageData.computeIfAbsent(zoomContext.targetZoom(), imageDataRetrieval).clone();
 	}
 
 	@Override
@@ -2297,7 +2297,7 @@ private abstract class BaseImageProviderWrapper<T> extends DynamicImageProviderW
 			handle.destroy();
 			return data;
 		};
-		return cachedImageData.computeIfAbsent(zoomContext.targetZoom(), imageDataRetrival);
+		return (ImageData) cachedImageData.computeIfAbsent(zoomContext.targetZoom(), imageDataRetrival).clone();
 	}
 
 


### PR DESCRIPTION
This fixes a regression from https://github.com/eclipse-platform/eclipse.platform.swt/pull/1989 as reported by @sratz: https://github.com/eclipse-platform/eclipse.platform.swt/pull/1989#issuecomment-3195890789

A caching mechanism for ImageData introduced to some provider implementations inside the Image class leads to Image#getImageData() returning an ImageData object, which if modified affects the underlying Image. This contradicts the contract of that method, which states that changes to that object will not affect the Image.

This change ensures that Image#getImagetData() only returns objects that are not used internal of the Image instance. To this end, clones of the ImageData are created where necessary.