### PR TITLE
[GTK4] Do not mix gtk 3 and 4 focus event handlers

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Canvas.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Canvas.java
@@ -260,14 +260,15 @@ long gtk_focus_out_event (long widget, long event) {
 }
 
 @Override
-void gtk4_focus_window_event(long handle, long event) {
-	if(event == SWT.FocusIn) {
-		gtk_focus_in_event (handle, event);
-		if (caret != null) caret.setFocus ();
-	} else {
-		gtk_focus_out_event(handle, event);
-		if (caret != null) caret.killFocus();
-	}
+void gtk4_focus_enter_event(long handle, long event) {
+	super.gtk4_focus_enter_event (handle, event);
+	if (caret != null) caret.setFocus ();
+}
+
+@Override
+void gtk4_focus_leave_event(long handle, long event) {
+	super.gtk4_focus_leave_event (handle, event);
+	if (caret != null) caret.setFocus ();
 }
 
 @Override


### PR DESCRIPTION
In https://github.com/eclipse-platform/eclipse.platform.swt/pull/2582 I've mixed the handlers. This fixes it to not call into each other.