### PR TITLE
[Win32] Clean up disposed images when retrieving image list handle #2432

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/ImageList.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/ImageList.java
@@ -51,10 +51,8 @@ public int add (Image image) {
 	int count = OS.ImageList_GetImageCount (handle);
 	int index = 0;
 	while (index < count) {
-		if (images [index] != null) {
-			if (images [index].isDisposed ()) images [index] = null;
-		}
-		if (images [index] == null) break;
+		Image imageAtIndex = getOrClearIfDisposed(index);
+		if (imageAtIndex == null) break;
 		index++;
 	}
 	if (count == 0) {
@@ -69,6 +67,13 @@ public int add (Image image) {
 	}
 	images [index] = image;
 	return index;
+}
+
+private Image getOrClearIfDisposed(int index) {
+	if (images[index] != null && images[index].isDisposed()) {
+		images[index] = null;
+	}
+	return images[index];
 }
 
 public int addRef() {
@@ -337,7 +342,7 @@ public long getHandle(int targetZoom) {
 		long newImageListHandle = OS.ImageList_Create(scaledWidth, scaledHeight, flags, 16, 16);
 		int count = OS.ImageList_GetImageCount (handle);
 		for (int i = 0; i < count; i++) {
-			Image image = images[i];
+			Image image = getOrClearIfDisposed(i);
 			if (image != null) {
 				set(i, image, i, newImageListHandle, targetZoom);
 			} else {
@@ -372,9 +377,9 @@ public Point getImageSize() {
 public int indexOf (Image image) {
 	int count = OS.ImageList_GetImageCount (handle);
 	for (int i=0; i<count; i++) {
-		if (images [i] != null) {
-			if (images [i].isDisposed ()) images [i] = null;
-			if (images [i] != null && images [i].equals (image)) return i;
+		Image potentialMatch = getOrClearIfDisposed(i);
+		if (potentialMatch != null && potentialMatch.equals(image)) {
+			return i;
 		}
 	}
 	return -1;
@@ -480,9 +485,9 @@ public int size () {
 	int result = 0;
 	int count = OS.ImageList_GetImageCount (handle);
 	for (int i=0; i<count; i++) {
-		if (images [i] != null) {
-			if (images [i].isDisposed ()) images [i] = null;
-			if (images [i] != null) result++;
+		Image image = getOrClearIfDisposed(i);
+		if (image != null) {
+			result++;
 		}
 	}
 	return result;


### PR DESCRIPTION
Images inside an ImageList may become disposed. For that reason, methods like indexOf() or add() check for the images inside the list being disposed to null them. This check is missing in the getHandle() method used when requesting the ImageList handle for a different zoom, which can lead to exceptions because of access to a disposed Image instance.

This change adapts the ImageList implementation to always consider that an image inside the list may have been disposed. The according cleanup logic is factored out from all places.

Fixes https://github.com/eclipse-platform/eclipse.platform.swt/issues/2432