### PR TITLE
Test for GTK4 crashes when creating and closing many shells

### DIFF
--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/AllNonBrowserTests.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/AllNonBrowserTests.java
@@ -39,6 +39,7 @@ import org.junit.platform.suite.api.Suite;
 		// Rest of tests alphabetically
 		DPIUtilTests.class, //
 		JSVGRasterizerTest.class, //
+		OpenShellManyManyTimesTest.class, //
 		Test_org_eclipse_swt_accessibility_Accessible.class, //
 		Test_org_eclipse_swt_accessibility_AccessibleControlEvent.class, //
 		Test_org_eclipse_swt_accessibility_AccessibleEvent.class, //

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/OpenShellManyManyTimesTest.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/OpenShellManyManyTimesTest.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Kichwa Coders Canada, Inc.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.swt.tests.junit;
+
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Shell;
+import org.junit.jupiter.api.RepeatedTest;
+
+
+public class OpenShellManyManyTimesTest {
+
+	@RepeatedTest(value = 1000)
+	public void test_OpenShell() {
+		Display display = Display.getCurrent();
+		if (display == null) {
+			display = Display.getDefault();
+		}
+
+		Shell shell = new Shell(display);
+		try {
+		shell.open();
+		shell.setFocus();
+		SwtTestUtil.processEvents();
+		} finally {
+			shell.dispose();
+		}
+	}
+}


### PR DESCRIPTION
While trying to test the clipboard (#2126) on a loop I found GTK4 crashed quite consistently, so I extracted the minimum test that fails to see if this problem is my machine only.

This is what happens when I run it from my Eclipse dev:

```
#
# A fatal error has been detected by the Java Runtime Environment:
#
#  SIGSEGV (0xb) at pc=0x0000732c1d859313, pid=466736, tid=466743
#
# JRE version: OpenJDK Runtime Environment Temurin-21.0.5+11 (21.0.5+11) (build 21.0.5+11-LTS)
# Java VM: OpenJDK 64-Bit Server VM Temurin-21.0.5+11 (21.0.5+11-LTS, mixed mode, sharing, tiered, compressed oops, compressed class ptrs, g1 gc, linux-amd64)
# Problematic frame:
# C  [libgtk-4.so.1+0x659313]
#
# Core dump will be written. Default location: Core dumps may be processed with "/usr/share/apport/apport -p%p -s%s -c%c -d%d -P%P -u%u -g%g -F%F -- %E" (or dumping to /scratch/eclipse/oomph/swt-master/git/eclipse.platform.swt/tests/org.eclipse.swt.tests/core.466736)
#
# An error report file with more information is saved as:
# /scratch/eclipse/oomph/swt-master/git/eclipse.platform.swt/tests/org.eclipse.swt.tests/hs_err_pid466736.log
[5.351s][warning][os] Loading hsdis library failed
#
# If you would like to submit a bug report, please visit:
#   https://github.com/adoptium/adoptium-support/issues
# The crash happened outside the Java Virtual Machine in native code.
# See problematic frame for where to report the bug.
```

[hs_err_pid466736.log](https://github.com/user-attachments/files/22681188/hs_err_pid466736.log)

