### PR TITLE
Prepare TransferData for GTK4 support

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/gtk/org/eclipse/swt/dnd/ByteArrayTransfer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/gtk/org/eclipse/swt/dnd/ByteArrayTransfer.java
@@ -156,7 +156,7 @@ public boolean isSupportedType(TransferData transferData){
  */
 @Override
 protected void javaToNative (Object object, TransferData transferData) {
-	transferData.result = 0;
+	transferData.gtk3().result = 0;
 	if (!checkByteArray(object) || !isSupportedType(transferData)) {
 		DND.error(DND.ERROR_INVALID_DATA);
 	}
@@ -165,10 +165,10 @@ protected void javaToNative (Object object, TransferData transferData) {
 	long pValue = OS.g_malloc(buffer.length);
 	if (pValue == 0) return;
 	C.memmove(pValue, buffer, buffer.length);
-	transferData.length = buffer.length;
-	transferData.format = 8;
-	transferData.pValue = pValue;
-	transferData.result = 1;
+	transferData.gtk3().length = buffer.length;
+	transferData.gtk3().format = 8;
+	transferData.gtk3().pValue = pValue;
+	transferData.gtk3().result = 1;
 }
 
 /**
@@ -183,11 +183,11 @@ protected void javaToNative (Object object, TransferData transferData) {
  */
 @Override
 protected Object nativeToJava(TransferData transferData) {
-	if ( !isSupportedType(transferData) || transferData.pValue == 0) return null;
-	int size = transferData.format * transferData.length / 8;
+	if ( !isSupportedType(transferData) || transferData.gtk3().pValue == 0) return null;
+	int size = transferData.gtk3().format * transferData.gtk3().length / 8;
 	if (size == 0) return null;
 	byte[] buffer = new byte[size];
-	C.memmove(buffer, transferData.pValue, size);
+	C.memmove(buffer, transferData.gtk3().pValue, size);
 	return buffer;
 }
 

--- a/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/gtk/org/eclipse/swt/dnd/Clipboard.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/gtk/org/eclipse/swt/dnd/Clipboard.java
@@ -312,9 +312,9 @@ public Object getContents(Transfer transfer, int clipboards) {
 		if (selection_data != 0) {
 			TransferData tdata = new TransferData();
 			tdata.type = GTK3.gtk_selection_data_get_data_type(selection_data);
-			tdata.pValue = GTK3.gtk_selection_data_get_data(selection_data);
-			tdata.length = GTK3.gtk_selection_data_get_length(selection_data);
-			tdata.format = GTK3.gtk_selection_data_get_format(selection_data);
+			tdata.gtk3().pValue = GTK3.gtk_selection_data_get_data(selection_data);
+			tdata.gtk3().length = GTK3.gtk_selection_data_get_length(selection_data);
+			tdata.gtk3().format = GTK3.gtk_selection_data_get_format(selection_data);
 			result = transfer.nativeToJava(tdata);
 			GTK3.gtk_selection_data_free(selection_data);
 			selection_data = 0;

--- a/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/gtk/org/eclipse/swt/dnd/ClipboardProxy.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/gtk/org/eclipse/swt/dnd/ClipboardProxy.java
@@ -139,11 +139,11 @@ long getFunc(long clipboard, long selection_data, long info, long user_data_or_o
 	if (index == -1) return 0;
 	Object[] data = (clipboard == Clipboard.GTKCLIPBOARD) ? clipboardData : primaryClipboardData;
 	types[index].javaToNative(data[index], tdata);
-	if (tdata.format < 8 || tdata.format % 8 != 0) {
+	if (tdata.gtk3().format < 8 || tdata.gtk3().format % 8 != 0) {
 		return 0;
 	}
-	GTK3.gtk_selection_data_set(selection_data, tdata.type, tdata.format, tdata.pValue, tdata.length);
-	OS.g_free(tdata.pValue);
+	GTK3.gtk_selection_data_set(selection_data, tdata.type, tdata.gtk3().format, tdata.gtk3().pValue, tdata.gtk3().length);
+	OS.g_free(tdata.gtk3().pValue);
 	return 1;
 }
 

--- a/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/gtk/org/eclipse/swt/dnd/DragSource.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/gtk/org/eclipse/swt/dnd/DragSource.java
@@ -516,9 +516,9 @@ void dragGetData(long widget, long context, long selection_data,  int info, int 
 
 	TransferData transferData = new TransferData();
 	transferData.type = target;
-	transferData.pValue = data;
-	transferData.length = length;
-	transferData.format = format;
+	transferData.gtk3().pValue = data;
+	transferData.gtk3().length = length;
+	transferData.gtk3().format = format;
 
 	DNDEvent event = new DNDEvent();
 	event.widget = this;
@@ -536,9 +536,9 @@ void dragGetData(long widget, long context, long selection_data,  int info, int 
 	}
 	if (transfer == null) return;
 	transfer.javaToNative(event.data, transferData);
-	if (transferData.result != 1) return;
-	GTK3.gtk_selection_data_set(selection_data, transferData.type, transferData.format, transferData.pValue, transferData.length);
-	OS.g_free(transferData.pValue);
+	if (transferData.gtk3().result != 1) return;
+	GTK3.gtk_selection_data_set(selection_data, transferData.type, transferData.gtk3().format, transferData.gtk3().pValue, transferData.gtk3().length);
+	OS.g_free(transferData.gtk3().pValue);
 	return;
 }
 

--- a/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/gtk/org/eclipse/swt/dnd/DropTarget.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/gtk/org/eclipse/swt/dnd/DropTarget.java
@@ -358,9 +358,9 @@ void drag_data_received ( long widget, long context, int x, int y, long selectio
 	long type = GTK3.gtk_selection_data_get_data_type(selection_data);
 	if (data != 0) {
 		transferData.type = type;
-		transferData.length = length;
-		transferData.pValue = data;
-		transferData.format = format;
+		transferData.gtk3().length = length;
+		transferData.gtk3().pValue = data;
+		transferData.gtk3().format = format;
 		for (int i = 0; i < transferAgents.length; i++) {
 			Transfer transfer = transferAgents[i];
 			if (transfer != null && transfer.isSupportedType(transferData)) {

--- a/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/gtk/org/eclipse/swt/dnd/FileTransfer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/gtk/org/eclipse/swt/dnd/FileTransfer.java
@@ -69,7 +69,7 @@ public static FileTransfer getInstance () {
  */
 @Override
 public void javaToNative(Object object, TransferData transferData) {
-	transferData.result = 0;
+	transferData.gtk3().result = 0;
 	if (!checkFile(object) || !isSupportedType(transferData)) {
 		DND.error(DND.ERROR_INVALID_DATA);
 	}
@@ -119,10 +119,10 @@ public void javaToNative(Object object, TransferData transferData) {
 	long ptr = OS.g_malloc(buffer.length+1);
 	C.memset(ptr, '\0', buffer.length+1);
 	C.memmove(ptr, buffer, buffer.length);
-	transferData.pValue = ptr;
-	transferData.length = buffer.length;
-	transferData.format = 8;
-	transferData.result = 1;
+	transferData.gtk3().pValue = ptr;
+	transferData.gtk3().length = buffer.length;
+	transferData.gtk3().format = 8;
+	transferData.gtk3().result = 1;
 }
 /**
  * This implementation of <code>nativeToJava</code> converts a platform specific
@@ -137,10 +137,10 @@ public void javaToNative(Object object, TransferData transferData) {
  */
 @Override
 public Object nativeToJava(TransferData transferData) {
-	if ( !isSupportedType(transferData) ||  transferData.pValue == 0 ||  transferData.length <= 0 ) return null;
-	int length = transferData.length;
+	if ( !isSupportedType(transferData) ||  transferData.gtk3().pValue == 0 ||  transferData.gtk3().length <= 0 ) return null;
+	int length = transferData.gtk3().length;
 	byte[] temp = new byte[length];
-	C.memmove(temp, transferData.pValue, length);
+	C.memmove(temp, transferData.gtk3().pValue, length);
 	boolean gnomeList = transferData.type == GNOME_LIST_ID;
 	int sepLength = gnomeList ? 1 : 2;
 	long [] files = new long [0];

--- a/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/gtk/org/eclipse/swt/dnd/HTMLTransfer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/gtk/org/eclipse/swt/dnd/HTMLTransfer.java
@@ -61,7 +61,7 @@ public static HTMLTransfer getInstance () {
  */
 @Override
 public void javaToNative (Object object, TransferData transferData){
-	transferData.result = 0;
+	transferData.gtk3().result = 0;
 	if (!checkHTML(object) || !isSupportedType(transferData)) {
 		DND.error(DND.ERROR_INVALID_DATA);
 	}
@@ -71,10 +71,10 @@ public void javaToNative (Object object, TransferData transferData){
 	long pValue = OS.g_malloc(byteCount);
 	if (pValue == 0) return;
 	C.memmove(pValue, utf8, byteCount);
-	transferData.length = byteCount;
-	transferData.format = 8;
-	transferData.pValue = pValue;
-	transferData.result = 1;
+	transferData.gtk3().length = byteCount;
+	transferData.gtk3().format = 8;
+	transferData.gtk3().pValue = pValue;
+	transferData.gtk3().result = 1;
 }
 
 /**
@@ -89,21 +89,21 @@ public void javaToNative (Object object, TransferData transferData){
  */
 @Override
 public Object nativeToJava(TransferData transferData){
-	if ( !isSupportedType(transferData) ||  transferData.pValue == 0 ) return null;
+	if ( !isSupportedType(transferData) ||  transferData.gtk3().pValue == 0 ) return null;
 	/* Ensure byteCount is a multiple of 2 bytes */
-	int size = (transferData.format * transferData.length / 8) / 2 * 2;
+	int size = (transferData.gtk3().format * transferData.gtk3().length / 8) / 2 * 2;
 	if (size <= 0) return null;
 	char[] bom = new char[1]; // look for a Byte Order Mark
-	if (size > 1) C.memmove (bom, transferData.pValue, 2);
+	if (size > 1) C.memmove (bom, transferData.gtk3().pValue, 2);
 	String string;
 	if (bom[0] == '\ufeff' || bom[0] == '\ufffe') {
 		// utf16
 		char[] chars = new char [size/2];
-		C.memmove (chars, transferData.pValue, size);
+		C.memmove (chars, transferData.gtk3().pValue, size);
 		string = new String (chars);
 	} else {
 		byte[] utf8 = new byte[size];
-		C.memmove(utf8, transferData.pValue, size);
+		C.memmove(utf8, transferData.gtk3().pValue, size);
 		// convert utf8 byte array to a unicode string
 		char [] unicode = org.eclipse.swt.internal.Converter.mbcsToWcs (utf8);
 		string = new String (unicode);

--- a/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/gtk/org/eclipse/swt/dnd/ImageTransfer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/gtk/org/eclipse/swt/dnd/ImageTransfer.java
@@ -111,14 +111,14 @@ public void javaToNative(Object object, TransferData transferData) {
 		if (type == null) return;
 		GDK.gdk_pixbuf_save_to_bufferv(pixbuf, buffer, len, type, null, null, null);
 		OS.g_object_unref(pixbuf);
-		transferData.pValue = buffer[0];
-		transferData.length = (int)(len[0] + 3) / 4 * 4;
-		transferData.result = 1;
+		transferData.gtk3().pValue = buffer[0];
+		transferData.gtk3().length = (int)(len[0] + 3) / 4 * 4;
+		transferData.gtk3().result = 1;
 		// The following value has been changed from 32 to 8 as a simple fix for #146
 		// See https://www.cc.gatech.edu/data_files/public/doc/gtk/tutorial/gtk_tut-16.html where it states:
 		// "The format field is actually important here - the X server uses it to figure out whether the data
 		// needs to be byte-swapped or not. Usually it will be 8 - i.e. a character - or 32 - i.e. a. integer."
-		transferData.format = 8;
+		transferData.gtk3().format = 8;
 	}
 	image.dispose();
 }
@@ -136,10 +136,10 @@ public void javaToNative(Object object, TransferData transferData) {
 @Override
 public Object nativeToJava(TransferData transferData) {
 	ImageData imgData = null;
-	if (transferData.length > 0) {
+	if (transferData.gtk3().length > 0) {
 		long loader = GDK.gdk_pixbuf_loader_new();
 		try {
-			GDK.gdk_pixbuf_loader_write(loader, transferData.pValue, transferData.length, null);
+			GDK.gdk_pixbuf_loader_write(loader, transferData.gtk3().pValue, transferData.gtk3().length, null);
 			GDK.gdk_pixbuf_loader_close(loader, null);
 			long pixbuf = GDK.gdk_pixbuf_loader_get_pixbuf(loader);
 			if (pixbuf != 0) {

--- a/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/gtk/org/eclipse/swt/dnd/RTFTransfer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/gtk/org/eclipse/swt/dnd/RTFTransfer.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.swt.dnd;
 
+import org.eclipse.swt.dnd.TransferData.*;
 import org.eclipse.swt.internal.*;
 import org.eclipse.swt.internal.gtk.*;
 
@@ -63,7 +64,7 @@ public static RTFTransfer getInstance () {
  */
 @Override
 public void javaToNative (Object object, TransferData transferData){
-	transferData.result = 0;
+	transferData.gtk3().result = 0;
 	if (!checkRTF(object) || !isSupportedType(transferData)) {
 		DND.error(DND.ERROR_INVALID_DATA);
 	}
@@ -72,10 +73,10 @@ public void javaToNative (Object object, TransferData transferData){
 	long pValue = OS.g_malloc(buffer.length);
 	if (pValue == 0) return;
 	C.memmove(pValue, buffer, buffer.length);
-	transferData.length = buffer.length - 1;
-	transferData.format = 8;
-	transferData.pValue = pValue;
-	transferData.result = 1;
+	transferData.gtk3().length = buffer.length - 1;
+	transferData.gtk3().format = 8;
+	transferData.gtk3().pValue = pValue;
+	transferData.gtk3().result = 1;
 }
 
 /**
@@ -90,11 +91,11 @@ public void javaToNative (Object object, TransferData transferData){
  */
 @Override
 public Object nativeToJava(TransferData transferData){
-	if ( !isSupportedType(transferData) ||  transferData.pValue == 0 ) return null;
-	int size = transferData.format * transferData.length / 8;
+	if ( !isSupportedType(transferData) ||  transferData.gtk3().pValue == 0 ) return null;
+	int size = transferData.gtk3().format * transferData.gtk3().length / 8;
 	if (size == 0) return null;
 	byte[] buffer = new byte[size];
-	C.memmove(buffer, transferData.pValue, size);
+	C.memmove(buffer, transferData.gtk3().pValue, size);
 	char [] chars = Converter.mbcsToWcs (buffer);
 	String string = new String (chars);
 	int end = string.indexOf('\0');

--- a/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/gtk/org/eclipse/swt/dnd/TextTransfer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/gtk/org/eclipse/swt/dnd/TextTransfer.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.swt.dnd;
 
+import org.eclipse.swt.dnd.TransferData.*;
 import org.eclipse.swt.internal.*;
 import org.eclipse.swt.internal.gtk.*;
 
@@ -71,7 +72,7 @@ public static TextTransfer getInstance () {
  */
 @Override
 public void javaToNative (Object object, TransferData transferData) {
-	transferData.result = 0;
+	transferData.gtk3().result = 0;
 	if (!checkText(object) || !isSupportedType(transferData)) {
 		DND.error(DND.ERROR_INVALID_DATA);
 	}
@@ -85,28 +86,28 @@ public void javaToNative (Object object, TransferData transferData) {
 		boolean result = GDK.gdk_x11_display_utf8_to_compound_text (GDK.gdk_display_get_default(), utf8, encoding, format, ctext, length);
 		if (!result) return;
 		transferData.type = encoding[0];
-		transferData.format = format[0];
-		transferData.length = length[0];
-		transferData.pValue = ctext[0];
-		transferData.result = 1;
+		transferData.gtk3().format = format[0];
+		transferData.gtk3().length = length[0];
+		transferData.gtk3().pValue = ctext[0];
+		transferData.gtk3().result = 1;
 	}
 	if (transferData.type == UTF8_STRING_ID || transferData.type == TEXT_PLAIN_UTF8_ID) {
 		long pValue = OS.g_malloc(utf8.length);
 		if (pValue ==  0) return;
 		C.memmove(pValue, utf8, utf8.length);
-		transferData.format = 8;
-		transferData.length = utf8.length - 1;
-		transferData.pValue = pValue;
-		transferData.result = 1;
+		transferData.gtk3().format = 8;
+		transferData.gtk3().length = utf8.length - 1;
+		transferData.gtk3().pValue = pValue;
+		transferData.gtk3().result = 1;
 	}
 	if (transferData.type == STRING_ID) {
 		long string_target = GDK.gdk_utf8_to_string_target(utf8);
 		if (string_target ==  0) return;
 		transferData.type = STRING_ID;
-		transferData.format = 8;
-		transferData.length = C.strlen(string_target);
-		transferData.pValue = string_target;
-		transferData.result = 1;
+		transferData.gtk3().format = 8;
+		transferData.gtk3().length = C.strlen(string_target);
+		transferData.gtk3().pValue = string_target;
+		transferData.gtk3().result = 1;
 	}
 }
 
@@ -122,9 +123,10 @@ public void javaToNative (Object object, TransferData transferData) {
  */
 @Override
 public Object nativeToJava(TransferData transferData){
-	if (!isSupportedType(transferData) ||  transferData.pValue == 0) return null;
+
+	if (!isSupportedType(transferData) ||  transferData.gtk3().pValue == 0) return null;
 	long [] list = new long [1];
-	int count = GDK.gdk_text_property_to_utf8_list_for_display(GDK.gdk_display_get_default(), transferData.type, transferData.format, transferData.pValue, transferData.length, list);
+	int count = GDK.gdk_text_property_to_utf8_list_for_display(GDK.gdk_display_get_default(), transferData.type, transferData.gtk3().format, transferData.gtk3().pValue, transferData.gtk3().length, list);
 	if (count == 0) return null;
 	long [] ptr = new long [1];
 	C.memmove(ptr, list[0], C.PTR_SIZEOF);

--- a/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/gtk/org/eclipse/swt/dnd/TransferData.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/gtk/org/eclipse/swt/dnd/TransferData.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2012 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.swt.dnd;
 
+import org.eclipse.swt.internal.gtk.*;
 
 /**
  * The <code>TransferData</code> class is a platform specific data structure for
@@ -46,66 +47,115 @@ public class TransferData {
 	public long type;
 
 	/**
-	 * Specifies the number of units in pValue.
-	 * (Warning: This field is platform dependent)
-	 * <p>
-	 * <b>IMPORTANT:</b> This field is <em>not</em> part of the SWT
-	 * public API. It is marked public only so that it can be shared
-	 * within the packages provided by SWT. It is not available on all
-	 * platforms and should never be accessed from application code.
-	 * </p>
-	 *
-	 * @see TransferData#format for the size of one unit
-	 *
-	 * @noreference This field is not intended to be referenced by clients.
+	 * @noreference This class is not intended to be referenced by clients.
+	 * @noinstantiate This class is not intended to be instantiated by clients.
+	 * @noextend This class is not intended to be subclassed by clients.
+	 * @since 3.132
 	 */
-	public int length;
+	public static class TransferDataGTK3 {
+		/**
+		 * Specifies the number of units in pValue.
+		 * (Warning: This field is platform dependent)
+		 * <p>
+		 * <b>IMPORTANT:</b> This field is <em>not</em> part of the SWT
+		 * public API. It is marked public only so that it can be shared
+		 * within the packages provided by SWT. It is not available on all
+		 * platforms and should never be accessed from application code.
+		 * </p>
+		 *
+		 * @see TransferDataGTK3#format for the size of one unit
+		 *
+		 * @noreference This field is not intended to be referenced by clients.
+		 */
+		public int length;
+		/**
+		 * Specifies the size in bits of a single unit in pValue.
+		 * (Warning: This field is platform dependent)
+		 * <p>
+		 * <b>IMPORTANT:</b> This field is <em>not</em> part of the SWT
+		 * public API. It is marked public only so that it can be shared
+		 * within the packages provided by SWT. It is not available on all
+		 * platforms and should never be accessed from application code.
+		 * </p>
+		 *
+		 * This is most commonly 8 bits.
+		 *
+		 * @noreference This field is not intended to be referenced by clients.
+		 */
+		public int format;
+		/**
+		 * Pointer to the data being transferred.
+		 * (Warning: This field is platform dependent)
+		 * <p>
+		 * <b>IMPORTANT:</b> This field is <em>not</em> part of the SWT
+		 * public API. It is marked public only so that it can be shared
+		 * within the packages provided by SWT. It is not available on all
+		 * platforms and should never be accessed from application code.
+		 * </p>
+		 *
+		 * @noreference This field is not intended to be referenced by clients.
+		 */
+		public long pValue;
+		/**
+		 * The result field contains the result of converting a
+		 * java data type into a platform specific value.
+		 * (Warning: This field is platform dependent)
+		 * <p>
+		 * <b>IMPORTANT:</b> This field is <em>not</em> part of the SWT
+		 * public API. It is marked public only so that it can be shared
+		 * within the packages provided by SWT. It is not available on all
+		 * platforms and should never be accessed from application code.
+		 * </p>
+		 * <p>The value of result is 1 if the conversion was successful.
+		 * The value of result is 0 if the conversion failed.</p>
+		 *
+		 * @noreference This field is not intended to be referenced by clients.
+		 */
+		public int result;
+
+		private TransferDataGTK3() {}
+	}
 
 	/**
-	 * Specifies the size in bits of a single unit in pValue.
-	 * (Warning: This field is platform dependent)
-	 * <p>
-	 * <b>IMPORTANT:</b> This field is <em>not</em> part of the SWT
-	 * public API. It is marked public only so that it can be shared
-	 * within the packages provided by SWT. It is not available on all
-	 * platforms and should never be accessed from application code.
-	 * </p>
-	 *
-	 * This is most commonly 8 bits.
-	 *
-	 * @noreference This field is not intended to be referenced by clients.
+	 * @noreference This class is not intended to be referenced by clients.
+	 * @noinstantiate This class is not intended to be instantiated by clients.
+	 * @noextend This class is not intended to be subclassed by clients.
+	 * @since 3.132
 	 */
-	public int format;
+	public static class TransferDataGTK4 {
+		// GTK4 specific fields will be introduced here
+
+		private TransferDataGTK4() {}
+	}
+
+	private TransferDataGTK3 gtk3;
+
+	private TransferDataGTK4 gtk4;
 
 	/**
-	 * Pointer to the data being transferred.
-	 * (Warning: This field is platform dependent)
-	 * <p>
-	 * <b>IMPORTANT:</b> This field is <em>not</em> part of the SWT
-	 * public API. It is marked public only so that it can be shared
-	 * within the packages provided by SWT. It is not available on all
-	 * platforms and should never be accessed from application code.
-	 * </p>
-	 *
-	 * @noreference This field is not intended to be referenced by clients.
+	 * @noreference This method is not intended to be referenced by clients.
 	 */
-	public long pValue;
-
+	public TransferDataGTK3 gtk3() {
+		if (gtk3 != null) {
+			return gtk3;
+		}
+		if (!GTK.GTK4) {
+			gtk3 = new TransferDataGTK3();
+			return gtk3;
+		}
+		throw new UnsupportedOperationException("Illegal attempt to use GTK3 TransferData on GTK4");
+	}
 	/**
-	 * The result field contains the result of converting a
-	 * java data type into a platform specific value.
-	 * (Warning: This field is platform dependent)
-	 * <p>
-	 * <b>IMPORTANT:</b> This field is <em>not</em> part of the SWT
-	 * public API. It is marked public only so that it can be shared
-	 * within the packages provided by SWT. It is not available on all
-	 * platforms and should never be accessed from application code.
-	 * </p>
-	 * <p>The value of result is 1 if the conversion was successful.
-	 * The value of result is 0 if the conversion failed.</p>
-	 *
-	 * @noreference This field is not intended to be referenced by clients.
+	 * @noreference This method is not intended to be referenced by clients.
 	 */
-	public int result;
-
+	public TransferDataGTK4 gtk4() {
+		if (gtk4 != null) {
+			return gtk4;
+		}
+		if (GTK.GTK4) {
+			gtk4 = new TransferDataGTK4();
+			return gtk4;
+		}
+		throw new UnsupportedOperationException("Illegal attempt to use GTK4 TransferData on GTK3");
+	}
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/gtk/org/eclipse/swt/dnd/URLTransfer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/gtk/org/eclipse/swt/dnd/URLTransfer.java
@@ -62,7 +62,7 @@ public static URLTransfer getInstance () {
  */
 @Override
 public void javaToNative (Object object, TransferData transferData){
-	transferData.result = 0;
+	transferData.gtk3().result = 0;
 	if (!checkURL(object) || !isSupportedType(transferData)) {
 		DND.error(DND.ERROR_INVALID_DATA);
 	}
@@ -74,10 +74,10 @@ public void javaToNative (Object object, TransferData transferData){
 	long pValue = OS.g_malloc(byteCount);
 	if (pValue == 0) return;
 	C.memmove(pValue, chars, byteCount);
-	transferData.length = byteCount;
-	transferData.format = 8;
-	transferData.pValue = pValue;
-	transferData.result = 1;
+	transferData.gtk3().length = byteCount;
+	transferData.gtk3().format = 8;
+	transferData.gtk3().pValue = pValue;
+	transferData.gtk3().result = 1;
 }
 
 /**
@@ -92,12 +92,12 @@ public void javaToNative (Object object, TransferData transferData){
  */
 @Override
 public Object nativeToJava(TransferData transferData){
-	if (!isSupportedType(transferData) ||  transferData.pValue == 0) return null;
+	if (!isSupportedType(transferData) ||  transferData.gtk3().pValue == 0) return null;
 	/* Ensure byteCount is a multiple of 2 bytes */
-	int size = (transferData.format * transferData.length / 8) / 2 * 2;
+	int size = (transferData.gtk3().format * transferData.gtk3().length / 8) / 2 * 2;
 	if (size <= 0) return null;
 	char[] chars = new char [size/2];
-	C.memmove (chars, transferData.pValue, size);
+	C.memmove (chars, transferData.gtk3().pValue, size);
 	String string = new String (chars);
 	int end = string.indexOf('\0');
 	return (end == -1) ? string : string.substring(0, end);


### PR DESCRIPTION
The fields in TransferData are platform specific - but GTK3 and GTK4 share the same class. The fields needed for GTK4 are quite different than for GTK3. Therefore this change refactors TransferData's internals to make it ready for GTK4 better.

This is achieved by splitting out all existing fields in a new GTK3 specific subtype, and including a starting point for GTK4 fields.

Some type checking is done to make sure that the correct object is used on GTK3 vs GTK4 respectively and this is done via the newly introduced gtk3() and gtk4() methods.

For now the GTK4 has no fields, but it will eventually have the internal fields needed for GTK4 serializing and deserializing of objects from the native side.

Part of #2126
Split out of #2538