### PR TITLE
Add OfFloat.from methods in Point/Rectangle

### DIFF
--- a/binaries/org.eclipse.swt.cocoa.macosx.aarch64/META-INF/MANIFEST.MF
+++ b/binaries/org.eclipse.swt.cocoa.macosx.aarch64/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Fragment-Host: org.eclipse.swt;bundle-version="[3.128.0,4.0.0)"
 Bundle-Name: %fragmentName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.swt.cocoa.macosx.aarch64; singleton:=true
-Bundle-Version: 3.131.100.qualifier
+Bundle-Version: 3.132.0.qualifier
 Bundle-ManifestVersion: 2
 Bundle-Localization: fragment
 Export-Package: 

--- a/binaries/org.eclipse.swt.cocoa.macosx.x86_64/META-INF/MANIFEST.MF
+++ b/binaries/org.eclipse.swt.cocoa.macosx.x86_64/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Fragment-Host: org.eclipse.swt;bundle-version="[3.128.0,4.0.0)"
 Bundle-Name: %fragmentName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.swt.cocoa.macosx.x86_64; singleton:=true
-Bundle-Version: 3.131.100.qualifier
+Bundle-Version: 3.132.0.qualifier
 Bundle-ManifestVersion: 2
 Bundle-Localization: fragment
 Export-Package: 

--- a/binaries/org.eclipse.swt.gtk.linux.aarch64/META-INF/MANIFEST.MF
+++ b/binaries/org.eclipse.swt.gtk.linux.aarch64/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Fragment-Host: org.eclipse.swt;bundle-version="[3.128.0,4.0.0)"
 Bundle-Name: %fragmentName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.swt.gtk.linux.aarch64; singleton:=true
-Bundle-Version: 3.131.100.qualifier
+Bundle-Version: 3.132.0.qualifier
 Bundle-ManifestVersion: 2
 Bundle-Localization: fragment
 Export-Package: 

--- a/binaries/org.eclipse.swt.gtk.linux.loongarch64/META-INF/MANIFEST.MF
+++ b/binaries/org.eclipse.swt.gtk.linux.loongarch64/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Fragment-Host: org.eclipse.swt;bundle-version="[3.128.0,4.0.0)"
 Bundle-Name: %fragmentName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.swt.gtk.linux.loongarch64; singleton:=true
-Bundle-Version: 3.131.0.qualifier
+Bundle-Version: 3.132.0.qualifier
 Bundle-ManifestVersion: 2
 Bundle-Localization: fragment
 Export-Package: 

--- a/binaries/org.eclipse.swt.gtk.linux.ppc64le/META-INF/MANIFEST.MF
+++ b/binaries/org.eclipse.swt.gtk.linux.ppc64le/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Fragment-Host: org.eclipse.swt;bundle-version="[3.128.0,4.0.0)"
 Bundle-Name: %fragmentName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.swt.gtk.linux.ppc64le;singleton:=true
-Bundle-Version: 3.131.100.qualifier
+Bundle-Version: 3.132.0.qualifier
 Bundle-ManifestVersion: 2
 Bundle-Localization: fragment
 Export-Package: 

--- a/binaries/org.eclipse.swt.gtk.linux.riscv64/META-INF/MANIFEST.MF
+++ b/binaries/org.eclipse.swt.gtk.linux.riscv64/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Fragment-Host: org.eclipse.swt;bundle-version="[3.128.0,4.0.0)"
 Bundle-Name: %fragmentName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.swt.gtk.linux.riscv64; singleton:=true
-Bundle-Version: 3.131.100.qualifier
+Bundle-Version: 3.132.0.qualifier
 Bundle-ManifestVersion: 2
 Bundle-Localization: fragment
 Export-Package: 

--- a/binaries/org.eclipse.swt.gtk.linux.x86_64/META-INF/MANIFEST.MF
+++ b/binaries/org.eclipse.swt.gtk.linux.x86_64/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Fragment-Host: org.eclipse.swt;bundle-version="[3.128.0,4.0.0)"
 Bundle-Name: %fragmentName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.swt.gtk.linux.x86_64; singleton:=true
-Bundle-Version: 3.131.100.qualifier
+Bundle-Version: 3.132.0.qualifier
 Bundle-ManifestVersion: 2
 Bundle-Localization: fragment
 Export-Package: 

--- a/binaries/org.eclipse.swt.win32.win32.aarch64/META-INF/MANIFEST.MF
+++ b/binaries/org.eclipse.swt.win32.win32.aarch64/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Fragment-Host: org.eclipse.swt;bundle-version="[3.128.0,4.0.0)"
 Bundle-Name: %fragmentName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.swt.win32.win32.aarch64; singleton:=true
-Bundle-Version: 3.131.100.qualifier
+Bundle-Version: 3.132.0.qualifier
 Bundle-ManifestVersion: 2
 Bundle-Localization: fragment
 Export-Package: 

--- a/binaries/org.eclipse.swt.win32.win32.x86_64/META-INF/MANIFEST.MF
+++ b/binaries/org.eclipse.swt.win32.win32.x86_64/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Fragment-Host: org.eclipse.swt;bundle-version="[3.128.0,4.0.0)"
 Bundle-Name: %fragmentName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.swt.win32.win32.x86_64; singleton:=true
-Bundle-Version: 3.131.100.qualifier
+Bundle-Version: 3.132.0.qualifier
 Bundle-ManifestVersion: 2
 Bundle-Localization: fragment
 Export-Package: 

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/Point.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/Point.java
@@ -43,7 +43,7 @@ import org.eclipse.swt.widgets.*;
  * @see <a href="http://www.eclipse.org/swt/">Sample code and further information</a>
  */
 
