### PR TITLE
Explicitly terminate the Clipboard remote application

### DIFF
--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_dnd_Clipboard.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_dnd_Clipboard.java
@@ -221,9 +221,11 @@ public class Test_org_eclipse_swt_dnd_Clipboard {
 		} finally {
 			if (remoteClipboardProcess != null) {
 				try {
-					remoteClipboardProcess.waitFor(1, TimeUnit.SECONDS);
+					remoteClipboardProcess.destroy();
+					assertTrue(remoteClipboardProcess.waitFor(10, TimeUnit.SECONDS));
 				} finally {
 					remoteClipboardProcess.destroyForcibly();
+					assertTrue(remoteClipboardProcess.waitFor(10, TimeUnit.SECONDS));
 					remoteClipboardProcess = null;
 				}
 			}

--- a/tests/org.eclipse.swt.tests/data/clipboard/ClipboardCommandsImpl.java
+++ b/tests/org.eclipse.swt.tests/data/clipboard/ClipboardCommandsImpl.java
@@ -43,6 +43,18 @@ public class ClipboardCommandsImpl extends UnicastRemoteObject implements Clipbo
 			clipboardTest.log("stop()");
 			clipboardTest.dispose();
 		});
+		// Force the test program to quit, but after a short delay so that
+		// the return value of stop can make it back to the caller and
+		// the JUnit test may destroy the process before this sleep
+		// expires anyway
+		SwingUtilities.invokeLater(() -> {
+			try {
+				Thread.sleep(1000);
+			} catch (InterruptedException e) {
+				Thread.interrupted();
+			}
+			System.exit(0);
+		});
 	}
 
 	@Override


### PR DESCRIPTION
The old code was unintentionally relying on destroyForcibly alone to terminate the remote process. This had a race condition that when the temp directory needed to be deleted at the end of the test the process may not have completed being terminated.

Therefore explicitly destroy/terminate the remote, and add some asserts so that we have explicit test failure if the remote is not finished terminating before `stopRemoteClipboardCommands` returns.

Fixes https://github.com/eclipse-platform/eclipse.platform.swt/issues/2568