### PR TITLE
Disable Win32 key event test in GitHub Actions runs #2516

### DIFF
--- a/tests/org.eclipse.swt.tests.win32/JUnit Tests/org/eclipse/swt/tests/win32/Test_org_eclipse_swt_events_KeyEvent.java
+++ b/tests/org.eclipse.swt.tests.win32/JUnit Tests/org/eclipse/swt/tests/win32/Test_org_eclipse_swt_events_KeyEvent.java
@@ -18,6 +18,7 @@ import org.eclipse.swt.internal.win32.OS;
 import org.eclipse.swt.widgets.Event;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
 
 /**
  * Automated Test Suite for class org.eclipse.swt.events.KeyEvent
@@ -25,6 +26,7 @@ import org.junit.jupiter.api.Test;
  * @see org.eclipse.swt.events.KeyEvent
  */
 @SuppressWarnings("restriction")
+@DisabledIfEnvironmentVariable(named = "GITHUB_ACTIONS", matches = "true", disabledReason = "Windows Server 2025 incompatibility: https://github.com/eclipse-platform/eclipse.platform.swt/issues/2516")
 public class Test_org_eclipse_swt_events_KeyEvent extends KeyboardLayoutTest {
 	// Windows layouts suitable for 'LoadKeyboardLayout()', obtained from 'GetKeyboardLayoutName()'
 	static char[] LAYOUT_BENGALI        = "00020445\0".toCharArray();

--- a/tests/org.eclipse.swt.tests.win32/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.swt.tests.win32/META-INF/MANIFEST.MF
@@ -9,6 +9,7 @@ Eclipse-BundleShape: dir
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Automatic-Module-Name: org.eclipse.swt.tests.win32
 Import-Package: org.junit.jupiter.api;version="[5.13.0,6.0.0)",
+ org.junit.jupiter.api.condition;version="[5.13.0,6.0.0)",
  org.junit.jupiter.params;version="[5.13.0,6.0.0)",
  org.junit.jupiter.params.provider;version="[5.13.0,6.0.0)",
  org.junit.platform.suite.api;version="[1.13.0,2.0.0)"


### PR DESCRIPTION
Since the upgrade of the default GitHub Actions runner for Windows to Windows Server 2025, the key event tests started to fail sporadically. Until a solution is found, this temporarily disables the tests to avoid that it hides actual issues when investigating the build results.

For the used system variable to identify the GHA environment, see https://docs.github.com/en/actions/reference/workflows-and-actions/variables#default-environment-variables

Contributes to https://github.com/eclipse-platform/eclipse.platform.swt/issues/2516