### PR TITLE
Scale Tree.INCREMENT by zoom level instead of using fixed pixels

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Tree.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Tree.java
@@ -5035,7 +5035,7 @@ void setScrollWidth (int width) {
 		}
 	}
 	if (horizontalBar != null) {
-		horizontalBar.setIncrement (INCREMENT);
+		horizontalBar.setIncrement (Win32DPIUtils.pointToPixel(INCREMENT, getZoom()));
 		horizontalBar.setPageIncrement (info.nPage);
 	}
 	OS.GetClientRect (hwndParent, rect);


### PR DESCRIPTION
The Tree.INCREMENT constant defines how many pixels the horizontal scrollbar jumps when clicking the left or right buttons. Previously, this was a fixed pixel value, which made scrolling feel too small on high-DPI monitors.  

This change redefines INCREMENT in points and converts it to pixels based on the current zoom level, ensuring consistent scrolling increments across different display scales.

### How to Test

- Run the following snippet with 250% zoom

```java
import org.eclipse.swt.*;
import org.eclipse.swt.graphics.*;
import org.eclipse.swt.layout.*;
import org.eclipse.swt.widgets.*;

public class TestHorizontalScrollWidth {
    public static void main (String [] args) {
        int rowCount = 40;
        int columnCount = 15;
		final Display display = new Display();
		System.setProperty("swt.autoScale", "quarter");
		System.setProperty("swt.autoScale.updateOnRuntime", "true");
        Shell shell = new Shell (display);
        shell.setText("Snippet 234 - Tree (Single)");
        shell.setLayout(new FillLayout());

        final Tree tree = new Tree(shell, SWT.MULTI | SWT.H_SCROLL | SWT.V_SCROLL | SWT.FULL_SELECTION);
        tree.setHeaderVisible(true);
        tree.setLinesVisible(true);

        // Create columns
        TreeColumn column1 = new TreeColumn(tree, SWT.NONE);
        column1.setText("Name");
        column1.setWidth(150);
        for (int i = 0; i < columnCount; i++) {
            TreeColumn column = new TreeColumn(tree, SWT.NONE);
            column.setText("Value " + i);
            column.setWidth(200);
        }

        // Create rows
        for (int i = 0; i < rowCount; i++) {
            TreeItem item = new TreeItem(tree, SWT.NONE);
            item.setText(0, "item " + i);
            for (int j = 0; j < columnCount; j++) {
                item.setText(j + 1, "Item " + i + " value @ " + j);
            }
        }

        // Draw consistent selection background (Windows: keep highlight even without focus)
        Listener eraseListener = event -> {
            event.detail &= ~SWT.HOT;
            if ((event.detail & SWT.SELECTED) != 0) {
                GC gc = event.gc;
                Rectangle rect = event.getBounds();
                gc.setForeground(display.getSystemColor(SWT.COLOR_LIST_SELECTION_TEXT));
                gc.setBackground(display.getSystemColor(SWT.COLOR_LIST_SELECTION));
                gc.fillRectangle(rect);
                event.detail &= ~SWT.SELECTED;
            }
        };
        tree.addListener(SWT.EraseItem, eraseListener);

        shell.setSize(800, 400);
        shell.open ();
        while (!shell.isDisposed ()) {
            if (!display.readAndDispatch ()) display.sleep ();
        }
        display.dispose ();
    }
}
```

### Result ( Please click on the gifs below to see it running )
**Before :**
![20250821-1222-30 4444204](https://github.com/user-attachments/assets/3f4b613a-6627-4cfa-9dd6-84d381b8e2b7)


**After : **
![20250821-1221-10 3902745](https://github.com/user-attachments/assets/bf128aa6-3447-49a1-aaf0-21bdd4c1dcc6)

Maybe it's harder to notice but now scrolling using button jumps 10 pixels ahead instead of 5 due to 200% zoom (double the size) and hence it jumps now as per zoom level. 