### PR TITLE
GetLocation as Point.WithMonitor to ensure correct monitor association

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/widgets/CoordinateSystemMapperTests.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/widgets/CoordinateSystemMapperTests.java
@@ -218,6 +218,31 @@ class CoordinateSystemMapperTests {
 		assertEquals(rectInPts, mapper.translateFromDisplayCoordinates(rectInPxs));
 	}
 
+	@ParameterizedTest
+	@MethodSource("provideCoordinateSystemMappers")
+	void translateBoundsToSecondMonitor(CoordinateSystemMapper mapper) {
+		final int OFFSET = 30;
+		final int SIZE = OFFSET * 3;
+		setupMonitors(mapper);
+		Rectangle currentPosition = new Rectangle.WithMonitor(monitors[1].getClientArea().x - OFFSET, 0, SIZE, SIZE,
+				monitors[1]);
+		Rectangle result = mapper.translateFromDisplayCoordinates(currentPosition);
+		assertTrue(monitors[1].getClientArea().intersects(result));
+	}
+
+	@ParameterizedTest
+	@MethodSource("provideCoordinateSystemMappers")
+	void translatePointsToSecondMonitor(CoordinateSystemMapper mapper) {
+		final int OFFSET = 30;
+		final int SIZE = OFFSET * 3;
+		setupMonitors(mapper);
+		Point currentPosition = new Point.WithMonitor(monitors[1].getClientArea().x - OFFSET, 0, monitors[1]);
+		Point size = new Point(SIZE, SIZE);
+		Point result = mapper.translateFromDisplayCoordinates(currentPosition);
+		Rectangle resultRect = new Rectangle(result.x, result.y, size.x, size.y);
+		assertTrue(monitors[1].getClientArea().intersects(resultRect));
+	}
+
 	private Point createExpectedPoint(CoordinateSystemMapper mapper, int x, int y, Monitor monitor) {
 		if (mapper instanceof SingleZoomCoordinateSystemMapper) {
 			return new Point(x, y);

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/MultiZoomCoordinateSystemMapper.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/MultiZoomCoordinateSystemMapper.java
@@ -93,7 +93,8 @@ class MultiZoomCoordinateSystemMapper implements CoordinateSystemMapper {
 
 	@Override
 	public Point translateFromDisplayCoordinates(Point point) {
-		return translateLocationInPixelsToPoints(point.x, point.y);
+		Monitor monitor = point instanceof Point.WithMonitor pointWithMonitor ? pointWithMonitor.getMonitor() : null;
+		return translateLocationInPixelsToPoints(point.x, point.y, monitor);
 	}
 
 	@Override
@@ -117,7 +118,7 @@ class MultiZoomCoordinateSystemMapper implements CoordinateSystemMapper {
 	@Override
 	public Point getCursorLocation() {
 		Point cursorLocationInPixels = display.getCursorLocationInPixels();
-		return translateLocationInPixelsToPoints(cursorLocationInPixels.x, cursorLocationInPixels.y);
+		return translateLocationInPixelsToPoints(cursorLocationInPixels.x, cursorLocationInPixels.y, null);
 	}
 
 	@Override
@@ -131,8 +132,10 @@ class MultiZoomCoordinateSystemMapper implements CoordinateSystemMapper {
 		return getPixelsFromPoint(monitor, x, y);
 	}
 
-	private Point translateLocationInPixelsToPoints(int x, int y) {
-		Monitor monitor = getContainingMonitorForPixels(x, y);
+	private Point translateLocationInPixelsToPoints(int x, int y, Monitor monitor) {
+		if (monitor == null) {
+			monitor = getContainingMonitorForPixels(x, y);
+		}
 		return getPointFromPixels(monitor, x, y);
 	}
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Shell.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Shell.java
@@ -924,7 +924,7 @@ public int getAlpha () {
 	OS.GetWindowRect (handle, rect);
 	int width = rect.right - rect.left;
 	int height = rect.bottom - rect.top;
-	return new Rectangle (rect.left, rect.top, width, height);
+	return new Rectangle.WithMonitor (rect.left, rect.top, width, height, getMonitor());
 }
 
 ToolTip getCurrentToolTip () {
@@ -1017,7 +1017,7 @@ public int getImeInputMode () {
 	if (OS.IsIconic (handle)) return super.getLocationInPixels ();
 	RECT rect = new RECT ();
 	OS.GetWindowRect (handle, rect);
-	return new Point (rect.left, rect.top);
+	return new Point.WithMonitor (rect.left, rect.top, getMonitor());
 }
 
 @Override


### PR DESCRIPTION
Previously, dialog positioning could be incorrect if the monitor was misidentified when restoring location. By returning the shell's location as a Point.WithMonitor (including monitor reference), we ensure dialogs and secondary shells open on the intended monitor, even in multi-monitor setups. This fixes issues where dialogs could appear on the wrong monitor after moving the parent shell.

### Steps to Reproduce

- Run the runtime workspace with monitor specific scaling turned on.
- Move the window to secondary monitor on the right (could be of any zoom)
- Resize the window to smaller size
- Open the **"Open Type"** window using `Ctrl + Shift + T`
- Move the Open Type window towards very left of the screen. 
- Close Open Type window
- Maximize the size of main window. 
- Open the **Open Type** dialog again
- You will see the dialog appearing on the left monitor instead of where it was last closed (on the right monitor)

**There are three cases which you could test and see if it preserves the previous state:**

**Case 1:** 
1 monitor, dialog should open where it was last closed as per parent shell. if child dialog is 10 px to the right to the parent shell, it should be 10 px from the parent shell doesnt matter where parent shell is or what size it is. 

**Case 2:** 
2 monitor, dialog moved to the left monitor, for e.g. -324 close the dialog. Reopen it should be -324 px from the parent shell. 

**Case 3:** 
2 monitor, parent shell is moved to the left monitor, dialog was closed to right monitor. Now it should follow parent shell. 