### PR TITLE
Extend ImageLoader to be able to load images at a given height and width

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/graphics/Image.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/graphics/Image.java
@@ -692,7 +692,7 @@ public Image(Device device, InputStream stream) {
 	try {
 		byte[] input = stream.readAllBytes();
 		initWithSupplier(zoom -> ImageDataLoader.canLoadAtZoom(new ByteArrayInputStream(input), FileFormat.DEFAULT_ZOOM, zoom),
-				zoom -> ImageDataLoader.load(new ByteArrayInputStream(input), FileFormat.DEFAULT_ZOOM, zoom).element());
+				zoom -> ImageDataLoader.loadByZoom(new ByteArrayInputStream(input), FileFormat.DEFAULT_ZOOM, zoom).element());
 		init();
 	} catch (IOException e) {
 		SWT.error(SWT.ERROR_INVALID_ARGUMENT, e);
@@ -742,7 +742,7 @@ public Image(Device device, String filename) {
 		initNative(filename);
 		if (this.handle == null) {
 			initWithSupplier(zoom -> ImageDataLoader.canLoadAtZoom(filename, FileFormat.DEFAULT_ZOOM, zoom),
-					zoom -> ImageDataLoader.load(filename, FileFormat.DEFAULT_ZOOM, zoom).element());
+					zoom -> ImageDataLoader.loadByZoom(filename, FileFormat.DEFAULT_ZOOM, zoom).element());
 		}
 		init();
 	} finally {
@@ -789,7 +789,7 @@ public Image(Device device, ImageFileNameProvider imageFileNameProvider) {
 	if (!NSThread.isMainThread()) pool = (NSAutoreleasePool) new NSAutoreleasePool().alloc().init();
 	try {
 		initNative(filename);
-		if (this.handle == null) init(ImageDataLoader.load(filename, 100, 100).element(), 100);
+		if (this.handle == null) init(ImageDataLoader.loadByZoom(filename, 100, 100).element(), 100);
 		init();
 		String filename2x = imageFileNameProvider.getImagePath(200);
 		if (filename2x != null) {
@@ -799,7 +799,7 @@ public Image(Device device, ImageFileNameProvider imageFileNameProvider) {
 			handle.addRepresentation(rep);
 		} else if (ImageDataLoader.canLoadAtZoom(filename, 100, 200)) {
 			// Try to natively scale up the image (e.g. possible if it's an SVG)
-			ImageData imageData2x = ImageDataLoader.load(filename, 100, 200).element();
+			ImageData imageData2x = ImageDataLoader.loadByZoom(filename, 100, 200).element();
 			alphaInfo_200 = new AlphaInfo();
 			NSBitmapImageRep rep = createRepresentation (imageData2x, alphaInfo_200);
 			handle.addRepresentation(rep);

--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/internal/NativeImageLoader.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/internal/NativeImageLoader.java
@@ -26,6 +26,10 @@ public class NativeImageLoader {
 		return FileFormat.load(streamAtZoom, imageLoader, targetZoom);
 	}
 
+	public static ImageData load(InputStream streamAtZoom, ImageLoader imageLoader, int width, int height) {
+		return FileFormat.load(streamAtZoom, imageLoader, width, height);
+	}
+
 	public static void save(OutputStream stream, int format, ImageLoader imageLoader) {
 		FileFormat.save(stream, format, imageLoader);
 	}

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/ImageDataLoader.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/ImageDataLoader.java
@@ -41,20 +41,32 @@ class ImageDataLoader {
 		return ImageLoader.canLoadAtZoom(stream, fileZoom, targetZoom);
 	}
 
-	public static ElementAtZoom<ImageData> load(InputStream stream, int fileZoom, int targetZoom) {
-		List<ElementAtZoom<ImageData>> data = new ImageLoader().load(stream, fileZoom, targetZoom);
-		if (data.isEmpty()) SWT.error(SWT.ERROR_INVALID_IMAGE);
-		return data.get(0);
-	}
-
 	public static boolean canLoadAtZoom(String filename, int fileZoom, int targetZoom) {
 		return ImageLoader.canLoadAtZoom(filename, fileZoom, targetZoom);
 	}
 
-	public static ElementAtZoom<ImageData> load(String filename, int fileZoom, int targetZoom) {
-		List<ElementAtZoom<ImageData>> data = new ImageLoader().load(filename, fileZoom, targetZoom);
+	public static ElementAtZoom<ImageData> loadByZoom(InputStream stream, int fileZoom, int targetZoom) {
+		List<ElementAtZoom<ImageData>> data = new ImageLoader().loadByZoom(stream, fileZoom, targetZoom);
 		if (data.isEmpty()) SWT.error(SWT.ERROR_INVALID_IMAGE);
 		return data.get(0);
+	}
+
+	public static ElementAtZoom<ImageData> loadByZoom(String filename, int fileZoom, int targetZoom) {
+		List<ElementAtZoom<ImageData>> data = new ImageLoader().loadByZoom(filename, fileZoom, targetZoom);
+		if (data.isEmpty()) SWT.error(SWT.ERROR_INVALID_IMAGE);
+		return data.get(0);
+	}
+
+	public static ImageData loadBySize(InputStream stream, int width, int height) {
+		ImageData data = new ImageLoader().loadBySize(stream, width, height);
+		if (data == null) SWT.error(SWT.ERROR_INVALID_IMAGE);
+		return data;
+	}
+
+	public static ImageData loadBySize(String filename, int width, int height) {
+		ImageData data = new ImageLoader().loadBySize(filename, width, height);
+		if (data == null) SWT.error(SWT.ERROR_INVALID_IMAGE);
+		return data;
 	}
 
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/ImageLoader.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/ImageLoader.java
@@ -151,16 +151,24 @@ void reset() {
  * </ul>
  */
 public ImageData[] load(InputStream stream) {
-	load(stream, FileFormat.DEFAULT_ZOOM, FileFormat.DEFAULT_ZOOM);
+	loadByZoom(stream, FileFormat.DEFAULT_ZOOM, FileFormat.DEFAULT_ZOOM);
 	return data;
 }
 
-List<ElementAtZoom<ImageData>> load(InputStream stream, int fileZoom, int targetZoom) {
+List<ElementAtZoom<ImageData>> loadByZoom(InputStream stream, int fileZoom, int targetZoom) {
 	if (stream == null) SWT.error(SWT.ERROR_NULL_ARGUMENT);
 	reset();
 	List<ElementAtZoom<ImageData>> images = NativeImageLoader.load(new ElementAtZoom<>(stream, fileZoom), this, targetZoom);
 	data = images.stream().map(ElementAtZoom::element).toArray(ImageData[]::new);
 	return images;
+}
+
+ImageData loadBySize(InputStream stream, int width, int height) {
+	if (stream == null) SWT.error(SWT.ERROR_NULL_ARGUMENT);
+	reset();
+	ImageData image = NativeImageLoader.load(stream, this, width, height);
+	data = new ImageData[] {image};
+	return image;
 }
 
 static boolean canLoadAtZoom(InputStream stream, int fileZoom, int targetZoom) {
@@ -187,14 +195,24 @@ static boolean canLoadAtZoom(InputStream stream, int fileZoom, int targetZoom) {
  * </ul>
  */
 public ImageData[] load(String filename) {
-	load(filename, FileFormat.DEFAULT_ZOOM, FileFormat.DEFAULT_ZOOM);
+	loadByZoom(filename, FileFormat.DEFAULT_ZOOM, FileFormat.DEFAULT_ZOOM);
 	return data;
 }
 
-List<ElementAtZoom<ImageData>> load(String filename, int fileZoom, int targetZoom) {
+List<ElementAtZoom<ImageData>> loadByZoom(String filename, int fileZoom, int targetZoom) {
 	if (filename == null) SWT.error(SWT.ERROR_NULL_ARGUMENT);
 	try (InputStream stream = new FileInputStream(filename)) {
-		return load(stream, fileZoom, targetZoom);
+		return loadByZoom(stream, fileZoom, targetZoom);
+	} catch (IOException e) {
+		SWT.error(SWT.ERROR_IO, e);
+	}
+	return null;
+}
+
+ImageData loadBySize(String filename, int width, int height) {
+	if (filename == null) SWT.error(SWT.ERROR_NULL_ARGUMENT);
+	try (InputStream stream = new FileInputStream(filename)) {
+		return loadBySize(stream, width, height);
 	} catch (IOException e) {
 		SWT.error(SWT.ERROR_IO, e);
 	}

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/image/FileFormat.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/image/FileFormat.java
@@ -85,6 +85,11 @@ public abstract class FileFormat {
 		List<ElementAtZoom<ImageData>> loadFromByteStream(int fileZoom, int targetZoom) {
 			return Arrays.stream(loadFromByteStream()).map(d -> new ElementAtZoom<>(d, fileZoom)).toList();
 		}
+
+		@Override
+		ImageData loadFromByteStreamBySize(int width, int height) {
+			return loadFromByteStream()[0];
+		}
 	}
 
 	LEDataInputStream inputStream;
@@ -104,6 +109,8 @@ public abstract class FileFormat {
 	 */
 	abstract List<ElementAtZoom<ImageData>> loadFromByteStream(int fileZoom, int targetZoom);
 
+	abstract ImageData loadFromByteStreamBySize(int width, int height);
+
 /**
  * Read the specified input stream, and return the
  * device independent image array represented by the stream.
@@ -112,6 +119,20 @@ public List<ElementAtZoom<ImageData>> loadFromStream(LEDataInputStream stream, i
 	try {
 		inputStream = stream;
 		return loadFromByteStream(fileZoom, targetZoom);
+	} catch (Exception e) {
+		if (e instanceof IOException) {
+			SWT.error(SWT.ERROR_IO, e);
+		} else {
+			SWT.error(SWT.ERROR_INVALID_IMAGE, e);
+		}
+		return null;
+	}
+}
+
+public ImageData loadFromStreamBySize(LEDataInputStream stream, int width, int height) {
+	try {
+		inputStream = stream;
+		return loadFromByteStreamBySize(width, height);
 	} catch (Exception e) {
 		if (e instanceof IOException) {
 			SWT.error(SWT.ERROR_IO, e);
@@ -134,6 +155,16 @@ public static List<ElementAtZoom<ImageData>> load(ElementAtZoom<InputStream> is,
 	});
 	fileFormat.loader = loader;
 	return fileFormat.loadFromStream(stream, is.zoom(), targetZoom);
+}
+
+public static ImageData load(InputStream is, ImageLoader loader, int width, int height) {
+	LEDataInputStream stream = new LEDataInputStream(is);
+	FileFormat fileFormat = determineFileFormat(stream).orElseGet(() -> {
+		SWT.error(SWT.ERROR_UNSUPPORTED_FORMAT);
+		return null;
+	});
+	fileFormat.loader = loader;
+	return fileFormat.loadFromStreamBySize(stream, width, height);
 }
 
 public static boolean canLoadAtZoom(ElementAtZoom<InputStream> is, int targetZoom) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/image/SVGFileFormat.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/image/SVGFileFormat.java
@@ -56,6 +56,18 @@ public class SVGFileFormat extends FileFormat {
 	}
 
 	@Override
+	ImageData loadFromByteStreamBySize(int width, int height) {
+		if (RASTERIZER == null) {
+			SWT.error(SWT.ERROR_UNSUPPORTED_FORMAT, null, " [No SVG rasterizer found]");
+		}
+		if (width <= 0 || height <= 0) {
+			SWT.error(SWT.ERROR_INVALID_ARGUMENT, null, " [Cannot rasterize SVG for width or height <= 0]");
+		}
+		ImageData rasterizedImageData = RASTERIZER.rasterizeSVG(inputStream, width, height);
+		return rasterizedImageData;
+	}
+
+	@Override
 	void unloadIntoByteStream(ImageLoader loader) {
 		throw new UnsupportedOperationException();
 	}

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/graphics/Image.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/graphics/Image.java
@@ -552,7 +552,7 @@ public Image(Device device, ImageData source, ImageData mask) {
 public Image(Device device, InputStream stream) {
 	super(device);
 	currentDeviceZoom = DPIUtil.getDeviceZoom();
-	ElementAtZoom<ImageData> image = ImageDataLoader.load(stream, FileFormat.DEFAULT_ZOOM, currentDeviceZoom);
+	ElementAtZoom<ImageData> image = ImageDataLoader.loadByZoom(stream, FileFormat.DEFAULT_ZOOM, currentDeviceZoom);
 	ImageData data = DPIUtil.scaleImageData(device, image, currentDeviceZoom);
 	init(data);
 	init();
@@ -594,7 +594,7 @@ public Image(Device device, String filename) {
 	super(device);
 	if (filename == null) SWT.error(SWT.ERROR_NULL_ARGUMENT);
 	currentDeviceZoom = DPIUtil.getDeviceZoom();
-	ElementAtZoom<ImageData> image = ImageDataLoader.load(filename, FileFormat.DEFAULT_ZOOM, currentDeviceZoom);
+	ElementAtZoom<ImageData> image = ImageDataLoader.loadByZoom(filename, FileFormat.DEFAULT_ZOOM, currentDeviceZoom);
 	ImageData data = DPIUtil.scaleImageData(device, image, currentDeviceZoom);
 	init(data);
 	init();
@@ -785,7 +785,7 @@ private void initFromFileNameProvider(int zoom) {
 		initNative(fileForZoom.element());
 	}
 	if (this.surface == 0) {
-		ElementAtZoom<ImageData> imageDataAtZoom = ImageDataLoader.load(fileForZoom.element(), fileForZoom.zoom(), zoom);
+		ElementAtZoom<ImageData> imageDataAtZoom = ImageDataLoader.loadByZoom(fileForZoom.element(), fileForZoom.zoom(), zoom);
 		ImageData imageData = imageDataAtZoom.element();
 		if (imageDataAtZoom.zoom() != zoom) {
 			imageData = DPIUtil.scaleImageData(device, imageDataAtZoom, zoom);

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/internal/NativeImageLoader.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/internal/NativeImageLoader.java
@@ -142,6 +142,10 @@ public class NativeImageLoader {
 		return Arrays.stream(imgDataArray).map(data -> new ElementAtZoom<>(data, streamAtZoom.zoom())).toList();
 	}
 
+	public static ImageData load(InputStream streamAtZoom, ImageLoader imageLoader, int width, int height) {
+		return FileFormat.load(streamAtZoom, imageLoader, width, height);
+	}
+
 	/**
 	 * Return true if the image is an interlaced PNG file. This is used to check
 	 * whether ImageLoaderEvent should be fired when loading images.

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Image.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Image.java
@@ -2127,7 +2127,7 @@ private class ImageDataLoaderStreamProviderWrapper extends ImageFromImageDataPro
 
 	@Override
 	protected ElementAtZoom<ImageData> loadImageData(int zoom) {
-		return ImageDataLoader.load(new ByteArrayInputStream(inputStreamData), FileFormat.DEFAULT_ZOOM, zoom);
+		return ImageDataLoader.loadByZoom(new ByteArrayInputStream(inputStreamData), FileFormat.DEFAULT_ZOOM, zoom);
 	}
 
 	@Override
@@ -2349,7 +2349,7 @@ private class ImageFileNameProviderWrapper extends BaseImageProviderWrapper<Imag
 
 		// Load at appropriate zoom via loader
 		if (fileForZoom.zoom() != zoom && ImageDataLoader.canLoadAtZoom(fileForZoom.element(), fileForZoom.zoom(), zoom)) {
-			ElementAtZoom<ImageData> imageDataAtZoom = ImageDataLoader.load(fileForZoom.element(), fileForZoom.zoom(), zoom);
+			ElementAtZoom<ImageData> imageDataAtZoom = ImageDataLoader.loadByZoom(fileForZoom.element(), fileForZoom.zoom(), zoom);
 			return new ElementAtZoom<>(imageDataAtZoom.element(), zoom);
 		}
 
@@ -2362,7 +2362,7 @@ private class ImageFileNameProviderWrapper extends BaseImageProviderWrapper<Imag
 		}
 		ElementAtZoom<ImageData> imageDataAtZoom;
 		if (nativeInitializedImage == null) {
-			imageDataAtZoom = ImageDataLoader.load(fileForZoom.element(), fileForZoom.zoom(), zoom);
+			imageDataAtZoom = ImageDataLoader.loadByZoom(fileForZoom.element(), fileForZoom.zoom(), zoom);
 		} else {
 			imageDataAtZoom = new ElementAtZoom<>(nativeInitializedImage.getImageData(), fileForZoom.zoom());
 			nativeInitializedImage.destroy();

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/NativeImageLoader.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/NativeImageLoader.java
@@ -26,6 +26,10 @@ public class NativeImageLoader {
 		return FileFormat.load(streamAtZoom, imageLoader, targetZoom);
 	}
 
+	public static ImageData load(InputStream streamAtZoom, ImageLoader imageLoader, int width, int height) {
+		return FileFormat.load(streamAtZoom, imageLoader, width, height);
+	}
+
 	public static void save(OutputStream stream, int format, ImageLoader imageLoader) {
 		FileFormat.save(stream, format, imageLoader);
 	}


### PR DESCRIPTION
Extend ImageLoader to able to load images at a given target height and width in addition to the current behavior of only being able to load images at a target zoom. This is required to load images in svg format at custom height and width.


The extensions added in this change is used in https://github.com/eclipse-platform/eclipse.platform.swt/pull/2526 That PR also contains snippets through which these changes are tested.

This depends on https://github.com/eclipse-platform/eclipse.platform.swt/pull/2514, Only last commit is relevant for this PR