### PR TITLE
Fix Javadoc of SVGRasterizer

### DIFF
--- a/bundles/org.eclipse.swt.svg/src/org/eclipse/swt/svg/JSVGRasterizer.java
+++ b/bundles/org.eclipse.swt.svg/src/org/eclipse/swt/svg/JSVGRasterizer.java
@@ -35,7 +35,6 @@ import java.awt.Graphics2D;
 import java.awt.RenderingHints.Key;
 import java.awt.image.BufferedImage;
 import java.awt.image.DataBufferInt;
-import java.io.IOException;
 import java.io.InputStream;
 import java.util.Map;
 
@@ -71,7 +70,10 @@ public class JSVGRasterizer implements SVGRasterizer {
 	);
 
 	@Override
-	public ImageData rasterizeSVG(InputStream inputStream, int zoom) throws IOException {
+	public ImageData rasterizeSVG(InputStream inputStream, int zoom) {
+		if (zoom < 0) {
+			SWT.error(SWT.ERROR_INVALID_ARGUMENT);
+		}
 		SVGDocument svgDocument = loadSVG(inputStream);
 		if (svgDocument == null) {
 			SWT.error(SWT.ERROR_INVALID_IMAGE);

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/image/SVGFileFormat.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/image/SVGFileFormat.java
@@ -51,13 +51,8 @@ public class SVGFileFormat extends FileFormat {
 		if (targetZoom <= 0) {
 			SWT.error(SWT.ERROR_INVALID_ARGUMENT, null, " [Cannot rasterize SVG for zoom <= 0]");
 		}
-		try {
-			ImageData rasterizedImageData = RASTERIZER.rasterizeSVG(inputStream, 100 * targetZoom / fileZoom);
-			return List.of(new ElementAtZoom<>(rasterizedImageData, targetZoom));
-		} catch (IOException e) {
-			SWT.error(SWT.ERROR_INVALID_IMAGE, e);
-			return List.of();
-		}
+		ImageData rasterizedImageData = RASTERIZER.rasterizeSVG(inputStream, 100 * targetZoom / fileZoom);
+		return List.of(new ElementAtZoom<>(rasterizedImageData, targetZoom));
 	}
 
 	@Override

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/image/SVGRasterizer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/image/SVGRasterizer.java
@@ -14,6 +14,7 @@ package org.eclipse.swt.internal.image;
 
 import java.io.*;
 
+import org.eclipse.swt.*;
 import org.eclipse.swt.graphics.*;
 
 /**
@@ -26,10 +27,18 @@ public interface SVGRasterizer {
 	 * specified zoom.
 	 *
 	 * @param stream the SVG image as an {@link InputStream}.
-	 * @param zoom   the scaling factor (in percent) e.g. {@code 200} for doubled
-	 *               size. This value must be greater zero.
-	 * @return the {@link ImageData} for the rasterized image, or {@code null} if
-	 *         the input is not a valid SVG file or cannot be processed.
+	 * @param zoom   the scaling percentage (e.g., 100 = original size, 200 = double size).
+	 *  	   This value must be greater zero.
+	 * @return the {@link ImageData} for the rasterized image.
+	 *
+	 * @exception SWTException
+	 * <ul>
+	 *    <li>ERROR_INVALID_IMAGE - if the SVG cannot be loaded</li>
+	 * </ul>
+	 * @exception IllegalArgumentException
+	 * <ul>
+	 *    <li>ERROR_INVALID_ARGUMENT - if the zoom is less than zero</li>
+	 * </ul>
 	 */
-	public ImageData rasterizeSVG(InputStream stream, int zoom) throws IOException;
+	public ImageData rasterizeSVG(InputStream stream, int zoom);
 }

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/AllNonBrowserTests.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/AllNonBrowserTests.java
@@ -46,7 +46,8 @@ import org.junit.platform.suite.api.Suite;
 		Test_org_eclipse_swt_accessibility_AccessibleEvent.class,
 		Test_org_eclipse_swt_accessibility_AccessibleTextEvent.class,
 		Test_org_eclipse_swt_internal_SVGRasterizer.class,
-		DPIUtilTests.class})
+		DPIUtilTests.class,
+		JSVGRasterizerTest.class})
 public class AllNonBrowserTests {
 	private static List<Error> leakedResources;
 

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/JSVGRasterizerTest.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/JSVGRasterizerTest.java
@@ -1,0 +1,71 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Yatta Solutions and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Yatta Solutions - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.swt.tests.junit;
+
+import static org.eclipse.swt.tests.junit.SwtTestUtil.assertSWTProblem;
+import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.SWTException;
+import org.eclipse.swt.graphics.ImageData;
+import org.eclipse.swt.svg.JSVGRasterizer;
+import org.junit.jupiter.api.Test;
+
+class JSVGRasterizerTest {
+
+	private final JSVGRasterizer rasterizer = new JSVGRasterizer();
+	private String svgString = """
+			<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+			    <rect width="100%" height="100%"/>
+			</svg>
+			""";
+
+	private ByteArrayInputStream svgStream(String svg) {
+		return new ByteArrayInputStream(svg.getBytes(StandardCharsets.UTF_8));
+	}
+
+	private ByteArrayInputStream invalidSvg = new ByteArrayInputStream(new byte[0]);
+
+	@Test
+	void testRasterizeWithZoom() {
+		ImageData data = rasterizer.rasterizeSVG(svgStream(svgString), 200);
+		assertEquals(200, data.width);
+		assertEquals(200, data.height);
+	}
+
+	@Test
+	void testRasterizeWithZoomNegative() {
+		try {
+			rasterizer.rasterizeSVG(svgStream(svgString), -100);
+
+		} catch (IllegalArgumentException e) {
+			assertSWTProblem("Incorrect exception thrown for negative zoom", SWT.ERROR_INVALID_ARGUMENT, e);
+		}
+
+	}
+
+	@Test
+	void testRasterizeWithZoomWithInvalidSVG() {
+
+		SWTException exception = assertThrows(SWTException.class, () -> {
+			rasterizer.rasterizeSVG(invalidSvg, 100);
+		});
+		assertEquals(SWT.ERROR_INVALID_IMAGE, exception.code);
+	}
+
+}


### PR DESCRIPTION
This commits fixes Javadoc of SVGRasterizer and adds tests to verify the contract

Fixes #2515 