### PR TITLE
Remove the SORT_WIDTH spacing logic in Table column rendering.

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Table.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Table.java
@@ -95,7 +95,6 @@ public class Table extends Composite {
 	static /*final*/ long HeaderProc;
 	static final int INSET = 4;
 	static final int GRID_WIDTH = 1;
-	static final int SORT_WIDTH = 10;
 	static final int HEADER_MARGIN = 12;
 	static final int HEADER_EXTRA = 3;
 	static final int VISTA_EXTRA = 2;

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TableColumn.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TableColumn.java
@@ -408,14 +408,10 @@ public void pack () {
 	int headerWidth = (int)OS.SendMessage (hwnd, OS.LVM_GETSTRINGWIDTH, 0, buffer) + Table.HEADER_MARGIN;
 	if (OS.IsAppThemed ()) headerWidth += Table.HEADER_EXTRA;
 	boolean hasHeaderImage = false;
-	if (image != null || parent.sortColumn == this) {
+	if (image != null) {
 		hasHeaderImage = true;
-		if (parent.sortColumn == this && parent.sortDirection != SWT.NONE) {
-			headerWidth += Win32DPIUtils.pointToPixel(Table.SORT_WIDTH, getZoom());
-		} else if (image != null) {
-			Rectangle bounds = Win32DPIUtils.pointToPixel(image.getBounds(), getZoom());
-			headerWidth += bounds.width;
-		}
+		Rectangle bounds = Win32DPIUtils.pointToPixel(image.getBounds(), getZoom());
+		headerWidth += bounds.width;
 		long hwndHeader = OS.SendMessage (hwnd, OS.LVM_GETHEADER, 0, 0);
 		int margin = (int)OS.SendMessage (hwndHeader, OS.HDM_GETBITMAPMARGIN, 0, 0);
 		headerWidth += margin * 4;


### PR DESCRIPTION
Since Windows 7, the sort indicator in tree columns is rendered above the column header text, whereas in Windows XP it was placed next to the text. The original SWT implementation added extra pixels (SORT_WIDTH) to the column width to make space for the indicator.