### PR TITLE
Control.gtk_motion_notify_event: format to understand it

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Control.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Control.java
@@ -4159,9 +4159,9 @@ long gtk_motion_notify_event (long widget, long event) {
 	if ((dragDetectionQueue != null) && OS.isWayland()) {
 		boolean dragging = false;
 		if ((state & DRAG_DETECT) != 0 && wantDragDropDetection ()) {
-				boolean [] consume = new boolean [1];
-				if (dragDetect ((int) eventX[0], (int) eventY[0], true, true, consume)) {
-					dragging = true;
+			boolean [] consume = new boolean [1];
+			if (dragDetect ((int) eventX[0], (int) eventY[0], true, true, consume)) {
+				dragging = true;
 				if (isDisposed ()) return 1;
 			}
 		}
@@ -4182,7 +4182,7 @@ long gtk_motion_notify_event (long widget, long event) {
 				GDK.gdk_event_get_state(event, eventState);
 			}
 
-			if (sendDragEvent (eventButton[0], eventState[0], scaledEvent.x, scaledEvent.y, false)){
+			if (sendDragEvent (eventButton[0], eventState[0], scaledEvent.x, scaledEvent.y, false)) {
 				return 1;
 			}
 		}
@@ -4235,7 +4235,8 @@ long gtk_motion_notify_event (long widget, long event) {
 		}
 	}
 
-	return sendMouseEvent(SWT.MouseMove, 0, time, x, y, isHint, state[0]) ? 0 : 1;
+	return sendMouseEvent(SWT.MouseMove, 0, time, x, y, isHint, state[0])
+			? 0 : 1;
 }
 
 @Override


### PR DESCRIPTION
The indentation was screwed up, so it was hard to understand the logic.

I also removed the unused assignment to `result` and the empty `else`-branch.