### PR TITLE
Scale Tree.HEADER_MARGIN by zoom level instead of using fixed pixels

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TreeColumn.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TreeColumn.java
@@ -375,8 +375,8 @@ public void pack () {
 	int flags = OS.DT_CALCRECT | OS.DT_NOPREFIX;
 	char [] buffer = text.toCharArray ();
 	OS.DrawText (hDC, buffer, buffer.length, rect, flags);
-	int headerWidth = rect.right - rect.left + Tree.HEADER_MARGIN;
-	if (OS.IsAppThemed ()) headerWidth += Tree.HEADER_EXTRA;
+	int headerWidth = rect.right - rect.left + Win32DPIUtils.pointToPixel(Tree.HEADER_MARGIN, getZoom());
+	if (OS.IsAppThemed ()) headerWidth += Win32DPIUtils.pointToPixel(Tree.HEADER_EXTRA, getZoom());
 	if (image != null || parent.sortColumn == this) {
 		Image headerImage = null;
 		if (parent.sortColumn == this && parent.sortDirection != SWT.NONE) {


### PR DESCRIPTION
The Tree.HEADER_MARGIN constant defines extra fixed-width spacing for tree headers. Previously, this was a fixed pixel value, which worked at 100% zoom but did not scale properly on high-DPI monitors.

This change redefines HEADER_MARGIN in points and converts it to pixels based on the current zoom level, ensuring consistent header spacing across different display scales.

### Before and After 

Header Width at 350% zoom

<img width="1287" height="1341" alt="image" src="https://github.com/user-attachments/assets/121483fc-1313-4903-95ab-d583bed5c5a3" />
