### PR TITLE
Control.flushQueueOnDnd: simplify commit

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Control.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Control.java
@@ -4849,9 +4849,9 @@ void flushQueueOnDnd() {
 	// to determine DnD threshold.
 	// This is to preserve backwards Cocoa/Win32 compatibility.
 	Event mouseDownEvent = dragDetectionQueue.getFirst();
-	mouseDownEvent.data = Boolean.valueOf(true); // force send MouseDown to avoid subsequent MouseMove before MouseDown.
+	mouseDownEvent.data = null;
 	dragDetectionQueue = null;
-	sendOrPost(SWT.MouseDown, mouseDownEvent);
+	sendEvent(SWT.MouseDown, mouseDownEvent);
 }
 
 boolean sendDragEvent (int button, int stateMask, int x, int y, boolean isStateMask) {


### PR DESCRIPTION
Inlined `sendOrPost` for this special case making it more obvious that an (immediate) `sendEvent` is happening.