### PR TITLE
[win32] Fix pointer size scaling precision for custom cursors

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Cursor.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Cursor.java
@@ -352,14 +352,14 @@ private void setHandleForZoomLevel(CursorHandle handle, Integer zoom) {
  *         size, etc.)
  */
 
-private static int getPointerSizeScaleFactor() {
+private static float getPointerSizeScaleFactor() {
 	if (OsVersion.IS_WIN10_1809) {
 		int[] cursorBaseSize = OS.readRegistryDwords(OS.HKEY_CURRENT_USER, "Control Panel\\Cursors", "CursorBaseSize");
 		if (cursorBaseSize != null && cursorBaseSize.length > 0 && cursorBaseSize[0] > 0) {
-			return cursorBaseSize[0] / 32;
+			return cursorBaseSize[0] / 32.0f;
 		}
 	}
-	return 1;
+	return 1.0f;
 }
 
 @Override
@@ -648,8 +648,9 @@ private static class ImageDataCursorHandleProvider extends HotspotAwareCursorHan
 
 	@Override
 	public CursorHandle createHandle(Device device, int zoom) {
-		int accessibilityFactor = getPointerSizeScaleFactor();
-		ImageData scaledSource = DPIUtil.scaleImageData(device, this.source, zoom * accessibilityFactor, DEFAULT_ZOOM);
+		float accessibilityFactor = getPointerSizeScaleFactor();
+		int scaledZoom = (int) (zoom * accessibilityFactor);
+		ImageData scaledSource = DPIUtil.scaleImageData(device, this.source, scaledZoom, DEFAULT_ZOOM);
 		return setupCursorFromImageData(device, scaledSource, null, getHotpotXInPixels(zoom),
 				getHotpotYInPixels(zoom));
 	}
@@ -680,8 +681,10 @@ private static class ImageDataWithMaskCursorHandleProvider extends ImageDataCurs
 
 	@Override
 	public CursorHandle createHandle(Device device, int zoom) {
-		ImageData scaledSource = DPIUtil.scaleImageData(device, this.source, getPointerSizeScaleFactor() * zoom, DEFAULT_ZOOM);
-		ImageData scaledMask = this.mask != null ? DPIUtil.scaleImageData(device, mask, getPointerSizeScaleFactor() * zoom, DEFAULT_ZOOM)
+		float accessibilityFactor = getPointerSizeScaleFactor();
+		int scaledZoom = (int) (zoom * accessibilityFactor);
+		ImageData scaledSource = DPIUtil.scaleImageData(device, this.source, scaledZoom, DEFAULT_ZOOM);
+		ImageData scaledMask = this.mask != null ? DPIUtil.scaleImageData(device, mask, scaledZoom, DEFAULT_ZOOM)
 				: null;
 
 		return setupCursorFromImageData(device, scaledSource, scaledMask, getHotpotXInPixels(zoom),


### PR DESCRIPTION
The value in the registry for CursorBaseSize is not always divisible by 32, so integer division was causing loss of precision in pointer scaling. This commit changes getPointerSizeScaleFactor() to return a float using floating-point division, and ensures all usages of this method in Cursor.java handle the scale as a float. The float is then cast to int only when calling DPIUtil.scaleImageData, which only accepts integer zoom values. This preserves as much precision as possible and avoids rounding errors in pointer scaling for accessibility settings.

**Description**
Recently I commited: https://github.com/eclipse-platform/eclipse.platform.swt/commit/6e4241da7ffbe82ca6e307a794bcb8b5be661a00, where we read the cursor size value from accessibility setting of windows. I assumed that each value is multiple of 32 which was wrong. 

Here for the cursor size 4 is 80
<img width="568" height="614" alt="Image" src="https://github.com/user-attachments/assets/da04f929-db96-4ba3-9f32-afb9e33852b9" />

<img width="568" height="614" alt="Image" src="https://github.com/user-attachments/assets/577fdc58-2a03-4174-a5c1-be00e2ed5b8b" />

and my method will return 2 (i assumed it should return 4). Changing it to float will return us 2.4 which is more precise when trying to scale up the size. 