### PR TITLE
Deprecation: Cursor(Device, ImageData, ImageData, int, int)

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/graphics/Cursor.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/graphics/Cursor.java
@@ -276,7 +276,10 @@ public Cursor(Device device, int style) {
  * </ul>
  *
  * @see #dispose()
+ *
+ * @deprecated Use {@link #Cursor(Device, ImageDataProvider, int, int)} instead.
  */
+@Deprecated
 public Cursor(Device device, ImageData source, ImageData mask, int hotspotX, int hotspotY) {
 	super(device);
 	if (source == null) SWT.error(SWT.ERROR_NULL_ARGUMENT);

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/graphics/Cursor.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/graphics/Cursor.java
@@ -184,7 +184,10 @@ public Cursor(Device device, int style) {
  * </ul>
  *
  * @see #dispose()
+ *
+ * @deprecated Use {@link #Cursor(Device, ImageDataProvider, int, int)} instead.
  */
+@Deprecated
 public Cursor(Device device, ImageData source, ImageData mask, int hotspotX, int hotspotY) {
 	super(device);
 	if (source == null) SWT.error(SWT.ERROR_NULL_ARGUMENT);

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Cursor.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Cursor.java
@@ -146,7 +146,10 @@ public Cursor(Device device, int style) {
  * </ul>
  *
  * @see #dispose()
+ *
+ * @deprecated Use {@link #Cursor(Device, ImageDataProvider, int, int)} instead.
  */
+@Deprecated
 public Cursor(Device device, ImageData source, ImageData mask, int hotspotX, int hotspotY) {
 	super(device);
 	this.cursorHandleProvider = new ImageDataWithMaskCursorHandleProvider(source, mask, hotspotX, hotspotY);

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_Cursor.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_Cursor.java
@@ -140,6 +140,7 @@ public void test_ConstructorLorg_eclipse_swt_graphics_DeviceLorg_eclipse_swt_gra
 			ImageData source = loader.load(stream)[0];
 			ImageData mask = source.getTransparencyMask();
 			if (mask != null && (source.depth == 1)) {
+				@SuppressWarnings("deprecation")
 				Cursor cursor = new Cursor(display, source, mask, 0, 0);
 				cursor.dispose();
 			}
@@ -176,12 +177,14 @@ public void test_InvalidArgumentsForAllConstructors() {
 			});
 
 	assertThrows("When source is null", IllegalArgumentException.class, () -> {
+		@SuppressWarnings("deprecation")
 		Cursor cursorFromImageAndMask = new Cursor(Display.getDefault(), null, mask, 0, 0);
 		cursorFromImageAndMask.dispose();
 	});
 
 	assertThrows("When mask is null and source doesn't heve a mask",
 			IllegalArgumentException.class, () -> {
+				@SuppressWarnings("deprecation")
 				Cursor cursorFromImageAndMask = new Cursor(Display.getDefault(), source, null, 0, 0);
 				cursorFromImageAndMask.dispose();
 			});
@@ -191,12 +194,14 @@ public void test_InvalidArgumentsForAllConstructors() {
 				ImageData source32 = new ImageData(32, 32, 1, new PaletteData(new RGB[] { new RGB(0, 0, 0) }));
 				ImageData mask16 = new ImageData(16, 16, 1, new PaletteData(new RGB[] { new RGB(0, 0, 0) }));
 
+				@SuppressWarnings("deprecation")
 				Cursor cursorFromImageAndMask = new Cursor(Display.getDefault(), source32, mask16, 0, 0);
 				cursorFromImageAndMask.dispose();
 			});
 
 	assertThrows("When hotspot is outside the bounds of the image",
 			IllegalArgumentException.class, () -> {
+				@SuppressWarnings("deprecation")
 				Cursor cursorFromImageAndMask = new Cursor(Display.getDefault(), source, mask, 18, 18);
 				cursorFromImageAndMask.dispose();
 			});


### PR DESCRIPTION
The constructor Cursor(Device, ImageData source, ImageData mask, int hotspotX, int hotspotY) allows creating a cursor by providing a source image and a 1-bit mask to define transparency. This approach requires developers to manually define mask pixels and works reliably only in fixed DPI environments.

With the introduction of multi-monitor DPI support, this constructor produces inconsistent results.

- Masks do not scale properly when using DPIUtil.autoScaleImageData, leading to visual artifacts.
- Developers need to handle scaling and mask adjustments manually, which is error-prone.