### PR TITLE
[Win32] Fix potential memory leak in GC#drawImage #2499

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/GC.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/GC.java
@@ -16,6 +16,7 @@ package org.eclipse.swt.graphics;
 
 import java.util.*;
 import java.util.List;
+import java.util.function.*;
 import java.util.stream.*;
 
 import org.eclipse.swt.*;
@@ -494,9 +495,11 @@ public void copyArea (Image image, int x, int y) {
 private abstract class ImageOperation extends Operation {
 	private Image image;
 
+	private final Consumer<Image> disposeCallback = this::setCopyOfImage;
+
 	ImageOperation(Image image) {
 		setImage(image);
-		image.addOnDisposeListener(this::setCopyOfImage);
+		image.addOnDisposeListener(disposeCallback);
 	}
 
 	private void setImage(Image image) {
@@ -515,6 +518,11 @@ private abstract class ImageOperation extends Operation {
 		return image;
 	}
 
+	@Override
+	void disposeAll() {
+		image.removeOnDisposeListener(disposeCallback);
+		super.disposeAll();
+	}
 }
 
 private class CopyAreaToImageOperation extends ImageOperation {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Image.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Image.java
@@ -1020,10 +1020,18 @@ void addOnDisposeListener(Consumer<Image> onDisposeListener) {
 	onDisposeListeners.add(onDisposeListener);
 }
 
+void removeOnDisposeListener(Consumer<Image> onDisposeListener) {
+	if (onDisposeListeners == null) {
+		return;
+	}
+	onDisposeListeners.remove(onDisposeListener);
+}
+
 @Override
 public void dispose() {
 	if (onDisposeListeners != null) {
 		onDisposeListeners.forEach(listener -> listener.accept(this));
+		onDisposeListeners.clear();
 	}
 	super.dispose();
 }


### PR DESCRIPTION
When calling `GC#drawImage()`, an operation is created (like for every execution on GC) which stores the image to draw. Since the image may be disposed afterwards, a dispose listener is registered to the image, such that the image can be copied and maintained inside the operation in case of a disposal until that operation itself is disposed. The listener is currently not de-registered when disposing the GC and its operations, thus the GC operations (and thus also the containing GC) will still be referenced (as listeners from the image) until that image is disposed. Since images may be long living (or never be disposed at all), this can lead to a memory leak.

This change removes the listener from the image upon disposal of a GC and its operations such that no memory can occur.

Fixes https://github.com/eclipse-platform/eclipse.platform.swt/issues/2499