### PR TITLE
Reset device zoom to 100 in ResetMonitorSpecificScalingExtension

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/internal/ResetMonitorSpecificScalingExtension.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/internal/ResetMonitorSpecificScalingExtension.java
@@ -33,6 +33,7 @@ public sealed class ResetMonitorSpecificScalingExtension implements BeforeEachCa
 	public void afterEach(ExtensionContext context) throws Exception {
 		Win32DPIUtils.setMonitorSpecificScaling(wasMonitorSpecificScalingActive);
 		Display.getDefault().dispose();
+		DPIUtil.setDeviceZoom(100);
 	}
 
 }


### PR DESCRIPTION
Disposing the display alone is insufficient, as some tests do not create a new display and continue to use the previously set device zoom when calling DPIUtil.getDeviceZoom. This change ensures that device zoom is explicitly reset to 100 after each test, preventing unintended side effects from lingering zoom values across tests.