### PR TITLE
Scale Tree.GRID_WIDTH by zoom level instead of using fixed pixels

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Tree.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Tree.java
@@ -2960,11 +2960,11 @@ TreeItem getFocusItem () {
  */
 public int getGridLineWidth () {
 	checkWidget ();
-	return DPIUtil.pixelToPoint(getGridLineWidthInPixels (), getZoom());
+	return GRID_WIDTH;
 }
 
 int getGridLineWidthInPixels () {
-	return GRID_WIDTH;
+	return Win32DPIUtils.pointToPixel(GRID_WIDTH, getZoom());
 }
 
 /**
@@ -8055,7 +8055,7 @@ LRESULT wmNotifyHeader (NMHDR hdr, long wParam, long lParam) {
 					int deltaX = newItem.cxy - oldItem.cxy;
 					RECT headerRect = new RECT ();
 					OS.SendMessage (hwndHeader, OS.HDM_GETITEMRECT, phdn.iItem, headerRect);
-					int gridWidth = linesVisible ? GRID_WIDTH : 0;
+					int gridWidth = linesVisible ? Win32DPIUtils.pointToPixel(GRID_WIDTH, getZoom()) : 0;
 					rect.left = headerRect.right - gridWidth;
 					int newX = rect.left + deltaX;
 					rect.right = Math.max (rect.right, rect.left + Math.abs (deltaX));

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TreeColumn.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TreeColumn.java
@@ -398,7 +398,7 @@ public void pack () {
 	}
 	if (newFont != 0) OS.SelectObject (hDC, oldFont);
 	OS.ReleaseDC (hwnd, hDC);
-	int gridWidth = parent.linesVisible ? Tree.GRID_WIDTH : 0;
+	int gridWidth = parent.linesVisible ? Win32DPIUtils.pointToPixel(Tree.GRID_WIDTH, getZoom()) : 0;
 	setWidthInPixels (Math.max (headerWidth, columnWidth + gridWidth));
 }
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TreeItem.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TreeItem.java
@@ -530,7 +530,7 @@ RECT getBounds (int index, boolean getText, boolean getImage, boolean fullText, 
 			}
 		}
 	}
-	int gridWidth = parent.linesVisible && columnCount != 0 ? Tree.GRID_WIDTH : 0;
+	int gridWidth = parent.linesVisible && columnCount != 0 ?  Win32DPIUtils.pointToPixel(Tree.GRID_WIDTH, getZoom()) : 0;
 	if (getText || !getImage) {
 		rect.right = Math.max (rect.left, rect.right - gridWidth);
 	}


### PR DESCRIPTION
The Tree.GRID_WIDTH constant specifies the extra width added to a tree item when lines between columns are visible (`lineVisible = true`). This compensates for the space taken by the grid line. Previously, this was defined as a fixed pixel value, which appeared too small on high-DPI monitors.

This change redefines GRID_WIDTH in points and converts it to pixels based on the current zoom level, ensuring consistent column spacing across different display scales.