### PR TITLE
Improve and extend tests for Image#getImageData()

### DIFF
--- a/tests/org.eclipse.swt.tests.win32/JUnit Tests/org/eclipse/swt/graphics/ImageWin32Tests.java
+++ b/tests/org.eclipse.swt.tests.win32/JUnit Tests/org/eclipse/swt/graphics/ImageWin32Tests.java
@@ -14,6 +14,7 @@
 package org.eclipse.swt.graphics;
 
 
+import static org.eclipse.swt.tests.win32.SwtWin32TestUtil.assertImageDataEqualsIgnoringAlphaInData;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
@@ -172,6 +173,44 @@ public class ImageWin32Tests {
 			targetCanvasGc.dispose();
 			targetCanvas.dispose();
 		}
+	}
+
+	// On Windows, the first used Image constructor creates a DDB, while the second
+	// transforms it into a DIB, still pixel RGB and alpha values should be the same.
+	@Test
+	public void test_getImageData_fromImageForImageDataFromImage() {
+		int width = 10;
+		int height = 10;
+		Color color = new Color(0, 0xff, 0);
+		Image image = new Image(display, width, height);
+		fillImage(image, color);
+		ImageData imageData = image.getImageData();
+		ImageData recreatedImageData = new Image(display, imageData).getImageData();
+		assertImageDataEqualsIgnoringAlphaInData(imageData, recreatedImageData);
+		image.dispose();
+	}
+
+	// On Windows, the first used Image constructor creates a DDB, while the second
+	// transforms it into a DIB, still pixel RGB and alpha values should be the same.
+	@Test
+	public void test_getImageData_fromCopiedImage() {
+		int width = 10;
+		int height = 10;
+		Color color = new Color(0, 0xff, 0);
+		Image image = new Image(display, width, height);
+		fillImage(image, color);
+		ImageData imageData = image.getImageData();
+		ImageData copiedImageData = new Image(display, image, SWT.IMAGE_COPY).getImageData();
+		assertImageDataEqualsIgnoringAlphaInData(imageData, copiedImageData);
+		image.dispose();
+	}
+
+	private static void fillImage(Image image, Color fillColor) {
+		GC gc = new GC(image);
+		gc.setBackground(fillColor);
+		gc.setForeground(fillColor);
+		gc.fillRectangle(image.getBounds());
+		gc.dispose();
 	}
 
 }

--- a/tests/org.eclipse.swt.tests.win32/JUnit Tests/org/eclipse/swt/tests/win32/SwtWin32TestUtil.java
+++ b/tests/org.eclipse.swt.tests.win32/JUnit Tests/org/eclipse/swt/tests/win32/SwtWin32TestUtil.java
@@ -13,8 +13,12 @@
  *******************************************************************************/
 package org.eclipse.swt.tests.win32;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
 import java.util.function.BooleanSupplier;
 
