### PR TITLE
Only redraw once after scaling every widget #62

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Composite.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Composite.java
@@ -1984,6 +1984,5 @@ private static void handleDPIChange(Widget widget, int newZoom, float scalingFac
 	for (Control child : composite.getChildren()) {
 		DPIZoomChangeRegistry.applyChange(child, newZoom, scalingFactor);
 	}
-	composite.redrawInPixels (null, true);
 }
 }


### PR DESCRIPTION
This PR contributes to reducing the number of redraws and only draw once all the widgets have performed scaling using their Widget:handleDpiChange handlers.

contributes to
https://github.com/eclipse-platform/eclipse.platform.swt/issues/62 and https://github.com/eclipse-platform/eclipse.platform.swt/issues/128