### PR TITLE
Fixing transparency on scaled variant of cursor with source and mask

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Cursor.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Cursor.java
@@ -684,12 +684,16 @@ private static class ImageDataWithMaskCursorHandleProvider extends ImageDataCurs
 
 	@Override
 	public CursorHandle createHandle(Device device, int zoom) {
-		float accessibilityFactor = getPointerSizeScaleFactor();
-		int scaledZoom = (int) (zoom * accessibilityFactor);
-		ImageData scaledSource = DPIUtil.scaleImageData(device, this.source, scaledZoom, DEFAULT_ZOOM);
-		ImageData scaledMask = this.mask != null ? DPIUtil.scaleImageData(device, mask, scaledZoom, DEFAULT_ZOOM)
-				: null;
-
+		float scaledZoomFactor = zoom * getPointerSizeScaleFactor() / 100f;
+		int scaledSourceWidth = Math.round(this.source.width * scaledZoomFactor);
+		int scaledSourceHeight = Math.round(this.source.height * scaledZoomFactor);
+		ImageData scaledSource = this.source.scaledTo(scaledSourceWidth, scaledSourceHeight);
+		ImageData scaledMask = null;
+		if (this.mask != null) {
+			int scaledMaskWidth = Math.round(this.mask.width * scaledZoomFactor);
+			int scaledMaskHeight = Math.round(this.mask.height * scaledZoomFactor);
+			scaledMask = this.mask.scaledTo(scaledMaskWidth, scaledMaskHeight);
+		}
 		return setupCursorFromImageData(device, scaledSource, scaledMask, getHotpotXInPixels(zoom),
 				getHotpotYInPixels(zoom));
 	}


### PR DESCRIPTION
When creating a custom cursor using source and mask ImageData, the transparency mask does not scale correctly when applying DPIUtil.autoScaleImageData() in a multi-monitor setup with different DPI settings. With this change we use scaleTo method to scale the data.

### How to test

- Run the `Snippet386` with following VM arguments

    ```
    -Dswt.autoScale=quarter
    -Dswt.autoScale.updateOnRuntime=true
    ```
- On 100% monitor zoom, choose the `Cursor(Device, ImageData, ImageData, int, int)` option from the dropdown
- You will see the dotted square (a transparent pixel after each solid pixel)
- Move the shell to another monitor with different zoom e.g. 150%
- Previously you would lose the transparency completely when it was scaled with `DPIUtil.scaleImageData`

### Comparison of mask data before and after scaling with and without this PR

**Before**

```
Zoom = 100
Scaled Mask:
Mask pixels (x,y):
0 1 0 1 0 1 0 1 0 1 0 1 0 1 0 1 
0 1 0 1 0 1 0 1 0 1 0 1 0 1 0 1 
0 1 0 1 0 1 0 1 0 1 0 1 0 1 0 1 
0 1 0 1 0 1 0 1 0 1 0 1 0 1 0 1 
0 1 0 1 0 1 0 1 0 1 0 1 0 1 0 1 
0 1 0 1 0 1 0 1 0 1 0 1 0 1 0 1 
0 1 0 1 0 1 0 1 0 1 0 1 0 1 0 1 
0 1 0 1 0 1 0 1 0 1 0 1 0 1 0 1 
0 1 0 1 0 1 0 1 0 1 0 1 0 1 0 1 
0 1 0 1 0 1 0 1 0 1 0 1 0 1 0 1 
0 1 0 1 0 1 0 1 0 1 0 1 0 1 0 1 
0 1 0 1 0 1 0 1 0 1 0 1 0 1 0 1 
0 1 0 1 0 1 0 1 0 1 0 1 0 1 0 1 
0 1 0 1 0 1 0 1 0 1 0 1 0 1 0 1 
0 1 0 1 0 1 0 1 0 1 0 1 0 1 0 1 
0 1 0 1 0 1 0 1 0 1 0 1 0 1 0 1 
Zoom = 150
Scaled Mask:
Mask pixels (x,y):
0 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -256 
0 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -256 
0 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -256 
0 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -256 
0 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -256 
0 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -256 
0 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -256 
0 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -256 
0 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -256 
0 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -256 
0 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -256 
0 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -256 
0 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -256 
0 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -256 
0 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -256 
0 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -256 
0 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -256 
0 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -256 
0 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -256 
0 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -256 
0 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -256 
0 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -256 
0 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -256 
0 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -707406592 707406336 -2139062272 -256 
```

