### PR TITLE
[win32] Register internal ZoomChange listener for monitor specific scaling

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/widgets/ControlWin32Tests.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/widgets/ControlWin32Tests.java
@@ -58,15 +58,15 @@ class ControlWin32Tests {
 	}
 
 	@Test
-	public void testScaleFontCorrectlyInNoAutoScaleScenario() {
+	public void testDoNotScaleFontInNoAutoScaleScenario() {
 		Win32DPIUtils.setMonitorSpecificScaling(false);
 		Display display = Display.getDefault();
 
 		assertFalse("Autoscale property is not set to false", display.isRescalingAtRuntime());
 		int scalingFactor = 2;
 		FontComparison fontComparison = updateFont(scalingFactor);
-		assertEquals("Font height in pixels is not adjusted according to the scale factor",
-				fontComparison.originalFontHeight * scalingFactor, fontComparison.currentFontHeight);
+		assertEquals("Font height in pixels is different when setting the same font again",
+				fontComparison.originalFontHeight, fontComparison.currentFontHeight);
 	}
 
 	@Test

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Widget.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Widget.java
@@ -194,10 +194,12 @@ public Widget (Widget parent, int style) {
 }
 
 void registerDPIChangeListener() {
-	this.addListener(SWT.ZoomChanged, event -> {
-		float scalingFactor = 1f * DPIUtil.getZoomForAutoscaleProperty(event.detail) / DPIUtil.getZoomForAutoscaleProperty(nativeZoom);
-		handleDPIChange(event, scalingFactor);
-	});
+	if (display.isRescalingAtRuntime()) {
+		this.addListener(SWT.ZoomChanged, event -> {
+			float scalingFactor = 1f * DPIUtil.getZoomForAutoscaleProperty(event.detail) / DPIUtil.getZoomForAutoscaleProperty(nativeZoom);
+			handleDPIChange(event, scalingFactor);
+		});
+	}
 }
 
 void _addListener (int eventType, Listener listener) {


### PR DESCRIPTION
As the DPI change behavior in the windows implementation is fully using the ZoomChange event now, it must be ensured, that the internal ZoomChange listener, that adapt the Wigets for monitor specific scaling must be be registered in this case.