### PR TITLE
[Win32] Improve decorations/shell images size selection

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Decorations.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Decorations.java
@@ -945,12 +945,22 @@ private static int findIndexOfClosest(ImageData[] imageData, int targetWidth, in
 }
 
 private static boolean isCloserThan(ImageData dataToTest, ImageData referenceData, int targetWidth, int targetDepth) {
-	int diffWidthToTest = Math.abs(dataToTest.width - targetWidth);
-	int diffReferenceWidth = Math.abs(referenceData.width - targetWidth);
-
-	// The closer the width the better
-	if (diffWidthToTest != diffReferenceWidth)
-		return diffWidthToTest < diffReferenceWidth;
+	// image is considered best-sized if width is nearest to target
+	// but scale down is better than scale up, thus count difference to target width
+	// of scaled-up image as 1.5 times
+	int widthDifferenceOfTestData = dataToTest.width - targetWidth;
+	if (widthDifferenceOfTestData < 0) {
+		widthDifferenceOfTestData *= -1.5;
+	}
+	int widthDifferenceOfReferenceData = referenceData.width - targetWidth;
+	if (widthDifferenceOfReferenceData < 0) {
+		widthDifferenceOfReferenceData *= -1.5;
+	}
+	if (widthDifferenceOfTestData < widthDifferenceOfReferenceData) {
+		return true;
+	} else if (widthDifferenceOfTestData > widthDifferenceOfReferenceData) {
+		return false;
+	}
 
 	int transparencyToTest = dataToTest.getTransparencyType();
 	int referenceTransparency = referenceData.getTransparencyType();


### PR DESCRIPTION
The algorithm to identify the best fitting image set to a decorations/shell instance for a specific size required by the OS currently only considers the difference between the target size and the actual size of the image. Smaller and larger images with the same difference are treated equally. However, usually one wants to prefer downscaling a higher-resolution image than upscaling a lower-resolution one to improve the quality.

This change ensures that larger images are preferred over smaller images if the difference is 1.5 times as high or less. One particular change is that on a 150% monitor now a 200% image will be downscaled instead of upscaling a 100% image.