### PR TITLE
[POC] When computing the size of a widget always return values rounded up

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/Point.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/Point.java
@@ -16,6 +16,7 @@ package org.eclipse.swt.graphics;
 
 import java.io.*;
 
+import org.eclipse.swt.internal.*;
 import org.eclipse.swt.widgets.*;
 
 /**
@@ -144,8 +145,8 @@ public static sealed class OfFloat extends Point permits Point.WithMonitor {
 		super(x, y);
 	}
 
-	public OfFloat(float x, float y) {
-		super(Math.round(x), Math.round(y));
+	public OfFloat(float x, float y, RoundingMode mode) {
+		super(mode.round(x), mode.round(y));
 		this.residualX = x - this.x;
 		this.residualY = y - this.y;
 	}

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/RoundingMode.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/RoundingMode.java
@@ -1,0 +1,17 @@
+package org.eclipse.swt.internal;
+/**
+* @noreference This class is not intended to be referenced by clients
+*/
+public enum RoundingMode {
+ ROUND, UP;
+
+int round(float x) {
+	if (this == ROUND) {
+		return Math.round(x);
+	}
+	if (this == UP) {
+		return (int) Math.ceil(x);
+	}
+	return (int) x;
+}
+}

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/Win32DPIUtils.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/Win32DPIUtils.java
@@ -114,12 +114,17 @@ public class Win32DPIUtils {
 	}
 
 	public static Point pixelToPoint(Point point, int zoom) {
+		//TODO actually all callers should explicitly state what mode the want!
+		return pixelToPoint(point, zoom, RoundingMode.ROUND);
+	}
+
+	public static Point pixelToPoint(Point point, int zoom, RoundingMode mode) {
 		if (zoom == 100 || point == null) return point;
 		Point.OfFloat fPoint = Point.OfFloat.from(point);
 		float scaleFactor = DPIUtil.getScalingFactor(zoom);
 		float scaledX = fPoint.getX() / scaleFactor;
 		float scaledY = fPoint.getY() / scaleFactor;
-		return new Point.OfFloat(scaledX, scaledY);
+		return new Point.OfFloat(scaledX, scaledY, mode);
 	}
 
 	public static Point pixelToPoint(Drawable drawable, Point point, int zoom) {
@@ -225,7 +230,7 @@ public class Win32DPIUtils {
 		float scaleFactor = DPIUtil.getScalingFactor(zoom);
 		float scaledX = fPoint.getX() * scaleFactor;
 		float scaledY = fPoint.getY() * scaleFactor;
-		return new Point.OfFloat(scaledX, scaledY);
+		return new Point.OfFloat(scaledX, scaledY, RoundingMode.ROUND);
 	}
 
 	public static Point pointToPixel(Drawable drawable, Point point, int zoom) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Control.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Control.java
@@ -620,7 +620,9 @@ public Point computeSize (int wHint, int hHint, boolean changed){
 	int zoom = getZoom();
 	wHint = (wHint != SWT.DEFAULT ? Win32DPIUtils.pointToPixel(wHint, zoom) : wHint);
 	hHint = (hHint != SWT.DEFAULT ? Win32DPIUtils.pointToPixel(hHint, zoom) : hHint);
-	return Win32DPIUtils.pixelToPoint(computeSizeInPixels(wHint, hHint, changed), zoom);
+	//We should never return a size that is to small, RoundingMode.UP ensures we at worst case report
+	//a size that is a bit too large by half a point
+	return Win32DPIUtils.pixelToPoint(computeSizeInPixels(wHint, hHint, changed), zoom, RoundingMode.UP);
 }
 
 Point computeSizeInPixels (int wHint, int hHint, boolean changed) {
@@ -1372,7 +1374,8 @@ public Object getLayoutData () {
  */
 public Point getLocation () {
 	checkWidget ();
-	return Win32DPIUtils.pixelToPoint(getLocationInPixels(), getZoom());
+	//For a location the closest point values is okay
+	return Win32DPIUtils.pixelToPoint(getLocationInPixels(), getZoom(), RoundingMode.ROUND);
 }
 
 Point getLocationInPixels () {
@@ -1528,7 +1531,7 @@ public Shell getShell () {
  */
 public Point getSize (){
 	checkWidget ();
-	return Win32DPIUtils.pixelToPoint(getSizeInPixels (), getZoom());
+	return Win32DPIUtils.pixelToPoint(getSizeInPixels (), getZoom(), RoundingMode.UP);
 }
 
 Point getSizeInPixels () {
@@ -4030,7 +4033,7 @@ public Point toControl (int x, int y) {
 	checkWidget ();
 	Point displayPointInPixels = getDisplay().translateToDisplayCoordinates(new Point(x, y));
 	final Point controlPointInPixels = toControlInPixels(displayPointInPixels.x, displayPointInPixels.y);
-	return Win32DPIUtils.pixelToPoint(controlPointInPixels, getZoom());
+	return Win32DPIUtils.pixelToPoint(controlPointInPixels, getZoom(), RoundingMode.ROUND);
 }
 
 Point toControlInPixels (int x, int y) {


### PR DESCRIPTION
When converting pixels to point there can be depending on the zoom level be a fractional result.
Currently in all cases these result is converted into an integer using `Math.round()` that will make values `+/-0.5` resulting in small values to be round towards a smaller value (see [here](https://github.com/eclipse-platform/eclipse.platform.swt/pull/2381#issuecomment-3266317612)).

While it is maybe valid for a _location_, when using points to express a _dimension_ this is not okay as it will result in the reported (integer) value to be to small leading to errors when the SWT API is then used after performing additional computations maybe.

This now makes the following adjustments:

1. Introduce a rounding mode that allows different ways of rounding and adds as a first step ROUND (the previous default) and UP (for always round towards the largest integer)
2. Adjust the `Control` class to decide what mode is best in what situation.

See
- https://github.com/eclipse-platform/eclipse.platform.swt/pull/2381
- https://github.com/eclipse-platform/eclipse.platform.swt/issues/2166