### PR TITLE
[GTK] Reports wrong mouse coordinates when starting a drag #2119

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Control.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Control.java
@@ -5091,6 +5091,7 @@ boolean sendMouseEvent (int type, int button, int count, int detail, boolean sen
 						flushQueueOnDnd();
 					} else {
 						dragDetectionQueue.add(event);
+						return true;
 					}
 					break;
 				case SWT.MouseUp:


### PR DESCRIPTION
Control: don't send MouseMove events with stateMask set for BUTTON1 before the MouseDown event was sent

These events are already added to the dragDetectionQueue, so there is no need to send/post them now.