### PR TITLE
[win32] ImageDataProvider getBounds performance

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Image.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Image.java
@@ -2330,8 +2330,14 @@ private abstract class BaseImageProviderWrapper<T> extends DynamicImageProviderW
 
 	@Override
 	protected Rectangle getBounds(int zoom) {
-		ImageData imageData = getImageData(zoom);
-		return new Rectangle(0, 0, imageData.width, imageData.height);
+		if (cachedImageData.containsKey(zoom)) {
+			ImageData imageData = cachedImageData.get(zoom);
+			return new Rectangle(0, 0, imageData.width, imageData.height);
+		}
+		ElementAtZoom<ImageData> imageDataAtZoom = loadImageData(zoom);
+		ImageData imageData = imageDataAtZoom.element();
+		Rectangle currentSize = new Rectangle(0, 0, imageData.width, imageData.height);
+		return Win32DPIUtils.scaleBounds(currentSize, zoom, imageDataAtZoom.zoom());
 	}
 }
 


### PR DESCRIPTION
This PR improves the performance of `Image#getBounds` if an `ImageDataProvider` is used and no matching handle exists yet. This only affects the windows implementation.

Reason for the worse performance is that currently multiple `ImageData` instances plus an image handle instance is created and cleaned up for the operation, although one call to `ImageDataProvider#getImageData` would be sufficient.

### How to test

Add an big image (at least 1000x1000 pixels) named "bigimage.png" so it can be found by the snippet and execute the snippet below with and without this PR und you'll see something similar to

**Without PR:**
Duration ImageDataProvider 3216 ms size: Rectangle {0, 0, 2000, 2000}
Duration ImageFileNameProvider 1668 ms size: Rectangle {0, 0, 2000, 2000}

**With PR:**
Duration ImageDataProvider 369 ms size: Rectangle {0, 0, 2000, 2000}
Duration ImageFileNameProvider 1547 ms size: Rectangle {0, 0, 2000, 2000}

For `ImageDataProvider` performance is drastically improved, for `ImageFileNameProvider` it stays similar. But I think adapting the existing common implementation for `getBounds` makes more sense as long is it does not have a negative effect.

```java
public class ImageDataProviderPerformanceSnippet {

	public static void main(String[] args) {
		Display display = new Display();
		ImageDataProvider idp = new ImageDataProvider() {
			@Override
			public ImageData getImageData(int zoom) {
				return new ImageData(2000, 2000, 32, new PaletteData(0, 0, 0));
			}
		};
		long start = System.currentTimeMillis();
		for (int i = 0; i < 100; i++) {
			new Image(display, idp).getBounds();
		}
		System.out.println("Duration ImageDataProvider " +  (System.currentTimeMillis() - start) + " ms size: " + new Image(display, idp).getBounds());

		ImageFileNameProvider ifnp = new ImageFileNameProvider() {
			@Override
			public String getImagePath(int zoom) {
				return "bigimage.png";
			}
		};
		start = System.currentTimeMillis();
		for (int i = 0; i < 100; i++) {
			new Image(display, ifnp).getBounds();
		}
		System.out.println("Duration ImageFileNameProvider " +  (System.currentTimeMillis() - start) + " ms size: " + new Image(display, idp).getBounds());
	}
}
```