### PR TITLE
[GTK] Fix Combo copy/paste tests on Gtk 4.x

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Combo.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Combo.java
@@ -1969,6 +1969,7 @@ public void paste () {
 		if (GTK.GTK4) {
 			long textHandle = GTK4.gtk_widget_get_first_child(entryHandle);
 			GTK4.gtk_widget_activate_action(textHandle, OS.action_paste_clipboard, null);
+			display.processEvents();
 		} else {
 			GTK3.gtk_editable_paste_clipboard (entryHandle);
 		}

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Display.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Display.java
@@ -4543,6 +4543,13 @@ public boolean readAndDispatch () {
 	return isDisposed () || runAsyncMessages (false);
 }
 
+void processEvents() {
+	if (!isDisposed()) {
+		while (readAndDispatch()) {
+		}
+	}
+}
+
 static void register (Display display) {
 	synchronized (Device.class) {
 		for (int i=0; i<Displays.length; i++) {


### PR DESCRIPTION
Gtk 4 no longer provides API for doing that but rather a built-in action to activate. This requires to spin the event loop to process it.