### PR TITLE
Scale Table.DRAG_IMAGE_SIZE by zoom level instead of using fixed pixels

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Table.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Table.java
@@ -5745,8 +5745,9 @@ long windowProc (long hwnd, int msg, long wParam, long lParam) {
 		OS.GetClientRect (handle, clientRect);
 		TableItem item = _getItem (selection);
 		RECT rect = item.getBounds (selection, 0, true, true, true);
+		int dragImageSizeInPixel = Win32DPIUtils.pointToPixel(DRAG_IMAGE_SIZE, getZoom());
 		if ((style & SWT.FULL_SELECTION) != 0) {
-			int width = DRAG_IMAGE_SIZE;
+			int width = dragImageSizeInPixel;
 			rect.left = Math.max (clientRect.left, mousePos.x - width / 2);
 			if (clientRect.right > rect.left + width) {
 				rect.right = rect.left + width;
@@ -5757,7 +5758,7 @@ long windowProc (long hwnd, int msg, long wParam, long lParam) {
 		}
 		long hRgn = OS.CreateRectRgn (rect.left, rect.top, rect.right, rect.bottom);
 		while ((selection = (int)OS.SendMessage (handle, OS.LVM_GETNEXTITEM, selection, OS.LVNI_SELECTED)) != -1) {
-			if (rect.bottom - rect.top > DRAG_IMAGE_SIZE) break;
+			if (rect.bottom - rect.top > dragImageSizeInPixel) break;
 			if (rect.bottom > clientRect.bottom) break;
 			RECT itemRect = item.getBounds (selection, 0, true, true, true);
 			long rectRgn = OS.CreateRectRgn (rect.left, itemRect.top, rect.right, itemRect.bottom);


### PR DESCRIPTION
The Table.DRAG_IMAGE_SIZE constant specifies the width of the drag image when a table item is dragged. Previously, this value was fixed in pixels, which caused the drag image to appear too small on high-DPI monitors.

This change redefines DRAG_IMAGE_SIZE in points and converts it to pixels based on the current zoom level, ensuring consistent drag image sizing across different display scales.

### How to test
- Run the following snippet in 100% monitor zoom and then 250% monitor zoom
- Try to drag the leaf item 
- The drag item should look bigger in 250% monitor

```java

import org.eclipse.swt.*;
import org.eclipse.swt.dnd.*;
import org.eclipse.swt.graphics.*;
import org.eclipse.swt.layout.*;
import org.eclipse.swt.widgets.*;

public class DragImageOfTableItemExample {

    public static void main(String[] args) {
        final Display display = new Display();
        System.setProperty("swt.autoScale", "quarter");
        System.setProperty("swt.autoScale.updateOnRuntime", "true");
        final Shell shell = new Shell(display);
        shell.setText("Table Drag & Drop Example");
        shell.setLayout(new FillLayout());

        final Table table = new Table(shell, SWT.MULTI | SWT.FULL_SELECTION | SWT.BORDER);
        table.setHeaderVisible(true);
        table.setLinesVisible(true);

        TableColumn col1 = new TableColumn(table, SWT.NONE);
        col1.setText("Column 1");
        col1.setWidth(150);

        TableColumn col2 = new TableColumn(table, SWT.NONE);
        col2.setText("Column 2");
        col2.setWidth(150);

        for (int i = 0; i < 10; i++) {
            TableItem item = new TableItem(table, SWT.NONE);
            item.setText(new String[]{"Row " + i, "Value " + i});
        }

        Transfer[] types = new Transfer[]{TextTransfer.getInstance()};
        int operations = DND.DROP_MOVE | DND.DROP_COPY;

        final DragSource source = new DragSource(table, operations);
        source.setTransfer(types);
        final TableItem[] dragSourceItem = new TableItem[1];

        source.addDragListener(new DragSourceListener() {
            @Override
            public void dragStart(DragSourceEvent event) {
                TableItem[] selection = table.getSelection();
                if (selection.length > 0) {
                    dragSourceItem[0] = selection[0];
                    event.doit = true;
                } else {
                    event.doit = false;
                }
            }

            @Override
            public void dragSetData(DragSourceEvent event) {
                event.data = dragSourceItem[0].getText(0); // send first column text
            }

            @Override
            public void dragFinished(DragSourceEvent event) {
                if (event.detail == DND.DROP_MOVE && dragSourceItem[0] != null) {
                    dragSourceItem[0].dispose();
                }
                dragSourceItem[0] = null;
            }
        });

        DropTarget target = new DropTarget(table, operations);
        target.setTransfer(types);
        target.addDropListener(new DropTargetAdapter() {
            @Override
            public void dragOver(DropTargetEvent event) {
                event.feedback = DND.FEEDBACK_SCROLL | DND.FEEDBACK_INSERT_BEFORE | DND.FEEDBACK_INSERT_AFTER;
                if (event.item != null) {
                    TableItem item = (TableItem) event.item;
                    Point pt = display.map(null, table, event.x, event.y);
                    Rectangle bounds = item.getBounds();
                    if (pt.y < bounds.y + bounds.height / 2) {
                        event.feedback = DND.FEEDBACK_INSERT_BEFORE;
                    } else {
                        event.feedback = DND.FEEDBACK_INSERT_AFTER;
                    }
                }
            }

            @Override
            public void drop(DropTargetEvent event) {
                if (event.data == null) {
                    event.detail = DND.DROP_NONE;
                    return;
                }
                String text = (String) event.data;

                if (event.item == null) {
                    TableItem newItem = new TableItem(table, SWT.NONE);
                    newItem.setText(new String[]{text, "new"});
                } else {
                    TableItem item = (TableItem) event.item;
                    Point pt = display.map(null, table, event.x, event.y);
                    Rectangle bounds = item.getBounds();
                    int index = table.indexOf(item);
                    if (pt.y < bounds.y + bounds.height / 2) {
                        TableItem newItem = new TableItem(table, SWT.NONE, index);
                        newItem.setText(new String[]{text, "inserted"});
                    } else {
                        TableItem newItem = new TableItem(table, SWT.NONE, index + 1);
                        newItem.setText(new String[]{text, "inserted"});
                    }
                }
            }
        });

        shell.setSize(400, 400);
        shell.open();
        while (!shell.isDisposed()) {
            if (!display.readAndDispatch()) display.sleep();
        }
        display.dispose();
    }
}

```

### Result (250% Zoom Monitor)

<img width="2083" height="1881" alt="image" src="https://github.com/user-attachments/assets/479b5e72-0b2b-4156-b7ab-d0f7bc412fc5" />
