### PR TITLE
Scale Table.INSET by zoom level instead of using fixed pixels

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Table.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Table.java
@@ -4860,7 +4860,7 @@ boolean setScrollWidth (TableItem item, boolean force) {
 		if (hStateList != 0) {
 			int [] cx = new int [1], cy = new int [1];
 			OS.ImageList_GetIconSize (hStateList, cx, cy);
-			newWidth += cx [0] + INSET;
+			newWidth += cx [0] + Win32DPIUtils.pointToPixel(INSET, getZoom());
 		}
 		long hImageList = OS.SendMessage (handle, OS.LVM_GETIMAGELIST, OS.LVSIL_SMALL, 0);
 		if (hImageList != 0) {
@@ -4880,7 +4880,7 @@ boolean setScrollWidth (TableItem item, boolean force) {
 			*/
 			newWidth++;
 		}
-		newWidth += INSET * 2 + Win32DPIUtils.pointToPixel(VISTA_EXTRA, getZoom());
+		newWidth += Win32DPIUtils.pointToPixel(INSET * 2, getZoom()) + Win32DPIUtils.pointToPixel(VISTA_EXTRA, getZoom());
 		int oldWidth = (int)OS.SendMessage (handle, OS.LVM_GETCOLUMNWIDTH, 0, 0);
 		if (newWidth > oldWidth) {
 			setScrollWidth (newWidth);
@@ -6962,7 +6962,7 @@ LRESULT wmNotifyHeader (NMHDR hdr, long wParam, long lParam) {
 							}
 						}
 
-						int x = rects[i].left + INSET + 2;
+						int x = rects[i].left + Win32DPIUtils.pointToPixel(INSET + 2, getZoom());
 						if (columns[i].image != null) {
 							GCData data = new GCData();
 							data.device = display;
@@ -7303,9 +7303,9 @@ LRESULT wmNotifyToolTip (NMTTCUSTOMDRAW nmcd, long lParam) {
 						int zoom = getZoom();
 						rect = Win32DPIUtils.pixelToPoint(rect, zoom);
 						gc.drawImage (image, rect.x, rect.y, rect.width, rect.height, DPIUtil.pixelToPoint(x, zoom), DPIUtil.pixelToPoint(y, zoom), DPIUtil.pixelToPoint(size.x, zoom), DPIUtil.pixelToPoint(size.y, zoom));
-						x += size.x + INSET + (pinfo.iSubItem == 0 ? -2 : 4);
+						x += size.x + Win32DPIUtils.pointToPixel(INSET + (pinfo.iSubItem == 0 ? -2 : 4), zoom);
 					} else {
-						x += INSET + 2;
+						x += Win32DPIUtils.pointToPixel(INSET + 2, getZoom());
 					}
 					String string = item.getText (pinfo.iSubItem);
 					if (string != null) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TableItem.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TableItem.java
@@ -300,7 +300,7 @@ RECT getBounds (int row, int column, boolean getText, boolean getImage, boolean 
 					}
 				}
 				if (!getImage) rect.left = rect.right;
-				rect.right += width + Table.INSET * 2;
+				rect.right += width + Win32DPIUtils.pointToPixel(Table.INSET * 2, getZoom());
 			}
 		} else {
 			if (getText) {
@@ -377,7 +377,7 @@ RECT getBounds (int row, int column, boolean getText, boolean getImage, boolean 
 					iconRect.top = column;
 					iconRect.left = OS.LVIR_ICON;
 					if (OS.SendMessage (hwnd, OS. LVM_GETSUBITEMRECT, row, iconRect) != 0) {
-						rect.left = iconRect.right + Table.INSET / 2;
+						rect.left = iconRect.right + Win32DPIUtils.pointToPixel(Table.INSET / 2, getZoom());
 					}
 				}
 			} else {
@@ -404,7 +404,7 @@ RECT getBounds (int row, int column, boolean getText, boolean getImage, boolean 
 					char [] buffer = string.toCharArray ();
 					int flags = OS.DT_NOPREFIX | OS.DT_SINGLELINE | OS.DT_CALCRECT;
 					OS.DrawText (hDC, buffer, buffer.length, textRect, flags);
-					rect.right += textRect.right - textRect.left + Table.INSET * 3 + 2;
+					rect.right += textRect.right - textRect.left + Win32DPIUtils.pointToPixel(Table.INSET * 3 + 2, getZoom());
 				}
 			}
 		}
@@ -700,9 +700,9 @@ Rectangle getTextBoundsInPixels (int index) {
 	if (itemIndex == -1) return new Rectangle (0, 0, 0, 0);
 	RECT rect = getBounds (itemIndex, index, true, false, true);
 	rect.left += 2;
-	if (index != 0) rect.left += Table.INSET;
+	if (index != 0) rect.left += Win32DPIUtils.pointToPixel(Table.INSET, getZoom());
 	rect.left = Math.min (rect.left, rect.right);
-	rect.right = rect.right - Table.INSET;
+	rect.right = rect.right - Win32DPIUtils.pointToPixel(Table.INSET, getZoom());
 	int width = Math.max (0, rect.right - rect.left);
 	int height = Math.max (0, rect.bottom - rect.top);
 	return new Rectangle (rect.left, rect.top, width, height);


### PR DESCRIPTION
The Table.INSET constant defines the spacing in the width of a table cell. Previously, this was a fixed value of 3px, which looks correct at 100% zoom but causes the image and text to appear cramped on higher-DPI displays.

This change defines INSET in points and converts it to pixels based on the current zoom level (e.g. 6px at 200%), ensuring consistent spacing across different monitor scale.

### How to Test

- Run the following snippet with 100% primary and 250% secondary monitor zoom
- Note down the width of a cell by moving it from one monitor to other. 
- See if the values adhere to zoom levels. 
- 
```
import org.eclipse.swt.*;
import org.eclipse.swt.graphics.*;
import org.eclipse.swt.widgets.*;

public class TableInsetTest {

public static void main (String [] args) {
	System.setProperty("swt.autoScale", "quarter");
	System.setProperty("swt.autoScale.updateOnRuntime", "true");
	Display display = new Display ();
	Shell shell = new Shell (display);
	shell.setText("Table Inset Test");
	Table table = new Table (shell, SWT.BORDER | SWT.MULTI);
	table.setLinesVisible(true);
	Rectangle clientArea = shell.getClientArea ();
	table.setBounds (clientArea.x, clientArea.y, 200, 200);
	for (int i=0; i<128; i++) {
		TableItem item = new TableItem (table, SWT.NONE);
		item.setText ("Item " + i);
	}
	table.setSelection (95);
	shell.pack ();
	shell.open ();
	while (!shell.isDisposed ()) {
		if (!display.readAndDispatch ()) display.sleep ();
	}
	display.dispose ();
}
}
```

**Results:**
Before Change 
Width 150% = 77
Width 250% = 128

After change
Width 150% = 84
Width 250% = 139

