### PR TITLE
Scale Table.GRID_WIDTH by zoom level instead of using fixed pixels

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Table.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Table.java
@@ -2334,11 +2334,11 @@ int getFocusIndex () {
  */
 public int getGridLineWidth () {
 	checkWidget ();
-	return DPIUtil.pixelToPoint(getGridLineWidthInPixels(), getZoom());
+	return GRID_WIDTH;
 }
 
 int getGridLineWidthInPixels () {
-	return GRID_WIDTH;
+	return Win32DPIUtils.pointToPixel(GRID_WIDTH, getZoom());
 }
 
 /**
@@ -5308,7 +5308,7 @@ public void showColumn (TableColumn column) {
 		OS.GetScrollInfo (handle, OS.SB_HORZ, info);
 		int newPos = info.nPos;
 		if (newPos < oldPos) {
-			rect.right = oldPos - newPos + GRID_WIDTH;
+			rect.right = oldPos - newPos + getGridLineWidthInPixels();
 			OS.InvalidateRect (handle, rect, true);
 		}
 	}
@@ -6353,7 +6353,7 @@ LRESULT WM_HSCROLL (long wParam, long lParam) {
 		if (newPos < oldPos) {
 			RECT rect = new RECT ();
 			OS.GetClientRect (handle, rect);
-			rect.right = oldPos - newPos + GRID_WIDTH;
+			rect.right = oldPos - newPos + getGridLineWidthInPixels();
 			OS.InvalidateRect (handle, rect, true);
 		}
 	}
@@ -6462,9 +6462,9 @@ LRESULT WM_VSCROLL (long wParam, long lParam) {
 				long oneItem = OS.SendMessage (handle, OS.LVM_APPROXIMATEVIEWRECT, 1, 0);
 				int itemHeight = OS.HIWORD (oneItem) - OS.HIWORD (empty);
 				if (code == OS.SB_LINEDOWN) {
-					clientRect.top = clientRect.bottom - itemHeight - GRID_WIDTH;
+					clientRect.top = clientRect.bottom - itemHeight - getGridLineWidthInPixels();
 				} else {
-					clientRect.bottom = clientRect.top + itemHeight + GRID_WIDTH;
+					clientRect.bottom = clientRect.top + itemHeight + getGridLineWidthInPixels();
 				}
 				OS.InvalidateRect (handle, clientRect, true);
 				break;
@@ -7283,7 +7283,7 @@ LRESULT wmNotifyToolTip (NMTTCUSTOMDRAW nmcd, long lParam) {
 				}
 				if (drawForeground) {
 					int nSavedDC = OS.SaveDC (nmcd.hdc);
-					int gridWidth = getLinesVisible () ? Table.GRID_WIDTH : 0;
+					int gridWidth = getLinesVisible () ? getGridLineWidthInPixels() : 0;
 					RECT insetRect = toolTipInset (cellRect);
 					OS.SetWindowOrgEx (nmcd.hdc, insetRect.left, insetRect.top, null);
 					GCData data = new GCData ();

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TableItem.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TableItem.java
@@ -415,7 +415,7 @@ RECT getBounds (int row, int column, boolean getText, boolean getImage, boolean 
 	* the grid width when the grid is visible.  The fix is to
 	* move the top of the rectangle up by the grid width.
 	*/
-	int gridWidth = parent.getLinesVisible () ? Table.GRID_WIDTH : 0;
+	int gridWidth = parent.getLinesVisible () ? parent.getGridLineWidthInPixels() : 0;
 	rect.top -= gridWidth;
 	if (column != 0) rect.left += gridWidth;
 	rect.right = Math.max (rect.right, rect.left);


### PR DESCRIPTION
The Table.GRID_WIDTH constant specifies the extra width added to a table item when lines between columns are visible (`lineVisible = true`). This accounts for the space taken by the grid line. Previously, it was defined as a fixed
pixel value, which appeared too small on high-DPI monitors.

This change redefines GRID_WIDTH in points and scales it to pixels based on the current zoom level. At 100% zoom this results in 2px instead of 1px, which is visually negligible but ensures consistency by keeping all constants defined in points and scaled according to zoom level.

### How to Test

- Run the following snippet on a Primary monitor with 250% zoom
- You will notice extra pixel in the width compared to previous state. 

```

import org.eclipse.swt.*;
import org.eclipse.swt.layout.*;
import org.eclipse.swt.widgets.*;

public class LinesVisibleTableExample {

    public static void main (String [] args) {
        System.setProperty("swt.autoScale", "quarter");
        System.setProperty("swt.autoScale.updateOnRuntime", "true");
        
        Display display = new Display ();
        Shell shell = new Shell (display);
        shell.setText("SWT Table Example");
        shell.setLayout(new FillLayout());

        // Create table
        final Table table = new Table(shell, SWT.BORDER | SWT.FULL_SELECTION);
        table.setHeaderVisible(true);
        table.setLinesVisible(true);

        // Create columns
        String[] titles = { "Level 0", "Level 1", "Level 2", "Level 3" };
        for (String title : titles) {
            TableColumn column = new TableColumn(table, SWT.NONE);
            column.setText(title);
            column.setWidth(100);
        }

        // Fill table with hierarchical-like data
        for (int i = 0; i < 4; i++) {
            for (int j = 0; j < 4; j++) {
                for (int k = 0; k < 4; k++) {
                    for (int l = 0; l < 4; l++) {
                        TableItem item = new TableItem(table, SWT.NONE);
                        item.setText(new String[] {
                            "TableItem (0) -" + i,
                            "TableItem (1) -" + j,
                            "TableItem (2) -" + k,
                            "TableItem (3) -" + l
                        });
                    }
                }
            }
        }

        shell.setSize(450, 250);
        shell.open();
        while (!shell.isDisposed()) {
            if (!display.readAndDispatch()) display.sleep();
        }
        display.dispose();
    }
}
```
