### PR TITLE
When computing the size of a widget always return values rounded up

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT AWT/win32/org/eclipse/swt/awt/SWT_AWT.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT AWT/win32/org/eclipse/swt/awt/SWT_AWT.java
@@ -293,7 +293,7 @@ public static Shell new_Shell (final Display display, final Canvas parent) {
 			display.syncExec (() -> {
 				if (shell.isDisposed()) return;
 				Dimension dim = parent.getSize ();
-				shell.setSize(Win32DPIUtils.pixelToPoint(new Point(dim.width, dim.height), DPIUtil.getDeviceZoom())); // To Points
+				shell.setSize(Win32DPIUtils.pixelToPointAsSize(new Point(dim.width, dim.height), DPIUtil.getDeviceZoom())); // To Points
 			});
 		}
 	};

--- a/bundles/org.eclipse.swt/Eclipse SWT Browser/win32/org/eclipse/swt/browser/IE.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Browser/win32/org/eclipse/swt/browser/IE.java
@@ -1880,7 +1880,7 @@ void handleDOMEvent (OleEvent e) {
 	int screenY = pVarResult.getInt();
 	pVarResult.dispose();
 
-	Point position = Win32DPIUtils.pixelToPoint(new Point(screenX, screenY), DPIUtil.getDeviceZoom()); // To Points
+	Point position = Win32DPIUtils.pixelToPointAsLocation(new Point(screenX, screenY), DPIUtil.getDeviceZoom()); // To Points
 	position = browser.getDisplay().map(null, browser, position);
 	newEvent.x = position.x; newEvent.y = position.y;
 

--- a/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/win32/org/eclipse/swt/dnd/DropTarget.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/win32/org/eclipse/swt/dnd/DropTarget.java
@@ -410,7 +410,7 @@ private Point convertPixelToPoint(int xInPixels, int yInPixels) {
 	if (this.control == null) {
 		// If there is no control for context, the behavior remains as before
 		int zoom = DPIUtil.getZoomForAutoscaleProperty(this.nativeZoom);
-		return Win32DPIUtils.pixelToPoint(new Point(xInPixels, yInPixels), zoom);
+		return Win32DPIUtils.pixelToPointAsLocation(new Point(xInPixels, yInPixels), zoom);
 	}
 	int zoom = DPIUtil.getZoomForAutoscaleProperty(this.control.nativeZoom);
 	// There is no API to convert absolute values in pixels to display relative
@@ -419,7 +419,7 @@ private Point convertPixelToPoint(int xInPixels, int yInPixels) {
 	POINT pt = new POINT ();
 	pt.x = xInPixels;  pt.y = yInPixels;
 	OS.ScreenToClient (this.control.handle, pt);
-	Point p = Win32DPIUtils.pixelToPoint(new Point (pt.x, pt.y), zoom);
+	Point p = Win32DPIUtils.pixelToPointAsLocation(new Point (pt.x, pt.y), zoom);
 	return this.control.toDisplay(p);
 }
 

--- a/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/win32/org/eclipse/swt/dnd/TableDropTargetEffect.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/win32/org/eclipse/swt/dnd/TableDropTargetEffect.java
@@ -151,7 +151,7 @@ public class TableDropTargetEffect extends DropTargetEffect {
 		int effect = checkEffect(event.feedback);
 		long handle = table.handle;
 		Point coordinates = new Point(event.x, event.y);
-		coordinates = Win32DPIUtils.pointToPixel(table.toControl(coordinates), DPIUtil.getZoomForAutoscaleProperty(table.nativeZoom)); // To Pixels
+		coordinates = Win32DPIUtils.pointToPixelAsLocation(table.toControl(coordinates), DPIUtil.getZoomForAutoscaleProperty(table.nativeZoom)); // To Pixels
 		LVHITTESTINFO pinfo = new LVHITTESTINFO();
 		pinfo.x = coordinates.x;
 		pinfo.y = coordinates.y;

--- a/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/win32/org/eclipse/swt/dnd/TreeDropTargetEffect.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/win32/org/eclipse/swt/dnd/TreeDropTargetEffect.java
@@ -165,7 +165,7 @@ public class TreeDropTargetEffect extends DropTargetEffect {
 		int effect = checkEffect(event.feedback);
 		long handle = tree.handle;
 		Point coordinates = new Point(event.x, event.y);
-		coordinates = Win32DPIUtils.pointToPixel(tree.toControl(coordinates), DPIUtil.getZoomForAutoscaleProperty(tree.nativeZoom)); // To Pixels
+		coordinates = Win32DPIUtils.pointToPixelAsLocation(tree.toControl(coordinates), DPIUtil.getZoomForAutoscaleProperty(tree.nativeZoom)); // To Pixels
 		TVHITTESTINFO lpht = new TVHITTESTINFO ();
 		lpht.x = coordinates.x;
 		lpht.y = coordinates.y;

--- a/bundles/org.eclipse.swt/Eclipse SWT OLE Win32/win32/org/eclipse/swt/ole/win32/OleClientSite.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT OLE Win32/win32/org/eclipse/swt/ole/win32/OleClientSite.java
@@ -987,7 +987,7 @@ private int OnInPlaceDeactivate() {
 	return COM.S_OK;
 }
 private int OnPosRectChange(long lprcPosRect) {
-	Point size = Win32DPIUtils.pointToPixel(getSize(), DPIUtil.getZoomForAutoscaleProperty(nativeZoom)); // To Pixels
+	Point size = Win32DPIUtils.pointToPixelAsSize(getSize(), DPIUtil.getZoomForAutoscaleProperty(nativeZoom)); // To Pixels
 	setExtent(size.x, size.y);
 	return COM.S_OK;
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/Point.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/Point.java
@@ -139,13 +139,20 @@ public static sealed class OfFloat extends Point permits Point.WithMonitor {
 	private static final long serialVersionUID = -1862062276431597053L;
 
 	public float residualX, residualY;
+	private final RoundingMode roundingMode;
 
 	public OfFloat(int x, int y) {
 		super(x, y);
+		this.roundingMode = null;
 	}
 
 	public OfFloat(float x, float y) {
-		super(Math.round(x), Math.round(y));
+		this(x, y, RoundingMode.ROUND);
+	}
+
+	public OfFloat(float x, float y, RoundingMode roundingMode) {
+		super(roundingMode.round(x), roundingMode.round(y));
+		this.roundingMode = roundingMode;
 		this.residualX = x - this.x;
 		this.residualY = y - this.y;
 	}
@@ -159,12 +166,12 @@ public static sealed class OfFloat extends Point permits Point.WithMonitor {
 	}
 
 	public void setX(float x) {
-		this.x = Math.round(x);
+		this.x = roundingMode.round(x);
 		this.residualX = x - this.x;
 	}
 
 	public void setY(float y) {
-		this.y = Math.round(y);
+		this.y = roundingMode.round(y);
 		this.residualY = y - this.y;
 	}
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/RoundingMode.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/RoundingMode.java
@@ -1,0 +1,17 @@
+package org.eclipse.swt.graphics;
+/**
+* @noreference This class is not intended to be referenced by clients
+*/
+public enum RoundingMode {
+ ROUND, UP;
+
+public int round(float x) {
+	if (this == ROUND) {
+		return Math.round(x);
+	}
+	if (this == UP) {
+		return (int) Math.ceil(x);
+	}
+	return (int) x;
+}
+}

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Device.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Device.java
@@ -526,7 +526,7 @@ public Point getDPI () {
 	int dpiX = OS.GetDeviceCaps (hDC, OS.LOGPIXELSX);
 	int dpiY = OS.GetDeviceCaps (hDC, OS.LOGPIXELSY);
 	internal_dispose_GC (hDC, null);
-	return Win32DPIUtils.pixelToPoint(new Point (dpiX, dpiY), DPIUtil.getZoomForAutoscaleProperty(getDeviceZoom()));
+	return Win32DPIUtils.pixelToPointAsLocation(new Point (dpiX, dpiY), DPIUtil.getZoomForAutoscaleProperty(getDeviceZoom()));
 }
 
 /**

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/GC.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/GC.java
@@ -1056,7 +1056,7 @@ private class DrawImageOperation extends ImageOperation {
 
 	@Override
 	void apply() {
-		drawImageInPixels(getImage(), Win32DPIUtils.pointToPixel(drawable, this.location, getZoom()));
+		drawImageInPixels(getImage(), Win32DPIUtils.pointToPixelAsLocation(drawable, this.location, getZoom()));
 	}
 
 	private void drawImageInPixels(Image image, Point location) {
@@ -1868,8 +1868,8 @@ private class DrawLineOperation extends Operation {
 	@Override
 	void apply() {
 		int deviceZoom = getZoom();
-		Point startInPixels = Win32DPIUtils.pointToPixel (drawable, start, deviceZoom);
-		Point endInPixels = Win32DPIUtils.pointToPixel (drawable, end, deviceZoom);
+		Point startInPixels = Win32DPIUtils.pointToPixelAsLocation (drawable, start, deviceZoom);
+		Point endInPixels = Win32DPIUtils.pointToPixelAsLocation (drawable, end, deviceZoom);
 		drawLineInPixels(startInPixels.x, startInPixels.y, endInPixels.x, endInPixels.y);
 	}
 }
@@ -2039,7 +2039,7 @@ private class DrawPointOperation extends Operation {
 
 	@Override
 	void apply() {
-		Point scaleUpLocation = Win32DPIUtils.pointToPixel(location, getZoom());
+		Point scaleUpLocation = Win32DPIUtils.pointToPixelAsLocation(location, getZoom());
 		drawPointInPixels(scaleUpLocation.x, scaleUpLocation.y);
 	}
 }
@@ -2457,7 +2457,7 @@ private class DrawStringOperation extends Operation {
 
 	@Override
 	void apply() {
-		Point scaledLocation = Win32DPIUtils.pointToPixel(drawable, location, getZoom());
+		Point scaledLocation = Win32DPIUtils.pointToPixelAsLocation(drawable, location, getZoom());
 		drawStringInPixels(string, scaledLocation.x, scaledLocation.y, isTransparent);
 	}
 }
@@ -2643,7 +2643,7 @@ private class DrawTextOperation extends Operation {
 
 	@Override
 	void apply() {
-		Point scaledLocation = Win32DPIUtils.pointToPixel(drawable, location, getZoom());
+		Point scaledLocation = Win32DPIUtils.pointToPixelAsLocation(drawable, location, getZoom());
 		drawTextInPixels(string, scaledLocation.x, scaledLocation.y, flags);
 	}
 }
@@ -5736,7 +5736,7 @@ private class SetTransformOperation extends Operation {
  */
 public Point stringExtent (String string) {
 	if (string == null) SWT.error (SWT.ERROR_NULL_ARGUMENT);
-	return Win32DPIUtils.pixelToPoint(drawable, stringExtentInPixels(string), getZoom());
+	return Win32DPIUtils.pixelToPointAsSize(drawable, stringExtentInPixels(string), getZoom());
 }
 
 Point stringExtentInPixels (String string) {
@@ -5781,7 +5781,7 @@ Point stringExtentInPixels (String string) {
  * </ul>
  */
 public Point textExtent (String string) {
-	return Win32DPIUtils.pixelToPoint(drawable, textExtentInPixels(string, SWT.DRAW_DELIMITER | SWT.DRAW_TAB), getZoom());
+	return Win32DPIUtils.pixelToPointAsSize(drawable, textExtentInPixels(string, SWT.DRAW_DELIMITER | SWT.DRAW_TAB), getZoom());
 }
 
 /**
@@ -5816,7 +5816,7 @@ public Point textExtent (String string) {
  * </ul>
  */
 public Point textExtent (String string, int flags) {
-	return Win32DPIUtils.pixelToPoint(drawable, textExtentInPixels(string, flags), getZoom());
+	return Win32DPIUtils.pixelToPointAsSize(drawable, textExtentInPixels(string, flags), getZoom());
 }
 
 Point textExtentInPixels(String string, int flags) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Region.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Region.java
@@ -232,7 +232,7 @@ public boolean contains (Point pt) {
 	if (pt == null) SWT.error(SWT.ERROR_NULL_ARGUMENT);
 	return applyUsingAnyHandle(regionHandle -> {
 		int zoom = regionHandle.zoom();
-		Point p = Win32DPIUtils.pointToPixel(pt, zoom);
+		Point p = Win32DPIUtils.pointToPixelAsLocation(pt, zoom);
 		return containsInPixels(regionHandle.handle(), p.x, p.y);
 	});
 }
@@ -889,7 +889,7 @@ private static class OperationWithPoint extends Operation {
 
 	@Override
 	void translate(long handle, int zoom) {
-		Point pt = Win32DPIUtils.pointToPixel((Point) data, zoom);
+		Point pt = Win32DPIUtils.pointToPixelAsLocation((Point) data, zoom);
 		OS.OffsetRgn (handle, pt.x, pt.y);
 	}
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/TextLayout.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/TextLayout.java
@@ -2199,7 +2199,7 @@ public int[] getLineOffsets () {
  */
 public Point getLocation (int offset, boolean trailing) {
 	checkLayout();
-	return Win32DPIUtils.pixelToPoint(getDevice(), getLocationInPixels(offset, trailing), getZoom());
+	return Win32DPIUtils.pixelToPointAsLocation(getDevice(), getLocationInPixels(offset, trailing), getZoom());
 }
 
 Point getLocationInPixels (int offset, boolean trailing) {
@@ -2409,7 +2409,7 @@ int _getOffset(int offset, int movement, boolean forward) {
  */
 public int getOffset (Point point, int[] trailing) {
 	checkLayout();
-	if (point == null) SWT.error (SWT.ERROR_NULL_ARGUMENT);	return getOffsetInPixels(Win32DPIUtils.pointToPixel(getDevice(), point, getZoom()), trailing);
+	if (point == null) SWT.error (SWT.ERROR_NULL_ARGUMENT);	return getOffsetInPixels(Win32DPIUtils.pointToPixelAsLocation(getDevice(), point, getZoom()), trailing);
 }
 
 int getOffsetInPixels (Point point, int[] trailing) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/ImageList.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/ImageList.java
@@ -371,7 +371,7 @@ private void addPlaceholderImageToImageList(long imageListHandle, int bitmapWidt
 public Point getImageSize() {
 	int [] cx = new int [1], cy = new int [1];
 	OS.ImageList_GetIconSize (handle, cx, cy);
-	return Win32DPIUtils.pixelToPoint(new Point (cx [0], cy [0]), zoom);
+	return Win32DPIUtils.pixelToPointAsSize(new Point (cx [0], cy [0]), zoom);
 }
 
 public int indexOf (Image image) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/Win32DPIUtils.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/Win32DPIUtils.java
@@ -113,26 +113,39 @@ public class Win32DPIUtils {
 		return DPIUtil.pixelToPoint (size, zoom);
 	}
 
-	public static Point pixelToPoint(Point point, int zoom) {
+	public static Point pixelToPointAsSize(Drawable drawable, Point point, int zoom) {
+		if (drawable != null && !drawable.isAutoScalable()) return point;
+		return pixelToPointAsSize (point, zoom);
+	}
+
+	public static Point pixelToPointAsLocation(Drawable drawable, Point point, int zoom) {
+		if (drawable != null && !drawable.isAutoScalable()) return point;
+		return pixelToPointAsLocation (point, zoom);
+	}
+
+	public static Point pixelToPointAsSize(Point point, int zoom) {
+		return pixelToPoint(point, zoom, RoundingMode.UP);
+	}
+
+	public static Point pixelToPointAsLocation(Point point, int zoom) {
+		return pixelToPoint(point, zoom, RoundingMode.ROUND);
+	}
+
+	private static Point pixelToPoint(Point point, int zoom, RoundingMode mode) {
 		if (zoom == 100 || point == null) return point;
 		Point.OfFloat fPoint = Point.OfFloat.from(point);
 		float scaleFactor = DPIUtil.getScalingFactor(zoom);
 		float scaledX = fPoint.getX() / scaleFactor;
 		float scaledY = fPoint.getY() / scaleFactor;
-		return new Point.OfFloat(scaledX, scaledY);
-	}
-
-	public static Point pixelToPoint(Drawable drawable, Point point, int zoom) {
-		if (drawable != null && !drawable.isAutoScalable()) return point;
-		return pixelToPoint (point, zoom);
+		return new Point.OfFloat(scaledX, scaledY, mode);
 	}
 
 	public static Rectangle pixelToPoint(Rectangle rect, int zoom) {
 		if (zoom == 100 || rect == null) return rect;
 		if (rect instanceof Rectangle.OfFloat rectOfFloat) return pixelToPoint(rectOfFloat, zoom);
 		Rectangle scaledRect = new Rectangle.OfFloat (0,0,0,0);
-		Point scaledTopLeft = pixelToPoint(new Point (rect.x, rect.y), zoom);
-		Point scaledBottomRight = pixelToPoint(new Point (rect.x + rect.width, rect.y + rect.height), zoom);
+		Point scaledTopLeft = pixelToPointAsLocation(new Point (rect.x, rect.y), zoom);
+		Point scaledBottomRight = pixelToPointAsLocation(new Point (rect.x + rect.width, rect.y + rect.height), zoom);
 
 		scaledRect.x = scaledTopLeft.x;
 		scaledRect.y = scaledTopLeft.y;
@@ -219,26 +232,39 @@ public class Win32DPIUtils {
 		return pointToPixel (size, zoom);
 	}
 
-	public static Point pointToPixel(Point point, int zoom) {
+	private static Point pointToPixel(Point point, int zoom, RoundingMode mode) {
 		if (zoom == 100 || point == null) return point;
 		Point.OfFloat fPoint = Point.OfFloat.from(point);
 		float scaleFactor = DPIUtil.getScalingFactor(zoom);
 		float scaledX = fPoint.getX() * scaleFactor;
 		float scaledY = fPoint.getY() * scaleFactor;
-		return new Point.OfFloat(scaledX, scaledY);
+		return new Point.OfFloat(scaledX, scaledY, mode);
 	}
 
-	public static Point pointToPixel(Drawable drawable, Point point, int zoom) {
+	public static Point pointToPixelAsSize(Drawable drawable, Point point, int zoom) {
 		if (drawable != null && !drawable.isAutoScalable()) return point;
-		return pointToPixel (point, zoom);
+		return pointToPixelAsSize(point, zoom);
+	}
+
+	public static Point pointToPixelAsLocation(Drawable drawable, Point point, int zoom) {
+		if (drawable != null && !drawable.isAutoScalable()) return point;
+		return pointToPixelAsLocation(point, zoom);
+	}
+
+	public static Point pointToPixelAsSize(Point point, int zoom) {
+		return pointToPixel(point, zoom, RoundingMode.UP);
+	}
+
+	public static Point pointToPixelAsLocation(Point point, int zoom) {
+		return pointToPixel(point, zoom, RoundingMode.ROUND);
 	}
 
 	public static Rectangle pointToPixel(Rectangle rect, int zoom) {
 		if (zoom == 100 || rect == null) return rect;
 		if (rect instanceof Rectangle.OfFloat rectOfFloat) return pointToPixel(rectOfFloat, zoom);
 		Rectangle scaledRect = new Rectangle.OfFloat(0,0,0,0);
-		Point scaledTopLeft = pointToPixel (new Point(rect.x, rect.y), zoom);
-		Point scaledBottomRight = pointToPixel (new Point(rect.x + rect.width, rect.y + rect.height), zoom);
+		Point scaledTopLeft = pointToPixelAsLocation (new Point(rect.x, rect.y), zoom);
+		Point scaledBottomRight = pointToPixelAsLocation (new Point(rect.x + rect.width, rect.y + rect.height), zoom);
 
 		scaledRect.x = scaledTopLeft.x;
 		scaledRect.y = scaledTopLeft.y;

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Caret.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Caret.java
@@ -223,7 +223,7 @@ public Canvas getParent () {
  */
 public Point getSize () {
 	checkWidget();
-	return Win32DPIUtils.pixelToPoint(getSizeInPixels(), getZoom());
+	return Win32DPIUtils.pixelToPointAsSize(getSizeInPixels(), getZoom());
 }
 
 Point getSizeInPixels () {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Combo.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Combo.java
@@ -910,7 +910,7 @@ boolean dragDetect (long hwnd, int x, int y, boolean filter, boolean [] detect, 
  */
 public Point getCaretLocation () {
 	checkWidget ();
-	return Win32DPIUtils.pixelToPoint(getCaretLocationInPixels(), getZoom());
+	return Win32DPIUtils.pixelToPointAsLocation(getCaretLocationInPixels(), getZoom());
 }
 
 Point getCaretLocationInPixels () {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Composite.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Composite.java
@@ -215,7 +215,7 @@ Point computeSizeInPixels (int wHint, int hHint, boolean changed) {
 			changed |= (state & LAYOUT_CHANGED) != 0;
 			state &= ~LAYOUT_CHANGED;
 			int zoom = getZoom();
-			size = Win32DPIUtils.pointToPixel(layout.computeSize (this, DPIUtil.pixelToPoint(wHint, zoom), DPIUtil.pixelToPoint(hHint, zoom), changed), zoom);
+			size = Win32DPIUtils.pointToPixelAsSize(layout.computeSize (this, DPIUtil.pixelToPoint(wHint, zoom), DPIUtil.pixelToPoint(hHint, zoom), changed), zoom);
 		} else {
 			size = new Point (wHint, hHint);
 		}

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Control.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Control.java
@@ -616,7 +616,9 @@ public Point computeSize (int wHint, int hHint, boolean changed){
 	int zoom = getZoom();
 	wHint = (wHint != SWT.DEFAULT ? Win32DPIUtils.pointToPixel(wHint, zoom) : wHint);
 	hHint = (hHint != SWT.DEFAULT ? Win32DPIUtils.pointToPixel(hHint, zoom) : hHint);
-	return Win32DPIUtils.pixelToPoint(computeSizeInPixels(wHint, hHint, changed), zoom);
+	//We should never return a size that is to small, RoundingMode.UP ensures we at worst case report
+	//a size that is a bit too large by half a point
+	return Win32DPIUtils.pixelToPointAsSize(computeSizeInPixels(wHint, hHint, changed), zoom);
 }
 
 Point computeSizeInPixels (int wHint, int hHint, boolean changed) {
@@ -1368,7 +1370,8 @@ public Object getLayoutData () {
  */
 public Point getLocation () {
 	checkWidget ();
-	return Win32DPIUtils.pixelToPoint(getLocationInPixels(), getZoom());
+	//For a location the closest point values is okay
+	return Win32DPIUtils.pixelToPointAsLocation(getLocationInPixels(), getZoom());
 }
 
 Point getLocationInPixels () {
@@ -1524,7 +1527,7 @@ public Shell getShell () {
  */
 public Point getSize (){
 	checkWidget ();
-	return Win32DPIUtils.pixelToPoint(getSizeInPixels (), getZoom());
+	return Win32DPIUtils.pixelToPointAsSize(getSizeInPixels (), getZoom());
 }
 
 Point getSizeInPixels () {
@@ -3548,7 +3551,7 @@ void setLocationInPixels (int x, int y) {
 public void setLocation (Point location) {
 	checkWidget ();
 	if (location == null) error (SWT.ERROR_NULL_ARGUMENT);
-	location = Win32DPIUtils.pointToPixel(location, getZoom());
+	location = Win32DPIUtils.pointToPixelAsLocation(location, getZoom());
 	setLocationInPixels(location.x, location.y);
 }
 
@@ -3811,7 +3814,7 @@ void setSizeInPixels (int width, int height) {
 public void setSize (Point size) {
 	checkWidget ();
 	if (size == null) error (SWT.ERROR_NULL_ARGUMENT);
-	size = Win32DPIUtils.pointToPixel(size, getZoom());
+	size = Win32DPIUtils.pointToPixelAsSize(size, getZoom());
 	setSizeInPixels(size.x, size.y);
 }
 
@@ -4026,7 +4029,7 @@ public Point toControl (int x, int y) {
 	checkWidget ();
 	Point displayPointInPixels = getDisplay().translateToDisplayCoordinates(new Point(x, y));
 	final Point controlPointInPixels = toControlInPixels(displayPointInPixels.x, displayPointInPixels.y);
-	return Win32DPIUtils.pixelToPoint(controlPointInPixels, getZoom());
+	return Win32DPIUtils.pixelToPointAsLocation(controlPointInPixels, getZoom());
 }
 
 Point toControlInPixels (int x, int y) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/CoolBar.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/CoolBar.java
@@ -548,7 +548,7 @@ public Point [] getItemSizes () {
 	Point [] sizes = getItemSizesInPixels();
 	if (sizes != null) {
 		for (int i = 0; i < sizes.length; i++) {
-			sizes[i] = Win32DPIUtils.pixelToPoint(sizes[i], getZoom());
+			sizes[i] = Win32DPIUtils.pixelToPointAsSize(sizes[i], getZoom());
 		}
 	}
 	return sizes;
@@ -808,7 +808,7 @@ public void setItemLayout (int [] itemOrder, int [] wrapIndices, Point [] sizes)
 	if (sizes == null) error (SWT.ERROR_NULL_ARGUMENT);
 	Point [] sizesInPoints = new Point [sizes.length];
 	for (int i = 0; i < sizes.length; i++) {
-		sizesInPoints[i] = Win32DPIUtils.pointToPixel(sizes[i], getZoom());
+		sizesInPoints[i] = Win32DPIUtils.pointToPixelAsSize(sizes[i], getZoom());
 	}
 	setItemLayoutInPixels (itemOrder, wrapIndices, sizesInPoints);
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/CoolItem.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/CoolItem.java
@@ -188,7 +188,7 @@ public Point computeSize (int wHint, int hHint) {
 	int zoom = getZoom();
 	wHint = (wHint != SWT.DEFAULT ? Win32DPIUtils.pointToPixel(wHint, zoom) : wHint);
 	hHint = (hHint != SWT.DEFAULT ? Win32DPIUtils.pointToPixel(hHint, zoom) : hHint);
-	return Win32DPIUtils.pixelToPoint(computeSizeInPixels(wHint, hHint), zoom);
+	return Win32DPIUtils.pixelToPointAsSize(computeSizeInPixels(wHint, hHint), zoom);
 }
 Point computeSizeInPixels (int wHint, int hHint) {
 	int index = parent.indexOf (this);
@@ -383,7 +383,7 @@ public void setControl (Control control) {
  */
 public Point getPreferredSize () {
 	checkWidget ();
-	return Win32DPIUtils.pixelToPoint(getPreferredSizeInPixels(), getZoom());
+	return Win32DPIUtils.pixelToPointAsSize(getPreferredSizeInPixels(), getZoom());
 }
 
 Point getPreferredSizeInPixels () {
@@ -464,7 +464,7 @@ void setPreferredSizeInPixels (int width, int height) {
 public void setPreferredSize (Point size) {
 	checkWidget ();
 	if (size == null) error(SWT.ERROR_NULL_ARGUMENT);
-	size = Win32DPIUtils.pointToPixel(size, getZoom());
+	size = Win32DPIUtils.pointToPixelAsSize(size, getZoom());
 	setPreferredSizeInPixels(size.x, size.y);
 }
 
@@ -483,7 +483,7 @@ public void setPreferredSize (Point size) {
  */
 public Point getSize () {
 	checkWidget ();
-	return Win32DPIUtils.pixelToPoint(getSizeInPixels(), getZoom());
+	return Win32DPIUtils.pixelToPointAsSize(getSizeInPixels(), getZoom());
 }
 
 Point getSizeInPixels() {
@@ -592,7 +592,7 @@ void setSizeInPixels (int width, int height) {
 public void setSize (Point size) {
 	checkWidget ();
 	if (size == null) error(SWT.ERROR_NULL_ARGUMENT);
-	size = Win32DPIUtils.pointToPixel(size, getZoom());
+	size = Win32DPIUtils.pointToPixelAsSize(size, getZoom());
 	setSizeInPixels(size.x, size.y);
 }
 
@@ -611,7 +611,7 @@ public void setSize (Point size) {
  */
 public Point getMinimumSize () {
 	checkWidget ();
-	return Win32DPIUtils.pixelToPoint(getMinimumSizeInPixels(), getZoom());
+	return Win32DPIUtils.pixelToPointAsSize(getMinimumSizeInPixels(), getZoom());
 }
 
 Point getMinimumSizeInPixels () {
@@ -695,7 +695,7 @@ void setMinimumSizeInPixels (int width, int height) {
 public void setMinimumSize (Point size) {
 	checkWidget ();
 	if (size == null) error (SWT.ERROR_NULL_ARGUMENT);
-	size = Win32DPIUtils.pointToPixel(size, getZoom());
+	size = Win32DPIUtils.pointToPixelAsSize(size, getZoom());
 	setMinimumSizeInPixels(size.x, size.y);
 }
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Display.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Display.java
@@ -3636,7 +3636,7 @@ public boolean post (Event event) {
 					int y = OS.GetSystemMetrics (OS.SM_YVIRTUALSCREEN);
 					int width = OS.GetSystemMetrics (OS.SM_CXVIRTUALSCREEN);
 					int height = OS.GetSystemMetrics (OS.SM_CYVIRTUALSCREEN);
-					Point loc = Win32DPIUtils.pointToPixel(event.getLocation(), getDeviceZoom());
+					Point loc = Win32DPIUtils.pointToPixelAsLocation(event.getLocation(), getDeviceZoom());
 					inputs.dx = ((loc.x - x) * 65535 + width - 2) / (width - 1);
 					inputs.dy = ((loc.y - y) * 65535 + height - 2) / (height - 1);
 				} else {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/MenuItem.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/MenuItem.java
@@ -1433,7 +1433,7 @@ private Point calculateRenderedTextSize() {
 			// GC calculated height of 15px, scales down with adjusted zoom of 100% and returns 15pt -> should be 10pt
 			// this calculation is corrected by the following line
 			// This is the only place, where the GC needs to use the native zoom to do that, therefore it is fixed only here
-			points = Win32DPIUtils.pixelToPoint(Win32DPIUtils.pointToPixel(points, adjustedPrimaryMonitorZoom), primaryMonitorZoom);
+			points = Win32DPIUtils.pixelToPointAsSize(Win32DPIUtils.pointToPixelAsSize(points, adjustedPrimaryMonitorZoom), primaryMonitorZoom);
 		}
 	}
 	return points;

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/MultiZoomCoordinateSystemMapper.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/MultiZoomCoordinateSystemMapper.java
@@ -49,14 +49,14 @@ class MultiZoomCoordinateSystemMapper implements CoordinateSystemMapper {
 		if (from == null) {
 			Point mappedPointInpixels = display.mapInPixels(from, to,
 					getPixelsFromPoint(to.getShell().getMonitor(), x, y));
-			mappedPointInPoints = Win32DPIUtils.pixelToPoint(mappedPointInpixels, to.getZoom());
+			mappedPointInPoints = Win32DPIUtils.pixelToPointAsLocation(mappedPointInpixels, to.getZoom());
 		} else if (to == null) {
-			Point mappedPointInpixels = display.mapInPixels(from, to, Win32DPIUtils.pointToPixel(new Point(x, y), from.getZoom()));
+			Point mappedPointInpixels = display.mapInPixels(from, to, Win32DPIUtils.pointToPixelAsLocation(new Point(x, y), from.getZoom()));
 			mappedPointInPoints = getPointFromPixels(from.getShell().getMonitor(), mappedPointInpixels.x,
 					mappedPointInpixels.y);
 		} else {
-			Point mappedPointInpixels = display.mapInPixels(from, to, Win32DPIUtils.pointToPixel(new Point(x, y), from.getZoom()));
-			mappedPointInPoints = Win32DPIUtils.pixelToPoint(mappedPointInpixels, to.getZoom());
+			Point mappedPointInpixels = display.mapInPixels(from, to, Win32DPIUtils.pointToPixelAsLocation(new Point(x, y), from.getZoom()));
+			mappedPointInPoints = Win32DPIUtils.pixelToPointAsLocation(mappedPointInpixels, to.getZoom());
 		}
 		return mappedPointInPoints;
 	}

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ScrollBar.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ScrollBar.java
@@ -355,7 +355,7 @@ public int getSelection () {
  */
 public Point getSize () {
 	checkWidget();
-	return Win32DPIUtils.pixelToPoint(getSizeInPixels(), getZoom());
+	return Win32DPIUtils.pixelToPointAsSize(getSizeInPixels(), getZoom());
 }
 
 Point getSizeInPixels () {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Shell.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Shell.java
@@ -1043,7 +1043,7 @@ public boolean getMaximized () {
  */
 public Point getMaximumSize () {
 	checkWidget ();
-	return Win32DPIUtils.pixelToPoint(getMaximumSizeInPixels(), getZoom());
+	return Win32DPIUtils.pixelToPointAsSize(getMaximumSizeInPixels(), getZoom());
 }
 
 Point getMaximumSizeInPixels () {
@@ -1084,7 +1084,7 @@ Point getMaximumSizeInPixels () {
  */
 public Point getMinimumSize () {
 	checkWidget ();
-	return Win32DPIUtils.pixelToPoint(getMinimumSizeInPixels(), getZoom());
+	return Win32DPIUtils.pixelToPointAsSize(getMinimumSizeInPixels(), getZoom());
 }
 
 Point getMinimumSizeInPixels () {
@@ -1797,7 +1797,7 @@ public void setMaximumSize (int width, int height) {
 public void setMaximumSize (Point size) {
 	checkWidget ();
 	if (size == null) error (SWT.ERROR_NULL_ARGUMENT);
-	size = Win32DPIUtils.pointToPixel(size, getZoom());
+	size = Win32DPIUtils.pointToPixelAsSize(size, getZoom());
 	setMaximumSizeInPixels(size.x, size.y);
 }
 
@@ -1892,7 +1892,7 @@ void setMinimumSizeInPixels (int width, int height) {
 public void setMinimumSize (Point size) {
 	checkWidget ();
 	if (size == null) error (SWT.ERROR_NULL_ARGUMENT);
-	size = Win32DPIUtils.pointToPixel(size, getZoom());
+	size = Win32DPIUtils.pointToPixelAsSize(size, getZoom());
 	setMinimumSizeInPixels(size.x, size.y);
 }
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/SingleZoomCoordinateSystemMapper.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/SingleZoomCoordinateSystemMapper.java
@@ -41,8 +41,8 @@ class SingleZoomCoordinateSystemMapper implements CoordinateSystemMapper {
 	@Override
 	public Point map(Control from, Control to, Point point) {
 		int zoom = getZoomLevelForMapping(from, to);
-		point = Win32DPIUtils.pointToPixel(point, zoom);
-		return Win32DPIUtils.pixelToPoint(display.mapInPixels(from, to, point), zoom);
+		point = Win32DPIUtils.pointToPixelAsLocation(point, zoom);
+		return Win32DPIUtils.pixelToPointAsLocation(display.mapInPixels(from, to, point), zoom);
 	}
 
 	@Override
@@ -57,7 +57,7 @@ class SingleZoomCoordinateSystemMapper implements CoordinateSystemMapper {
 		int zoom = getZoomLevelForMapping(from, to);
 		x = Win32DPIUtils.pointToPixel(x, zoom);
 		y = Win32DPIUtils.pointToPixel(y, zoom);
-		return Win32DPIUtils.pixelToPoint(display.mapInPixels(from, to, x, y), zoom);
+		return Win32DPIUtils.pixelToPointAsLocation(display.mapInPixels(from, to, x, y), zoom);
 	}
 
 	@Override
@@ -77,12 +77,12 @@ class SingleZoomCoordinateSystemMapper implements CoordinateSystemMapper {
 
 	@Override
 	public Point translateFromDisplayCoordinates(Point point) {
-		return Win32DPIUtils.pixelToPoint(point, DPIUtil.getDeviceZoom());
+		return Win32DPIUtils.pixelToPointAsLocation(point, DPIUtil.getDeviceZoom());
 	}
 
 	@Override
 	public Point translateToDisplayCoordinates(Point point) {
-		return Win32DPIUtils.pointToPixel(point, DPIUtil.getDeviceZoom());
+		return Win32DPIUtils.pointToPixelAsLocation(point, DPIUtil.getDeviceZoom());
 	}
 
 	@Override
@@ -99,7 +99,7 @@ class SingleZoomCoordinateSystemMapper implements CoordinateSystemMapper {
 	public Point getCursorLocation() {
 		int zoom = DPIUtil.getDeviceZoom();
 		Point cursorLocationInPixels = display.getCursorLocationInPixels();
-		return Win32DPIUtils.pixelToPoint(cursorLocationInPixels, zoom);
+		return Win32DPIUtils.pixelToPointAsLocation(cursorLocationInPixels, zoom);
 	}
 
 	@Override
@@ -111,7 +111,7 @@ class SingleZoomCoordinateSystemMapper implements CoordinateSystemMapper {
 	@Override
 	public Rectangle getContainingMonitorBoundsInPixels(Point point) {
 		int zoom = DPIUtil.getDeviceZoom();
-		point = Win32DPIUtils.pointToPixel(point, zoom);
+		point = Win32DPIUtils.pointToPixelAsLocation(point, zoom);
 		for (Monitor monitor : display.getMonitors()) {
 			Rectangle monitorBounds = Win32DPIUtils.pointToPixel(monitor.getBounds(), zoom);
 			if (monitorBounds.contains(point)) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TabFolder.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TabFolder.java
@@ -517,7 +517,7 @@ Point minimumSize (int wHint, int hHint, boolean flushCache) {
 			 * Since computeSize can be overridden by subclasses, we cannot
 			 * call computeSizeInPixels directly.
 			 */
-			Point size = Win32DPIUtils.pointToPixel(child.computeSize (DPIUtil.pixelToPoint(wHint, zoom), DPIUtil.pixelToPoint(hHint, zoom), flushCache), zoom);
+			Point size = Win32DPIUtils.pointToPixelAsSize(child.computeSize (DPIUtil.pixelToPoint(wHint, zoom), DPIUtil.pixelToPoint(hHint, zoom), flushCache), zoom);
 			width = Math.max (width, size.x);
 			height = Math.max (height, size.y);
 		}

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Table.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Table.java
@@ -2474,7 +2474,7 @@ public TableItem getItem (int index) {
 public TableItem getItem (Point point) {
 	checkWidget ();
 	if (point == null) error (SWT.ERROR_NULL_ARGUMENT);
-	return getItemInPixels (Win32DPIUtils.pointToPixel(point, getZoom()));
+	return getItemInPixels (Win32DPIUtils.pointToPixelAsLocation(point, getZoom()));
 }
 
 TableItem getItemInPixels (Point point) {
@@ -7297,7 +7297,7 @@ LRESULT wmNotifyToolTip (NMTTCUSTOMDRAW nmcd, long lParam) {
 					if (image != null) {
 						Rectangle rect = Win32DPIUtils.pointToPixel(image.getBounds(), getZoom());
 						RECT imageRect = item.getBounds (pinfo.iItem, pinfo.iSubItem, false, true, false, false, hDC);
-						Point size = imageList == null ? new Point (rect.width, rect.height) : Win32DPIUtils.pointToPixel(imageList.getImageSize(), getZoom());
+						Point size = imageList == null ? new Point (rect.width, rect.height) : Win32DPIUtils.pointToPixelAsSize(imageList.getImageSize(), getZoom());
 						int y = imageRect.top + Math.max (0, (imageRect.bottom - imageRect.top - size.y) / 2);
 						int zoom = getZoom();
 						rect = Win32DPIUtils.pixelToPoint(rect, zoom);

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Text.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Text.java
@@ -985,7 +985,7 @@ public int getCaretLineNumber () {
  */
 public Point getCaretLocation () {
 	checkWidget ();
-	return Win32DPIUtils.pixelToPoint(getCaretLocationInPixels(), getZoom());
+	return Win32DPIUtils.pixelToPointAsLocation(getCaretLocationInPixels(), getZoom());
 }
 
 Point getCaretLocationInPixels () {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ToolBar.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ToolBar.java
@@ -569,7 +569,7 @@ public ToolItem getItem (int index) {
 public ToolItem getItem (Point point) {
 	checkWidget ();
 	if (point == null) error (SWT.ERROR_NULL_ARGUMENT);
-	return getItemInPixels(Win32DPIUtils.pointToPixel(point, getZoom()));
+	return getItemInPixels(Win32DPIUtils.pointToPixelAsLocation(point, getZoom()));
 }
 
 ToolItem getItemInPixels (Point point) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ToolTip.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ToolTip.java
@@ -393,7 +393,7 @@ void setLocationInPixels (int x, int y) {
 public void setLocation (Point location) {
 	checkWidget ();
 	if (location == null) error (SWT.ERROR_NULL_ARGUMENT);
-	location = Win32DPIUtils.pointToPixel(location, getZoom());
+	location = Win32DPIUtils.pointToPixelAsLocation(location, getZoom());
 	setLocationInPixels(location.x, location.y);
 }
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Tree.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Tree.java
@@ -523,7 +523,7 @@ LRESULT CDDS_ITEMPOSTPAINT (NMTVCUSTOMDRAW nmcd, long wParam, long lParam) {
 							}
 							if (image != null) {
 								Rectangle bounds = image.getBounds (); // Points
-								if (size == null) size = Win32DPIUtils.pixelToPoint (getImageSize (), zoom); // To Points
+								if (size == null) size = Win32DPIUtils.pixelToPointAsSize (getImageSize (), zoom); // To Points
 								if (!ignoreDrawForeground) {
 									GCData data = new GCData();
 									data.device = display;
@@ -761,7 +761,7 @@ LRESULT CDDS_ITEMPOSTPAINT (NMTVCUSTOMDRAW nmcd, long wParam, long lParam) {
 					int offset = i != 0 ? Win32DPIUtils.pointToPixel(INSET, zoom) : Win32DPIUtils.pointToPixel(INSET + 2, zoom);
 					if (image != null) {
 						Rectangle bounds = image.getBounds (); // Points
-						if (size == null) size = Win32DPIUtils.pixelToPoint (getImageSize (), zoom); // To Points
+						if (size == null) size = Win32DPIUtils.pixelToPointAsSize (getImageSize (), zoom); // To Points
 						if (!ignoreDrawForeground) {
 							//int y1 = rect.top + (index == 0 ? (getItemHeight () - size.y) / 2 : 0);
 							int y1 = rect.top + Win32DPIUtils.pointToPixel((getItemHeight () - size.y) / 2, zoom);
@@ -3060,7 +3060,7 @@ public boolean getHeaderVisible () {
 }
 
 Point getImageSize () {
-	if (imageList != null) return Win32DPIUtils.pointToPixel(imageList.getImageSize(), getZoom());
+	if (imageList != null) return Win32DPIUtils.pointToPixelAsSize(imageList.getImageSize(), getZoom());
 	return new Point (0, getItemHeightInPixels ());
 }
 
@@ -3289,7 +3289,7 @@ TreeItem getItem (NMTVCUSTOMDRAW nmcd) {
 public TreeItem getItem (Point point) {
 	checkWidget ();
 	if (point == null) error (SWT.ERROR_NULL_ARGUMENT);
-	return getItemInPixels(Win32DPIUtils.pointToPixel(point, getZoom()));
+	return getItemInPixels(Win32DPIUtils.pointToPixelAsLocation(point, getZoom()));
 }
 
 TreeItem getItemInPixels (Point point) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Widget.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Widget.java
@@ -1715,7 +1715,7 @@ boolean showMenu (int x, int y, int detail) {
 	if (!event.doit) return true;
 	Menu menu = getMenu ();
 	if (menu != null && !menu.isDisposed ()) {
-		Point locInPixels = Win32DPIUtils.pointToPixel(event.getLocation(), getZoom()); // In Pixels
+		Point locInPixels = Win32DPIUtils.pointToPixelAsLocation(event.getLocation(), getZoom()); // In Pixels
 		if (x != locInPixels.x || y != locInPixels.y) {
 			menu.setLocation (event.getLocation());
 		}

--- a/tests/org.eclipse.swt.tests.win32/JUnit Tests/org/eclipse/swt/tests/win32/Win32DPIUtilTests.java
+++ b/tests/org.eclipse.swt.tests.win32/JUnit Tests/org/eclipse/swt/tests/win32/Win32DPIUtilTests.java
@@ -86,17 +86,17 @@ public class Win32DPIUtilTests {
 		Point valueAt150 = new Point(7, 10);
 		Point valueAt100 = new Point(5, 7);
 
-		Point scaledValue = Win32DPIUtils.pixelToPoint(valueAt200, 200);
+		Point scaledValue = Win32DPIUtils.pixelToPointAsLocation(valueAt200, 200);
 		assertEquals(valueAt100, scaledValue, "Scaling down Point from 200 failed");
-		scaledValue = Win32DPIUtils.pixelToPoint((Device) null, valueAt200, 200);
+		scaledValue = Win32DPIUtils.pixelToPointAsLocation((Device) null, valueAt200, 200);
 		assertEquals(valueAt100, scaledValue, "Scaling down Point from 200 with device failed");
-		scaledValue = Win32DPIUtils.pixelToPoint(valueAt150, 150);
+		scaledValue = Win32DPIUtils.pixelToPointAsLocation(valueAt150, 150);
 		assertEquals(valueAt100, scaledValue, "Scaling down Point from 150 failed");
-		scaledValue = Win32DPIUtils.pixelToPoint((Device) null, valueAt150, 150);
+		scaledValue = Win32DPIUtils.pixelToPointAsLocation((Device) null, valueAt150, 150);
 		assertEquals(valueAt100, scaledValue, "Scaling down Point from 150 with device failed");
-		scaledValue = Win32DPIUtils.pixelToPoint(valueAt100, 100);
+		scaledValue = Win32DPIUtils.pixelToPointAsLocation(valueAt100, 100);
 		assertSame(valueAt100, scaledValue, "Scaling down Point without zoom change failed");
-		scaledValue = Win32DPIUtils.pixelToPoint((Device) null, valueAt100, 100);
+		scaledValue = Win32DPIUtils.pixelToPointAsLocation((Device) null, valueAt100, 100);
 		assertSame(valueAt100, scaledValue, "Scaling down Point without zoom change with device failed");
 	}
 
@@ -186,17 +186,17 @@ public class Win32DPIUtilTests {
 		Point valueAt150 = new Point(8, 11);
 		Point valueAt100 = new Point(5, 7);
 
-		Point scaledValue = Win32DPIUtils.pointToPixel(valueAt100, 200);
+		Point scaledValue = Win32DPIUtils.pointToPixelAsLocation(valueAt100, 200);
 		assertEquals(valueAt200, scaledValue, "Scaling up Point to 200 failed");
-		scaledValue = Win32DPIUtils.pointToPixel((Device) null, valueAt100, 200);
+		scaledValue = Win32DPIUtils.pointToPixelAsLocation((Device) null, valueAt100, 200);
 		assertEquals(valueAt200, scaledValue, "Scaling up Point to 200 with device failed");
-		scaledValue = Win32DPIUtils.pointToPixel(valueAt100, 150);
+		scaledValue = Win32DPIUtils.pointToPixelAsLocation(valueAt100, 150);
 		assertEquals(valueAt150, scaledValue, "Scaling up Point to 150 failed");
-		scaledValue = Win32DPIUtils.pointToPixel((Device) null, valueAt100, 150);
+		scaledValue = Win32DPIUtils.pointToPixelAsLocation((Device) null, valueAt100, 150);
 		assertEquals(valueAt150, scaledValue, "Scaling up Point to 150 with device failed");
-		scaledValue = Win32DPIUtils.pointToPixel(valueAt100, 100);
+		scaledValue = Win32DPIUtils.pointToPixelAsLocation(valueAt100, 100);
 		assertSame(valueAt100, scaledValue, "Scaling up Point without zoom change failed");
-		scaledValue = Win32DPIUtils.pointToPixel((Device) null, valueAt100, 100);
+		scaledValue = Win32DPIUtils.pointToPixelAsLocation((Device) null, valueAt100, 100);
 		assertSame(valueAt100, scaledValue, "Scaling up Point without zoom change with device failed");
 	}
 
@@ -245,10 +245,10 @@ public class Win32DPIUtilTests {
 			for (int zoom2 : zooms) {
 				for (int i = 1; i <= 10000; i++) {
 					Point pt = new Point(i, i);
-					Point scaleDown = Win32DPIUtils.pixelToPoint(pt, zoom1);
-					Point scaleUp = Win32DPIUtils.pointToPixel(scaleDown, zoom2);
-					scaleDown = Win32DPIUtils.pixelToPoint(scaleUp, zoom2);
-					scaleUp = Win32DPIUtils.pointToPixel(scaleDown, zoom1);
+					Point scaleDown = Win32DPIUtils.pixelToPointAsSize(pt, zoom1);
+					Point scaleUp = Win32DPIUtils.pointToPixelAsLocation(scaleDown, zoom2);
+					scaleDown = Win32DPIUtils.pixelToPointAsSize(scaleUp, zoom2);
+					scaleUp = Win32DPIUtils.pointToPixelAsLocation(scaleDown, zoom1);
 					assertEquals(pt.x, scaleUp.x);
 					assertEquals(pt.y, scaleUp.y);
 				}


### PR DESCRIPTION
When converting pixels to point there can be-  depending on the zoom level - a fractional result. Currently, in all cases the result is converted into an integer using `Math.round()` that will make values `+/-0.5` resulting in small values to be rounded towards a smaller value.
While it is maybe valid for a _location_, when using points to express a _dimension_ this is not okay as it will result in the reported (integer) value to be to small leading to errors when the SWT API is then used after performing additional computations maybe.
See
- eclipse-platform#2381
- eclipse-platform#2166

This PR also resolves the issue https://github.com/eclipse-platform/eclipse.platform.swt/issues/2166