### PR TITLE
Improve support for Arrays of Strings in JNI Generator

### DIFF
--- a/bundles/org.eclipse.swt.tools/JNI Generation/org/eclipse/swt/tools/internal/ASTType.java
+++ b/bundles/org.eclipse.swt.tools/JNI Generation/org/eclipse/swt/tools/internal/ASTType.java
@@ -148,7 +148,10 @@ public String getTypeSignature2() {
 	if (name.equals("Ljava/lang/String;")) return "jstring";
 	if (name.equals("Ljava/lang/Class;")) return "jclass";
 	if (isArray()) {
-		return getComponentType().getTypeSignature2() + "Array";
+		if (getComponentType().isPrimitive()) {
+			return getComponentType().getTypeSignature2() + "Array";
+		}
+		return "jobjectArray";
 	}
 	return "jobject";
 }

--- a/bundles/org.eclipse.swt.tools/JNI Generation/org/eclipse/swt/tools/internal/NativesGenerator.java
+++ b/bundles/org.eclipse.swt.tools/JNI Generation/org/eclipse/swt/tools/internal/NativesGenerator.java
@@ -299,6 +299,14 @@ boolean generateGetParameter(JNIParameter param, boolean critical, int indent) {
 				output(iStr);
 				output(", NULL)");
 			}
+		} else if (componentType.isType("java.lang.String")) {
+			if (param.getFlag(FLAG_UNICODE)) {
+				throw new Error("not done");
+			}
+
+			output("swt_getArrayOfStringsUTF(env, arg");
+			output(iStr);
+			output(")");
 		} else {
 			throw new Error("not done");
 		}
@@ -381,6 +389,16 @@ void generateSetParameter(JNIParameter param, boolean critical) {
 				output("0");
 			}
 			output(");");
+		} else if (componentType.isType("java.lang.String")) {
+			if (param.getFlag(FLAG_UNICODE)) {
+				throw new Error("not done");
+			}
+
+			output("swt_releaseArrayOfStringsUTF(env, arg");
+			output(iStr);
+			output(", lparg");
+			output(iStr);
+			output(");");
 		} else {
 			throw new Error("not done");
 		}
@@ -452,6 +470,12 @@ boolean generateLocalVars(JNIParameter[] params, JNIType returnType) {
 				output(componentType.getTypeSignature2());
 				output(" *lparg" + i);
 				output("=NULL;");
+			} else if (componentType.isType("java.lang.String")) {
+				if (param.getFlag(FLAG_UNICODE)) {
+					output("jchar **lparg" + i + "=NULL");
+				} else {
+					output("char **lparg" + i+ "=NULL");
+				}
 			} else {
 				throw new Error("not done");
 			}

--- a/bundles/org.eclipse.swt.tools/JNI Generation/org/eclipse/swt/tools/internal/ReflectType.java
+++ b/bundles/org.eclipse.swt.tools/JNI Generation/org/eclipse/swt/tools/internal/ReflectType.java
@@ -91,7 +91,10 @@ public String getTypeSignature2() {
 	if (clazz == String.class) return "jstring";
 	if (clazz == Class.class) return "jclass";
 	if (clazz.isArray()) {
-		return getComponentType().getTypeSignature2() + "Array";
+		if (getComponentType().isPrimitive()) {
+			return getComponentType().getTypeSignature2() + "Array";
+		}
+		return "jobjectArray";
 	}
 	return "jobject";
 }

--- a/bundles/org.eclipse.swt.tools/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.swt.tools/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.swt.tools; singleton:=true
-Bundle-Version: 3.110.800.qualifier
+Bundle-Version: 3.110.900.qualifier
 Bundle-ManifestVersion: 2
 Export-Package: org.eclipse.swt.tools.internal; x-internal:=true
 Bundle-ActivationPolicy: lazy

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/os_custom.c
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/os_custom.c
@@ -2187,3 +2187,48 @@ void swt_debug_on_fatal_warnings() {
 	  gtk_parse_args(&argcount, &arg2);
 }
 #endif
+
+/**
+ * Convert an array of Java strings to an array of char *
+ */
+char **
+swt_getArrayOfStringsUTF(JNIEnv *env, jobjectArray javaArray) {
+    jsize length = (*env)->GetArrayLength(env, javaArray);
+
+    char **cStrings = (char **)malloc((length + 1) * sizeof(char*));
+    if (!cStrings) {
+		return NULL;
+	}
+
+    for (jsize i = 0; i < length; i++) {
+        jstring jstr = (jstring)(*env)->GetObjectArrayElement(env, javaArray, i);
+        if (jstr) {
+	        const char *utfStr = (*env)->GetStringUTFChars(env, jstr, 0);
+
+	        cStrings[i] = strdup(utfStr);
+
+	        (*env)->ReleaseStringUTFChars(env, jstr, utfStr);
+	        (*env)->DeleteLocalRef(env, jstr);
+        } else {
+	        cStrings[i] = NULL;
+        }
+    }
+
+    cStrings[length] = NULL;
+    return cStrings;
+}
+
+/**
+ * Free the memory allocated by swt_getArrayOfStringsUTF
+ */
+void
+swt_releaseArrayOfStringsUTF(JNIEnv *env, jobjectArray javaArray, char **cStrings) {
+    jsize length = (*env)->GetArrayLength(env, javaArray);
+
+    for (jsize i = 0; i < length; i++) {
+		if (cStrings[i]) {
+			free(cStrings[i]);
+		}
+    }
+    free(cStrings);
+}

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/os_custom.h
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/os_custom.h
@@ -187,4 +187,7 @@ jlong call_accessible_object_function (const char *method_name, const char *meth
 void swt_set_lock_functions();
 void swt_debug_on_fatal_warnings() ;
 
+char **swt_getArrayOfStringsUTF(JNIEnv *env, jobjectArray javaArray);
+void swt_releaseArrayOfStringsUTF(JNIEnv *env, jobjectArray javaArray, char **cStrings);
+
 #endif /* ORG_ECLIPSE_SWT_GTK_OS_CUSTOM_H (include guard, this should be the last line) */

--- a/features/org.eclipse.swt.tools.feature/feature.xml
+++ b/features/org.eclipse.swt.tools.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.swt.tools.feature"
       label="%featureName"
-      version="3.109.800.qualifier"
+      version="3.109.900.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">


### PR DESCRIPTION
A number of places in the GTK4 API there is the possibility of passing in arrays of Strings, i.e. Java String[] -> char ** as input argument to C side.

This change adds better support to the JNI generator for this use case by converting the jobjectArray (String[]) to char ** on the C side.

Part of #2126
Split out of #2538