### PR TITLE
Spin event loop to process pending UI updates before checking the pasted content on the Text.

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Combo.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Combo.java
@@ -494,12 +494,6 @@ Point computeNativeSize (long h, int wHint, int hHint, boolean changed) {
  * <p>
  * The current selection is copied to the clipboard.
  * </p>
- * <p>
- * <strong>Note:</strong> Copy data to the Clipboard may be asynchronous. This
- * means that the new clipboard content may not be immediately available right
- * after calling this method. To ensure the update is visible, use
- * {@link Display#asyncExec(Runnable)} before accessing the clipboard data.
- * </p>
  * @exception SWTException <ul>
  *    <li>ERROR_WIDGET_DISPOSED - if the receiver has been disposed</li>
  *    <li>ERROR_THREAD_INVALID_ACCESS - if not called from the thread that created the receiver</li>

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Text.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Text.java
@@ -739,7 +739,6 @@ Rectangle computeTrimInPixels (int x, int y, int width, int height) {
  * <p>
  * The current selection is copied to the clipboard.
  * </p>
- *
  * @exception SWTException <ul>
  *    <li>ERROR_WIDGET_DISPOSED - if the receiver has been disposed</li>
  *    <li>ERROR_THREAD_INVALID_ACCESS - if not called from the thread that created the receiver</li>
@@ -2105,7 +2104,12 @@ long paintWindow () {
  * The selected text is deleted from the widget
  * and new text inserted from the clipboard.
  * </p>
- *
+ * <p>
+ * <strong>Note:</strong> Pasting data to controls may occurs asynchronously. The widget
+ * text may not reflect the updated value immediately after calling this method.
+ * The new text will appear once pending events are processed in the event loop.
+ * Use {@link Display#asyncExec(Runnable)} before accessing <code>getText()</code>.
+ * </p>
  * @exception SWTException <ul>
  *    <li>ERROR_WIDGET_DISPOSED - if the receiver has been disposed</li>
  *    <li>ERROR_THREAD_INVALID_ACCESS - if not called from the thread that created the receiver</li>

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Text.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Text.java
@@ -288,6 +288,11 @@ public void test_copy() {
 
 	text.setText("");
 	text.paste();
+	// Spin the event loop to let GTK process the clipboard + entry update
+	Display display = text.getDisplay();
+	while (display.readAndDispatch()) {
+	    // loop until no more events
+	}
 	assertEquals("00000", text.getText());
 
 	// tests a SINGLE line text editor
@@ -307,6 +312,9 @@ public void test_copy() {
 
 	text.setText("");
 	text.paste();
+	while (display.readAndDispatch()) {
+	    // loop until no more events
+	}
 	assertEquals("00000", text.getText());
 }
 


### PR DESCRIPTION
As content copy/paste works well manually junit fails because junit checks the text content well before it is updated by GTK. So it is a timing delay. Processing all the pending events make sure text is updated(Either by introducing some delay in junit or really processing any pending UI updates).

see https://github.com/eclipse-platform/eclipse.platform.swt/issues/2491