### PR TITLE
[GTK] Fix MenuItem/ToolItem setImage(null)

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/MenuItem.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/MenuItem.java
@@ -986,8 +986,9 @@ private void _setEnabledOrDisabledImage() {
 			defaultDisableImage = new Image(getDisplay(), image, SWT.IMAGE_DISABLE);
 		}
 		_setImage(defaultDisableImage);
+	} else {
+		_setImage(image);
 	}
-	if (enabled && image != null) _setImage(image);
 }
 
 /**

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/ToolItem.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/ToolItem.java
@@ -1228,8 +1228,9 @@ private void _setEnabledOrDisabledImage() {
 		} else {
 			_setImage(disabledImage);
 		}
+	} else {
+		_setImage(image);
 	}
-	if (enabled && image != null) _setImage(image);
 }
 
 boolean setFocus () {


### PR DESCRIPTION
Fix for https://bugs.eclipse.org/bugs/show_bug.cgi?id=568771 had the wrong assumption that _setImage should be called only when non null image.
Fixes https://github.com/eclipse-platform/eclipse.platform.swt/issues/2457