### PR TITLE
[GTK] Support launching Flatpak/Snap applications

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/os.c
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/os.c
@@ -10728,6 +10728,18 @@ JNIEXPORT jlong JNICALL OS_NATIVE(g_1app_1info_1get_1all)
 }
 #endif
 
+#ifndef NO_g_1app_1info_1get_1commandline
+JNIEXPORT jlong JNICALL OS_NATIVE(g_1app_1info_1get_1commandline)
+	(JNIEnv *env, jclass that, jlong arg0)
+{
+	jlong rc = 0;
+	OS_NATIVE_ENTER(env, that, g_1app_1info_1get_1commandline_FUNC);
+	rc = (jlong)g_app_info_get_commandline((GAppInfo *)arg0);
+	OS_NATIVE_EXIT(env, that, g_1app_1info_1get_1commandline_FUNC);
+	return rc;
+}
+#endif
+
 #ifndef NO_g_1app_1info_1get_1default_1for_1type
 JNIEXPORT jlong JNICALL OS_NATIVE(g_1app_1info_1get_1default_1for_1type)
 	(JNIEnv *env, jclass that, jbyteArray arg0, jboolean arg1)

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/os_stats.h
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/os_stats.h
@@ -876,6 +876,7 @@ typedef enum {
 	g_1action_1map_1remove_1action_FUNC,
 	g_1app_1info_1create_1from_1commandline_FUNC,
 	g_1app_1info_1get_1all_FUNC,
+	g_1app_1info_1get_1commandline_FUNC,
 	g_1app_1info_1get_1default_1for_1type_FUNC,
 	g_1app_1info_1get_1executable_FUNC,
 	g_1app_1info_1get_1icon_FUNC,

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/org/eclipse/swt/internal/gtk/OS.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/org/eclipse/swt/internal/gtk/OS.java
@@ -870,6 +870,10 @@ public static final native long g_app_info_get_all();
 /**
  * @param appInfo cast=(GAppInfo *)
  */
+public static final native long g_app_info_get_commandline(long appInfo);
+/**
+ * @param appInfo cast=(GAppInfo *)
+ */
 public static final native long g_app_info_get_executable(long appInfo);
 /**
  * @param appInfo cast=(GAppInfo *)

--- a/bundles/org.eclipse.swt/Eclipse SWT Program/gtk/org/eclipse/swt/program/Program.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Program/gtk/org/eclipse/swt/program/Program.java
@@ -304,7 +304,19 @@ static Program gio_getProgram (long application) {
 		if (length > 0) {
 			buffer = new byte [length];
 			C.memmove (buffer, applicationCommand, length);
-			program.command = new String (Converter.mbcsToWcs (buffer));
+			String command = new String (Converter.mbcsToWcs (buffer));
+			if (command.equals("/usr/bin/flatpak") || command.equals("env")) {
+				long applicationCommandLine = OS.g_app_info_get_commandline(application);
+				if (applicationCommandLine != 0) {
+					length = C.strlen (applicationCommandLine);
+					if (length > 0) {
+						buffer = new byte [length];
+						C.memmove (buffer, applicationCommandLine, length);
+						command = new String (Converter.mbcsToWcs (buffer));
+					}
+				}
+			}
+			program.command = command ;
 		}
 	}
 	program.gioExpectUri = OS.g_app_info_supports_uris(application);


### PR DESCRIPTION
Make Program class explicitly check for "/usr/bin/flatpak"(flatpak) and for "env"(snap) commands and use the commandline in this case instead of the command only.
Command line is not used every time to not introduce breakage unintentionally in some other cases.