### PR TITLE
[GTK4] Fix Test*Shell.test_setSizeCustomResize test failure

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Shell.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Shell.java
@@ -1171,7 +1171,6 @@ void forceResize (int width, int height) {
 			if (validTranslation && !isMappedToPopup()) {
 				allocation.x += window_offset_x[0];
 				allocation.y += window_offset_y[0];
-				allocation.height -= window_offset_y[0];
 			}
 		} else {
 			int [] dest_x = new int[1];


### PR DESCRIPTION
Translating coordinates from client area to GtkWindow for Gtk 4.x made the wrong assumption that it should reduce allocation.height with the offset (header/titlebar height) which makes no sense as it shrinks the window vertically.