### PR TITLE
Add internal API in SVGrasterizer to rasterize images at given height and width

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/image/SVGRasterizer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/image/SVGRasterizer.java
@@ -41,4 +41,24 @@ public interface SVGRasterizer {
 	 * </ul>
 	 */
 	public ImageData rasterizeSVG(InputStream stream, int zoom);
+
+	/**
+	 * Rasterizes an SVG image from the provided {@code InputStream} into a raster
+	 * image of the specified width and height.
+	 *
+	 * @param stream the SVG image as an {@link InputStream}.
+	 * @param width  the width of the rasterized image in pixels (must be positive).
+	 * @param height the height of the rasterized image in pixels (must be positive).
+	 * @return the {@link ImageData} for the rasterized image.
+	 *
+	 * @exception SWTException
+	 * <ul>
+	 *    <li>ERROR_INVALID_IMAGE - if the SVG cannot be loaded</li>
+	 * </ul>
+	 * @exception IllegalArgumentException
+	 * <ul>
+	 *    <li>ERROR_INVALID_ARGUMENT - if the width or height is less than zero</li>
+	 * </ul>
+	 */
+	public ImageData rasterizeSVG(InputStream stream, int width, int height);
 }

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/JSVGRasterizerTest.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/JSVGRasterizerTest.java
@@ -68,4 +68,33 @@ class JSVGRasterizerTest {
 		assertEquals(SWT.ERROR_INVALID_IMAGE, exception.code);
 	}
 
+	@Test
+	void testRasterizeWithTargetSize() {
+		ImageData data = rasterizer.rasterizeSVG(svgStream(svgString), 300, 150);
+		assertEquals(300, data.width);
+		assertEquals(150, data.height);
+	}
+
+	@Test
+	void testRasterizeWithTargetSizeHavingInvalidHeight() {
+		assertThrows(IllegalArgumentException.class, () -> {
+			rasterizer.rasterizeSVG(svgStream(svgString), -1, 150);
+		});
+	}
+
+	@Test
+	void testRasterizeWithTargetSizeHavingInvalidWidth() {
+		assertThrows(IllegalArgumentException.class, () -> {
+			rasterizer.rasterizeSVG(svgStream(svgString), 150, -1);
+		});
+	}
+
+	@Test
+	void testRasterizeWithTargetSizeWithInvalidSVG() {
+		SWTException exception = assertThrows(SWTException.class, () -> {
+			rasterizer.rasterizeSVG(invalidSvg, 150, 150);
+		});
+		assertEquals(SWT.ERROR_INVALID_IMAGE, exception.code);
+	}
+
 }


### PR DESCRIPTION
It shall be possible to draw images at a custom zoom or size while maintaining the best achievable quality. To support this, images originating from an SVG source must be rasterized at the required size.

The internal API introduced in this PR enables loading SVGs at custom sizes, allowing images to be drawn at any requested zoom level or resolution, as discussed in in https://github.com/vi-eclipse/Eclipse-Platform/issues/326

> **Goal** It shall be possible to draw images at a custom zoom/size at the best achievable quality. This means either
> 
> * rescaling from the most fitting zoomed version of the image that exists
> * rasterizing the image at the according size from an SVG source


This PR specifically adds the internal API to handle rasterization for images coming from SVG sources.