### PR TITLE
Remove the additional SORT_WIDTH spacing logic in Tree column rendering.

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Tree.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Tree.java
@@ -114,7 +114,6 @@ public class Tree extends Composite {
 	static final int TIMER_MAX_COUNT = 8;
 	static final int INSET = 3;
 	static final int GRID_WIDTH = 1;
-	static final int SORT_WIDTH = 10;
 	static final int HEADER_MARGIN = 12;
 	static final int HEADER_EXTRA = 3;
 	static final int INCREMENT = 5;

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TreeColumn.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TreeColumn.java
@@ -377,17 +377,9 @@ public void pack () {
 	OS.DrawText (hDC, buffer, buffer.length, rect, flags);
 	int headerWidth = rect.right - rect.left + Win32DPIUtils.pointToPixel(Tree.HEADER_MARGIN, getZoom());
 	if (OS.IsAppThemed ()) headerWidth += Win32DPIUtils.pointToPixel(Tree.HEADER_EXTRA, getZoom());
-	if (image != null || parent.sortColumn == this) {
-		Image headerImage = null;
-		if (parent.sortColumn == this && parent.sortDirection != SWT.NONE) {
-			headerWidth += Win32DPIUtils.pointToPixel(Tree.SORT_WIDTH, getZoom()) ;
-		} else {
-			headerImage = image;
-		}
-		if (headerImage != null) {
-			Rectangle bounds = Win32DPIUtils.pointToPixel(headerImage.getBounds(), getZoom());
-			headerWidth += bounds.width;
-		}
+	if (image != null) {
+		Rectangle bounds = Win32DPIUtils.pointToPixel(image.getBounds(), getZoom());
+		headerWidth += bounds.width;
 		int margin = 0;
 		if (hwndHeader != 0) {
 			margin = (int)OS.SendMessage (hwndHeader, OS.HDM_GETBITMAPMARGIN, 0, 0);


### PR DESCRIPTION
Since Windows 7, the sort indicator in tree columns is rendered above the column header text, whereas in Windows XP it was placed next to the text. The original SWT implementation added extra pixels (SORT_WIDTH) to the column width to make space for the indicator.

**In Windows XP**, the indicator was next to the line, where the logic probably originated from. See,

<img width="386" height="154" alt="image" src="https://github.com/user-attachments/assets/afaa92bb-9e6e-4404-8203-07ec43908293" />

**From Windows 7** onwards, the sort indicator is on top like this, 

<img width="332" height="299" alt="image" src="https://github.com/user-attachments/assets/206cf534-c6b1-4c4d-b86b-9dd28f977bc6" />
