### PR TITLE
Adding readAndDispatch() in drawImage test to make  the test not flaky

### DIFF
--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_GC.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_GC.java
@@ -279,6 +279,8 @@ public void test_drawImage_nonAutoScalableGC_bug_2504() {
     });
 
     shell.open();
+    while (display.readAndDispatch()) {
+    }
     Image target = new Image(display, canvasWidth, canvasHeight);
     GC gcCopy = new GC(canvas);
     gcCopy.copyArea(target, 0, 0);


### PR DESCRIPTION
The reasoning to add readAndDispatch() in test_drawImage_nonAutoScalableGC_bug_2504 is to consider the case when e.gc.drawImage()'s draw request to the OS, might not have completed by the time gcCopy.copyArea() was called. Using readAndDispatch() is to ensure all OS events are processed, so there’s no pending work left.