### PR TITLE
[Gtk] Make Tree/Table cellDataProc safe for disposed items

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Table.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Table.java
@@ -199,6 +199,9 @@ long cellDataProc (long tree_column, long cell, long tree_model, long iter, long
 	int [] index = new int [1];
 	C.memmove (index, GTK.gtk_tree_path_get_indices (path), 4);
 	TableItem item = _getItem (index[0]);
+	if (item.isDisposed()) {
+		return 0;
+	}
 	GTK.gtk_tree_path_free (path);
 	if (item != null) OS.g_object_set_qdata (cell, Display.SWT_OBJECT_INDEX2, item.handle);
 	boolean isPixbuf = GTK.GTK_IS_CELL_RENDERER_PIXBUF (cell);

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Tree.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Tree.java
@@ -276,6 +276,9 @@ static int checkStyle (int style) {
 long cellDataProc (long tree_column, long cell, long tree_model, long iter, long data) {
 	if (cell == ignoreCell) return 0;
 	TreeItem item = _getItem (iter);
+	if (item.isDisposed()) {
+		return 0;
+	}
 	if (item != null) OS.g_object_set_qdata (cell, Display.SWT_OBJECT_INDEX2, item.handle);
 	boolean isPixbuf = GTK.GTK_IS_CELL_RENDERER_PIXBUF (cell);
 	boolean isText = GTK.GTK_IS_CELL_RENDERER_TEXT (cell);


### PR DESCRIPTION
Table/Tree.remove method ends up firing Gtk signal(s) that cause cellDataProc to start. Make cellDataProc explicitly check whether item is disposed to prevent operating on disposed item. Fixes https://github.com/eclipse-platform/eclipse.platform.swt/issues/1606