### PR TITLE
[Win32] Return unrounded value in FontMetrics.getAverageCharacterWidth

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/DPIUtil.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/DPIUtil.java
@@ -197,6 +197,12 @@ public static float pixelToPoint(float size, int zoom) {
 	return (size / scaleFactor);
 }
 
+public static double pixelToPoint(double size, int zoom) {
+	if (zoom == 100 || size == SWT.DEFAULT) return size;
+	double scaleFactor = getScalingFactor (zoom, 100);
+	return size / scaleFactor;
+}
+
 
 /**
  * Auto-scale image with ImageData

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/FontMetrics.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/FontMetrics.java
@@ -108,7 +108,7 @@ public int getAscent() {
  * @since 3.107
  */
 public double getAverageCharacterWidth() {
-	return getAverageCharWidth();
+	return DPIUtil.pixelToPoint((double) handle.tmAveCharWidth, getZoom());
 }
 
 /**


### PR DESCRIPTION
Fixes: https://github.com/eclipse-platform/eclipse.platform.swt/issues/2461