### PR TITLE
Make test valid for backspace/delete

### DIFF
--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_custom_StyledText.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_custom_StyledText.java
@@ -5877,6 +5877,8 @@ public void test_backspaceAndDelete() {
 		}
 	}
 
+	assertEquals(1, text.getText().length());
+
 	// Simulate the backspace, ensuring that the caret is in the correct position
 	text.invokeAction(ST.DELETE_PREVIOUS);
 

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Text.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Text.java
@@ -1575,6 +1575,8 @@ public void test_backspaceAndDelete() {
 		}
 	}
 
+	assertEquals(1, text.getText().length());
+
 	display.post(backspace);
 	display.post(backspaceUp);
 


### PR DESCRIPTION
I noticed this test taking a very long time (10 seconds). The test as written is invalid because the loop has a timeout with hitting the exit condition.

The "a" is never inserted into the text box (at least on gtk3), so the sending of back space appears to work when it didn't

I guess this isn't for merging until the test can be properly fixed. I am creating PR so I can see if it reports failing on build system in the same way I see it failing locally.