### PR TITLE
MenuItem.setImage() GTK4 fix.

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/gtk4.c
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/gtk4.c
@@ -319,6 +319,26 @@ JNIEXPORT void JNICALL GTK4_NATIVE(gtk_1box_1prepend)
 }
 #endif
 
+#ifndef NO_gtk_1box_1remove
+JNIEXPORT void JNICALL GTK4_NATIVE(gtk_1box_1remove)
+	(JNIEnv *env, jclass that, jlong arg0, jlong arg1)
+{
+	GTK4_NATIVE_ENTER(env, that, gtk_1box_1remove_FUNC);
+	gtk_box_remove((GtkBox *)arg0, (GtkWidget *)arg1);
+	GTK4_NATIVE_EXIT(env, that, gtk_1box_1remove_FUNC);
+}
+#endif
+
+#ifndef NO_gtk_1box_1reorder_1child_1after
+JNIEXPORT void JNICALL GTK4_NATIVE(gtk_1box_1reorder_1child_1after)
+	(JNIEnv *env, jclass that, jlong arg0, jlong arg1, jlong arg2)
+{
+	GTK4_NATIVE_ENTER(env, that, gtk_1box_1reorder_1child_1after_FUNC);
+	gtk_box_reorder_child_after((GtkBox *)arg0, (GtkWidget *)arg1, (GtkWidget *)arg2);
+	GTK4_NATIVE_EXIT(env, that, gtk_1box_1reorder_1child_1after_FUNC);
+}
+#endif
+
 #ifndef NO_gtk_1button_1new_1from_1icon_1name
 JNIEXPORT jlong JNICALL GTK4_NATIVE(gtk_1button_1new_1from_1icon_1name)
 	(JNIEnv *env, jclass that, jbyteArray arg0)
@@ -1557,6 +1577,18 @@ JNIEXPORT jlong JNICALL GTK4_NATIVE(gtk_1image_1new_1from_1icon_1name)
 fail:
 	if (arg0 && lparg0) (*env)->ReleaseByteArrayElements(env, arg0, lparg0, 0);
 	GTK4_NATIVE_EXIT(env, that, gtk_1image_1new_1from_1icon_1name_FUNC);
+	return rc;
+}
+#endif
+
+#ifndef NO_gtk_1image_1new_1from_1paintable
+JNIEXPORT jlong JNICALL GTK4_NATIVE(gtk_1image_1new_1from_1paintable)
+	(JNIEnv *env, jclass that, jlong arg0)
+{
+	jlong rc = 0;
+	GTK4_NATIVE_ENTER(env, that, gtk_1image_1new_1from_1paintable_FUNC);
+	rc = (jlong)gtk_image_new_from_paintable((GdkPaintable *)arg0);
+	GTK4_NATIVE_EXIT(env, that, gtk_1image_1new_1from_1paintable_FUNC);
 	return rc;
 }
 #endif

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/org/eclipse/swt/internal/gtk4/GTK4.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/org/eclipse/swt/internal/gtk4/GTK4.java
@@ -75,6 +75,17 @@ public class GTK4 {
 	 * @param child cast=(GtkWidget *)
 	 * @param sibling cast=(GtkWidget *)
 	 */
+	public static final native void gtk_box_reorder_child_after(long box, long child, long sibling);
+	/**
+	 * @param box cast=(GtkBox *)
+	 * @param child cast=(GtkWidget *)
+	 */
+	public static final native void gtk_box_remove(long box, long child);
+	/**
+	 * @param box cast=(GtkBox *)
+	 * @param child cast=(GtkWidget *)
+	 * @param sibling cast=(GtkWidget *)
+	 */
 	public static final native void gtk_box_insert_child_after(long box, long child, long sibling);
 
 	/* GtkCalendar */
@@ -724,6 +735,8 @@ public class GTK4 {
 	public static final native void gtk_image_set_from_paintable(long image, long paintable);
 	/** @param icon_name cast=(const char *) */
 	public static final native long gtk_image_new_from_icon_name(byte[] icon_name);
+	/** @param paintable cast=(GdkPaintable *) */
+	public static final native long gtk_image_new_from_paintable(long paintable);
 	/**
 	 * @param image cast=(GtkImage *)
 	 * @param icon_name cast=(const gchar *)
@@ -882,5 +895,4 @@ public class GTK4 {
 	 * @param gesture cast=(GtkGesture *)
 	 */
 	public static final native long gtk_gesture_get_last_updated_sequence(long gesture);
-
 }


### PR DESCRIPTION
ImageSet() fix for GTK4. #2299 
Previously ImageSet() returned null on GTK4, This is an implementation of ImageSet() for GTK4. 

To test:
- Ensure GTK4 is forced with "SWT_GTK4 = 1" environment variable in ControlExample.  
- Start ControlExample -> Click "Menu"  -> Check "Images" -> Click "Create Shell"

If Cascade dropdown has icons then the change is working.

<img width="906" height="549" alt="image" src="https://github.com/user-attachments/assets/95c1b010-4d02-4016-bed5-66831ed56561" />
