### PR TITLE
Fix GDI handle leak when clearing MenuItem images

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/MenuItem.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/MenuItem.java
@@ -807,6 +807,7 @@ private void updateImage () {
 		info.hbmpItem = OS.HBMMENU_CALLBACK;
 	} else {
 		if (OS.IsAppThemed ()) {
+			if (hBitmap != 0) OS.DeleteObject (hBitmap);
 			hBitmap = getMenuItemIconBitmapHandle(image);
 			if ((style & (SWT.CHECK | SWT.RADIO)) != 0 && CUSTOM_SELECTION_IMAGE > 0) {
 				info.fMask |= OS.MIIM_CHECKMARKS;
@@ -895,7 +896,6 @@ private long getMenuItemIconBitmapHandle(Image image) {
 	if (image == null) {
 		return 0;
 	}
-	if (hBitmap != 0) OS.DeleteObject (hBitmap);
 	int zoom = adaptZoomForMenuItem(nativeZoom, image);
 	return Display.create32bitDIB (image, zoom);
 }


### PR DESCRIPTION
When setting a null image on a MenuItem, the existing bitmap handle was overwritten with 0 without being released, causing a GDI handle leak if the MenuItem previously had an icon. This commit makes sure the handle is always deleted if it was set before.

Steps to reproduce 
1)Open a Runtime workspace 
2)Double click(or open) a file in the Package explorer 
3)Compare the GDI handles in the task manager before and after; it increases by 3 without this fix

This regression was introduced in [#1914](https://github.com/eclipse-platform/eclipse.platform.swt/pull/1914). The fix ensures that old handles are properly deleted before being replaced.