### PR TITLE
Scale Table.HEADER_MARGIN by zoom level instead of using fixed pixels

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TableColumn.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TableColumn.java
@@ -405,8 +405,8 @@ public void pack () {
 	long hwnd = parent.handle;
 	int oldWidth = (int)OS.SendMessage (hwnd, OS.LVM_GETCOLUMNWIDTH, index, 0);
 	TCHAR buffer = new TCHAR (parent.getCodePage (), text, true);
-	int headerWidth = (int)OS.SendMessage (hwnd, OS.LVM_GETSTRINGWIDTH, 0, buffer) + Table.HEADER_MARGIN;
-	if (OS.IsAppThemed ()) headerWidth += Table.HEADER_EXTRA;
+	int headerWidth = (int)OS.SendMessage (hwnd, OS.LVM_GETSTRINGWIDTH, 0, buffer) + Win32DPIUtils.pointToPixel(Table.HEADER_MARGIN, getZoom());
+	if (OS.IsAppThemed ()) headerWidth += Win32DPIUtils.pointToPixel(Table.HEADER_EXTRA, getZoom());
 	boolean hasHeaderImage = false;
 	if (image != null || parent.sortColumn == this) {
 		hasHeaderImage = true;


### PR DESCRIPTION
The Table.HEADER_MARGIN constant defines the extra fixed-width spacing for table headers, while the Table.HEADER_EXTRA constant specifies the additional spacing applied to the header area. Previously, both were defined as fixed pixel values,
which worked at 100% zoom but did not scale properly on high-DPI monitors.

This change redefines HEADER_MARGIN and HEADER_EXTRA in points and converts them to pixels based on the current zoom level, ensuring consistent header spacing across different display scales.

### How to Test

- Run Snippet 8 from Snippet Explorer with Primary monitor of 250%
- You will notice the width of the header wider than previous state since we take zoom into consideration.