### PR TITLE
Scale Tree.EXPLORER_EXTRA by zoom level instead of using fixed pixels

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Tree.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Tree.java
@@ -467,8 +467,8 @@ LRESULT CDDS_ITEMPOSTPAINT (NMTVCUSTOMDRAW nmcd, long wParam, long lParam) {
 					if (explorerTheme) {
 						if (hooks (SWT.EraseItem)) {
 							RECT itemRect = item.getBounds (index, true, true, false, false, true, hDC);
-							itemRect.left -= EXPLORER_EXTRA;
-							itemRect.right += EXPLORER_EXTRA + 1;
+							itemRect.left -= Win32DPIUtils.pointToPixel(EXPLORER_EXTRA, getZoom());
+							itemRect.right += Win32DPIUtils.pointToPixel(EXPLORER_EXTRA, getZoom()) + 1;
 							pClipRect.left = itemRect.left;
 							pClipRect.right = itemRect.right;
 							if (columnCount > 0 && hwndHeader != 0) {
@@ -1135,11 +1135,11 @@ LRESULT CDDS_ITEMPREPAINT (NMTVCUSTOMDRAW nmcd, long wParam, long lParam) {
 						if (measureEvent != null) {
 							pRect.right = Math.min (pClipRect.right, boundsInPixels.x + boundsInPixels.width);
 						} else {
-							pRect.right += EXPLORER_EXTRA;
-							pClipRect.right += EXPLORER_EXTRA;
+							pRect.right += Win32DPIUtils.pointToPixel(EXPLORER_EXTRA, getZoom());
+							pClipRect.right += Win32DPIUtils.pointToPixel(EXPLORER_EXTRA, getZoom());
 						}
-						pRect.left -= EXPLORER_EXTRA;
-						pClipRect.left -= EXPLORER_EXTRA;
+						pRect.left -= Win32DPIUtils.pointToPixel(EXPLORER_EXTRA, getZoom());
+						pClipRect.left -= Win32DPIUtils.pointToPixel(EXPLORER_EXTRA, getZoom());
 						long hTheme = OS.OpenThemeData (handle, Display.TREEVIEW, getZoom());
 						int iStateId = selected ? OS.TREIS_SELECTED : OS.TREIS_HOT;
 						if (OS.GetFocus () != handle && selected && !hot) iStateId = OS.TREIS_SELECTEDNOTFOCUS;
@@ -1208,8 +1208,8 @@ LRESULT CDDS_ITEMPREPAINT (NMTVCUSTOMDRAW nmcd, long wParam, long lParam) {
 			OS.SaveDC (hDC);
 			OS.SelectClipRgn (hDC, 0);
 			if (explorerTheme) {
-				itemRect.left -= EXPLORER_EXTRA;
-				itemRect.right += EXPLORER_EXTRA;
+				itemRect.left -= Win32DPIUtils.pointToPixel(EXPLORER_EXTRA, getZoom());
+				itemRect.right += Win32DPIUtils.pointToPixel(EXPLORER_EXTRA, getZoom());
 			}
 			//TODO - bug in Windows selection or SWT itemRect
 			/*if (selected)*/ itemRect.right++;


### PR DESCRIPTION
The Tree.EXPLORER_EXTRA constant specifies the additional spacing applied to tree items when using the Explorer theme. Previously, this was defined as a fixed pixel value, which caused the extra spacing to appear too small on high-DPI monitors.

This change redefines EXPLORER_EXTRA in points and converts it to pixels based on the current zoom level, ensuring consistent spacing in Explorer-themed trees across different display scales.

### How to Test

- Run the Runtime workspace on primary monitor 250%
- See the project/package explorer.
- The items should look little bit bigger.

### Results 
**Before :**
<img width="1072" height="955" alt="image" src="https://github.com/user-attachments/assets/39a5fb3f-c1ed-445a-bb44-4cd628150630" />

**After :**
<img width="1125" height="534" alt="image" src="https://github.com/user-attachments/assets/f96b7e71-7c3f-4dbc-b53d-d8c2b00d6a33" />

**Note:** the difference is very minor (from 2px to 4px) so you might not notice the difference but using some sort of scale, you can compare the size of items before and after this change. 