### PR TITLE
Scale Tree.SORT_WIDTH by zoom level instead of using fixed pixels

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TreeColumn.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TreeColumn.java
@@ -380,7 +380,7 @@ public void pack () {
 	if (image != null || parent.sortColumn == this) {
 		Image headerImage = null;
 		if (parent.sortColumn == this && parent.sortDirection != SWT.NONE) {
-			headerWidth += Tree.SORT_WIDTH;
+			headerWidth += Win32DPIUtils.pointToPixel(Tree.SORT_WIDTH, getZoom()) ;
 		} else {
 			headerImage = image;
 		}


### PR DESCRIPTION
The Tree.SORT_WIDTH constant defines the width reserved for the sort indicator  
in tree headers. Previously, this was a fixed pixel value, which appeared too  
small on high-DPI displays.  

This change redefines SORT_WIDTH in points and converts it to pixels according  
to the current zoom level, ensuring consistent sort indicator spacing across  
different display scales.

### Example 

- Run the following snippet with 250% zoom

```java
import org.eclipse.swt.*;
import org.eclipse.swt.graphics.*;
import org.eclipse.swt.layout.*;
import org.eclipse.swt.widgets.*;

public class TreeColumnSortWidthExample {


public static void main(String [] args) {
	final Display display = new Display();
	System.setProperty("swt.autoScale", "quarter");
	System.setProperty("swt.autoScale.updateOnRuntime", "true");
	Shell shell = new Shell(display);
	shell.setText("Custom gradient selection for Tree");
	shell.setLayout(new FillLayout());
	final Tree tree = new Tree(shell, SWT.MULTI | SWT.FULL_SELECTION);
	tree.setHeaderVisible(true);
	tree.setLinesVisible(true);
	int columnCount = 4;
	for (int i=0; i<columnCount; i++) {
		TreeColumn column = new TreeColumn(tree, SWT.NONE);
		column.setText("Column " + i);
	}
	int itemCount = 3;
	for (int i=0; i<itemCount; i++) {
		TreeItem item1 = new TreeItem(tree, SWT.NONE);
		item1.setText("item "+i);
		for (int c=1; c < columnCount; c++) {
			item1.setText(c, "item ["+i+"-"+c+"]");
		}
		for (int j=0; j<itemCount; j++) {
			TreeItem item2 = new TreeItem(item1, SWT.NONE);
			item2.setText("item ["+i+" "+j+"]");
			for (int c=1; c<columnCount; c++) {
				item2.setText(c, "item ["+i+" "+j+"-"+c+"]");
			}
			for (int k=0; k<itemCount; k++) {
				TreeItem item3 = new TreeItem(item2, SWT.NONE);
				item3.setText("item ["+i+" "+j+" "+k+"]");
				for (int c=1; c<columnCount; c++) {
					item3.setText(c, "item ["+i+" "+j+" "+k+"-"+c+"]");
				}
			}
		}
	}
	tree.addListener(SWT.EraseItem, event -> {
		event.detail &= ~SWT.HOT;
		if ((event.detail & SWT.SELECTED) != 0) {
			GC gc = event.gc;
			Rectangle area = tree.getClientArea();
			/*
			 * If you wish to paint the selection beyond the end of
			 * last column, you must change the clipping region.
			 */
			int columnCount1 = tree.getColumnCount();
			if (event.index == columnCount1 - 1 || columnCount1 == 0) {
				int width = area.x + area.width - event.x;
				if (width > 0) {
					Region region = new Region();
					gc.getClipping(region);
					region.add(event.x, event.y, width, event.height);
					gc.setClipping(region);
					region.dispose();
				}
			}
			gc.setAdvanced(true);
			if (gc.getAdvanced()) gc.setAlpha(127);
			Rectangle rect = event.getBounds();
			Color foreground = gc.getForeground();
			Color background = gc.getBackground();
			gc.setForeground(display.getSystemColor(SWT.COLOR_RED));
			gc.setBackground(display.getSystemColor(SWT.COLOR_LIST_BACKGROUND));
			gc.fillGradientRectangle(0, rect.y, 500, rect.height, false);
			// restore colors for subsequent drawing
			gc.setForeground(foreground);
			gc.setBackground(background);
			event.detail &= ~SWT.SELECTED;
		}
	});
	tree.setSortColumn(tree.getColumn(0));
	tree.setSortDirection(SWT.UP);
	for (int i=0; i<columnCount; i++) {
		tree.getColumn(i).pack();
	}
	tree.setSelection(tree.getItem(0));
	shell.setSize(500, 200);
	shell.open();
	while (!shell.isDisposed()) {
		if (!display.readAndDispatch()) display.sleep();
	}
	display.dispose();
}
}
```
- Note that the first window is before change and second window is after this change. The first column (sort column) has extra pixels as the SORT_WIDTH value is stored in points and scaled up to pixels as per zoom level.

<img width="979" height="892" alt="image" src="https://github.com/user-attachments/assets/411784d9-cf1c-4da0-8956-7d190fc0235c" />