+import org.eclipse.swt.graphics.ImageData;
 import org.eclipse.swt.widgets.Display;
 
 public class SwtWin32TestUtil {
@@ -38,6 +42,47 @@ public static void processEvents(Display display, int timeoutMs, BooleanSupplier
 			} else {
 				return;
 			}
+		}
+	}
+}
+
+/**
+ * Asserts that both given ImageData are equal, i.e. that:
+ * <ul>
+ *   <li>depths are equal (considering 24/32 bit as equals since alpha data is stored separately)</li>
+ *   <li>width and height are equal</li>
+ *   <li>all pixel RGB values are equal</li>
+ *   <li>all pixel alpha values in the alphaData are equal</li>
+ * </ul>
+ * In case any of these properties differ, the test will fail.
+ *
+ * @param expected the expected ImageData
+ * @param actual the actual ImageData
+ */
+// This method is necessary because ImageData has no custom equals method and the default one isn't sufficient.
+public static void assertImageDataEqualsIgnoringAlphaInData(final ImageData expected, final ImageData actual) {
+	assertNotNull(expected, "expected data must not be null");
+	assertNotNull(actual, "actual data must not be null");
+	if (expected == actual) {
+		return;
+	}
+	assertEquals(expected.height, actual.height, "height of expected image is different from actual image");
+	// Alpha values are taken from alpha data, so ignore whether data depth is 24 or 32 bits
+	int expectedNormalizedDepth = expected.depth == 32 ? 24 : expected.depth;
+	int actualNormalizedDepth = expected.depth == 32 ? 24 : expected.depth;
+	assertEquals(expectedNormalizedDepth, actualNormalizedDepth, "depth of image data to compare must be equal");
+	assertEquals(expected.width, actual.width, "width of expected image is different from actual image");
+
+	for (int y = 0; y < expected.height; y++) {
+		for (int x = 0; x < expected.width; x++) {
+			// FIXME win32: dragged ALPHA=FF, dropped ALPHA=00, but other transparencyType
+			// => alpha stored in ImageData.alphaData
+			String expectedPixel = String.format("0x%08X", expected.getPixel(x, y) >> (expected.depth == 32 ? 8 : 0));
+			String actualPixel = String.format("0x%08X", actual.getPixel(x, y) >> (actual.depth == 32 ? 8 : 0));
+			assertEquals(expectedPixel, actualPixel, "actual pixel at x=" + x + " y=" + y + " is different from expected pixel");
+			int expectedAlpha = expected.getAlpha(x, y);
+			int actualAlpha = actual.getAlpha(x, y);
+			assertEquals(expectedAlpha, actualAlpha, "actual pixel alpha at x=" + x + " y=" + y + " is different from expected pixel");
 		}
 	}
 }

--- a/tests/org.eclipse.swt.tests.win32/JUnit Tests/org/eclipse/swt/tests/win32/Test_org_eclipse_swt_dnd_DND.java
+++ b/tests/org.eclipse.swt.tests.win32/JUnit Tests/org/eclipse/swt/tests/win32/Test_org_eclipse_swt_dnd_DND.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.swt.tests.win32;
 