-public sealed class Point implements Serializable permits Point.OfFloat {
+public sealed class Point implements Serializable, Cloneable permits Point.OfFloat {
 
 	/**
 	 * the x coordinate of the point
@@ -119,6 +119,15 @@ public String toString () {
 }
 
 /**
+ * Creates and returns a shallow copy of this {@code Point}.
+ * @since 3.132
+ */
+@Override
+public Point clone() {
+	return new Point(x, y);
+}
+
+/**
  * Instances of this class represent {@link org.eclipse.swt.graphics.Point}
  * objects with the fields capable of storing more precise value in float.
  *
@@ -158,6 +167,21 @@ public static sealed class OfFloat extends Point permits Point.WithMonitor {
 		this.y = Math.round(y);
 		this.residualY = y - this.y;
 	}
+
+	@Override
+	public Point.OfFloat clone() {
+		return new Point.OfFloat(getX(), getY());
+	}
+
+	/**
+	 * Creates a shallow copy of the provided point as a Point.OfFloat instance.
+	 */
+	public static Point.OfFloat from(Point point) {
+		if (point instanceof Point.OfFloat pointOfFloat) {
+			return pointOfFloat.clone();
+		}
+		return new Point.OfFloat(point.x, point.y);
+	}
 }
 
 /**
@@ -187,6 +211,11 @@ public static final class WithMonitor extends Point.OfFloat {
 		this.monitor = monitor;
 	}
 
+	private WithMonitor(float x, float y, Monitor monitor) {
+		super(x, y);
+		this.monitor = monitor;
+	}
+
 	/**
 	 * {@return the monitor with whose context the instance is created}
 	 */
@@ -194,6 +223,10 @@ public static final class WithMonitor extends Point.OfFloat {
 		return monitor;
 	}
 
+	@Override
+	public Point.WithMonitor clone() {
+		return new WithMonitor(getX(), getY(), monitor);
+	}
 }
 
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/Rectangle.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/Rectangle.java
@@ -459,6 +459,21 @@ public static sealed class OfFloat extends Rectangle permits Rectangle.WithMonit
 		this.residualHeight = height - this.height;
 	}
 
+	@Override
+	public Rectangle.OfFloat clone() {
+		return new Rectangle.OfFloat(getX(), getY(), getWidth(), getHeight());
+	}
+
+	/**
+	 * Creates a shallow copy of the provided Rectangle as a Rectangle.OfFloat instance.
+	 */
+	public static Rectangle.OfFloat from(Rectangle rectangle) {
+		if (rectangle instanceof Rectangle.OfFloat rectangleOfFloat) {
+			return rectangleOfFloat.clone();
+		}
+		return new Rectangle.OfFloat(rectangle.x, rectangle.y, rectangle.width, rectangle.height);
+	}
+
 }
 
 /**

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/Win32DPIUtils.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/Win32DPIUtils.java
@@ -115,7 +115,7 @@ public class Win32DPIUtils {
 
 	public static Point pixelToPoint(Point point, int zoom) {
 		if (zoom == 100 || point == null) return point;
-		Point.OfFloat fPoint = FloatAwareGeometryFactory.createFrom(point);
+		Point.OfFloat fPoint = Point.OfFloat.from(point);
 		float scaleFactor = DPIUtil.getScalingFactor(zoom);
 		float scaledX = fPoint.getX() / scaleFactor;
 		float scaledY = fPoint.getY() / scaleFactor;
@@ -170,7 +170,7 @@ public class Win32DPIUtils {
 	 */
 	private static Rectangle scaleBounds (Rectangle.OfFloat rect, int targetZoom, int currentZoom) {
 		if (rect == null || targetZoom == currentZoom) return rect;
-		Rectangle.OfFloat fRect = FloatAwareGeometryFactory.createFrom(rect);
+		Rectangle.OfFloat fRect = Rectangle.OfFloat.from(rect);
 		float scaleFactor = DPIUtil.getScalingFactor(targetZoom, currentZoom);
 		float scaledX = fRect.getX() * scaleFactor;
 		float scaledY = fRect.getY() * scaleFactor;
@@ -221,7 +221,7 @@ public class Win32DPIUtils {
 
 	public static Point pointToPixel(Point point, int zoom) {
 		if (zoom == 100 || point == null) return point;
-		Point.OfFloat fPoint = FloatAwareGeometryFactory.createFrom(point);
+		Point.OfFloat fPoint = Point.OfFloat.from(point);
 		float scaleFactor = DPIUtil.getScalingFactor(zoom);
 		float scaledX = fPoint.getX() * scaleFactor;
 		float scaledY = fPoint.getY() * scaleFactor;
@@ -328,22 +328,6 @@ public class Win32DPIUtils {
 		@Override
 		public ImageData getImageData(int zoom) {
 			return DPIUtil.scaleImageData(device, imageData, zoom, currentZoom);
-		}
-	}
-
-	private class FloatAwareGeometryFactory {
-		static Rectangle.OfFloat createFrom(Rectangle rectangle) {
-			if (rectangle instanceof Rectangle.OfFloat) {
-				return (Rectangle.OfFloat) rectangle;
-			}
-			return new Rectangle.OfFloat(rectangle.x, rectangle.y, rectangle.width, rectangle.height);
-		}
-
-		static Point.OfFloat createFrom(Point point) {
-			if (point instanceof Point.OfFloat) {
-				return (Point.OfFloat) point;
-			}
-			return new Point.OfFloat(point.x, point.y);
 		}
 	}
 }


### PR DESCRIPTION
This PR adds Rectangle.OfFloat.from and Point.OfFloat.from methods and removes the Win32DPIUtils.FloatAwareGeometryFactory class to make these methods OS-independent.