### PR TITLE
[Win32] Remove unused zoom parameter from CoordinateSystemMapper methods

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/widgets/CoordinateSystemMapperTests.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/widgets/CoordinateSystemMapperTests.java
@@ -64,8 +64,8 @@ class CoordinateSystemMapperTests {
 	void translatePointInNoMonitorBackAndForthShouldBeTheSame(CoordinateSystemMapper mapper) {
 		setupMonitors(mapper);
 		Point pt = createExpectedPoint(mapper, 5000, -400, monitors[0]);
-		Point px = mapper.translateToDisplayCoordinates(pt, monitors[0].getZoom());
-		assertEquals(pt, mapper.translateFromDisplayCoordinates(px, monitors[0].getZoom()));
+		Point px = mapper.translateToDisplayCoordinates(pt);
+		assertEquals(pt, mapper.translateFromDisplayCoordinates(px));
 	}
 
 	@Test
@@ -73,8 +73,8 @@ class CoordinateSystemMapperTests {
 		SingleZoomCoordinateSystemMapper mapper = getSingleZoomCoordinateSystemMapper();
 		setupMonitors(mapper);
 		Point pt = new Point(1900, 400);
-		Point px = mapper.translateToDisplayCoordinates(pt, monitors[0].getZoom());
-		assertEquals(pt, mapper.translateFromDisplayCoordinates(px, monitors[0].getZoom()));
+		Point px = mapper.translateToDisplayCoordinates(pt);
+		assertEquals(pt, mapper.translateFromDisplayCoordinates(px));
 	}
 
 	@Test
@@ -82,9 +82,9 @@ class CoordinateSystemMapperTests {
 		MultiZoomCoordinateSystemMapper mapper = getMultiZoomCoordinateSystemMapper();
 		setupMonitors(mapper);
 		Point pt = new Point(1900, 400);
-		Point px = mapper.translateToDisplayCoordinates(pt, monitors[0].getZoom());
-		Point translatedPt = mapper.translateFromDisplayCoordinates(px, monitors[0].getZoom());
-		Point translatedPx = mapper.translateToDisplayCoordinates(translatedPt, monitors[0].getZoom());
+		Point px = mapper.translateToDisplayCoordinates(pt);
+		Point translatedPt = mapper.translateFromDisplayCoordinates(px);
+		Point translatedPx = mapper.translateToDisplayCoordinates(translatedPt);
 		assertEquals(new Point(translatedPt.x, translatedPt.y), translatedPx);
 		assertEquals(translatedPx, px);
 	}
@@ -94,8 +94,8 @@ class CoordinateSystemMapperTests {
 	void translateRectangleInNoMonitorBackAndForthShouldBeTheSame(CoordinateSystemMapper mapper) {
 		setupMonitors(mapper);
 		Rectangle rectInPts = createExpectedRectangle(mapper, 5000, -400, 200, 200, monitors[0]);
-		Rectangle rectInPxs = mapper.translateToDisplayCoordinates(rectInPts, monitors[0].getZoom());
-		assertEquals(rectInPts, mapper.translateFromDisplayCoordinates(rectInPxs, monitors[0].getZoom()));
+		Rectangle rectInPxs = mapper.translateToDisplayCoordinates(rectInPts);
+		assertEquals(rectInPts, mapper.translateFromDisplayCoordinates(rectInPxs));
 	}
 
 	@Test
@@ -103,8 +103,8 @@ class CoordinateSystemMapperTests {
 		SingleZoomCoordinateSystemMapper mapper = getSingleZoomCoordinateSystemMapper();
 		setupMonitors(mapper);
 		Rectangle rectInPts = new Rectangle(1800, 400, 100, 100);
-		Rectangle rectInPxs = mapper.translateToDisplayCoordinates(rectInPts, monitors[0].getZoom());
-		assertEquals(rectInPts, mapper.translateFromDisplayCoordinates(rectInPxs, monitors[0].getZoom()));
+		Rectangle rectInPxs = mapper.translateToDisplayCoordinates(rectInPts);
+		assertEquals(rectInPts, mapper.translateFromDisplayCoordinates(rectInPxs));
 	}
 
 	@Test
@@ -112,8 +112,8 @@ class CoordinateSystemMapperTests {
 		MultiZoomCoordinateSystemMapper mapper = getMultiZoomCoordinateSystemMapper();
 		setupMonitors(mapper);
 		Rectangle rectInPts = new Rectangle(1800, 400, 100, 100);
-		Rectangle rectInPxs = mapper.translateToDisplayCoordinates(rectInPts, monitors[0].getZoom());
-		Rectangle rectInPtsTranslated = mapper.translateFromDisplayCoordinates(rectInPxs, monitors[0].getZoom());
+		Rectangle rectInPxs = mapper.translateToDisplayCoordinates(rectInPts);
+		Rectangle rectInPtsTranslated = mapper.translateFromDisplayCoordinates(rectInPxs);
 		boolean isInsideMonitor = false;
 		for (Monitor monitor : monitors) {
 			if (monitor.getClientArea().intersects(rectInPtsTranslated)) {
@@ -129,8 +129,8 @@ class CoordinateSystemMapperTests {
 		SingleZoomCoordinateSystemMapper mapper = getSingleZoomCoordinateSystemMapper();
 		setupMonitors(mapper);
 		Rectangle rectInPts = new Rectangle(1950, 400, 150, 100);
-		Rectangle rectInPxs = mapper.translateToDisplayCoordinates(rectInPts, monitors[0].getZoom());
-		assertEquals(rectInPts, mapper.translateFromDisplayCoordinates(rectInPxs, monitors[0].getZoom()));
+		Rectangle rectInPxs = mapper.translateToDisplayCoordinates(rectInPts);
+		assertEquals(rectInPts, mapper.translateFromDisplayCoordinates(rectInPxs));
 	}
 
 	@Test
@@ -138,8 +138,8 @@ class CoordinateSystemMapperTests {
 		MultiZoomCoordinateSystemMapper mapper = getMultiZoomCoordinateSystemMapper();
 		setupMonitors(mapper);
 		Rectangle rectInPts = new Rectangle.WithMonitor(1950, 400, 150, 100, monitors[1]);
-		Rectangle rectInPxs = mapper.translateToDisplayCoordinates(rectInPts, monitors[0].getZoom());
-		assertEquals(rectInPts, mapper.translateFromDisplayCoordinates(rectInPxs, monitors[0].getZoom()));
+		Rectangle rectInPxs = mapper.translateToDisplayCoordinates(rectInPts);
+		assertEquals(rectInPts, mapper.translateFromDisplayCoordinates(rectInPxs));
 	}
 
 	@ParameterizedTest
@@ -147,8 +147,8 @@ class CoordinateSystemMapperTests {
 	void translateRectangleInGapPartiallyInLeftBackAndForthShouldBeTheSame(CoordinateSystemMapper mapper) {
 		setupMonitors(mapper);
 		Rectangle rectInPts = createExpectedRectangle(mapper, 750, 400, 100, 100, monitors[0]);
-		Rectangle rectInPxs = mapper.translateToDisplayCoordinates(rectInPts, monitors[0].getZoom());
-		assertEquals(rectInPts, mapper.translateFromDisplayCoordinates(rectInPxs, monitors[0].getZoom()));
+		Rectangle rectInPxs = mapper.translateToDisplayCoordinates(rectInPts);
+		assertEquals(rectInPts, mapper.translateFromDisplayCoordinates(rectInPxs));
 	}
 
 	@Test
@@ -156,8 +156,8 @@ class CoordinateSystemMapperTests {
 		SingleZoomCoordinateSystemMapper mapper = getSingleZoomCoordinateSystemMapper();
 		setupMonitors(mapper);
 		Rectangle rectInPts = new Rectangle(950, 400, 1500, 100);
-		Rectangle rectInPxs = mapper.translateToDisplayCoordinates(rectInPts, monitors[0].getZoom());
-		assertEquals(rectInPts, mapper.translateFromDisplayCoordinates(rectInPxs, monitors[0].getZoom()));
+		Rectangle rectInPxs = mapper.translateToDisplayCoordinates(rectInPts);
+		assertEquals(rectInPts, mapper.translateFromDisplayCoordinates(rectInPxs));
 	}
 
 	@Test
@@ -165,10 +165,9 @@ class CoordinateSystemMapperTests {
 		MultiZoomCoordinateSystemMapper mapper = getMultiZoomCoordinateSystemMapper();
 		setupMonitors(mapper);
 		Rectangle rectInPts = new Rectangle(950, 400, 1500, 100);
-		Rectangle rectInPxs = mapper.translateToDisplayCoordinates(rectInPts, monitors[0].getZoom());
-		Rectangle rectInPtsTranslated = mapper.translateFromDisplayCoordinates(rectInPxs, monitors[0].getZoom());
-		Rectangle rectInPxsTranslated = mapper.translateToDisplayCoordinates(rectInPtsTranslated,
-				monitors[0].getZoom());
+		Rectangle rectInPxs = mapper.translateToDisplayCoordinates(rectInPts);
+		Rectangle rectInPtsTranslated = mapper.translateFromDisplayCoordinates(rectInPxs);
+		Rectangle rectInPxsTranslated = mapper.translateToDisplayCoordinates(rectInPtsTranslated);
 		assertEquals(rectInPxs, rectInPxsTranslated);
 	}
 
@@ -182,13 +181,13 @@ class CoordinateSystemMapperTests {
 		expectedSmallRectInPxs.y = rectInPxs.y + (rectInPxs.height / 2) - 200;
 		expectedSmallRectInPxs.width = 400;
 		expectedSmallRectInPxs.height = 400;
-		Rectangle rectInPts = mapper.translateFromDisplayCoordinates(rectInPxs, monitors[0].getZoom());
+		Rectangle rectInPts = mapper.translateFromDisplayCoordinates(rectInPxs);
 		Rectangle smallRectInPts = new Rectangle(0, 0, 0, monitors[0].getZoom());
 		smallRectInPts.x = rectInPts.x + (rectInPts.width / 2) - 200;
 		smallRectInPts.y = rectInPts.y + (rectInPts.height / 2) - 200;
 		smallRectInPts.width = 400;
 		smallRectInPts.height = 400;
-		Rectangle smallRectInPxs = mapper.translateToDisplayCoordinates(smallRectInPts, monitors[0].getZoom());
+		Rectangle smallRectInPxs = mapper.translateToDisplayCoordinates(smallRectInPts);
 		assertEquals(expectedSmallRectInPxs, smallRectInPxs);
 	}
 
@@ -197,8 +196,8 @@ class CoordinateSystemMapperTests {
 	void translateRectangleInPixelsOutisdeMonitorsBackAndForthShouldBeTheSame(CoordinateSystemMapper mapper) {
 		setupMonitors(mapper);
 		Rectangle rectInPxs = new Rectangle(400, 2400, 1000, 1000);
-		Rectangle rectInPts = mapper.translateFromDisplayCoordinates(rectInPxs, monitors[0].getZoom());
-		assertEquals(rectInPxs, mapper.translateToDisplayCoordinates(rectInPts, monitors[0].getZoom()));
+		Rectangle rectInPts = mapper.translateFromDisplayCoordinates(rectInPxs);
+		assertEquals(rectInPxs, mapper.translateToDisplayCoordinates(rectInPts));
 	}
 
 	@ParameterizedTest
@@ -206,8 +205,8 @@ class CoordinateSystemMapperTests {
 	void translateRectangleInPixelsInBothMonitorsBackAndForthShouldBeTheSame(CoordinateSystemMapper mapper) {
 		setupMonitors(mapper);
 		Rectangle rectInPxs = new Rectangle(1500, 400, 502, 500);
-		Rectangle rectInPts = mapper.translateFromDisplayCoordinates(rectInPxs, monitors[0].getZoom());
-		assertEquals(rectInPxs, mapper.translateToDisplayCoordinates(rectInPts, monitors[0].getZoom()));
+		Rectangle rectInPts = mapper.translateFromDisplayCoordinates(rectInPxs);
+		assertEquals(rectInPxs, mapper.translateToDisplayCoordinates(rectInPts));
 	}
 
 	@ParameterizedTest
@@ -215,8 +214,8 @@ class CoordinateSystemMapperTests {
 	void translateRectangleInPixelsForZeroSize(CoordinateSystemMapper mapper) {
 		setupMonitors(mapper);
 		Rectangle rectInPts = createExpectedRectangle(mapper, 0, 0, 0, 0, monitors[0]);
-		Rectangle rectInPxs = mapper.translateToDisplayCoordinates(rectInPts, monitors[0].getZoom());
-		assertEquals(rectInPts, mapper.translateFromDisplayCoordinates(rectInPxs, monitors[0].getZoom()));
+		Rectangle rectInPxs = mapper.translateToDisplayCoordinates(rectInPts);
+		assertEquals(rectInPts, mapper.translateFromDisplayCoordinates(rectInPxs));
 	}
 
 	private Point createExpectedPoint(CoordinateSystemMapper mapper, int x, int y, Monitor monitor) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Control.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Control.java
@@ -4028,10 +4028,9 @@ void subclass () {
  */
 public Point toControl (int x, int y) {
 	checkWidget ();
-	int zoom = getZoom();
-	Point displayPointInPixels = getDisplay().translateToDisplayCoordinates(new Point(x, y), zoom);
+	Point displayPointInPixels = getDisplay().translateToDisplayCoordinates(new Point(x, y));
 	final Point controlPointInPixels = toControlInPixels(displayPointInPixels.x, displayPointInPixels.y);
-	return Win32DPIUtils.pixelToPoint(controlPointInPixels, zoom);
+	return Win32DPIUtils.pixelToPoint(controlPointInPixels, getZoom());
 }
 
 Point toControlInPixels (int x, int y) {
@@ -4091,7 +4090,7 @@ public Point toDisplay (int x, int y) {
 	checkWidget ();
 	int zoom = getZoom();
 	Point displayPointInPixels = toDisplayInPixels(Win32DPIUtils.pointToPixel(x, zoom), Win32DPIUtils.pointToPixel(y, zoom));
-	return getDisplay().translateFromDisplayCoordinates(displayPointInPixels, zoom);
+	return getDisplay().translateFromDisplayCoordinates(displayPointInPixels);
 }
 
 Point toDisplayInPixels (int x, int y) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/CoordinateSystemMapper.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/CoordinateSystemMapper.java
@@ -27,13 +27,13 @@ interface CoordinateSystemMapper {
 
 	Rectangle mapMonitorBounds(Rectangle rectangle, int zoom);
 
-	Point translateFromDisplayCoordinates(Point point, int zoom);
+	Point translateFromDisplayCoordinates(Point point);
 
-	Point translateToDisplayCoordinates(Point point, int zoom);
+	Point translateToDisplayCoordinates(Point point);
 
-	Rectangle translateFromDisplayCoordinates(Rectangle rect, int zoom);
+	Rectangle translateFromDisplayCoordinates(Rectangle rect);
 
-	Rectangle translateToDisplayCoordinates(Rectangle rect, int zoom);
+	Rectangle translateToDisplayCoordinates(Rectangle rect);
 
 	Rectangle getContainingMonitorBoundsInPixels(Point point);
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Display.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Display.java
@@ -3166,20 +3166,20 @@ Rectangle mapInPixels (Control from, Control to, int x, int y, int width, int he
 	return new Rectangle (rect.left, rect.top, rect.right - rect.left, rect.bottom - rect.top);
 }
 
-Point translateFromDisplayCoordinates(Point point, int zoom) {
-	return coordinateSystemMapper.translateFromDisplayCoordinates(point, zoom);
+Point translateFromDisplayCoordinates(Point point) {
+	return coordinateSystemMapper.translateFromDisplayCoordinates(point);
 }
 
-Point translateToDisplayCoordinates(Point point, int zoom) {
-	return coordinateSystemMapper.translateToDisplayCoordinates(point, zoom);
+Point translateToDisplayCoordinates(Point point) {
+	return coordinateSystemMapper.translateToDisplayCoordinates(point);
 }
 
-Rectangle translateFromDisplayCoordinates(Rectangle rect, int zoom) {
-	return coordinateSystemMapper.translateFromDisplayCoordinates(rect, zoom);
+Rectangle translateFromDisplayCoordinates(Rectangle rect) {
+	return coordinateSystemMapper.translateFromDisplayCoordinates(rect);
 }
 
-Rectangle translateToDisplayCoordinates(Rectangle rect, int zoom) {
-	return coordinateSystemMapper.translateToDisplayCoordinates(rect, zoom);
+Rectangle translateToDisplayCoordinates(Rectangle rect) {
+	return coordinateSystemMapper.translateToDisplayCoordinates(rect);
 }
 
 long messageProc (long hwnd, long msg, long wParam, long lParam) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Menu.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Menu.java
@@ -1225,7 +1225,7 @@ void setLocationInPixels (int x, int y) {
 public void setLocation (Point location) {
 	checkWidget ();
 	if (location == null) error (SWT.ERROR_NULL_ARGUMENT);
-	Point locationInPixels = getDisplay().translateToDisplayCoordinates(location, getZoom());
+	Point locationInPixels = getDisplay().translateToDisplayCoordinates(location);
 	setLocationInPixels(locationInPixels.x, locationInPixels.y);
 }
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/MultiZoomCoordinateSystemMapper.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/MultiZoomCoordinateSystemMapper.java
@@ -92,24 +92,24 @@ class MultiZoomCoordinateSystemMapper implements CoordinateSystemMapper {
 	}
 
 	@Override
-	public Point translateFromDisplayCoordinates(Point point, int zoom) {
+	public Point translateFromDisplayCoordinates(Point point) {
 		return translateLocationInPixelsToPoints(point.x, point.y);
 	}
 
 	@Override
-	public Point translateToDisplayCoordinates(Point point, int zoom) {
+	public Point translateToDisplayCoordinates(Point point) {
 		Monitor monitor = point instanceof Point.WithMonitor pointWithMonitor ? pointWithMonitor.getMonitor() : null;
 		return translateLocationInPointsToPixels(point.x, point.y, monitor);
 	}
 
 	@Override
-	public Rectangle translateFromDisplayCoordinates(Rectangle rect, int zoom) {
+	public Rectangle translateFromDisplayCoordinates(Rectangle rect) {
 		Monitor monitor = rect instanceof Rectangle.WithMonitor rectWithMonitor ? rectWithMonitor.getMonitor() : null;
 		return translateRectangleInPixelsToPoints(rect.x, rect.y, rect.width, rect.height, monitor);
 	}
 
 	@Override
-	public Rectangle translateToDisplayCoordinates(Rectangle rect, int zoom) {
+	public Rectangle translateToDisplayCoordinates(Rectangle rect) {
 		Monitor monitor = rect instanceof Rectangle.WithMonitor rectWithMonitor ? rectWithMonitor.getMonitor() : null;
 		return translateRectangleInPointsToPixels(rect.x, rect.y, rect.width, rect.height, monitor);
 	}

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Shell.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Shell.java
@@ -1561,20 +1561,20 @@ public void setAlpha (int alpha) {
 @Override
 public Rectangle getBounds() {
 	checkWidget ();
-	return getDisplay().translateFromDisplayCoordinates(getBoundsInPixels(), getZoom());
+	return getDisplay().translateFromDisplayCoordinates(getBoundsInPixels());
 }
 
 @Override
 public Point getLocation() {
 	checkWidget ();
-	return getDisplay().translateFromDisplayCoordinates(getLocationInPixels(), getZoom());
+	return getDisplay().translateFromDisplayCoordinates(getLocationInPixels());
 }
 
 @Override
 public void setLocation(Point location) {
 	if (location == null) error (SWT.ERROR_NULL_ARGUMENT);
 	checkWidget ();
-	Point locationInPixels = getDisplay().translateToDisplayCoordinates(location, getZoom());
+	Point locationInPixels = getDisplay().translateToDisplayCoordinates(location);
 	setLocationInPixels(locationInPixels.x, locationInPixels.y);
 }
 
@@ -1587,7 +1587,7 @@ public void setLocation(int x, int y) {
 public void setBounds(Rectangle rect) {
 	if (rect == null) error (SWT.ERROR_NULL_ARGUMENT);
 	checkWidget ();
-	Rectangle boundsInPixels = getDisplay().translateToDisplayCoordinates(rect, getZoom());
+	Rectangle boundsInPixels = getDisplay().translateToDisplayCoordinates(rect);
 	// The scaling of the width and height in case of a monitor change is handled by
 	// the WM_DPICHANGED event processing. So to avoid duplicate scaling, we always
 	// have to scale width and height with the zoom of the original monitor (still

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/SingleZoomCoordinateSystemMapper.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/SingleZoomCoordinateSystemMapper.java
@@ -76,22 +76,22 @@ class SingleZoomCoordinateSystemMapper implements CoordinateSystemMapper {
 	}
 
 	@Override
-	public Point translateFromDisplayCoordinates(Point point, int zoom) {
+	public Point translateFromDisplayCoordinates(Point point) {
 		return Win32DPIUtils.pixelToPoint(point, DPIUtil.getDeviceZoom());
 	}
 
 	@Override
-	public Point translateToDisplayCoordinates(Point point, int zoom) {
+	public Point translateToDisplayCoordinates(Point point) {
 		return Win32DPIUtils.pointToPixel(point, DPIUtil.getDeviceZoom());
 	}
 
 	@Override
-	public Rectangle translateFromDisplayCoordinates(Rectangle rect, int zoom) {
+	public Rectangle translateFromDisplayCoordinates(Rectangle rect) {
 		return Win32DPIUtils.pixelToPoint(rect, DPIUtil.getDeviceZoom());
 	}
 
 	@Override
-	public Rectangle translateToDisplayCoordinates(Rectangle rect, int zoom) {
+	public Rectangle translateToDisplayCoordinates(Rectangle rect) {
 		return Win32DPIUtils.pointToPixel(rect, DPIUtil.getDeviceZoom());
 	}
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Widget.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Widget.java
@@ -1696,7 +1696,7 @@ boolean showMenu (int x, int y) {
 
 boolean showMenu (int x, int y, int detail) {
 	Event event = new Event ();
-	Point mappedLocation = getDisplay().translateFromDisplayCoordinates(new Point(x, y), getZoom());
+	Point mappedLocation = getDisplay().translateFromDisplayCoordinates(new Point(x, y));
 	event.setLocation(mappedLocation.x, mappedLocation.y);
 	event.detail = detail;
 	if (event.detail == SWT.MENU_KEYBOARD) {


### PR DESCRIPTION
The zoom parameter in some of the translation methods of the CoordinateSystemMappers and the according methods in Display is unused. This change simply removes the obsolete parameters.