**After:**
```
Zoom = 100
Scaled Mask:
Mask pixels (x,y):
0 1 0 1 0 1 0 1 0 1 0 1 0 1 0 1 
0 1 0 1 0 1 0 1 0 1 0 1 0 1 0 1 
0 1 0 1 0 1 0 1 0 1 0 1 0 1 0 1 
0 1 0 1 0 1 0 1 0 1 0 1 0 1 0 1 
0 1 0 1 0 1 0 1 0 1 0 1 0 1 0 1 
0 1 0 1 0 1 0 1 0 1 0 1 0 1 0 1 
0 1 0 1 0 1 0 1 0 1 0 1 0 1 0 1 
0 1 0 1 0 1 0 1 0 1 0 1 0 1 0 1 
0 1 0 1 0 1 0 1 0 1 0 1 0 1 0 1 
0 1 0 1 0 1 0 1 0 1 0 1 0 1 0 1 
0 1 0 1 0 1 0 1 0 1 0 1 0 1 0 1 
0 1 0 1 0 1 0 1 0 1 0 1 0 1 0 1 
0 1 0 1 0 1 0 1 0 1 0 1 0 1 0 1 
0 1 0 1 0 1 0 1 0 1 0 1 0 1 0 1 
0 1 0 1 0 1 0 1 0 1 0 1 0 1 0 1 
0 1 0 1 0 1 0 1 0 1 0 1 0 1 0 1 
Zoom = 150
Scaled Mask:
Mask pixels (x,y):
0 0 1 0 0 1 0 0 1 0 0 1 0 1 1 0 1 1 0 1 1 0 1 1 
0 0 1 0 0 1 0 0 1 0 0 1 0 1 1 0 1 1 0 1 1 0 1 1 
0 0 1 0 0 1 0 0 1 0 0 1 0 1 1 0 1 1 0 1 1 0 1 1 
0 0 1 0 0 1 0 0 1 0 0 1 0 1 1 0 1 1 0 1 1 0 1 1 
0 0 1 0 0 1 0 0 1 0 0 1 0 1 1 0 1 1 0 1 1 0 1 1 
0 0 1 0 0 1 0 0 1 0 0 1 0 1 1 0 1 1 0 1 1 0 1 1 
0 0 1 0 0 1 0 0 1 0 0 1 0 1 1 0 1 1 0 1 1 0 1 1 
0 0 1 0 0 1 0 0 1 0 0 1 0 1 1 0 1 1 0 1 1 0 1 1 
0 0 1 0 0 1 0 0 1 0 0 1 0 1 1 0 1 1 0 1 1 0 1 1 
0 0 1 0 0 1 0 0 1 0 0 1 0 1 1 0 1 1 0 1 1 0 1 1 
0 0 1 0 0 1 0 0 1 0 0 1 0 1 1 0 1 1 0 1 1 0 1 1 
0 0 1 0 0 1 0 0 1 0 0 1 0 1 1 0 1 1 0 1 1 0 1 1 
0 0 1 0 0 1 0 0 1 0 0 1 0 1 1 0 1 1 0 1 1 0 1 1 
0 0 1 0 0 1 0 0 1 0 0 1 0 1 1 0 1 1 0 1 1 0 1 1 
0 0 1 0 0 1 0 0 1 0 0 1 0 1 1 0 1 1 0 1 1 0 1 1 
0 0 1 0 0 1 0 0 1 0 0 1 0 1 1 0 1 1 0 1 1 0 1 1 
0 0 1 0 0 1 0 0 1 0 0 1 0 1 1 0 1 1 0 1 1 0 1 1 
0 0 1 0 0 1 0 0 1 0 0 1 0 1 1 0 1 1 0 1 1 0 1 1 
0 0 1 0 0 1 0 0 1 0 0 1 0 1 1 0 1 1 0 1 1 0 1 1 
0 0 1 0 0 1 0 0 1 0 0 1 0 1 1 0 1 1 0 1 1 0 1 1 
0 0 1 0 0 1 0 0 1 0 0 1 0 1 1 0 1 1 0 1 1 0 1 1 
0 0 1 0 0 1 0 0 1 0 0 1 0 1 1 0 1 1 0 1 1 0 1 1 
0 0 1 0 0 1 0 0 1 0 0 1 0 1 1 0 1 1 0 1 1 0 1 1 
0 0 1 0 0 1 0 0 1 0 0 1 0 1 1 0 1 1 0 1 1 0 1 1 
```



**P.S: With this change we will not get smooth scaling for the cursor created with source and mask data. That's why we will deprecate the Cursor(Device, ImageData, ImageData, int, int) constructor in another PR, see https://github.com/vi-eclipse/Eclipse-Platform/issues/462. Instead, we will recommend using: Cursor(Device device, ImageDataProvider imageDataProvider, int hotspotX, int hotspotY) as this provides better results with multi-monitor DPI scaling.**