### PR TITLE
[Gtk] Ensure gtk_tree_path_free is called before returning

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Table.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Table.java
@@ -199,10 +199,10 @@ long cellDataProc (long tree_column, long cell, long tree_model, long iter, long
 	int [] index = new int [1];
 	C.memmove (index, GTK.gtk_tree_path_get_indices (path), 4);
 	TableItem item = _getItem (index[0]);
+	GTK.gtk_tree_path_free (path);
 	if (item.isDisposed()) {
 		return 0;
 	}
-	GTK.gtk_tree_path_free (path);
 	if (item != null) OS.g_object_set_qdata (cell, Display.SWT_OBJECT_INDEX2, item.handle);
 	boolean isPixbuf = GTK.GTK_IS_CELL_RENDERER_PIXBUF (cell);
 	boolean isText = GTK.GTK_IS_CELL_RENDERER_TEXT (cell);


### PR DESCRIPTION
Fixes an issue in
https://github.com/eclipse-platform/eclipse.platform.swt/pull/2472