### PR TITLE
Caret scaling implementation improvement on StyledText DPI change

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/StyledText.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/StyledText.java
@@ -10912,18 +10912,17 @@ void updateSelection(int startOffset, int replacedLength, int newLength) {
  * @noreference This method is not intended to be referenced by clients.
  */
 public static void updateAndRefreshCarets(StyledText styledText, Consumer<Caret> caretUpdater) {
-	Set<Caret> caretSet = new HashSet<>();
-	caretSet.add(styledText.getCaret());
+	styledText.updateCaretVisibility();
+	styledText.setCaretLocations();
+	Set<Caret> caretSet = new LinkedHashSet<>();
 	caretSet.add(styledText.defaultCaret);
+	caretSet.add(styledText.getCaret());
 	if (styledText.carets != null) {
 		for (Caret caret : styledText.carets) {
 			caretSet.add(caret);
 		}
 	}
 	caretSet.stream().filter(Objects::nonNull).forEach(caretUpdater);
-
-	styledText.updateCaretVisibility();
-	styledText.setCaretLocations();
 
 }
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/CommonWidgetsDPIChangeHandlers.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/CommonWidgetsDPIChangeHandlers.java
@@ -51,11 +51,8 @@ public class CommonWidgetsDPIChangeHandlers {
 		if (!(widget instanceof StyledText styledText)) {
 			return;
 		}
-
-
 		StyledText.updateAndRefreshCarets(styledText, caretToRefresh -> {
 			DPIZoomChangeRegistry.applyChange(caretToRefresh, newZoom, scalingFactor);
-			Caret.win32_setHeight(caretToRefresh, styledText.getLineHeight());
 		});
 	}
 	private static void handleCComboDPIChange(Widget widget, int newZoom, float scalingFactor) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Caret.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Caret.java
@@ -658,29 +658,6 @@ public void setVisible (boolean visible) {
 	}
 }
 
-/**
- * <b>IMPORTANT:</b> This method is not part of the public
- * API for Image. It is marked public only so that it
- * can be shared within the packages provided by SWT. It is not
- * available on all platforms, and should never be called from
- * application code.
- *
- * Sets the height o the caret in points.
- *
- * @param caret the caret to set the height of
- * @param height the height of caret to be set in points.
- *
- * @noreference This method is not intended to be referenced by clients.
- */
-public static void win32_setHeight(Caret caret, int height) {
-	caret.checkWidget();
-	if(caret.height != height) {
-		caret.height = height;
-		caret.resized = true;
-	}
-	if(caret.isVisible && caret.hasFocus()) caret.resize();
-}
-
 private static void handleDPIChange(Widget widget, int newZoom, float scalingFactor) {
 	if (!(widget instanceof Caret caret)) {
 		return;
@@ -694,6 +671,7 @@ private static void handleDPIChange(Widget widget, int newZoom, float scalingFac
 	if (caret.font != null) {
 		caret.setFont(caret.font);
 	}
+	if (caret.isVisible && caret.hasFocus ()) caret.resize();
 }
 }
 


### PR DESCRIPTION
This PR improves the way carets of StyledText is scaled on DPI change event by utilizing APIs instead of win32 specific static methods.

Earlier we used to provide a Consumer in CommonWidgetDPIChangeHandlers.handleStyledTextDPIChange to StyledText.updateAndRefreshCarets for performing scaling on DPI change.

To move forward with DPI change performance improvement, we need to get rid of CommonWidgetsDPIChangeHandlers. Which is only possible if we move these handlers to their respective classes and register these handlers on a ZoomChanged event. Which is the next step here: https://github.com/eclipse-platform/eclipse.platform.swt/pull/2483

However, the consumer mentioned above uses a platform specific piece of code: `Caret.win32_setHeight(caretToRefresh, styledText.getLineHeight());` Which cannot be moved to Common Widgets.

Hence, we need to improve the way we scale StyledText and its carets. So, this PR does the following changes:
1. The StyledText at first updates the carets' location and size.
2. Then the DPI change handlers in the carets in the styledText are called, where we call the caret.resize() which explicitly draws the caret with the newly scaled size.
3. Earlier caret.resize() was called using win32_setHeight. As using any other API like setSize, setBounds, etc. had a condition that if the size (in points) doesn't change, resize will not be called leading to no repaint. However, on a DPI change, the size changes in pixels and a repaint must be triggered. Hence, resize is not explicitly called (leading to repaint) in Caret.handleDPIChange which is triggered right after StyledText has adapted the size, location and visibility of the carets.

This change removes the need to use a platform specific (win32_) static method on DPI change and enables us to move forward with implementation of asynchronous DPI change.

contributes to https://github.com/eclipse-platform/eclipse.platform.swt/issues/62 and https://github.com/eclipse-platform/eclipse.platform.swt/issues/128

Depends on https://github.com/eclipse-platform/eclipse.platform.swt/pull/2469 and https://github.com/eclipse-platform/eclipse.platform.swt/pull/2471