### PR TITLE
[Win32] Use exact selected font size from FontDialog

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/FontDialog.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/FontDialog.java
@@ -249,36 +249,7 @@ public FontData open () {
 		if (success) {
 			LOGFONT logFont = new LOGFONT();
 			OS.MoveMemory(logFont, lpLogFont, LOGFONT.sizeof);
-
-			/*
-			 * This will not work on multiple screens or for printing. Should use DC for the
-			 * proper device.
-			 */
-			int logPixelsY = getDPI();
-			int pixels = 0;
-			long hDC = OS.GetDC(0);
-			if (logFont.lfHeight > 0) {
-				/*
-				 * Feature in Windows. If the lfHeight of the LOGFONT structure is positive, the
-				 * lfHeight measures the height of the entire cell, including internal leading,
-				 * in logical units. Since the height of a font in points does not include the
-				 * internal leading, we must subtract the internal leading, which requires a
-				 * TEXTMETRIC, which in turn requires font creation.
-				 */
-				long hFont = OS.CreateFontIndirect(logFont);
-				long oldFont = OS.SelectObject(hDC, hFont);
-				TEXTMETRIC lptm = new TEXTMETRIC();
-				OS.GetTextMetrics(hDC, lptm);
-				OS.SelectObject(hDC, oldFont);
-				OS.DeleteObject(hFont);
-				pixels = logFont.lfHeight - lptm.tmInternalLeading;
-			} else {
-				pixels = -logFont.lfHeight;
-			}
-			OS.ReleaseDC(0, hDC);
-
-			float points = pixels * 72f / logPixelsY;
-			fontData = FontData.win32_new(logFont, points);
+			fontData = FontData.win32_new(logFont, lpcf.iPointSize / 10f);
 			if (effectsVisible) {
 				int red = lpcf.rgbColors & 0xFF;
 				int green = (lpcf.rgbColors >> 8) & 0xFF;


### PR DESCRIPTION
The FontDialog implementation creates a font handle based on the selection in the dialog to extract information about the font size out of that created font. Due to point/pixel conversion and roundings that depend on the current DPI (affected by the primary monitor zoom), the resulting font size selected differs from what the user has selected. For example, when selecting a 10pt font, the result of the dialog will contain a height of 9.75pt on a 100% monitor and of 10.2pt on a 125% monitor.
At the same time, the dialog manages the logically selected size, i.e., in the given scenario the selected 10pt, which could be used instead.

This change replaces the complex and imprecise font height extraction logic with a simple read of the actual value selected by the user.

Note that this will not have any visible impact, as font sizes are rounded anyway, such that all the imprecise values (such as 9.75pt or 10.2pt) will still lead to a 10pt font.  

### How to reproduce

The behavior can be reproduced by any FontDialog, such as in `Snippet133`:
- Add a println for the height selected in the dialog (`System.out.println(fontData.height)`) of Snippet 133 after opening the dialog: https://github.com/eclipse-platform/eclipse.platform.swt/blob/93a484ef9e7e5223cf7fe5551154789f0377f9bd/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet133.java#L140
- Run `Snippet133` and open "Font" in the "File" menu
- Select a problematic font size such as "10".

Without the change you will see 9.75pt on a 100% monitor, with the change you will see 10pt on a 100% (and any other) monitor.