### PR TITLE
GTK4: Fix GTK4 shell location test.

### DIFF
--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Shell.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Shell.java
@@ -457,6 +457,10 @@ public void test_getImeInputMode() {
 @Override
 @Test
 public void test_getLocation() {
+	//Setting location for Windows is not supported in GTK4
+	if (isGTK4()) {
+		return;
+	}
 	shell.setLocation(10,15);
 	assertEquals(":a:", 10, shell.getLocation().x);
 	assertEquals(":b:", 15, shell.getLocation().y);
@@ -998,5 +1002,28 @@ public void test_Issue450_NoShellActivateOnSetFocus() {
 			System.getProperties().remove(key);
 		}
 	}
+}
+
+@Override
+public void test_setLocationLorg_eclipse_swt_graphics_Point() {
+	//Setting location for Windows is not supported in GTK4
+	if (isGTK4()) {
+		return;
+	}
+	super.test_setLocationLorg_eclipse_swt_graphics_Point();
+}
+
+@Override
+public void test_setLocationII() {
+	//Setting location for Windows is not supported in GTK4
+	if (isGTK4()) {
+		return;
+	}
+	super.test_setLocationII();
+}
+
+public static boolean isGTK4() {
+    String gtkVersion = System.getProperty("org.eclipse.swt.internal.gtk.version", "");
+    return SwtTestUtil.isGTK && gtkVersion.startsWith("4");
 }
 }


### PR DESCRIPTION
We cannot set/determine the location of the shell using Window Handle on
GTK4. So fix the test not to test the set and get location on GTK4.

see https://github.com/eclipse-platform/eclipse.platform.swt/issues/2498