### PR TITLE
GC#DrawImage(image, destX, destY, destWidth, destHeight) now tries to load images at the requested destination size before drawing

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/graphics/Image.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/graphics/Image.java
@@ -1818,23 +1818,21 @@ public String toString () {
  *
  * @param gc the GC to draw on the resulting image
  * @param imageData the imageData which is used to draw the scaled Image
- * @param width the width of the original image
- * @param height the height of the original image
- * @param scaleFactor the factor with which the image is supposed to be scaled
+ * @param width the width to which the image is supposed to be scaled
+ * @param height the height to which the image is supposed to be scaled
  *
  * @noreference This method is not intended to be referenced by clients.
  */
-public static void drawScaled(GC gc, ImageData imageData, int width, int height, float scaleFactor) {
+public static void drawAtSize(GC gc, ImageData imageData, int width, int height) {
 	StrictChecks.runWithStrictChecksDisabled(() -> {
 		Image imageToDraw = new Image(gc.device, (ImageDataProvider) zoom -> imageData);
-		gc.drawImage(imageToDraw, 0, 0, CocoaDPIUtil.pixelToPoint(width), CocoaDPIUtil.pixelToPoint(height),
+		gc.drawImage(imageToDraw, 0, 0, CocoaDPIUtil.pixelToPoint(imageData.width), CocoaDPIUtil.pixelToPoint(imageData.height),
 				/*
 				 * E.g. destWidth here is effectively DPIUtil.autoScaleDown (scaledWidth), but
 				 * avoiding rounding errors. Nevertheless, we still have some rounding errors
 				 * due to the point-based API GC#drawImage(..).
 				 */
-				0, 0, Math.round(CocoaDPIUtil.pixelToPoint(width * scaleFactor)),
-				Math.round(CocoaDPIUtil.pixelToPoint(height * scaleFactor)));
+				0, 0,  Math.round(CocoaDPIUtil.pixelToPoint(width)),  Math.round(CocoaDPIUtil.pixelToPoint(height)));
 		imageToDraw.dispose();
 	});
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/ImageDataAtSizeProvider.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/ImageDataAtSizeProvider.java
@@ -1,0 +1,49 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Vector Informatik GmbH and others.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse
+ * Public License 2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Michael Bangas (Vector Informatik GmbH) - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.swt.graphics;
+
+/**
+ * Provides an API that is invoked by SWT when an image needs to be drawn at a
+ * specified width and height.
+ * <p>
+ * Client code must implement this interface to supply {@link ImageData} on demand.
+ * </p>
+ *
+ * @since 3.132
+ * @noreference This class is still experimental API and might be subject to change.
+ */
+public interface ImageDataAtSizeProvider extends ImageDataProvider {
+
+	/**
+	 * Returns the {@link ImageData} for the given width and height.
+	 *
+	 * <p>
+	 * <b>Implementation notes:</b>
+	 * </p>
+	 * <ul>
+	 * <li>Returning <code>null</code> is not permitted. If <code>null</code> is
+	 * returned, SWT will throw an exception when loading the image.</li>
+	 * <li>The returned {@link ImageData} must match the requested width and height
+	 * exactly. Implementations should ensure proper resizing and scaling of the
+	 * image based on the height and width requested</li>
+	 * </ul>
+	 *
+	 * @param width  the desired width of the {@link ImageData} to be returned
+	 * @param height the desired height of the {@link ImageData} to be returned
+	 * @return the {@link ImageData} that exactly matches the requested width and
+	 *         height
+	 * @since 3.132
+	 */
+	ImageData getImageData(int width, int height);
+
+}

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/ImageDataLoader.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/ImageDataLoader.java
@@ -45,6 +45,14 @@ class ImageDataLoader {
 		return ImageLoader.canLoadAtZoom(filename, fileZoom, targetZoom);
 	}
 
+	static boolean isDynamicallySizable(String filename) {
+		return ImageLoader.isDynamicallySizable(filename);
+	}
+
+	static boolean isDynamicallySizable(InputStream stream) {
+		return ImageLoader.isDynamicallySizable(stream);
+	}
+
 	public static ElementAtZoom<ImageData> loadByZoom(InputStream stream, int fileZoom, int targetZoom) {
 		List<ElementAtZoom<ImageData>> data = new ImageLoader().loadByZoom(stream, fileZoom, targetZoom);
 		if (data.isEmpty()) SWT.error(SWT.ERROR_INVALID_IMAGE);

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/ImageLoader.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/ImageLoader.java
@@ -229,6 +229,19 @@ static boolean canLoadAtZoom(String filename, int fileZoom, int targetZoom) {
 	return false;
 }
 
+static boolean isDynamicallySizable(String filename) {
+	try (InputStream stream = new FileInputStream(filename)) {
+		return FileFormat.isDynamicallySizableFormat(stream);
+	} catch (IOException e) {
+		SWT.error(SWT.ERROR_IO, e);
+	}
+	return false;
+}
+
+static boolean isDynamicallySizable(InputStream stream) {
+	return FileFormat.isDynamicallySizableFormat(stream);
+}
+
 /**
  * Saves the image data in this ImageLoader to the specified stream.
  * The format parameter can have one of the following values:

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/DPIUtil.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/DPIUtil.java
@@ -146,6 +146,16 @@ public static ImageData autoScaleImageData (Device device, final ImageData image
 	int height = imageData.height;
 	int scaledWidth = Math.round (width * scaleFactor);
 	int scaledHeight = Math.round (height * scaleFactor);
+	return scaleImage(device, imageData, Image::drawAtSize, scaledWidth, scaledHeight);
+}
+
+@FunctionalInterface
+private interface ImageDrawFunction {
+	void draw(GC gc, ImageData imageData, int width, int height);
+}
+
+private static ImageData scaleImage(Device device, final ImageData imageData, ImageDrawFunction drawFunction,
+		int scaledWidth, int scaledHeight) {
 	int defaultZoomLevel = 100;
 	boolean useSmoothScaling = isSmoothScalingEnabled() && imageData.getTransparencyType() != SWT.TRANSPARENCY_MASK;
 	if (useSmoothScaling) {
@@ -153,7 +163,7 @@ public static ImageData autoScaleImageData (Device device, final ImageData image
 			@Override
 			public void drawOn(GC gc, int imageWidth, int imageHeight) {
 				gc.setAntialias (SWT.ON);
-				Image.drawScaled(gc, imageData, width, height, scaleFactor);
+				drawFunction.draw(gc, imageData, imageWidth, imageHeight);
 			};
 
 			@Override
@@ -168,6 +178,10 @@ public static ImageData autoScaleImageData (Device device, final ImageData image
 	} else {
 		return imageData.scaledTo (scaledWidth, scaledHeight);
 	}
+}
+
+public static ImageData autoScaleImageData(Device device, final ImageData imageData, int targetWidth, int targetHeight) {
+	return scaleImage(device, imageData, Image::drawAtSize, targetWidth, targetHeight);
 }
 
 public static boolean isSmoothScalingEnabled() {

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/graphics/Image.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/graphics/Image.java
@@ -1579,22 +1579,21 @@ public String toString () {
  *
  * @param gc the GC to draw on the resulting image
  * @param imageData the imageData which is used to draw the scaled Image
- * @param width the width of the original image
- * @param height the height of the original image
- * @param scaleFactor the factor with which the image is supposed to be scaled
+ * @param width the width to which the image is supposed to be scaled
+ * @param height the height to which the image is supposed to be scaled
  *
  * @noreference This method is not intended to be referenced by clients.
  */
-public static void drawScaled(GC gc, ImageData imageData, int width, int height, float scaleFactor) {
+public static void drawAtSize(GC gc, ImageData imageData, int width, int height) {
 	StrictChecks.runWithStrictChecksDisabled(() -> {
 		Image imageToDraw = new Image(gc.device, (ImageDataProvider) zoom -> imageData);
-		gc.drawImage(imageToDraw, 0, 0, width, height,
+		gc.drawImage(imageToDraw, 0, 0, imageData.width, imageData.height,
 				/*
 				 * E.g. destWidth here is effectively DPIUtil.autoScaleDown (scaledWidth), but
 				 * avoiding rounding errors. Nevertheless, we still have some rounding errors
 				 * due to the point-based API GC#drawImage(..).
 				 */
-				0, 0, Math.round(width * scaleFactor), Math.round(height * scaleFactor));
+				0, 0, width, height);
 		imageToDraw.dispose();
 	});
 }


### PR DESCRIPTION
The DrawImage API with just destination coordinates now tries to load images at the requested size.
If the requested size is not available, it falls back to the closest available size by calculating the appropriate zoom.
Images are loadable at the target size if the image is created from an SVG stream or filename, or The image is created with an ImageDataProvider that is ImageDataAtSizeProvider.

This commit also introduces the ImageDataAtSizeProvider interface to support dynamic sizing. 


With this changes we need to test the following
1) The svgs are rendered at custom sizes without blurry scaling (this can be compared with current commit vs master)
2)  Drawing images with targetHeight and targetWidth with ImageDataAtSizeProvider (comparison can be made against ImageDataProvider vs ImageDataAtSizeProvider both at this commit)
Steps to reproduce:


<details><summary>  snippet 1 to check drawing svgs at custom sizes  (click to show snippet) </summary>
**Step 1**: Copy the eclipse.svg to same path where the snippets are and run the below snippet.
**Step 2**: Run the snippet

package org.eclipse.swt.snippets;

```java
package org.eclipse.swt.snippets;

import org.eclipse.swt.*;
import org.eclipse.swt.custom.*;
import org.eclipse.swt.graphics.*;
import org.eclipse.swt.layout.*;
import org.eclipse.swt.widgets.*;

public class Snippet386 {

    public static void main(String[] args) {
        Display display = new Display();

        Image[] images = new Image[] {

            new Image(display, createImageFileNameProvider("src/org/eclipse/swt/snippets/eclipse.svg")),

        };

        String[] descriptions = new String[] {

            "ImageFileNameProvider with SVGs scaled by SVG rasterization"
        };

        Slice[] slices = {
        		 new Slice("Full", 0.0, 0.0, 1.0, 1.0),
                 new Slice("Top Half", 0.0, 0.0, 1.0, 0.5)
        };

        createShellWithImages(display, images, descriptions, slices, "Snippet 386 - Flipped Layout");
    }

    private static ImageFileNameProvider createImageFileNameProvider(String fileName) {
        return zoom -> {
        	if(zoom==100)
        	return fileName;
        	return null;};
    }

    static class Slice {
        String name;
        double xFrac, yFrac, wFrac, hFrac;
        Slice(String name, double x, double y, double w, double h) {
            this.name = name;
            this.xFrac = x;
            this.yFrac = y;
            this.wFrac = w;
            this.hFrac = h;
        }
    }

    private static void createShellWithImages(Display display, Image[] images, String[] descriptions, Slice[] slices, String title) {
        Shell shell = new Shell(display, SWT.SHELL_TRIM | SWT.MAX | SWT.RESIZE);
        shell.setText(title);
        shell.setLayout(new FillLayout());

        ScrolledComposite scrolledComposite = new ScrolledComposite(shell, SWT.V_SCROLL | SWT.H_SCROLL | SWT.BORDER);
        Canvas canvas = new Canvas(scrolledComposite, SWT.DOUBLE_BUFFERED);
        scrolledComposite.setContent(canvas);
        scrolledComposite.setExpandHorizontal(true);
        scrolledComposite.setExpandVertical(true);

        int boxW = 1500, boxH = 1500, gap = 20;
        int titleHeight = 20, descHeight = 40, sliceHeaderHeight = 30;

        int rows = images.length;
        int cols = slices.length;

        int canvasWidth = (boxW + gap) * cols + gap;
        int canvasHeight = (boxH + titleHeight + gap) * rows + descHeight + sliceHeaderHeight;
        canvas.setSize(canvasWidth, canvasHeight);
        scrolledComposite.setMinSize(canvasWidth, canvasHeight);

        canvas.addListener(SWT.Paint, e -> {
            // Column headers
            for (int col = 0; col < cols; col++) {
                int x = col * (boxW + gap) + gap;
                Font font = new Font(display, "Arial", 18, SWT.NORMAL);
                e.gc.setFont(font);
                e.gc.drawText(slices[col].name, x, 0, true);
                font.dispose();

            }

            // Rows
            for (int row = 0; row < rows; row++) {
                Image image = images[row];
                Rectangle rect = image.getBounds();
                int y = row * (boxH + titleHeight + gap) + descHeight + sliceHeaderHeight;

                Font font = new Font(display, "Arial", 18, SWT.NORMAL);
                e.gc.setFont(font);
                e.gc.drawText(descriptions[row], 0, y - 10, true);
                font.dispose();

                for (int col = 0; col < cols; col++) {
                    Slice s = slices[col];
                    int x = col * (boxW + gap) + gap;

                    int boxTop = y + titleHeight;
                    e.gc.drawRectangle(x, boxTop, (int) Math.round(boxW / s.wFrac), (int) Math.round(boxH / s.hFrac));

                    e.gc.drawImage(image, x, boxTop, (int) Math.round(boxW / s.wFrac), (int) Math.round(boxH / s.hFrac));
                }
            }
        });

        shell.setMaximized(true);
        shell.open();

        while (!shell.isDisposed()) {
            if (!display.readAndDispatch()) display.sleep();
        }

        for (Image img : images) img.dispose();
        display.dispose();
    }
}



```

</details>

<table>
  <tr>
    <td align="center" valign="top" style="padding-bottom: 20px;">
      <img src="https://github.com/user-attachments/assets/2bd64e72-e8f2-4c2f-9303-2f968d7db02d" />
      <br/>
      <sub>before</sub>
    </td>
  </tr>
  <tr>
    <td align="center" valign="top">
      <img src="https://github.com/user-attachments/assets/80f01e26-a3c2-48e1-82bf-7e01306b4f1d" />
      <br/>
      <sub>after</sub>
    </td>
  </tr>
</table>


<details><summary>**snippet 2** Drawing images with ImageDataAtSizeProvider</summary>

package org.eclipse.swt.snippets;

```java
package org.eclipse.swt.snippets;

import org.eclipse.swt.*;
import org.eclipse.swt.custom.*;
import org.eclipse.swt.graphics.*;
import org.eclipse.swt.layout.*;
import org.eclipse.swt.widgets.*;

public class Snippet386 {

    public static void main(String[] args) {
        Display display = new Display();

        Image[] images = new Image[] {
            new Image(display, createImageDataProvider()),
            new Image(display, createImageDataAtSizeProvider())
        };

        String[] descriptions = new String[] {

            "ImageDataProvider with fixed font size for a given zoom",
            "ImageDataAtSizeProvider which scales font size based on target height and width"
        };

        Slice[] slices = {
            new Slice("Full", 0.0, 0.0, 1.0, 1.0),
   
        };

        createShellWithImages(display, images, descriptions, slices, "Snippet 386 - Flipped Layout");
    }



    private static ImageDataProvider createImageDataProvider() {
        return new ImageDataProvider() {
            @Override
            public ImageData getImageData(int zoomLevel) {
                int scaleFactor = zoomLevel / 100;
                return createScaledTextImageData(100 * scaleFactor, 100 * scaleFactor);
            }
        };
    }

    private static ImageDataProvider createImageDataAtSizeProvider() {
        return new ImageDataAtSizeProvider() {
            @Override
            public ImageData getImageData(int zoomLevel) {
                int scaleFactor = zoomLevel / 100;
                return createScaledTextImageData(100 * scaleFactor, 100 * scaleFactor);
            }

            @Override
            public ImageData getImageData(int width, int height) {
                return createScaledTextImageData(width, height);
            }
        };
    }

    private static ImageData createScaledTextImageData(int width, int height) {
        Display display = Display.getDefault();
        String text = "abcd";

        int fontSize = Math.max(1, height / 100);
        Font font = new Font(display, "Arial", fontSize, SWT.NORMAL);

        Image tmp = new Image(display, 1, 1);
        GC measureGC = new GC(tmp);
        measureGC.setFont(font);
        Point textExtent = measureGC.textExtent(text);
        measureGC.dispose();
        tmp.dispose();

        double scale = Math.min((double) width / textExtent.x, (double) height / textExtent.y);
        font.dispose();
        font = new Font(display, "Arial", Math.max(1, (int) (fontSize * scale)), SWT.NORMAL);

        Image image = new Image(display, width, height);
        GC gc = new GC(image);
        gc.setFont(font);
        gc.setForeground(display.getSystemColor(SWT.COLOR_BLACK));
        gc.setBackground(display.getSystemColor(SWT.COLOR_WHITE));
        gc.fillRectangle(image.getBounds());

        gc.setLineWidth(Math.max(1, width / 20));
        gc.drawLine(0, 0, width / 2, height);

        Point newTextExtent = gc.textExtent(text);
        gc.drawText(text, (width - newTextExtent.x) / 2, (height - newTextExtent.y) / 2, true);

        gc.dispose();
        ImageData data = image.getImageData();

        image.dispose();
        font.dispose();

        return data;
    }

    static class Slice {
        String name;
        double xFrac, yFrac, wFrac, hFrac;
        Slice(String name, double x, double y, double w, double h) {
            this.name = name;
            this.xFrac = x;
            this.yFrac = y;
            this.wFrac = w;
            this.hFrac = h;
        }
    }

    private static void createShellWithImages(Display display, Image[] images, String[] descriptions, Slice[] slices, String title) {
        Shell shell = new Shell(display, SWT.SHELL_TRIM | SWT.MAX | SWT.RESIZE);
        shell.setText(title);
        shell.setLayout(new FillLayout());

        ScrolledComposite scrolledComposite = new ScrolledComposite(shell, SWT.V_SCROLL | SWT.H_SCROLL | SWT.BORDER);
        Canvas canvas = new Canvas(scrolledComposite, SWT.DOUBLE_BUFFERED);
        scrolledComposite.setContent(canvas);
        scrolledComposite.setExpandHorizontal(true);
        scrolledComposite.setExpandVertical(true);

        int boxW = 500, boxH = 500, gap = 20;
        int titleHeight = 20, descHeight = 40, sliceHeaderHeight = 30;

        int rows = images.length;
        int cols = slices.length;

        int canvasWidth = (boxW + gap) * cols + gap;
        int canvasHeight = (boxH + titleHeight + gap) * rows + descHeight + sliceHeaderHeight;
        canvas.setSize(canvasWidth, canvasHeight);
        scrolledComposite.setMinSize(canvasWidth, canvasHeight);

        canvas.addListener(SWT.Paint, e -> {
            // Column headers
            for (int col = 0; col < cols; col++) {
                int x = col * (boxW + gap) + gap;
                Font font = new Font(display, "Arial", 18, SWT.NORMAL);
                e.gc.setFont(font);
                e.gc.drawText(slices[col].name, x, 0, true);
                font.dispose();

            }

            // Rows
            for (int row = 0; row < rows; row++) {
                Image image = images[row];
                Rectangle rect = image.getBounds();
                int y = row * (boxH + titleHeight + gap) + descHeight + sliceHeaderHeight;

                Font font = new Font(display, "Arial", 18, SWT.NORMAL);
                e.gc.setFont(font);
                e.gc.drawText(descriptions[row], 0, y - 10, true);
                font.dispose();

                for (int col = 0; col < cols; col++) {
                    Slice s = slices[col];
                    int x = col * (boxW + gap) + gap;

                    int srcX = (int) (rect.width * s.xFrac);
                    int srcY = (int) (rect.height * s.yFrac);
                    int srcW = (int) (rect.width * s.wFrac);
                    int srcH = (int) (rect.height * s.hFrac);

                    int boxTop = y + titleHeight;
                    e.gc.drawRectangle(x, boxTop, boxW, boxH);


                    e.gc.drawImage(image, x, boxTop, boxW, boxH);

                }
            }
        });

        shell.setMaximized(true);
        shell.open();

        while (!shell.isDisposed()) {
            if (!display.readAndDispatch()) display.sleep();
        }

        for (Image img : images) img.dispose();
        display.dispose();
    }
}


```

</details>








 This depends on #2514 and #2509, Only last commit is relevant to this PR 