### PR TITLE
[Win32] Correct zoom level used for image of decorations/shell #2037

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Decorations.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Decorations.java
@@ -888,11 +888,11 @@ private void setImages (Image image, Image [] images) {
 	if (smallIcon != null) {
 		switch (smallIcon.type) {
 			case SWT.BITMAP:
-				smallImage = Display.createIcon (smallIcon, getZoom());
-				hSmallIcon = Image.win32_getHandle(smallImage, getZoom());
+				smallImage = Display.createIcon (smallIcon, 100);
+				hSmallIcon = Image.win32_getHandle(smallImage, 100);
 				break;
 			case SWT.ICON:
-				hSmallIcon = Image.win32_getHandle(smallIcon, getZoom());
+				hSmallIcon = Image.win32_getHandle(smallIcon, 100);
 				break;
 		}
 	}
@@ -900,11 +900,11 @@ private void setImages (Image image, Image [] images) {
 	if (largeIcon != null) {
 		switch (largeIcon.type) {
 			case SWT.BITMAP:
-				largeImage = Display.createIcon (largeIcon, getZoom());
-				hLargeIcon = Image.win32_getHandle(largeImage, getZoom());
+				largeImage = Display.createIcon (largeIcon, 100);
+				hLargeIcon = Image.win32_getHandle(largeImage, 100);
 				break;
 			case SWT.ICON:
-				hLargeIcon = Image.win32_getHandle(largeIcon, getZoom());
+				hLargeIcon = Image.win32_getHandle(largeIcon, 100);
 				break;
 		}
 	}


### PR DESCRIPTION
When setting the images for a decorations instance (in particular for a shell) or when updating them upon a zoom change, the two images best fitting to sizes required by the OS in their 100% version are calculated. Then, however, a zoomed version of the image is used based on the auto-scaled zoom of the decorations object. This zoom is, however, completely unrelated to what is required, as the auto-scaled zoom was not taken into account for identifying the best fitting image before.

In the best case, a zoomed version of the image exactly fitting to the size required by the OS would be generated. This would be possible via auto-scaling the image (or in case of SVGs rendering it at the desired size), but this would also lead to bad results if a simple auto-scaling mode was used. Thus, the best possible solution is to use the 100% version of the image, as its size does best fit to the required sizes as conforming to the calculation done before.

Contributes to https://github.com/eclipse-platform/eclipse.platform.swt/issues/2037