+import static org.eclipse.swt.tests.win32.SwtWin32TestUtil.assertImageDataEqualsIgnoringAlphaInData;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -144,7 +145,7 @@ public void testImageTransfer_fromImage() throws InterruptedException {
 	try {
 		final ImageData drag = image.getImageData();
 		final ImageData drop = testTransferRoundtrip(ImageTransfer.getInstance(), drag);
-		assertImageDataEqualsIgoringAlphaInData(drag, drop);
+		assertImageDataEqualsIgnoringAlphaInData(drag, drop);
 	} finally {
 		image.dispose();
 	}
@@ -159,7 +160,7 @@ public void testImageTransfer_fromCopiedImage() throws InterruptedException {
 	try {
 		final ImageData drag = new Image(shell.getDisplay(), image, SWT.IMAGE_COPY).getImageData();
 		final ImageData drop = testTransferRoundtrip(ImageTransfer.getInstance(), drag);
-		assertImageDataEqualsIgoringAlphaInData(drag, drop);
+		assertImageDataEqualsIgnoringAlphaInData(drag, drop);
 	} finally {
 		image.dispose();
 	}
@@ -176,7 +177,7 @@ public void testImageTransfer_fromImageData() throws InterruptedException {
 	}
 	final ImageData drag = imageData;
 	final ImageData drop = testTransferRoundtrip(ImageTransfer.getInstance(), drag);
-	assertImageDataEqualsIgoringAlphaInData(drag, drop);
+	assertImageDataEqualsIgnoringAlphaInData(drag, drop);
 }
 
 /**
@@ -190,7 +191,7 @@ public void testImageTransfer_fromImageDataFromImage() throws InterruptedExcepti
 		try {
 			final ImageData drag = imageFromImageData.getImageData();
 			final ImageData drop = testTransferRoundtrip(ImageTransfer.getInstance(), drag);
-			assertImageDataEqualsIgoringAlphaInData(drag, drop);
+			assertImageDataEqualsIgnoringAlphaInData(drag, drop);
 		} finally {
 			imageFromImageData.dispose();
 		}
@@ -250,47 +251,6 @@ private Image createTestImage() {
 		fail("test image could not be initialized: " + e);
 	}
 	return null;
-}
-
-/**
- * Asserts that both given ImageData are equal, i.e. that:
- * <ul>
- *   <li>depths are equal (considering 24/32 bit as equals since alpha data is stored separately)</li>
- *   <li>width and height are equal</li>
- *   <li>all pixel RGB values are equal</li>
- *   <li>all pixel alpha values in the alphaData are equal</li>
- * </ul>
- * In case any of these properties differ, the test will fail.
- *
- * @param expected the expected ImageData
- * @param actual the actual ImageData
- */
-// This method is necessary because ImageData has no custom equals method and the default one isn't sufficient.
-private void assertImageDataEqualsIgoringAlphaInData(final ImageData expected, final ImageData actual) {
-	assertNotNull(expected, "expected data must not be null");
-	assertNotNull(actual, "actual data must not be null");
-	if (expected == actual) {
-		return;
-	}
-	assertEquals(expected.height, actual.height, "height of expected image is different from actual image");
-	// Alpha values are taken from alpha data, so ignore whether data depth is 24 or 32 bits
-	int expectedNormalizedDepth = expected.depth == 32 ? 24 : expected.depth;
-	int actualNormalizedDepth = expected.depth == 32 ? 24 : expected.depth;
-	assertEquals(expectedNormalizedDepth, actualNormalizedDepth, "depth of image data to compare must be equal");
-	assertEquals(expected.width, actual.width, "width of expected image is different from actual image");
-
-	for (int y = 0; y < expected.height; y++) {
-		for (int x = 0; x < expected.width; x++) {
-			// FIXME win32: dragged ALPHA=FF, dropped ALPHA=00, but other transparencyType
-			// => alpha stored in ImageData.alphaData
-			String expectedPixel = String.format("0x%08X", expected.getPixel(x, y) >> (expected.depth == 32 ? 8 : 0));
-			String actualPixel = String.format("0x%08X", actual.getPixel(x, y) >> (actual.depth == 32 ? 8 : 0));
-			assertEquals(expectedPixel, actualPixel, "actual pixel at x=" + x + " y=" + y + " is different from expected pixel");
-			int expectedAlpha = expected.getAlpha(x, y);
-			int actualAlpha = actual.getAlpha(x, y);
-			assertEquals(expectedAlpha, actualAlpha, "actual pixel alpha at x=" + x + " y=" + y + " is different from expected pixel");
-		}
-	}
 }
 
 /**

--- a/tests/org.eclipse.swt.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.swt.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SWT Tests
 Bundle-SymbolicName: org.eclipse.swt.tests
-Bundle-Version: 3.107.900.qualifier
+Bundle-Version: 3.107.1000.qualifier
 Bundle-Vendor: Eclipse.org
 Export-Package: org.eclipse.swt.tests.junit,
  org.eclipse.swt.tests.junit.performance

--- a/tests/org.eclipse.swt.tests/pom.xml
+++ b/tests/org.eclipse.swt.tests/pom.xml
@@ -20,7 +20,7 @@
     <relativePath>../../local-build/local-build-parent/</relativePath>
   </parent>
   <artifactId>org.eclipse.swt.tests</artifactId>
-  <version>3.107.900-SNAPSHOT</version>
+  <version>3.107.1000-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
   <properties>
     <tycho.testArgLine></tycho.testArgLine>


### PR DESCRIPTION
- makes multiple test methods with more comprehensive names out of a combined single one
- adds test method for additional use case
- adds win32-specific tests methods for specifics in Windows image handling