### PR TITLE
Scale Table.SORT_WIDTH by zoom level instead of using fixed pixels

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TableColumn.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TableColumn.java
@@ -411,7 +411,7 @@ public void pack () {
 	if (image != null || parent.sortColumn == this) {
 		hasHeaderImage = true;
 		if (parent.sortColumn == this && parent.sortDirection != SWT.NONE) {
-			headerWidth += Table.SORT_WIDTH;
+			headerWidth += Win32DPIUtils.pointToPixel(Table.SORT_WIDTH, getZoom());
 		} else if (image != null) {
 			Rectangle bounds = Win32DPIUtils.pointToPixel(image.getBounds(), getZoom());
 			headerWidth += bounds.width;


### PR DESCRIPTION
The Tree.SORT_WIDTH constant specifies the extra width added to a column when a sort column is set (`setSortColumn`). This reserves space for the sort indicator. Previously, it was defined as a fixed pixel.

### How to Test 

- Run the following snippet with 250% zoom
- You will notice extra pixels on the Sort column width than previous state.

```
package org.eclipse.swt.snippets;
import org.eclipse.swt.*;
import org.eclipse.swt.graphics.*;
import org.eclipse.swt.layout.*;
import org.eclipse.swt.widgets.*;

public class TableColumnSortWidthExample {

    public static void main(String [] args) {
        final Display display = new Display();
        System.setProperty("swt.autoScale", "quarter");
        System.setProperty("swt.autoScale.updateOnRuntime", "true");
        Shell shell = new Shell(display);
        shell.setText("Custom gradient selection for Table");
        shell.setLayout(new FillLayout());

        final Table table = new Table(shell, SWT.MULTI | SWT.FULL_SELECTION);
        table.setHeaderVisible(true);
        table.setLinesVisible(true);

        int columnCount = 4;
        for (int i=0; i<columnCount; i++) {
            TableColumn column = new TableColumn(table, SWT.NONE);
            column.setText("Column " + i);
        }

        int itemCount = 3;
        for (int i=0; i<itemCount; i++) {
            for (int j=0; j<itemCount; j++) {
                for (int k=0; k<itemCount; k++) {
                    TableItem item = new TableItem(table, SWT.NONE);
                    item.setText(0, "item ["+i+" "+j+" "+k+"]");
                    for (int c=1; c<columnCount; c++) {
                        item.setText(c, "item ["+i+" "+j+" "+k+"-"+c+"]");
                    }
                }
            }
        }

        // Custom gradient selection
        table.addListener(SWT.EraseItem, event -> {
            event.detail &= ~SWT.HOT;
            if ((event.detail & SWT.SELECTED) != 0) {
                GC gc = event.gc;
                Rectangle area = table.getClientArea();
                int columnCount1 = table.getColumnCount();
                if (event.index == columnCount1 - 1 || columnCount1 == 0) {
                    int width = area.x + area.width - event.x;
                    if (width > 0) {
                        Region region = new Region();
                        gc.getClipping(region);
                        region.add(event.x, event.y, width, event.height);
                        gc.setClipping(region);
                        region.dispose();
                    }
                }
                gc.setAdvanced(true);
                if (gc.getAdvanced()) gc.setAlpha(127);
                Rectangle rect = event.getBounds();
                Color foreground = gc.getForeground();
                Color background = gc.getBackground();
                gc.setForeground(display.getSystemColor(SWT.COLOR_RED));
                gc.setBackground(display.getSystemColor(SWT.COLOR_LIST_BACKGROUND));
                gc.fillGradientRectangle(0, rect.y, 500, rect.height, false);
                // restore colors for subsequent drawing
                gc.setForeground(foreground);
                gc.setBackground(background);
                event.detail &= ~SWT.SELECTED;
            }
        });

        table.setSortColumn(table.getColumn(0));
        table.setSortDirection(SWT.UP);
        for (int i=0; i<columnCount; i++) {
            table.getColumn(i).pack();
        }
        table.setSelection(table.getItem(0));

        shell.setSize(500, 200);
        shell.open();
        while (!shell.isDisposed()) {
            if (!display.readAndDispatch()) display.sleep();
        }
        display.dispose();
    }
}

```