### PR TITLE
Avoid reading org.eclipse.swt.internal.gdk.backend too early

### DIFF
--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/SwtTestUtil.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/SwtTestUtil.java
@@ -103,7 +103,16 @@ public class SwtTestUtil {
 	/** Useful if you want some tests not to run on Jenkins with user "genie.platform" */
 	public final static boolean isRunningOnContinousIntegration = isGTK && ("genie.platform".equalsIgnoreCase(System.getProperty("user.name")));
 
-	public final static boolean isX11 = isGTK
+	/**
+	 * The value of org.eclipse.swt.internal.gdk.backend is not set until a display
+	 * is created at least once since this value is assigned in the Display
+	 * constructor. Normally tests are run in such an order that SwtTestUtil isn't
+	 * accessed until after the first Display is created.
+	 *
+	 * Rather than requiring all users of SwtTestUtil to be careful with their access,
+	 * instead defer checking x11 by using a supplier to defer getting the value.
+	 */
+	public final static BooleanSupplier isX11 = () -> isGTK
 			&& "x11".equals(System.getProperty("org.eclipse.swt.internal.gdk.backend"));
 	public final static boolean isGTK4 = isGTK
 			&& System.getProperty("org.eclipse.swt.internal.gtk.version", "").startsWith("4");

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_dnd_Clipboard.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_dnd_Clipboard.java
@@ -351,7 +351,7 @@ public class Test_org_eclipse_swt_dnd_Clipboard {
 			String result = runOperationInThread(remote::getStringContents);
 			assertEquals(helloWorld, result);
 		} catch (Exception | AssertionError e) {
-			if (SwtTestUtil.isGTK4 && !SwtTestUtil.isX11) {
+			if (SwtTestUtil.isGTK4 && !SwtTestUtil.isX11.getAsBoolean()) {
 				// TODO make the code + test stable
 				throw new RuntimeException(
 						"This test is really unstable on wayland backend, at least with Ubuntu 25.04", e);

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Display.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Display.java
@@ -1247,7 +1247,7 @@ public void test_setCursorLocationII(TestInfo info) {
 		display.setCursorLocation(location.x, location.y); // don't put cursor into a corner, since that could trigger special platform events
 		drainEventQueue(display, 150); // workaround for https://bugs.eclipse.org/492569
 		Point actual = display.getCursorLocation();
-		if (!BUG_492569 && SwtTestUtil.isX11) {
+		if (!BUG_492569 && SwtTestUtil.isX11.getAsBoolean()) {
 			if (!location.equals(actual)) {
 				Screenshots.takeScreenshot(getClass(), info.getDisplayName()); // Bug 528968 This call causes crash on Wayland.
 				fail("\nExpected:"+location.toString()+"  Actual:"+actual.toString());
@@ -1279,7 +1279,7 @@ public void test_setCursorLocationLorg_eclipse_swt_graphics_Point(TestInfo info)
 		}
 		drainEventQueue(display, 150); // workaround for https://bugs.eclipse.org/492569
 		Point actual = display.getCursorLocation();
-		if (!BUG_492569 && SwtTestUtil.isX11) {
+		if (!BUG_492569 && SwtTestUtil.isX11.getAsBoolean()) {
 			if (!location.equals(actual)) {
 				Screenshots.takeScreenshot(getClass(), info.getDisplayName()); // Bug 528968 This call causes crash on Wayland.
 				fail("\nExpected:"+location.toString()+"  Actual:"+actual.toString());

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Shell.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Shell.java
@@ -654,7 +654,7 @@ public void test_setBoundsLorg_eclipse_swt_graphics_Rectangle() {
  */
 @Test
 public void test_activateEventSend() {
-	if (SwtTestUtil.isGTK && SwtTestUtil.isX11) {
+	if (SwtTestUtil.isGTK && SwtTestUtil.isX11.getAsBoolean()) {
 		Shell testShell = new Shell(shell, SWT.SHELL_TRIM);
 		testShell.addListener(SWT.Activate, e -> {
 			listenerCalled = true;
@@ -679,7 +679,7 @@ public void test_activateEventSend() {
  */
 @Test
 public void test_setBounds() throws Exception {
-	if (SwtTestUtil.isX11) {
+	if (SwtTestUtil.isX11.getAsBoolean()) {
 		Rectangle bounds = new Rectangle(100, 200, 200, 200);
 		Rectangle bounds2 = new Rectangle(150, 250, 250, 250);
 


### PR DESCRIPTION
The value of `org.eclipse.swt.internal.gdk.backend` is not set until a display is created at least once since this value is assigned in the Display constructor. Normally tests are run in such an order that SwtTestUtil isn't accessed until after the first Display is created. Make sure to create a display before calling SwtTestUtil.isX11.getAsBoolean().

This is a fix for a regression caused by moving the setting of org.eclipse.swt.internal.gdk.backend from OS to Display in 5d67ce66d23165bd252339134ca86889b9594b63. That commit fixed an unrelated bug, but sometimes bad initialization of isX11 is an unintended side effect causing tests to be skipped or run in unexpected ways since isX11 was not correct.