### PR TITLE
Fix specific WidgetWin32Tests to not use Layout

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/widgets/WidgetWin32Tests.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/widgets/WidgetWin32Tests.java
@@ -55,17 +55,14 @@ class WidgetWin32Tests {
 		int scaledZoom = zoom * 2;
 
 		shell.setBounds(0, 0, 100, 160);
-		shell.setLayout(new FillLayout());
-		shell.pack();
 
 		Button button = new Button(shell, SWT.PUSH);
 		button.setText("Button");
 		button.setBounds(0, 0, 100, 200);
-		Point sizeBeforeEvent = button.getSize();
-		Point p1 = button.computeSizeInPixels(sizeBeforeEvent.x, sizeBeforeEvent.y, false);
+		Point p1 = button.getSize();
+
 		DPITestUtil.changeDPIZoom(shell, scaledZoom);
-		Point sizeAfterEvent = button.getSize();
-		Point p2 = button.computeSizeInPixels(sizeAfterEvent.x, sizeAfterEvent.y, false);
+		Point p2 = button.getSize();
 
 		assertEquals("Width should be half in points after zooming to 200", p1.x / 2 , p2.x);
 		assertEquals("Height should be half in points after zooming to 200", p1.y / 2, p2.y);
@@ -134,8 +131,6 @@ class WidgetWin32Tests {
 
 
 		shell.setBounds(0, 0, 100, 160);
-		shell.setLayout(new FillLayout());
-		shell.pack();
 
 		CoolBar coolBar = new CoolBar(shell, SWT.NONE);
 		CoolItem item1 = new CoolItem(coolBar, SWT.NONE);
@@ -200,8 +195,6 @@ class WidgetWin32Tests {
 		int scaledZoom = zoom * 2;
 
 		shell.setBounds(0, 0, 100, 160);
-		shell.setLayout(new FillLayout());
-		shell.pack();
 
 		TabFolder tabFolder = new TabFolder(shell, SWT.NONE);
 		tabFolder.setBounds(20, 20, 360, 240);


### PR DESCRIPTION
Some of the tests in WidgetWin32Tests assert the size of the controls after DPI_CHANGE. The tests work fine since theres no updateLayout called but its deffered to be executed after the thread is free and hence the controls size are unaffected. However this is risky and layouting can make the values arbitrary and the tests can fail. Hence, we simply test the absolute values without using any Layout in this PR.