### PR TITLE
Convert tests to JUnit5

### DIFF
--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/graphics/ImageDataTestHelper.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/graphics/ImageDataTestHelper.java
@@ -14,7 +14,7 @@
 
 package org.eclipse.swt.tests.graphics;
 
-import static org.junit.Assert.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/AllWidgetTests.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/AllWidgetTests.java
@@ -48,7 +48,9 @@ import org.junit.platform.suite.api.Suite;
 		Test_org_eclipse_swt_widgets_Composite.class, //
 		Test_org_eclipse_swt_widgets_CoolBar.class, //
 		// Failing test: Test_org_eclipse_swt_widgets_CoolItem.class, //
-		Test_org_eclipse_swt_widgets_DateTime.class, //
+		Test_org_eclipse_swt_widgets_DateTime_Style_CALENDAR.class, //
+		Test_org_eclipse_swt_widgets_DateTime_Style_DATE.class, //
+		Test_org_eclipse_swt_widgets_DateTime_Style_TIME.class, //
 		Test_org_eclipse_swt_widgets_DirectoryDialog.class, //
 		Test_org_eclipse_swt_widgets_Event.class, //
 		Test_org_eclipse_swt_widgets_ExpandBar.class, //

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/ImageTestUtil.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/ImageTestUtil.java
@@ -13,10 +13,10 @@
  *******************************************************************************/
 package org.eclipse.swt.tests.junit;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.function.BiFunction;
 
@@ -64,12 +64,12 @@ public class ImageTestUtil {
 	public static void assertImagesEqual(ImageData[] expected, ImageData[] actual) {
 		assertNotNull(expected);
 		assertNotNull(actual);
-		assertEquals("Different number of frames.", expected.length, actual.length);
+		assertEquals(expected.length, actual.length, "Different number of frames.");
 		BiFunction<String, Integer, String> formatMsg = (msg, i) -> expected.length == 1 ? msg + "."
 				: msg + " in frame " + i + ".";
 		for (int i = 0; i < expected.length; i++) {
-			assertEquals(formatMsg.apply("Different width", i), expected[i].width, actual[i].width);
-			assertEquals(formatMsg.apply("Different height", i), expected[i].height, actual[i].height);
+			assertEquals(expected[i].width, actual[i].width, formatMsg.apply("Different width", i));
+			assertEquals(expected[i].height, actual[i].height, formatMsg.apply("Different height", i));
 			// improve performance in case the frame has a global fixed alpha value
 			int expectedFixAlpha = getEffectiveAlpha(expected[i], -1, -1);
 			int actualFixAlpha = getEffectiveAlpha(actual[i], -1, -1);
@@ -79,15 +79,15 @@ public class ImageTestUtil {
 				expected[i].getPixels(0, y, expected[i].width, expectedLine, 0);
 				actual[i].getPixels(0, y, actual[i].width, actualLine, 0);
 				for (int x = 0; x < expected[i].width; x++) {
-					assertEquals(formatMsg.apply("Different color at x=" + x + ", y=" + y, i),
-							expected[i].palette.getRGB(expectedLine[x]), actual[i].palette.getRGB(actualLine[x]));
+					assertEquals(expected[i].palette.getRGB(expectedLine[x]), actual[i].palette.getRGB(actualLine[x]),
+							formatMsg.apply("Different color at x=" + x + ", y=" + y, i));
 					int expectedAlpha = expectedFixAlpha < 0 ? getEffectiveAlpha(expected[i], x, y) : expectedFixAlpha;
 					int actualAlpha = actualFixAlpha < 0 ? getEffectiveAlpha(actual[i], x, y) : actualFixAlpha;
 					if (expectedAlpha != actualAlpha) {
-						assertEquals(formatMsg.apply("Different alpha at x=" + x + ", y=" + y, i), expectedAlpha,
-								actualAlpha);
+						assertEquals(expectedAlpha, actualAlpha,
+								formatMsg.apply("Different alpha at x=" + x + ", y=" + y, i));
 					}
-					assertNotEquals(formatMsg.apply("Invalid alpha at x=" + x + ", y=" + y, i), -1, actualAlpha);
+					assertNotEquals(-1, actualAlpha, formatMsg.apply("Invalid alpha at x=" + x + ", y=" + y, i));
 				}
 			}
 		}

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/JSVGRasterizerTest.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/JSVGRasterizerTest.java
@@ -14,8 +14,8 @@
 package org.eclipse.swt.tests.junit;
 
 import static org.eclipse.swt.tests.junit.SwtTestUtil.assertSWTProblem;
-import static org.junit.Assert.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/SwtTestUtil.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/SwtTestUtil.java
@@ -14,12 +14,10 @@
 package org.eclipse.swt.tests.junit;
 
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -49,7 +47,6 @@ import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Listener;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.test.Screenshots;
-import org.junit.rules.TemporaryFolder;
 
 public class SwtTestUtil {
 	/**
@@ -130,19 +127,19 @@ public class SwtTestUtil {
 public static void assertSWTProblem(String message, int expectedCode, Throwable actualThrowable) {
 	if (actualThrowable instanceof SWTError) {
 		SWTError error = (SWTError) actualThrowable;
-		assertEquals(message, expectedCode, error.code);
+		assertEquals(expectedCode, error.code, message);
 	} else if (actualThrowable instanceof SWTException) {
 		SWTException exception = (SWTException) actualThrowable;
-		assertEquals(message, expectedCode, exception.code);
+		assertEquals(expectedCode, exception.code, message);
 	} else {
 		try {
 			SWT.error(expectedCode);
 		} catch (Throwable expectedThrowable) {
 			if (actualThrowable.getMessage().length() > expectedThrowable.getMessage().length()) {
-				assertTrue(message, actualThrowable.getMessage().startsWith(expectedThrowable.getMessage()));
+				assertTrue(actualThrowable.getMessage().startsWith(expectedThrowable.getMessage()), message);
 			}
 			else {
-				assertEquals(message, expectedThrowable.getMessage(), actualThrowable.getMessage());
+				assertEquals(expectedThrowable.getMessage(), actualThrowable.getMessage(), message);
 			}
 		}
 	}
@@ -369,7 +366,7 @@ public static void assertSimilarBrightness(String message, int expected, int act
 		// 2) and ensure  brightness is within 12.5% of the range.
 		double expectedIntensity = getBrightness(expected);
 		double actualIntensity = getBrightness(actual);
-		assertEquals(message, expectedIntensity, actualIntensity, 255f / 8);
+		assertEquals(expectedIntensity, actualIntensity, 255f / 8, message);
 	}
 }
 
@@ -478,7 +475,7 @@ public static void waitShellActivate(Runnable trigger, Shell shell) {
 	// Something went wrong? Get more info to diagnose
 	Screenshots.takeScreenshot(SwtTestUtil.class, "waitShellActivate-" + System.currentTimeMillis());
 	dumpShellState(System.out);
-	assertThat("Shell did not activate", shell.getDisplay().getActiveShell(), is(shell));
+	assertEquals(shell.getDisplay().getActiveShell(), shell, "Shell did not activate");
 	fail("SWT.Activate was not received but Shell is (incorrectly?) reported active");
 }
 
@@ -586,13 +583,12 @@ public static boolean hasPixelNotMatching(Image image, Color nonMatchingColor, R
 	return false;
 }
 
-public static Path getPath(String fileName, TemporaryFolder tempFolder) {
-	Path path = tempFolder.getRoot().toPath();
-	Path filePath = path.resolve("image-resources").resolve(Path.of(fileName));
-	return getPath(fileName, filePath);
+public static Path getPath(String fileName, Path tempFolder) {
+	Path filePath = tempFolder.resolve("image-resources").resolve(Path.of(fileName));
+	return copyFile(fileName, filePath);
 }
 
-public static Path getPath(String sourceFilename, Path destinationPath) {
+public static Path copyFile(String sourceFilename, Path destinationPath) {
 	if (!Files.isRegularFile(destinationPath)) {
 		// Extract resource on the classpath to a temporary file to ensure it's
 		// available as plain file, even if this bundle is packed as jar

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_browser_Browser.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_browser_Browser.java
@@ -17,16 +17,16 @@ import static org.eclipse.swt.browser.LocationListener.changedAdapter;
 import static org.eclipse.swt.browser.LocationListener.changingAdapter;
 import static org.eclipse.swt.browser.ProgressListener.completedAdapter;
 import static org.eclipse.swt.browser.VisibilityWindowListener.showAdapter;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-import static org.junit.Assume.assumeFalse;
-import static org.junit.Assume.assumeTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import java.io.IOException;
 import java.lang.management.ManagementFactory;
@@ -42,7 +42,6 @@ import java.nio.file.Paths;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -82,29 +81,22 @@ import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.Text;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
-import org.junit.FixMethodOrder;
-import org.junit.Ignore;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-import org.junit.rules.TestName;
-import org.junit.runner.RunWith;
-import org.junit.runners.MethodSorters;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.io.TempDir;
 
 /**
  * Automated Test Suite for class org.eclipse.swt.browser.Browser
  *
  * @see org.eclipse.swt.browser.Browser
  */
-@RunWith(Parameterized.class)
-@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+@TestMethodOrder(MethodOrderer.MethodName.class)
 public class Test_org_eclipse_swt_browser_Browser extends Test_org_eclipse_swt_widgets_Composite {
-
 	// TODO Reduce to reasonable value
 	private static Duration MAXIMUM_BROWSER_CREATION_TIME = Duration.ofSeconds(90);
 
@@ -128,8 +120,7 @@ public class Test_org_eclipse_swt_browser_Browser extends Test_org_eclipse_swt_w
 	int secondsToWaitTillFail; // configured in setUp() to allow individual tests to override this.
 	// CONFIG END
 
-	@Rule
-	public TestName name = new TestName();
+	private TestInfo testInfo;
 
 	Browser browser;
 	boolean isEdge = false;
@@ -147,24 +138,13 @@ public class Test_org_eclipse_swt_browser_Browser extends Test_org_eclipse_swt_w
 	List<Browser> createdBroswers = new ArrayList<>();
 	static List<String> descriptors = new ArrayList<>();
 
-	private final int swtBrowserSettings;
+	protected int swtBrowserSettings;
 
-@Parameters(name = "browser flags: {0}")
-public static Collection<Object[]> browserFlagsToTest() {
-	List<Object[]> browserFlags = new ArrayList<>();
-	browserFlags.add(new Object[] {SWT.NONE});
-	if (SwtTestUtil.isWindows) {
-		// Execute IE tests after Edge, because IE starts some OS timer that conflicts with Edge event handling
-		browserFlags.add(new Object[] {SWT.IE});
-	}
-	return browserFlags;
+public Test_org_eclipse_swt_browser_Browser() {
+	this.swtBrowserSettings = SWT.NONE;
 }
 
-public Test_org_eclipse_swt_browser_Browser(int swtBrowserSettings) {
-	this.swtBrowserSettings = swtBrowserSettings;
-}
-
-@BeforeClass
+@BeforeAll
 public static void setupEdgeEnvironment() {
 	// Initialize Edge environment before any test runs to isolate environment setup
 	// as this takes quite long in GitHub Actions builds
@@ -178,9 +158,9 @@ public static void setupEdgeEnvironment() {
 	}
 }
 
-@Override
-@Before
-public void setUp() {
+@BeforeEach
+public void setUp(TestInfo testInfo) {
+	this.testInfo = testInfo;
 	super.setUp();
 	testNumber ++;
 	secondsToWaitTillFail = Math.max(15, debug_show_browser_timeout_seconds);
@@ -189,14 +169,14 @@ public void setUp() {
 	// To get around this, we print each test's name and if there is a crash, it will be printed right after.
 	// This is kept for future use as sometimes crashes can appear out of the blue with no changes in SWT code.
 	// E.g an upgrade from WebkitGtk2.16 to WebkitGtk2.18 caused random crashes because dispose logic was changed.
-	System.out.println("Running Test_org_eclipse_swt_browser_Browser#" + name.getMethodName());
+	System.out.println("Running Test_org_eclipse_swt_browser_Browser#" + testInfo.getDisplayName());
 
 	shell.setLayout(new FillLayout());
 	browser = createBrowser(shell, swtBrowserSettings);
 
 	isEdge = browser.getBrowserType().equals("edge");
 
-	String shellTitle = name.getMethodName();
+	String shellTitle = testInfo.getDisplayName();
 	if (SwtTestUtil.isGTK) {
 
 		// Note, webkitGtk version is only available once Browser is instantiated.
@@ -213,7 +193,7 @@ public void setUp() {
 		processUiEvents();
 
 		descriptors = Collections.unmodifiableList(getOpenedDescriptors());
-		System.out.println("\n### Descriptors opened BEFORE " + name.getMethodName() + ": " + descriptors.size());
+		System.out.println("\n### Descriptors opened BEFORE " + testInfo.getDisplayName() + ": " + descriptors.size());
 	}
 }
 
@@ -250,7 +230,7 @@ protected void afterDispose(Display display) {
 			disposedBrowsers ++;
 		}
 	}
-	assertEquals("Found " + disposedBrowsers + " not disposed browsers!", 0, disposedBrowsers);
+	assertEquals(0, disposedBrowsers);
 	boolean verbose = false;
 	if(verbose) {
 		if(testNumber % 2 == 0) {
@@ -283,7 +263,7 @@ protected void afterDispose(Display display) {
 
 private int reportOpenedDescriptors() {
 	List<String> newDescriptors = getOpenedDescriptors();
-	System.out.println("\n### Descriptors opened AFTER " + name.getMethodName() + ": " + newDescriptors.size());
+	System.out.println("\n### Descriptors opened AFTER " + testInfo.getDisplayName() + ": " + newDescriptors.size());
 	int count = newDescriptors.size();
 	int diffToPrevious = count - descriptors.size();
 	int diffToInitial = count - initialOpenedDescriptors.size();
@@ -312,13 +292,14 @@ private Browser createBrowser(Shell s, int flags) {
 	b.getUrl();
 	createdBroswers.add(b);
 	Duration createDuration = Duration.between(createStartTime, Instant.now());
-	assertTrue("creating browser took too long: " + createDuration.toMillis() + "ms", createDuration.minus(MAXIMUM_BROWSER_CREATION_TIME).isNegative());
+	assertTrue(createDuration.minus(MAXIMUM_BROWSER_CREATION_TIME).isNegative());
 	return b;
 }
 
 /**
  * Test that if Browser is constructed with the parent being "null", Browser throws an exception.
  */
+@Test
 @Override
 public void test_ConstructorLorg_eclipse_swt_widgets_CompositeI() {
 	Browser browser = createBrowser(shell, swtBrowserSettings);
@@ -397,7 +378,7 @@ private class EdgeBrowserApplication extends Thread {
 
 @Test
 public void test_Constructor_multipleInstantiationsInDifferentThreads() {
-	assumeTrue("This test is intended for Edge only", isEdge);
+	assumeTrue(isEdge, "This test is intended for Edge only");
 
 	int numberOfApplication = 5;
 	List<EdgeBrowserApplication> browserApplications = new ArrayList<>();
@@ -495,7 +476,7 @@ public void test_getChildren() {
 	if (SwtTestUtil.isWindows && !isEdge) {
 		int childCount = composite.getChildren().length;
 		String msg = "Browser on Win32 is a special case, the first child is an OleFrame (ActiveX control). Actual child count is: " + childCount;
-		assertEquals(msg, 1, childCount);
+		assertEquals(1, childCount, msg);
 	} else {
 		super.test_getChildren();
 	}
@@ -537,7 +518,7 @@ public void test_CloseWindowListener_close () {
 	browser.setText("<script language='JavaScript'>window.close()</script>");
 	shell.open();
 	boolean passed = waitForPassCondition(browserCloseListenerFired::get);
-	assertTrue("Test timed out.", passed);
+	assertTrue(passed);
 }
 
 @Test
@@ -581,7 +562,7 @@ public void test_LocationListener_changing() {
 	shell.open();
 	browser.setText("Hello world");
 	boolean passed = waitForPassCondition(changingFired::get);
-	assertTrue("LocationListener.changing() event was never fired", passed);
+	assertTrue(passed);
 }
 
 @Test
@@ -594,7 +575,7 @@ public void test_LocationListener_changed() {
 	String errorMsg = String.format(
 			"LocationListener.changed() event was never fired. Browser URL after waitForPassCondition: %s",
 			browser.getUrl());
-	assertTrue(errorMsg, passed);
+	assertTrue(passed, errorMsg);
 }
 @Test
 public void test_LocationListener_changed_twoSetTextCycles() {
@@ -603,10 +584,10 @@ public void test_LocationListener_changed_twoSetTextCycles() {
 	shell.open();
 	browser.setText("Hello world");
 	boolean passed = waitForPassCondition(() -> changedCount.get() == 1);
-	assertTrue("LocationListener.changed() event was never fired", passed);
+	assertTrue(passed);
 	browser.setText("2nd text");
 	passed = waitForPassCondition(() -> changedCount.get() == 2);
-	assertTrue("LocationListener.changed() event was not fired for the 2nd text change", passed);
+	assertTrue(passed);
 }
 
 @Test
@@ -679,7 +660,7 @@ public void test_LocationListener_then_ProgressListener() {
 			+ "progressChanged: " + progressChanged.get() + "\n"
 			+ "browser text on completed event: " + browserTextOnCompletedEvent.get() + "\n"
 			+ "browser text after waitForPassCondition: " + browser.getText();
-	assertTrue(errorMsg, progressChangedAfterLocationChanged.get());
+	assertTrue(progressChangedAfterLocationChanged.get(), errorMsg);
 }
 
 @Test
@@ -739,7 +720,7 @@ public void test_LocationListener_ProgressListener_canceledLoad () {
 			+ "ProgressChanged unexpectedly (should be false): " + unexpectedProgressCompleted.get() + (unexpectedProgressCompleted.get() ? " (" +unexpectedProgressCompletedDetails.get() +")": "")+ "\n";
 
 
-	assertTrue(errMsg, passed);
+	assertTrue(passed, errMsg);
 
 	/* FOOTNOTE 1
 	 *
@@ -762,12 +743,12 @@ public void test_LocationListener_LocationListener_ordered_changing () {
 	browser.setText("You should not see this message.");
 	String url = getValidUrl();
 	browser.setUrl(url);
-	assertTrue("Change of locations do not fire in order: " + locations.toString(), waitForPassCondition(() -> locations.size() == 2));
-	assertTrue("Change of locations do not fire in order", locations.get(0).equals("about:blank") && locations.get(1).contains("testWebsiteWithTitle.html"));
+	assertTrue(waitForPassCondition(() -> locations.size() == 2));
+	assertTrue(locations.get(0).equals("about:blank") && locations.get(1).contains("testWebsiteWithTitle.html"));
 }
 
-@ClassRule
-public static TemporaryFolder tempFolder = new TemporaryFolder();
+@TempDir
+static Path tempFolder;
 
 private String getValidUrl() {
 	return SwtTestUtil.getPath("testWebsiteWithTitle.html", tempFolder).toUri().toString();
@@ -796,7 +777,7 @@ public void test_LocationListener_ProgressListener_noExtraEvents() {
 			+ "\nExpected one of each, but received:"
 			+ "\nChanged count: " + changedCount.get()
 			+ "\nCompleted count: " + completedCount.get();
-	assertTrue(errorMsg, passed);
+	assertTrue(passed, errorMsg);
 }
 
 @Test
@@ -830,8 +811,8 @@ public void test_OpenWindowListener_openHasValidEventDetails() {
 	AtomicBoolean openFiredCorrectly = new AtomicBoolean(false);
 	browser.addOpenWindowListener(event -> {
 		final Browser browserChild = createBrowser(shell, swtBrowserSettings);
-		assertSame("Expected Browser1 instance, but have another instance", browser, event.widget);
-		assertNull("Expected event.browser to be null", event.browser);
+		assertSame(browser, event.widget);
+		assertNull(event.browser);
 		openFiredCorrectly.set(true);
 		event.browser = browserChild;
 	});
@@ -843,7 +824,7 @@ public void test_OpenWindowListener_openHasValidEventDetails() {
 			""");
 
 	boolean passed = waitForPassCondition(openFiredCorrectly::get);
-	assertTrue("Test timed out. OpenWindow event not fired.", passed);
+	assertTrue(passed);
 }
 
 /** Test that a script 'window.open()' opens a child popup shell. */
@@ -880,7 +861,7 @@ public void test_OpenWindowListener_open_ChildPopup() {
 	boolean passed = waitForPassCondition(childCompleted::get);
 
 	String errMsg = "Test timed out.";
-	assertTrue(errMsg, passed);
+	assertTrue(passed, errMsg);
 }
 
 /** Validate event order : Child's visibility should come before progress completed event */
@@ -929,10 +910,9 @@ public void test_OpenWindow_Progress_Listener_ValidateEventOrder() {
 			+"\nExpected true for the below, but have:"
 			+"\nVisibilityShowed:" + visibilityShowed.get()
 			+"\nChildCompleted:" + childCompleted.get();
-	assertTrue(errMsg, passed);
+	assertTrue(passed, errMsg);
 
-	assertEquals("Child Visibility.show should have fired before progress completed",
-			List.of("Visibility.show", "Progress.completed"), List.copyOf(eventOrder));
+	assertEquals(List.of("Visibility.show", "Progress.completed"), List.copyOf(eventOrder));
 }
 
 @Test
@@ -1011,7 +991,7 @@ public void test_ProgressListener_completed_Called() {
 	boolean passed = waitForPassCondition(childCompleted::get);
 	String errorMsg = "Browser text before completed: " + browserTextOnChangedEvent.get() +
 					"\nBrowser text after completed: " + browser.getText();
-	assertTrue(errorMsg, passed);
+	assertTrue(passed, errorMsg);
 }
 
 @Test
@@ -1053,7 +1033,7 @@ public void test_StatusTextListener_addAndRemove() {
  */
 @Test
 public void test_StatusTextListener_hoverMouseOverLink() {
-	assumeFalse("no API in Edge for this", isEdge);
+	assumeFalse(isEdge, "no API in Edge for this");
 
 	AtomicBoolean statusChanged = new AtomicBoolean(false);
 	int size = 500;
@@ -1092,7 +1072,7 @@ public void test_StatusTextListener_hoverMouseOverLink() {
 	shell.open();
 	boolean passed = waitForPassCondition(statusChanged::get);
 	String msg = "Mouse movement over text was suppose to trigger StatusTextListener. But it didn't";
-	assertTrue(msg, passed);
+	assertTrue(passed, msg);
 }
 
 @Test
@@ -1130,7 +1110,7 @@ public void test_TitleListener_event() {
 	shell.open();
 	boolean passed = waitForPassCondition(titleListenerFired::get);
 	String errMsg = "Title listener never fired. Test timed out.";
-	assertTrue(errMsg, passed);
+	assertTrue(passed, errMsg);
 }
 
 @Test
@@ -1139,7 +1119,7 @@ public void test_setText() {
 	Runnable browserSetFunc = () -> {
 		String html = "<html><title>Website Title</title><body>Html page with custom title</body></html>";
 		boolean opSuccess = browser.setText(html);
-		assertTrue("Expecting setText() to return true", opSuccess);
+		assertTrue(opSuccess);
 	};
 	validateTitleChanged(expectedTitle, browserSetFunc);
 }
@@ -1177,21 +1157,20 @@ public void test_setTextContainingScript_applicationLayerProgressListenerMustSee
 				</body>
 			</html>
 			""");
-	assertTrue("progress completion not reported", waitForPassCondition(completed::get));
-	assertTrue("title not set", waitForPassCondition(() -> title.get() != null));
-	assertTrue(
-			"unexpected title: " + title.get(), waitForPassCondition(() -> title.get().contains("ProgressListener: Found 1 h1 tag(s)")));
+	assertTrue(waitForPassCondition(completed::get));
+	assertTrue(waitForPassCondition(() -> title.get() != null));
+	assertTrue(waitForPassCondition(() -> title.get().contains("ProgressListener: Found 1 h1 tag(s)")));
 }
 
 @Test
 public void test_setUrl_local() {
-	assumeFalse("Test fails on Mac, see https://github.com/eclipse-platform/eclipse.platform.swt/issues/722", SwtTestUtil.isCocoa);
+	assumeFalse(SwtTestUtil.isCocoa, "Test fails on Mac, see https://github.com/eclipse-platform/eclipse.platform.swt/issues/722");
 	String expectedTitle = "Website Title";
 	Runnable browserSetFunc = () -> {
 		String url = getValidUrl();
 		testLogAppend("URL: " + url);
 		boolean opSuccess = browser.setUrl(url);
-		assertTrue("Expecting setUrl() to return true" + testLog.toString(), opSuccess);
+		assertTrue(opSuccess);
 	};
 	validateTitleChanged(expectedTitle, browserSetFunc);
 }
@@ -1199,7 +1178,7 @@ public void test_setUrl_local() {
 /** This test requires working Internet connection */
 @Test
 public void test_setUrl_remote() {
-	assumeFalse("Test fails on Mac, see https://github.com/eclipse-platform/eclipse.platform.swt/issues/722", SwtTestUtil.isCocoa);
+	assumeFalse(SwtTestUtil.isCocoa, "Test fails on Mac, see https://github.com/eclipse-platform/eclipse.platform.swt/issues/722");
 
 	// This test sometimes times out if build server has a bad connection. Thus for this test we have a longer timeout.
 	secondsToWaitTillFail = 35;
@@ -1207,14 +1186,14 @@ public void test_setUrl_remote() {
 	String url = "https://example.com"; // example.com loads very quickly and conveniently has a consistent title
 
 	// Skip this test if we don't have a working Internet connection.
-	assumeTrue("Skipping test due to bad internet connection", checkInternet(url));
+	assumeTrue(checkInternet(url), "Skipping test due to bad internet connection");
 	testLog.append("checkInternet() passed");
 
 	String expectedTitle = "Example Domain";
 	Runnable browserSetFunc = () -> {
 		testLog.append("Setting Browser url to:" + url);
 		boolean opSuccess = browser.setUrl(url);
-		assertTrue("Expecting setUrl() to return true", opSuccess);
+		assertTrue(opSuccess);
 	};
 	validateTitleChanged(expectedTitle, browserSetFunc);
 }
@@ -1228,7 +1207,7 @@ public void test_setUrl_remote_with_post() {
 	String url = "https://bugs.eclipse.org/bugs/buglist.cgi";
 
 	// Skip this test if we don't have a working Internet connection.
-	assumeTrue("Skipping test due to bad internet connection", checkInternet(url));
+	assumeTrue(checkInternet(url), "Skipping test due to bad internet connection");
 	testLog.append("checkInternet() passed");
 
 	Runnable browserSetFunc = () -> {
@@ -1236,7 +1215,7 @@ public void test_setUrl_remote_with_post() {
 		boolean opSuccess = browser.setUrl(
 				url, "bug_severity=enhancement&bug_status=NEW&email1=rgrunber&emailassigned_to1=1&emailtype1=substring",
 				null);
-		assertTrue("Expecting setUrl() to return true", opSuccess);
+		assertTrue(opSuccess);
 	};
 
 	final AtomicReference<Boolean> completed = new AtomicReference<>(false);
@@ -1248,26 +1227,26 @@ public void test_setUrl_remote_with_post() {
 	shell.open();
 
 	boolean hasFinished = waitForPassCondition(() -> completed.get().booleanValue());
-	assertTrue("Test timed out. ProgressListener not fired " + testLog.toString(), hasFinished);
+	assertTrue(hasFinished);
 
 	// Even a successful empty query returns about 10000 chars of HTML
 	int numChars = browser.getText().length();
-	assertTrue("Response data contained " + numChars + " chars.", numChars > 10000);
+	assertTrue(numChars > 10000);
 }
 
 private void validateTitleChanged(String expectedTitle, Runnable browserSetFunc) {
 	final AtomicReference<String> actualTitle = new AtomicReference<>("");
 	browser.addTitleListener(event ->  {
 		testLog.append("TitleListener fired");
-		assertNotNull("event title is empty" + testLog.toString(), event.title);
+		assertNotNull(event.title);
 		actualTitle.set(event.title);
 	});
 	browserSetFunc.run();
 	shell.open();
 
 	waitForPassCondition(() -> actualTitle.get().equals(expectedTitle));
-	assertTrue("Test timed out. TitleListener not fired", actualTitle.get().length() != 0);
-	assertEquals(testLog.toString(), expectedTitle, actualTitle.get());
+	assertTrue(actualTitle.get().length() != 0);
+	assertEquals(expectedTitle, actualTitle.get());
 }
 
 @Test
@@ -1378,7 +1357,7 @@ public void test_VisibilityWindowListener_multiple_shells() {
 		boolean passed = waitForPassCondition(secondChildCompleted::get);
 
 		String errMsg = "\nTest timed out.";
-		assertTrue(errMsg, passed);
+		assertTrue(passed, errMsg);
 }
 
 /**
@@ -1433,7 +1412,7 @@ public void test_VisibilityWindowListener_eventSize() {
 			+ "\nexpected width=300, actual:" + result.get().x
 			+ "\nexpected height=100, actual:" + result.get().y
 			: "test timed out. Child's visibility Window listener didn't trigger";
-	assertTrue(errMsg + testLog.toString(), passed);
+	assertTrue(passed, errMsg);
 }
 
 @Override
@@ -1491,8 +1470,7 @@ public void test_setJavascriptEnabled() {
 			} catch (Exception e) {
 				fail("1) if javascript is disabled, browser.evaluate() should return null. But an Exception was thrown");
 			}
-			assertNull("2) Javascript should not have executed. But not-null was returned:" + expectedNull,
-					expectedNull);
+			assertNull(expectedNull);
 
 			testPassed.set(true);
 			testFinished.set(true);
@@ -1503,7 +1481,7 @@ public void test_setJavascriptEnabled() {
 	browser.setText("First page with javascript enabled. This should not be visible as a second page should load");
 
 	waitForPassCondition(testFinished::get);
-	assertTrue("3) Javascript was executed on the second page. But it shouldn't have", testPassed.get());
+	assertTrue(testPassed.get());
 }
 
 /** Check that if there are two browser instances, turning off JS in one instance doesn't turn off JS in the other instance. */
@@ -1532,7 +1510,7 @@ public void test_setJavascriptEnabled_multipleInstances() {
 			pageLoadCount.set(3);
 
 			Boolean shouldBeNull = (Boolean) browser.evaluate("return true");
-			assertNull("1) Evaluate execution should be null, but 'true was returned'", shouldBeNull);
+			assertNull(shouldBeNull);
 			instanceOneFinishedCorrectly.set(true);
 		}
 	}));
@@ -1544,8 +1522,7 @@ public void test_setJavascriptEnabled_multipleInstances() {
 				pageLoadCountSecondInstance.set(3);
 
 				Boolean shouldBeTrue = (Boolean) browserSecondInsance.evaluate("return true");
-				assertTrue("2) Javascript should be executable in second instance (as javascript was not turned off), but it was not. "
-						+ "Expected:'someStr', Actual:"+shouldBeTrue, shouldBeTrue);
+				assertTrue(shouldBeTrue);
 				instanceTwoFinishedCorrectly.set(true);
 			}
 		}
@@ -1562,7 +1539,7 @@ public void test_setJavascriptEnabled_multipleInstances() {
 			"InstanceTwoFinishedCorrectly: " + instanceTwoFinishedCorrectly.get() + "\n" +
 			"Instance 1 & 2 page counts: " + pageLoadCount.get() + " & " + pageLoadCountSecondInstance.get();
 
-	assertTrue(message, passed);
+	assertTrue(passed, message);
 }
 
 /**
@@ -1620,7 +1597,7 @@ public void test_LocationListener_evaluateInCallback() {
 		// Further, only 'changing' is fired if evaluation is invoked inside listeners.
 		passed = changingFinished.get();
 	}
-	assertTrue(errMsg, passed);
+	assertTrue(passed, errMsg);
 }
 
 /** Verify that evaluation works inside an OpenWindowListener */
@@ -1639,7 +1616,7 @@ public void test_OpenWindowListener_evaluateInCallback() {
 	try { evaluated = (Boolean) browser.evaluate("return SWTopenListener"); } catch (SWTException e) {}
 	boolean passed = fired && evaluated;
 	String errMsg = "Event fired:" + fired + "   evaluated:" + evaluated;
-	assertTrue(errMsg, passed);
+	assertTrue(passed, errMsg);
 }
 
 /**
@@ -1814,12 +1791,12 @@ private void getText_helper(String testString, String expectedOutput) {
 	}));
 	shell.open();
 	waitForPassCondition(finished::get);
-	String error_msg = finished.get() ?
+	String errMsg = finished.get() ?
 			"Test did not return correct string.\n"
 			+ "Expected:"+testString+"\n"
 			+ "Actual:"+returnString.get()
 			: "Test timed out";
-	assertEquals(error_msg, normalizeHtmlString(expectedOutput), normalizeHtmlString(returnString.get()));
+	assertEquals(normalizeHtmlString(expectedOutput), normalizeHtmlString(returnString.get()), errMsg);
 }
 
 private String normalizeHtmlString(String htmlString) {
@@ -1865,7 +1842,7 @@ public void test_execute_and_closeListener () {
 		disposedIntentionally = true;
 	String message = "Either browser.execute() did not work (if you still see the html page) or closeListener Was not triggered if "
 			+ "browser looks disposed, but test still fails.";
-	assertTrue(message, passed);
+	assertTrue(passed, message);
 }
 
 
@@ -1887,7 +1864,7 @@ public void test_evaluate_string() {
 	browser.setText("<html><body><p id='myid'>HelloWorld</p></body></html>");
 	shell.open();
 	boolean passed = waitForPassCondition(()-> "HelloWorld".equals(returnValue.get()));
-	assertTrue("Evaluation did not return a value. Or test timed out.", passed);
+	assertTrue(passed);
 }
 
 // Test where the script has the 'return' not in the beginning,
@@ -1902,7 +1879,7 @@ public void test_evaluate_returnMoved() {
 	browser.setText("test text");
 	shell.open();
 	boolean passed = waitForPassCondition(()-> "hello".equals(returnValue.get()));
-	assertTrue("Evaluation did not return a value. Or test timed out.", passed);
+	assertTrue(passed);
 }
 
 /**
@@ -1912,8 +1889,7 @@ public void test_evaluate_returnMoved() {
 @Test
 public void test_evaluate_number_normal() {
 	Double testNum = 123.0;
-	assertTrue("Failed to evaluate number: " + testNum.toString(),
-			evaluate_number_helper(testNum));
+	assertTrue(evaluate_number_helper(testNum));
 }
 
 /**
@@ -1923,8 +1899,7 @@ public void test_evaluate_number_normal() {
 @Test
 public void test_evaluate_number_negative() {
 	Double testNum = -123.0;
-	assertTrue("Failed to evaluate number: " + testNum.toString(),
-			evaluate_number_helper(testNum));
+	assertTrue(evaluate_number_helper(testNum));
 }
 
 /**
@@ -1934,8 +1909,7 @@ public void test_evaluate_number_negative() {
 @Test
 public void test_evaluate_number_big() {
 	Double testNum = 10000000000.0;
-	assertTrue("Failed to evaluate number: " + testNum.toString(),
-			evaluate_number_helper(testNum));
+	assertTrue(evaluate_number_helper(testNum));
 }
 
 boolean evaluate_number_helper(Double testNum) {
@@ -1970,7 +1944,7 @@ public void test_evaluate_boolean() {
 	browser.setText("<html><body>HelloWorld</body></html>");
 	shell.open();
 	boolean passed = waitForPassCondition(atomicBoolean::get);
-	assertTrue("Evaluation did not return a boolean. Or test timed out.", passed);
+	assertTrue(passed);
 }
 
 /**
@@ -1992,7 +1966,7 @@ public void test_evaluate_null() {
 	browser.setText("<html><body>HelloWorld</body></html>");
 	shell.open();
 	boolean passed = waitForPassCondition(() -> returnValue.get() == null);
-	assertTrue("Evaluate did not return a null (current value: " + returnValue.get() + "). Timed out.", passed);
+	assertTrue(passed);
 }
 
 /**
@@ -2037,7 +2011,7 @@ public void test_evaluate_invalid_return_value() {
 				+ " Expected ERROR_INVALID_RETURN_VALUE but got ERROR_FAILED_EVALUATE");
 	}
 	String message = exception.get() == -1 ? "Exception was not thrown. Test timed out" : "Exception thrown, but wrong code: " + exception.get();
-	assertTrue(message, passed);
+	assertTrue(passed, message);
 }
 
 /**
@@ -2070,7 +2044,7 @@ public void test_evaluate_evaluation_failed_exception() {
 	});
 	String message = "".equals(additionalErrorInfo.get()) ? "Javascript did not throw an error. Test timed out" :
 		"Javascript threw an error, but not the right one." + additionalErrorInfo.get();
-	assertTrue(message, passed);
+	assertTrue(passed, message);
 }
 
 /**
@@ -2109,7 +2083,7 @@ public void test_evaluate_array_numbers() {
 	});
 	String message = "".equals(additionalErrorInfo.get()) ? "Javascript did not call java" :
 				"Javascript called java, but passed wrong values: " + additionalErrorInfo.get();
-	assertTrue(message, passed);
+	assertTrue(passed, message);
 }
 
 /**
@@ -2148,7 +2122,7 @@ public void test_evaluate_array_strings () {
 			"Expected an array of strings, but did not receive array or got the wrong result."
 			: "Received a callback from javascript, but: " + additionalErrorInfo.get() +
 			" : " + atomicStringArray.toString();
-	assertTrue(message, passed);
+	assertTrue(passed, message);
 }
 
 /**
@@ -2185,7 +2159,7 @@ public void test_evaluate_array_mixedTypes () {
 	});
 	String message = "".equals(additionalErrorInfo.get()) ? "Javascript did not call java" :
 					"Javascript called java but passed wrong values: " + atomicArray.toString();
-	assertTrue(message, passed);
+	assertTrue(passed, message);
 }
 
 /**
@@ -2257,7 +2231,7 @@ public void test_BrowserFunction_callback () {
 	shell.open();
 	boolean passed = waitForPassCondition(javaCallbackExecuted::get);
 	String message = "Java failed to get a callback from javascript. Test timed out";
-	assertTrue(message, passed);
+	assertTrue(passed, message);
 }
 
 /**
@@ -2269,7 +2243,7 @@ public void test_BrowserFunction_callback () {
  */
 @Test
 public void test_BrowserFunction_callback_stackedCalls() {
-	assumeFalse("Not currently working on Linux, see https://github.com/eclipse-platform/eclipse.platform.swt/issues/2021", SwtTestUtil.isGTK);
+	assumeFalse(SwtTestUtil.isGTK, "Not currently working on Linux, see https://github.com/eclipse-platform/eclipse.platform.swt/issues/2021");
 	AtomicInteger javaCallbackExecuted = new AtomicInteger();
 	final int DEPTH = 5;
 
@@ -2312,7 +2286,7 @@ public void test_BrowserFunction_callback_stackedCalls() {
 	shell.open();
 	boolean passed = waitForPassCondition(() -> javaCallbackExecuted.get() == DEPTH);
 	String message = "Java failed to get a callback from javascript. Test timed out";
-	assertTrue(message, passed);
+	assertTrue(passed, message);
 }
 
 /**
@@ -2358,7 +2332,7 @@ public void test_BrowserFunction_callback_with_integer () {
 	shell.open();
 	boolean passed = waitForPassCondition(() -> returnInt.get() == 5);
 	String message = "Javascript should have passed an integer to Java, but this did not happen.";
-	assertTrue(message, passed);
+	assertTrue(passed, message);
 }
 
 
@@ -2405,7 +2379,7 @@ public void test_BrowserFunction_callback_with_boolean () {
 	shell.open();
 	boolean passed = waitForPassCondition(javaCallbackExecuted::get);
 	String message = "Javascript did not pass a boolean back to Java.";
-	assertTrue(message, passed);
+	assertTrue(passed, message);
 }
 
 
@@ -2452,7 +2426,7 @@ public void test_BrowserFunction_callback_with_String () {
 	boolean passed = waitForPassCondition(() -> "hellojava".equals(returnValue.get()));
 	String message = "Javascript was suppose to call java with a String, " +
 				"but it seems Java did not receive the call or an incorrect value was passed.";
-	assertTrue(message, passed);
+	assertTrue(passed, message);
 }
 
 
@@ -2515,7 +2489,7 @@ public void test_BrowserFunction_callback_with_multipleValues () {
 	//Screenshots.takeScreenshot(getClass(), "test_BrowserFunction_callback_with_multipleValues__AfterWaiting");
 
 	String msg = "Values not set. Test timed out. Array should be [\"hellojava\", 5, true], but is: " + atomicArray.toString();
-	assertTrue(msg, passed);
+	assertTrue(passed, msg);
 }
 
 
@@ -2585,7 +2559,7 @@ public void test_BrowserFunction_callback_with_javaReturningInt () {
 	shell.open();
 	boolean passed = waitForPassCondition(() -> returnInt.get() == 42);
 	String message = "Java should have returned something back to Javascript. But something went wrong";
-	assertTrue(message, passed);
+	assertTrue(passed, message);
 }
 
 
@@ -2639,7 +2613,7 @@ public void test_BrowserFunction_callback_with_javaReturningString () {
 	shell.open();
 	boolean passed = waitForPassCondition(() -> testString.equals(returnString.get()));
 	String message = "Java should have returned something back to Javascript. But something went wrong";
-	assertTrue(message, passed);
+	assertTrue(passed, message);
 }
 
 
@@ -2688,7 +2662,7 @@ public void test_BrowserFunction_callback_afterPageReload() {
 	shell.open();
 	boolean passed = waitForPassCondition(javaCallbackExecuted::get);
 	String message = "A Javascript callback should work after a page has been reloaded, but something went wrong.";
-	assertTrue(message, passed);
+	assertTrue(passed, message);
 }
 
 @Test
@@ -2733,10 +2707,10 @@ public void test_BrowserFunction_multiprocess() {
 }
 
 @Test
-@Ignore("Too fragile on CI, Display.getDefault().post(event) does not work reliably")
+@Disabled("Too fragile on CI, Display.getDefault().post(event) does not work reliably")
 public void test_TabTraversalOutOfBrowser() {
-	assumeFalse("Not currently working on macOS, see https://github.com/eclipse-platform/eclipse.platform.swt/issues/1644", SwtTestUtil.isCocoa);
-	assumeFalse("Not currently working on Linux, see https://github.com/eclipse-platform/eclipse.platform.swt/issues/1644", SwtTestUtil.isGTK);
+	assumeFalse(SwtTestUtil.isCocoa, "Not currently working on macOS, see https://github.com/eclipse-platform/eclipse.platform.swt/issues/1644");
+	assumeFalse(SwtTestUtil.isGTK, "Not currently working on Linux, see https://github.com/eclipse-platform/eclipse.platform.swt/issues/1644");
 
 	Text text = new Text(shell, SWT.NONE);
 
@@ -2749,7 +2723,7 @@ public void test_TabTraversalOutOfBrowser() {
 	AtomicBoolean changedFired = new AtomicBoolean(false);
 	browser.addLocationListener(changedAdapter(e ->	changedFired.set(true)));
 	browser.setText("Hello world");
-	assertTrue("LocationListener.changed() event was never fired", waitForPassCondition(changedFired::get));
+	assertTrue(waitForPassCondition(changedFired::get));
 
 	// browser should have focus
 	assertTrue(browser.isFocusControl());
@@ -2766,7 +2740,7 @@ public void test_TabTraversalOutOfBrowser() {
 	Display.getDefault().post(event);
 
 	// focus should move to Text
-	assertTrue("Text did not gain focus", waitForPassCondition(textGainedFocus::get));
+	assertTrue(waitForPassCondition(textGainedFocus::get));
 	assertFalse(browser.isFocusControl());
 	assertTrue(text.isFocusControl());
 }

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_browser_Browser_IE.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_browser_Browser_IE.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2015 IBM Corporation and others.
+ * Copyright (c) 2025 Kichwa Coders Canada, Inc.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -7,20 +7,16 @@
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package org.eclipse.swt.tests.junit;
 
+import org.eclipse.swt.SWT;
+import org.junit.jupiter.api.condition.EnabledOnOs;
 
-import org.junit.platform.suite.api.SelectClasses;
-import org.junit.platform.suite.api.Suite;
-
-@Suite
-@SelectClasses({
-	Test_org_eclipse_swt_browser_Browser.class,
-	Test_org_eclipse_swt_browser_Browser_IE.class
-})
-public class AllBrowserTests {
+@EnabledOnOs(org.junit.jupiter.api.condition.OS.WINDOWS)
+public class Test_org_eclipse_swt_browser_Browser_IE extends Test_org_eclipse_swt_browser_Browser {
+	public Test_org_eclipse_swt_browser_Browser_IE() {
+		super();
+		this.swtBrowserSettings = SWT.IE;
+	}
 }

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_custom_CCombo.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_custom_CCombo.java
@@ -13,15 +13,14 @@
  *******************************************************************************/
 package org.eclipse.swt.tests.junit;
 
-
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.CCombo;
@@ -33,8 +32,8 @@ import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Text;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Automated Test Suite for class org.eclipse.swt.custom.CCombo
@@ -44,7 +43,7 @@ import org.junit.Test;
 public class Test_org_eclipse_swt_custom_CCombo extends Test_org_eclipse_swt_widgets_Composite {
 
 @Override
-@Before
+@BeforeEach
 public void setUp() {
 	super.setUp();
 	ccombo = new CCombo(shell, 0);
@@ -59,19 +58,19 @@ protected Composite getElementExpectedToHaveFocusAfterSetFocusOnParent(Composite
 @Override
 @Test
 public void test_ConstructorLorg_eclipse_swt_widgets_CompositeI() {
-		assertThrows("No exception thrown for parent == null", IllegalArgumentException.class, () -> ccombo = new CCombo(null, 0));
+		assertThrows(IllegalArgumentException.class, () -> ccombo = new CCombo(null, 0));
 		int cases[] = { SWT.FLAT, SWT.BORDER };
 		for (int i = 0; i < cases.length; i++) {
 			ccombo = new CCombo(shell, cases[i]);
-			assertEquals(":a:" + String.valueOf(i), cases[i], (ccombo.getStyle() & cases[i]));
+			assertEquals(cases[i], (ccombo.getStyle() & cases[i]));
 		}
 		ccombo = new CCombo(shell, SWT.BORDER | SWT.READ_ONLY);
 		// Test all the combo listeners
 		int comboListeners[] = { SWT.Dispose, SWT.FocusIn, SWT.Move, SWT.Resize };
 		for (int comboListener : comboListeners) {
-			assertTrue("Combo Listener events not implemented", ccombo.getListeners(comboListener).length > 0);
+			assertTrue(ccombo.getListeners(comboListener).length > 0);
 		}
-		assertEquals("Pop up items are present.",0,  ccombo.getItems().length);
+		assertEquals(0, ccombo.getItems().length);
 		// test that accessible features are added
 		assertNotNull(ccombo.getAccessible());
 }
@@ -91,7 +90,7 @@ public void test_copy() {
 	ccombo.copy();
 	ccombo.setSelection(new Point(0,0));
 	ccombo.paste();
-	assertEquals(":a:", "23123456", ccombo.getText());
+	assertEquals("23123456", ccombo.getText());
 }
 
 @Test
@@ -107,7 +106,7 @@ public void test_cut() {
 	ccombo.setText("123456");
 	ccombo.setSelection(new Point(1,3));
 	ccombo.cut();
-	assertEquals(":a:", "1456", ccombo.getText());
+	assertEquals("1456", ccombo.getText());
 }
 
 @Override
@@ -144,9 +143,9 @@ public void test_paste() {
 	ccombo.setText("123456");
 	ccombo.setSelection(new Point(1,3));
 	ccombo.cut();
-	assertEquals(":a:", "1456", ccombo.getText());
+	assertEquals("1456", ccombo.getText());
 	ccombo.paste();
-	assertEquals(":a:", "123456", ccombo.getText());
+	assertEquals("123456", ccombo.getText());
 }
 
 @Override
@@ -165,7 +164,7 @@ public void test_setBackgroundLorg_eclipse_swt_graphics_Color() {
 	Color colors[] = {new Color(0, 0, 0), new Color(255, 255, 255), new Color(0, 45, 255)};
 	for(int i=0; i<3; i++) {
 		ccombo.setBackground(colors[i]);
-		assertEquals("i="+i, ccombo.getBackground(), colors[i]);
+		assertEquals(ccombo.getBackground(), colors[i]);
 	}
 }
 
@@ -173,9 +172,9 @@ public void test_setBackgroundLorg_eclipse_swt_graphics_Color() {
 @Test
 public void test_setEnabledZ() {
 	ccombo.setEnabled(true);
-	assertTrue("Set true error", ccombo.getEnabled());
+	assertTrue(ccombo.getEnabled());
 	ccombo.setEnabled(false);
-	assertFalse("Set false error", ccombo.getEnabled());
+	assertFalse(ccombo.getEnabled());
 }
 
 @Override
@@ -188,18 +187,18 @@ public void test_setFocus() {
 	try{
 		ccombo.setEnabled(false);
 		ccombo.setVisible(true);
-		assertFalse("Expect false wehn not enabled", ccombo.setFocus());
+		assertFalse(ccombo.setFocus());
 		ccombo.setEnabled(true);
 		ccombo.setVisible(false);
-		assertFalse("Expect false wehn not visible", ccombo.setFocus());
+		assertFalse(ccombo.setFocus());
 		ccombo.setEnabled(false);
 		ccombo.setVisible(false);
-		assertFalse("Expect false wehn not visible and not enabled", ccombo.setFocus());
+		assertFalse(ccombo.setFocus());
 		ccombo.setEnabled(true);
 		ccombo.setVisible(true);
 		SwtTestUtil.processEvents();
 		if(ccombo.isFocusControl())
-			assertTrue("Set focus error", ccombo.setFocus());
+			assertTrue(ccombo.setFocus());
 
 		if (!SwtTestUtil.isCocoa) {
 			ccombo.setEnabled(true);
@@ -215,7 +214,7 @@ public void test_setFocus() {
 	catch (Exception e) {
 		exceptionThrown = true;
 	}
-	assertFalse("Exception thrown", exceptionThrown);
+	assertFalse(exceptionThrown);
 }
 
 @Override
@@ -254,7 +253,7 @@ public void test_setToolTipTextLjava_lang_String() {
 	String[] cases = {"", "fang", "fang0"};
 	for (int i = 0; i < cases.length; i++) {
 		ccombo.setText(cases[i]);
-		assertEquals(":a:" + i, cases[i], ccombo.getText());
+		assertEquals(cases[i], ccombo.getText());
 	}
 }
 
@@ -320,21 +319,21 @@ public void test_consistency_DragDetect () {
 @Test
 public void test_addLjava_lang_String() {
 	ccombo = new CCombo(shell, 0);
-	assertThrows("Did not catch null argument",IllegalArgumentException.class, ()-> ccombo.add(null));
+	assertThrows(IllegalArgumentException.class, ()-> ccombo.add(null));
 	add();
-	assertTrue("Items not successfully added", ccombo.getItems().length > 0);
+	assertTrue(ccombo.getItems().length > 0);
 
 }
 
 @Test
 public void test_addLjava_lang_StringI() {
 	ccombo = new CCombo(shell, 0);
-	assertThrows("Did not catch null argument",IllegalArgumentException.class, ()-> ccombo.add(null, 0));
+	assertThrows(IllegalArgumentException.class, ()-> ccombo.add(null, 0));
 
 	add();// add three items
-	assertTrue("Items not successfully added", ccombo.getItems().length > 0);
+	assertTrue(ccombo.getItems().length > 0);
 
-	assertThrows("Did not catch range exception",IllegalArgumentException.class, ()-> ccombo.add("Hello", 7));
+	assertThrows(IllegalArgumentException.class, ()-> ccombo.add("Hello", 7));
 
 	ccombo.add("Hello", 1);
 	String test = ccombo.getItem(1);
@@ -345,20 +344,20 @@ public void test_addLjava_lang_StringI() {
 public void test_addModifyListenerLorg_eclipse_swt_events_ModifyListener() {
 	ccombo = new CCombo(shell, 0);
 	ModifyListener listener = event -> listenerCalled = true;
-	assertThrows("Expected exception not thrown", IllegalArgumentException.class, () -> ccombo.addModifyListener(null));
+	assertThrows(IllegalArgumentException.class, () -> ccombo.addModifyListener(null));
 
 	// test whether all content modifying API methods send a Modify event
 	ccombo.addModifyListener(listener);
 	listenerCalled = false;
 	ccombo.setText("new text");
-	assertTrue("setText does not send event", listenerCalled);
+	assertTrue(listenerCalled);
 
 	listenerCalled = false;
 	ccombo.removeModifyListener(listener);
 	// cause to call the listener.
 	ccombo.setText("line");
-	assertFalse("Listener not removed", listenerCalled);
-	assertThrows("Expected exception not thrown", IllegalArgumentException.class, () -> ccombo.removeModifyListener(null));
+	assertFalse(listenerCalled);
+	assertThrows(IllegalArgumentException.class, () -> ccombo.removeModifyListener(null));
 }
 
 @Test
@@ -374,12 +373,12 @@ public void test_addSelectionListenerLorg_eclipse_swt_events_SelectionListener()
 		public void widgetDefaultSelected(SelectionEvent event) {
 		}
 	};
-	assertThrows("Expected exception not thrown", IllegalArgumentException.class, () -> ccombo.addSelectionListener(null));
+	assertThrows(IllegalArgumentException.class, () -> ccombo.addSelectionListener(null));
 	ccombo.addSelectionListener(listener);
 	ccombo.select(0);
-	assertFalse(":a:", listenerCalled);
+	assertFalse(listenerCalled);
 	ccombo.removeSelectionListener(listener);
-	assertThrows("Expected exception not thrown", IllegalArgumentException.class, () -> ccombo.removeSelectionListener(null));
+	assertThrows(IllegalArgumentException.class, () -> ccombo.removeSelectionListener(null));
 }
 
 @Test
@@ -389,14 +388,14 @@ public void test_clearSelection() {
 	for (int i = 0; i < number; i++)
 		ccombo.add("fred" + i);
 	ccombo.clearSelection();
-	assertEquals(":a:", new Point(0, 0), ccombo.getSelection());
+	assertEquals(new Point(0, 0), ccombo.getSelection());
 	ccombo.setSelection(new Point(0, 5));
-	assertEquals(":b:", new Point(0, 0), ccombo.getSelection());  //nothing is selected
+	assertEquals(new Point(0, 0), ccombo.getSelection());  //nothing is selected
 	ccombo.setText("some text");
 	ccombo.setSelection(new Point(0, 5));
-	assertEquals(":c:", new Point(0, 5), ccombo.getSelection());
+	assertEquals(new Point(0, 5), ccombo.getSelection());
 	ccombo.clearSelection();
-	assertEquals(":d:", ccombo.getSelection().x, ccombo.getSelection().y);
+	assertEquals(ccombo.getSelection().x, ccombo.getSelection().y);
  }
 
 @Test
@@ -408,7 +407,7 @@ public void test_deselectAll() {
 	ccombo.select(0);
 	ccombo.select(2);
 	ccombo.deselectAll();
-	assertEquals(":a:", -1,  ccombo.getSelectionIndex());
+	assertEquals(-1, ccombo.getSelectionIndex());
 }
 
 @Test
@@ -429,35 +428,35 @@ public void test_deselectI() {
 		ccombo.add("fred" + i);
 	for (int i = 0; i < number; i++) {
 		ccombo.select(i);
-		assertEquals(":a:" + i, i, ccombo.getSelectionIndex());
+		assertEquals(i, ccombo.getSelectionIndex());
 		ccombo.deselect(i);
-		assertEquals(":b:" + i,-1, ccombo.getSelectionIndex());
+		assertEquals(-1, ccombo.getSelectionIndex());
 	}
  }
 
 @Test
 public void test_getEditable() {
 	ccombo = new CCombo(shell, 0);
-	assertTrue("a: Receiver is not editable", ccombo.getEditable());
+	assertTrue(ccombo.getEditable());
 	ccombo = new CCombo(shell, SWT.BORDER);
-	assertTrue("a: Receiver is not editable", ccombo.getEditable());
+	assertTrue(ccombo.getEditable());
 }
 
 @Test
 public void test_getItemCount() {
 	int number = 10;
 	for (int i = 0; i < number; i++) {
-		assertEquals(":a:" + i, i, ccombo.getItemCount());
+		assertEquals(i, ccombo.getItemCount());
 		ccombo.add("fred" + i);
 	}
-	assertEquals(":aa:", number, ccombo.getItemCount());
+	assertEquals(number, ccombo.getItemCount());
 
 	for (int i = 0; i < number; i++) {
-		assertEquals(":b:" + i,number-i, ccombo.getItemCount());
+		assertEquals(number-i, ccombo.getItemCount());
 		ccombo.remove(0);
 	}
 	ccombo.removeAll();
-	assertEquals(":c:",0,ccombo.getItemCount());
+	assertEquals(0, ccombo.getItemCount());
 }
 
 @Test
@@ -467,7 +466,7 @@ public void test_getItemHeight() {
 
 @Test
 public void test_getItemI() {
-	assertThrows("No exception thrown for illegal index argument", IllegalArgumentException.class, () -> ccombo.getItem(0));
+	assertThrows(IllegalArgumentException.class, () -> ccombo.getItem(0));
 
 	int number = 10;
 	for (int i = 0; i < number; i++) {
@@ -484,10 +483,10 @@ public void test_getItems() {
 	ccombo.add("2");
 	ccombo.add("3");
 	String[] items = ccombo.getItems();
-	assertEquals(":a:",3, items.length);
-	assertEquals(":a:", "1", items[0]);
-	assertEquals(":a:", "2", items[1]);
-	assertEquals(":a:", "3", items[2]);
+	assertEquals(3, items.length);
+	assertEquals("1", items[0]);
+	assertEquals("2", items[1]);
+	assertEquals("3", items[2]);
 }
 
 @Test
@@ -495,7 +494,7 @@ public void test_getSelection() {
 	ccombo.setText("123456");
 	ccombo.setSelection(new Point(1,3));
 	ccombo.getSelection();
-	assertEquals(":a:", new Point(1,3), ccombo.getSelection());
+	assertEquals(new Point(1,3), ccombo.getSelection());
 }
 
 @Test
@@ -535,7 +534,7 @@ public void test_getText() {
 	String[] cases = {"", "fred", "fredfred"};
 	for (int i = 0; i < cases.length; i++) {
 		ccombo.setText(cases[i]);
-		assertEquals(":a:" + String.valueOf(i), cases[i], ccombo.getText());
+		assertEquals(cases[i], ccombo.getText());
 	}
 }
 
@@ -547,13 +546,13 @@ public void test_getTextHeight() {
 @Test
 public void test_getTextLimit() {
 	ccombo.setTextLimit(3);
-	assertEquals(":a:", 3, ccombo.getTextLimit());
+	assertEquals(3, ccombo.getTextLimit());
 }
 
 @Test
 public void test_indexOfLjava_lang_String() {
 	ccombo.add("string1");
-	assertThrows("No exception thrown for string == null",IllegalArgumentException.class, ()-> ccombo.indexOf(null));
+	assertThrows(IllegalArgumentException.class, ()-> ccombo.indexOf(null));
 
 	ccombo.removeAll();
 
@@ -592,7 +591,7 @@ public void test_indexOfLjava_lang_String() {
 @Test
 public void test_indexOfLjava_lang_StringI() {
 	ccombo.add("string0");
-	assertThrows("No exception thrown for string == null",IllegalArgumentException.class, ()-> ccombo.indexOf(null));
+	assertThrows(IllegalArgumentException.class, ()-> ccombo.indexOf(null));
 	assertEquals(0, ccombo.indexOf("string0", 0));
 	ccombo.removeAll();
 
@@ -600,18 +599,18 @@ public void test_indexOfLjava_lang_StringI() {
 	for (int i = 0; i < number; i++)
 		ccombo.add("fred" + i);
 	for (int i = 0; i < number; i++)
-		assertEquals(":a:" + i, i, ccombo.indexOf("fred" + i, 0));
+		assertEquals(i, ccombo.indexOf("fred" + i, 0));
 	for (int i = 0; i < number; i++)
-		assertEquals(":b:" + i,-1,  ccombo.indexOf("fred" + i, i + 1));
+		assertEquals(-1, ccombo.indexOf("fred" + i, i + 1));
 
 	for (int i = 0; i < number; i++)
 		ccombo.add("fred" + i);
 	for (int i = 0; i < 3; i++)
-		assertEquals(":a:" + i, i, ccombo.indexOf("fred" + i, 0));
+		assertEquals(i, ccombo.indexOf("fred" + i, 0));
 	for (int i = 3; i < number; i++)
-		assertEquals(":b:" + i, i, ccombo.indexOf("fred" + i, 3));
+		assertEquals(i, ccombo.indexOf("fred" + i, 3));
 	for (int i = 0; i < number; i++)
-		assertEquals(":b:" + i, i, ccombo.indexOf("fred" + i, i));
+		assertEquals(i, ccombo.indexOf("fred" + i, i));
 }
 
 @Test
@@ -619,7 +618,7 @@ public void test_removeAll() {
 	ccombo = new CCombo(shell, 0);
 	add();
 	ccombo.removeAll();
-	assertEquals(":a:",0, ccombo.getItems().length);
+	assertEquals(0, ccombo.getItems().length);
 }
 
 
@@ -659,9 +658,9 @@ public void test_removeII() {
 		ccombo.add("fred");
 	}
 
-	assertThrows("No exception thrown for illegal index argument", IllegalArgumentException.class, () -> ccombo.remove(2, 100));
+	assertThrows(IllegalArgumentException.class, () -> ccombo.remove(2, 100));
 
-	assertThrows("No exception thrown for start index < 0", IllegalArgumentException.class, () ->ccombo.remove(-1, number-1));
+	assertThrows(IllegalArgumentException.class, () ->ccombo.remove(-1, number-1));
 }
 
 @Test
@@ -685,13 +684,13 @@ public void test_removeLjava_lang_String() {
 	for (int i = 0; i < number; i++)
 		ccombo.add("fred");
 
-	assertThrows("No exception thrown for item == null", IllegalArgumentException.class, () -> ccombo.remove(null));
+	assertThrows(IllegalArgumentException.class, () -> ccombo.remove(null));
 
 	ccombo.removeAll();
 	for (int i = 0; i < number; i++)
 		ccombo.add("fred" + i);
 
-	assertThrows("No exception thrown for item not found", IllegalArgumentException.class, () -> ccombo.remove("fred"));
+	assertThrows(IllegalArgumentException.class, () -> ccombo.remove("fred"));
 
 	assertEquals(number, ccombo.getItemCount());
 }
@@ -699,20 +698,20 @@ public void test_removeLjava_lang_String() {
 @Test
 public void test_removeModifyListenerLorg_eclipse_swt_events_ModifyListener() {
 	ModifyListener listener = event -> listenerCalled = true;
-	assertThrows("Expected exception not thrown", IllegalArgumentException.class, () -> ccombo.addModifyListener(null));
+	assertThrows(IllegalArgumentException.class, () -> ccombo.addModifyListener(null));
 
 	// test whether all content modifying API methods send a Modify event
 	ccombo.addModifyListener(listener);
 	listenerCalled = false;
 	ccombo.setText("new text");
-	assertTrue("setText does not send event", listenerCalled);
+	assertTrue(listenerCalled);
 
 	listenerCalled = false;
 	ccombo.removeModifyListener(listener);
 	// cause to call the listener.
 	ccombo.setText("line");
-	assertFalse("Listener not removed", listenerCalled);
-	assertThrows("Expected exception not thrown", IllegalArgumentException.class, () -> ccombo.removeModifyListener(null));
+	assertFalse(listenerCalled);
+	assertThrows(IllegalArgumentException.class, () -> ccombo.removeModifyListener(null));
 }
 
 @Test
@@ -728,12 +727,12 @@ public void test_removeSelectionListenerLorg_eclipse_swt_events_SelectionListene
 		public void widgetDefaultSelected(SelectionEvent event) {
 		}
 	};
-	assertThrows("Expected exception not thrown", IllegalArgumentException.class, () -> ccombo.addSelectionListener(null));
+	assertThrows(IllegalArgumentException.class, () -> ccombo.addSelectionListener(null));
 	ccombo.addSelectionListener(listener);
 	ccombo.select(0);
-	assertFalse(":a:", listenerCalled);
+	assertFalse(listenerCalled);
 	ccombo.removeSelectionListener(listener);
-	assertThrows("Expected exception not thrown", IllegalArgumentException.class, () -> ccombo.removeSelectionListener(null));
+	assertThrows(IllegalArgumentException.class, () -> ccombo.removeSelectionListener(null));
 }
 
 @Test
@@ -743,7 +742,7 @@ public void test_selectI() {
 	ccombo.add("789");
 	ccombo.select(0);
 	ccombo.select(1);
-	assertEquals(":a:", 1, ccombo.getSelectionIndex());
+	assertEquals(1, ccombo.getSelectionIndex());
 
 	// indices out of range are ignored
 	ccombo.select(10);
@@ -753,31 +752,31 @@ public void test_selectI() {
 @Test
 public void test_setEditableZ() {
 	ccombo.setEditable(true);
-	assertTrue("Set true error", ccombo.getEditable());
+	assertTrue(ccombo.getEditable());
 	ccombo.setEditable(false);
-	assertFalse("Set false error", ccombo.getEditable());
+	assertFalse(ccombo.getEditable());
 }
 
 @Test
 public void test_setItemILjava_lang_String() {
-	assertThrows("No exception thrown for item == null", IllegalArgumentException.class, () -> ccombo.setItem(0, null));
+	assertThrows(IllegalArgumentException.class, () -> ccombo.setItem(0, null));
 
-	assertThrows("No exception thrown for illegal index argument", IllegalArgumentException.class, () ->ccombo.setItem(3, "fang"));
+	assertThrows(IllegalArgumentException.class, () ->ccombo.setItem(3, "fang"));
 
-	assertThrows("No exception thrown for illegal index argument", IllegalArgumentException.class, () ->ccombo.setItem(0, "fang"));
+	assertThrows(IllegalArgumentException.class, () ->ccombo.setItem(0, "fang"));
 
 	ccombo.add("string0");
-	assertThrows("No exception thrown for item == null", IllegalArgumentException.class, () -> ccombo.setItem(0, null));
+	assertThrows(IllegalArgumentException.class, () -> ccombo.setItem(0, null));
 
-	assertThrows("No exception thrown for index < 0", IllegalArgumentException.class, () ->ccombo.setItem(-1, "new value"));
+	assertThrows(IllegalArgumentException.class, () ->ccombo.setItem(-1, "new value"));
 
-	assertThrows("No exception thrown for illegal index argument", IllegalArgumentException.class, () -> ccombo.setItem(3, "fang"));
+	assertThrows(IllegalArgumentException.class, () -> ccombo.setItem(3, "fang"));
 
 	ccombo.add("joe");
 	ccombo.setItem(0, "fang");
-	assertEquals("fang", "fang", ccombo.getItem(0));
+	assertEquals("fang", ccombo.getItem(0));
 
-	assertThrows("No exception thrown for illegal index argument", IllegalArgumentException.class, () ->ccombo.setItem(4, "fang"));
+	assertThrows(IllegalArgumentException.class, () ->ccombo.setItem(4, "fang"));
 
 	ccombo.removeAll();
 	int number = 5;
@@ -785,90 +784,90 @@ public void test_setItemILjava_lang_String() {
 		ccombo.add("fang");
 	for (int i = 0; i < number; i++)
 		ccombo.setItem(i, "fang" + i);
-	assertArrayEquals(":a:", new String[]{"fang0", "fang1", "fang2", "fang3", "fang4"}, ccombo.getItems());
+	assertArrayEquals(new String[]{"fang0", "fang1", "fang2", "fang3", "fang4"}, ccombo.getItems());
 }
 
 @Test
 public void test_setItems$Ljava_lang_String() {
-	assertThrows("No exception thrown for items == null", IllegalArgumentException.class, () -> ccombo.setItems(null));
+	assertThrows(IllegalArgumentException.class, () -> ccombo.setItems(null));
 
 	String nullItem[] = new String[1];
 	nullItem[0] = null;
 
-	assertThrows("No exception thrown for items[0] == null", IllegalArgumentException.class, () ->ccombo.setItems(nullItem));
+	assertThrows(IllegalArgumentException.class, () ->ccombo.setItems(nullItem));
 
 	String[][] items = {{}, {""}, {"", ""}, {"fang"}, {"fang0", "fang0"}, {"fang", "fang"}};
 
 	for (int i = 0 ; i< items.length; i++){
 		ccombo.setItems(items[i]);
-		assertArrayEquals(":a:" + i, items[i], ccombo.getItems());
+		assertArrayEquals(items[i], ccombo.getItems());
 	}
 }
 
 @Test
 public void test_setSelectionLorg_eclipse_swt_graphics_Point() {
-	assertThrows("No exception thrown for point == null", IllegalArgumentException.class, () -> ccombo.setSelection(null));
+	assertThrows(IllegalArgumentException.class, () -> ccombo.setSelection(null));
 
 	int number = 5;
 	for (int i = 0; i < number; i++)
 		ccombo.add("fang" + i);
 	ccombo.setSelection(new Point(0, 5));
-	assertEquals(":a:", new Point(0, 0), ccombo.getSelection());
+	assertEquals(new Point(0, 0), ccombo.getSelection());
 	ccombo.setText("some text");
 	ccombo.setSelection(new Point(0, 5));
-	assertEquals("Has not been implemented :b:", new Point(0, 5), ccombo.getSelection());
+	assertEquals(new Point(0, 5), ccombo.getSelection());
 }
 
 @Test
 public void test_setTextLimitI() {
-	assertThrows("No exception thrown for limit == 0", IllegalArgumentException.class, () -> ccombo.setTextLimit(0));
+	assertThrows(IllegalArgumentException.class, () -> ccombo.setTextLimit(0));
 
 	ccombo.setTextLimit(3);
-	assertEquals(":a:", 3, ccombo.getTextLimit());
+	assertEquals(3, ccombo.getTextLimit());
 }
 
 @Test
 public void test_setTextLjava_lang_String() {
-	assertThrows("No exception thrown for text == null", IllegalArgumentException.class, () -> ccombo.setText(null));
+	assertThrows(IllegalArgumentException.class, () -> ccombo.setText(null));
 
 	String[] cases = {"", "fang", "fang0"};
 	for (int i = 0; i < cases.length; i++) {
 		ccombo.setText(cases[i]);
-		assertEquals(":a:" + i, cases[i], ccombo.getText());
+		assertEquals(cases[i], ccombo.getText());
 	}
 	for (int i = 0; i < 5; i++) {
 		ccombo.add("fang");
 	}
 	for (int i = 0; i < cases.length; i++) {
 		ccombo.setText(cases[i]);
-		assertEquals(":b:" + i, cases[i], ccombo.getText());
+		assertEquals(cases[i], ccombo.getText());
 	}
 	for (int i = 0; i < 5; i++) {
 		ccombo.add("fang" + i);
 	}
 	for (int i = 0; i < cases.length; i++) {
 		ccombo.setText(cases[i]);
-		assertEquals(":c:" + i, cases[i], ccombo.getText());
+		assertEquals(cases[i], ccombo.getText());
 	}
 }
 
 @Test
 public void test_setAlignment() {
-	assertEquals(":a:", SWT.LEAD, ccombo.getAlignment());
+	assertEquals(SWT.LEAD, ccombo.getAlignment());
 
 	ccombo.setText("Trail");
 	ccombo.setAlignment(SWT.TRAIL);
-	assertEquals(":b:", SWT.TRAIL, ccombo.getAlignment());
-	assertEquals(":b:", "Trail", ccombo.getText());
+	assertEquals(SWT.TRAIL, ccombo.getAlignment());
+	assertEquals("Trail", ccombo.getText());
 
 	ccombo.add("Center");
 	ccombo.select(ccombo.getItemCount() - 1);
 	ccombo.setAlignment(SWT.CENTER);
-	assertEquals(":c:", SWT.CENTER, ccombo.getAlignment());
-	assertEquals(":c:", "Center", ccombo.getText());
+	assertEquals(SWT.CENTER, ccombo.getAlignment());
+	assertEquals("Center", ccombo.getText());
 
 	ccombo.setAlignment(SWT.LEFT);
-	assertEquals(":d:", SWT.LEFT, ccombo.getAlignment());
-	assertEquals(":d:", "Center", ccombo.getText());
+	assertEquals(SWT.LEFT, ccombo.getAlignment());
+	assertEquals("Center", ccombo.getText());
 }
 }

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_custom_CLabel.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_custom_CLabel.java
@@ -15,8 +15,8 @@ package org.eclipse.swt.tests.junit;
 
 
 import org.eclipse.swt.custom.CLabel;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Automated Test Suite for class org.eclipse.swt.custom.CLabel
@@ -26,7 +26,7 @@ import org.junit.Test;
 public class Test_org_eclipse_swt_custom_CLabel extends Test_org_eclipse_swt_widgets_Canvas {
 
 @Override
-@Before
+@BeforeEach
 public void setUp() {
 	super.setUp();
 	label = new CLabel(shell, 0);

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_custom_CTabFolder.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_custom_CTabFolder.java
@@ -14,11 +14,11 @@
 package org.eclipse.swt.tests.junit;
 
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
@@ -53,9 +53,9 @@ import org.eclipse.swt.widgets.Text;
 import org.eclipse.swt.widgets.ToolBar;
 import org.eclipse.swt.widgets.ToolItem;
 import org.eclipse.swt.widgets.Widget;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 /**
  * Automated Test Suite for class org.eclipse.swt.custom.CTabFolder
@@ -65,7 +65,7 @@ import org.junit.Test;
 public class Test_org_eclipse_swt_custom_CTabFolder extends Test_org_eclipse_swt_widgets_Composite {
 
 @Override
-@Before
+@BeforeEach
 public void setUp() {
 	super.setUp();
 	shell.setLayout(new FillLayout());
@@ -237,14 +237,14 @@ public void test_consistency_DragDetect () {
 
 @Test
 public void test_setHighlightEnabled () {
-	assertTrue("By default, highlighting should be enabled", ctabFolder.getHighlightEnabled());
+	assertTrue(ctabFolder.getHighlightEnabled());
 	ctabFolder.setHighlightEnabled(false);
 	assertFalse(ctabFolder.getHighlightEnabled());
 	ctabFolder.setHighlightEnabled(true);
 	assertTrue(ctabFolder.getHighlightEnabled());
 }
 
-@Ignore("Currently failing due to Bug 507611. E.g: Height is 50 instead of being at least 59")
+@Disabled("Currently failing due to Bug 507611. E.g: Height is 50 instead of being at least 59")
 @Test
 public void test_checkSize() {
 	shell.setLayout(new GridLayout(1, false));
@@ -271,8 +271,7 @@ public void test_checkSize() {
 	shell.open();
 	int folderY = folder.getSize().y;
 	int expectedminHeight = systemImage.getImageData().height + text2.getFont().getFontData()[0].getHeight();
-	assertTrue("\nBug 507611 - CTabFolder is too thin for its actual content. \nCtabFolder height:"
-								+folderY+"\nExpected min:"+expectedminHeight,  folderY > expectedminHeight);
+	assertTrue(folderY > expectedminHeight);
 }
 
 /**
@@ -305,8 +304,7 @@ public void test_nestedTabHighlighting () {
 
 	// nothing is selected, expect no highlight
 	boolean shouldHighlightConsoleViewTab = reflection_shouldHighlight(partStackTabFolder);
-	assertFalse("expected CTabFolder to not need highlighting without any selection",
-			shouldHighlightConsoleViewTab);
+	assertFalse(shouldHighlightConsoleViewTab);
 
 	// "click" on the Console View tab
 	partStackTabFolder.notifyListeners(SWT.Activate, new Event());
@@ -323,8 +321,7 @@ public void test_nestedTabHighlighting () {
 
 	// the Console View tab is selected, so it should still be highlighted
 	shouldHighlightConsoleViewTab = reflection_shouldHighlight(partStackTabFolder);
-	assertTrue("Bug 528251 - View tab not highlighted due to another view with a CTabFolder",
-			shouldHighlightConsoleViewTab);
+	assertTrue(shouldHighlightConsoleViewTab);
 }
 
 /** Test for Bug 559887: Chevron not updated on foreground color or font change. */
@@ -525,9 +522,9 @@ private ToolItem showChevron() {
 	shell.setSize(newWidth, shell.getSize().y);
 	boolean resizeFailed = Math.abs(newWidth - shell.getSize().x) > 10;
 	ToolItem chevron = getChevron(ctabFolder);
-	assertNotNull("Chevron not shown" + (resizeFailed
+	assertNotNull(chevron, "Chevron not shown" + (resizeFailed
 			? ". Shell could not be resized to the desired size. Tab row width might be smaller than the minimum shell width."
-			: ""), chevron);
+			: ""));
 	return chevron;
 }
 
@@ -581,11 +578,9 @@ private void checkElementOverlap(CTabFolder tabFolder) {
 					continue;
 				boundsB = cTab.getBounds();
 			}
-			assertFalse("Overlap between <" + subControls.get(i) + "> and <" + subControls.get(j) + ">\n" + boundsA
-					+ " overlaps " + boundsB, boundsA.intersects(boundsB));
+			assertFalse(boundsA.intersects(boundsB));
 		}
-		assertEquals("Element <" + subControls.get(i) + "> outside folder.", folderBounds.intersection(boundsA),
-				boundsA);
+		assertEquals(folderBounds.intersection(boundsA), boundsA);
 	}
 }
 
@@ -619,12 +614,10 @@ private void assertTabElementsInLine() {
 	Rectangle maxBound = tabBarElementBounds.get(0);
 	for (Rectangle bound : tabBarElementBounds) {
 		if (bound.height > maxBound.height) {
-			assertTrue("Element at " + maxBound + " is not on line.",
-					bound.y <= maxBound.y && (bound.y + bound.height) >= (maxBound.y + maxBound.height));
+			assertTrue(bound.y <= maxBound.y && (bound.y + bound.height) >= (maxBound.y + maxBound.height));
 			maxBound = bound;
 		} else {
-			assertTrue("Element at " + bound + " is not on line.",
-					bound.y >= maxBound.y && (bound.y + bound.height) <= (maxBound.y + maxBound.height));
+			assertTrue(bound.y >= maxBound.y && (bound.y + bound.height) <= (maxBound.y + maxBound.height));
 		}
 	}
 }

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_custom_CTabItem.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_custom_CTabItem.java
@@ -13,14 +13,14 @@
  *******************************************************************************/
 package org.eclipse.swt.tests.junit;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.CTabFolder;
 import org.eclipse.swt.custom.CTabItem;
 import org.eclipse.swt.graphics.Color;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Automated Test Suite for class org.eclipse.swt.custom.CTabItem
@@ -33,7 +33,7 @@ public class Test_org_eclipse_swt_custom_CTabItem extends Test_org_eclipse_swt_w
 	CTabItem cTabItem;
 
 @Override
-@Before
+@BeforeEach
 public void setUp() {
 	super.setUp();
 	cTabFolder = new CTabFolder(shell, SWT.NONE);

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_custom_StyledText.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_custom_StyledText.java
@@ -15,17 +15,17 @@ package org.eclipse.swt.tests.junit;
 
 
 import static org.eclipse.swt.tests.junit.SwtTestUtil.hasPixel;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-import static org.junit.Assume.assumeFalse;
-import static org.junit.Assume.assumeTrue;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import java.util.ArrayList;
 import java.util.Random;
@@ -77,10 +77,8 @@ import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.ScrollBar;
 import org.eclipse.swt.widgets.Text;
 import org.eclipse.swt.widgets.Widget;
-import org.junit.Assume;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Automated Test Suite for class org.eclipse.swt.custom.StyledText
@@ -102,7 +100,7 @@ private boolean listenerCalled;
 private boolean listener2Called;
 
 @Override
-@Before
+@BeforeEach
 public void setUp() {
 	super.setUp();
 	text = new StyledText(shell, SWT.NULL);
@@ -207,9 +205,9 @@ public void test_addExtendedModifyListenerLorg_eclipse_swt_custom_ExtendedModify
 	final String line = "Line1";
 	ExtendedModifyListener listener = event -> {
 		listenerCalled = true;
-		assertEquals("ExtendedModify event data invalid", 0, event.start);
-		assertEquals("ExtendedModify event data invalid", line.length(), event.length);
-		assertEquals("ExtendedModify event data invalid", "", event.replacedText);
+		assertEquals(0, event.start);
+		assertEquals(line.length(), event.length);
+		assertEquals("", event.replacedText);
 	};
 
 	assertThrows(IllegalArgumentException.class, ()->
@@ -220,41 +218,41 @@ public void test_addExtendedModifyListenerLorg_eclipse_swt_custom_ExtendedModify
 
 	listenerCalled = false;
 	text.append(line);
-	assertTrue("append does not send event", listenerCalled);
+	assertTrue(listenerCalled);
 
 	listenerCalled = false;
 	text.insert(line);
-	assertTrue("replaceTextRange does not send event", listenerCalled);
+	assertTrue(listenerCalled);
 
 	listenerCalled = false;
 	text.removeExtendedModifyListener(listener);
 	listener = event -> {
 		listenerCalled = true;
-		assertEquals("ExtendedModify event data invalid", 0, event.start);
-		assertEquals("ExtendedModify event data invalid", line.length(), event.length);
-		assertEquals("ExtendedModify event data invalid", line.substring(0, 1), event.replacedText);
+		assertEquals(0, event.start);
+		assertEquals(line.length(), event.length);
+		assertEquals(line.substring(0, 1), event.replacedText);
 	};
 	text.addExtendedModifyListener(listener);
 	text.replaceTextRange(0, 1, line);
-	assertTrue("replaceTextRange does not send event", listenerCalled);
+	assertTrue(listenerCalled);
 
 	listenerCalled = false;
 	text.removeExtendedModifyListener(listener);
 	listener = event -> {
 		listenerCalled = true;
-		assertEquals("ExtendedModify event data invalid", 0, event.start);
-		assertEquals("ExtendedModify event data invalid", line.length(), event.length);
-		assertEquals("ExtendedModify event data invalid", line + line.substring(1, line.length()) + line, event.replacedText);
+		assertEquals(0, event.start);
+		assertEquals(line.length(), event.length);
+		assertEquals(line + line.substring(1, line.length()) + line, event.replacedText);
 	};
 	text.addExtendedModifyListener(listener);
 	text.setText(line);
-	assertTrue("setText does not send event", listenerCalled);
+	assertTrue(listenerCalled);
 
 	listenerCalled = false;
 	text.removeExtendedModifyListener(listener);
 	// cause StyledText to call the listener.
 	text.setText(line);
-	assertFalse("Listener not removed", listenerCalled);
+	assertFalse(listenerCalled);
 }
 
 @Test
@@ -289,20 +287,20 @@ public void test_addBidiSegmentListenerLorg_eclipse_swt_custom_BidiSegmentListen
 	// cause StyledText to call the BidiSegmentListener.
 	text.getLocationAtOffset(0);
 	if (SwtTestUtil.isBidi()) {
-		assertTrue("Listener not called", listenerCalled);
+		assertTrue(listenerCalled);
 	} else {
-		assertFalse("Listener called when it shouldn't be", listenerCalled);
+		assertFalse(listenerCalled);
 	}
 	listenerCalled = false;
 	text.removeBidiSegmentListener(listener);
 	// cause StyledText to call the BidiSegmentListener.
 	text.getLocationAtOffset(0);
-	assertFalse("Listener not removed", listenerCalled);
+	assertFalse(listenerCalled);
 }
 
-@Test(expected=IllegalArgumentException.class)
+@Test
 public void test_addCaretListener_passingNullThrowsException() {
-	text.addCaretListener(null);
+	assertThrows(IllegalArgumentException.class, () -> text.addCaretListener(null));
 }
 
 @Test
@@ -312,7 +310,7 @@ public void test_addCaretListener_CaretListenerCalled() {
 	text.setText("Line1");
 	text.addCaretListener(listener);
 	text.setCaretOffset(1);
-	assertTrue("Listener not called", listenerCalled);
+	assertTrue(listenerCalled);
 }
 
 @Test
@@ -322,7 +320,7 @@ public void test_removeCaretListener_CaretListenerNotCalled() {
 	text.addCaretListener(listener);
 	text.removeCaretListener(listener);
 	text.setCaretOffset(1);
-	assertFalse("Listener not removed", listenerCalled);
+	assertFalse(listenerCalled);
 }
 
 @Test
@@ -339,7 +337,7 @@ public void test_addLineBackgroundListenerLorg_eclipse_swt_custom_LineBackground
 	// cause StyledText to call the listener.
 	text.setSelection(0, text.getCharCount());
 	text.copy();
-	assertTrue("Listener not called", listenerCalled);
+	assertTrue(listenerCalled);
 
 	listenerCalled = false;
 	text.removeLineBackgroundListener(listener);
@@ -347,7 +345,7 @@ public void test_addLineBackgroundListenerLorg_eclipse_swt_custom_LineBackground
 	text.setText(line);
 	text.setSelection(0, text.getCharCount());
 	text.copy();
-	assertFalse("Listener not removed", listenerCalled);
+	assertFalse(listenerCalled);
 }
 
 @Test
@@ -363,7 +361,7 @@ public void test_addLineStyleListenerLorg_eclipse_swt_custom_LineStyleListener()
 	// cause StyledText to call the listener.
 	text.setSelection(0, text.getCharCount());
 	text.copy();
-	assertTrue("Listener not called", listenerCalled);
+	assertTrue(listenerCalled);
 
 	listenerCalled = false;
 	text.removeLineStyleListener(listener);
@@ -371,7 +369,7 @@ public void test_addLineStyleListenerLorg_eclipse_swt_custom_LineStyleListener()
 	text.setText(line);
 	text.setSelection(0, text.getCharCount());
 	text.copy();
-	assertFalse("Listener not removed", listenerCalled);
+	assertFalse(listenerCalled);
 }
 
 @Test
@@ -386,25 +384,25 @@ public void test_addModifyListenerLorg_eclipse_swt_events_ModifyListener() {
 
 	listenerCalled = false;
 	text.append(line);
-	assertTrue("append does not send event", listenerCalled);
+	assertTrue(listenerCalled);
 
 	listenerCalled = false;
 	text.insert(line);
-	assertTrue("replaceTextRange does not send event", listenerCalled);
+	assertTrue(listenerCalled);
 
 	listenerCalled = false;
 	text.replaceTextRange(0, 1, line);
-	assertTrue("replaceTextRange does not send event", listenerCalled);
+	assertTrue(listenerCalled);
 
 	listenerCalled = false;
 	text.setText(line);
-	assertTrue("setText does not send event", listenerCalled);
+	assertTrue(listenerCalled);
 
 	listenerCalled = false;
 	text.removeModifyListener(listener);
 	// cause StyledText to call the listener.
 	text.setText(line);
-	assertFalse("Listener not removed", listenerCalled);
+	assertFalse(listenerCalled);
 }
 
 @Test
@@ -429,16 +427,16 @@ public void test_addSelectionListenerLorg_eclipse_swt_events_SelectionListener()
 	text.addSelectionListener(listener);
 	// cause StyledText to call the listener.
 	text.invokeAction(ST.SELECT_LINE_END);
-	assertTrue("Listener not called", listenerCalled);
-	assertFalse("Listener called unexpectedly", listener2Called);
+	assertTrue(listenerCalled);
+	assertFalse(listener2Called);
 
 	listenerCalled = false;
 	listener2Called = false;
 	text.removeSelectionListener(listener);
 	// cause StyledText to call the listener.
 	text.invokeAction(ST.SELECT_LINE_END);
-	assertFalse("Listener not removed", listenerCalled);
-	assertFalse("Listener called unexpectedly", listener2Called);
+	assertFalse(listenerCalled);
+	assertFalse(listener2Called);
 }
 
 
@@ -452,13 +450,13 @@ public void test_addSelectionListenerWidgetSelectedAdapterLorg_eclipse_swt_event
 	text.addSelectionListener(listener);
 	// cause StyledText to call the listener.
 	text.invokeAction(ST.SELECT_LINE_END);
-	assertTrue("Listener not called", listenerCalled);
+	assertTrue(listenerCalled);
 
 	listenerCalled = false;
 	text.removeSelectionListener(listener);
 	// cause StyledText to call the listener.
 	text.invokeAction(ST.SELECT_LINE_END);
-	assertFalse("Listener not removed", listenerCalled);
+	assertFalse(listenerCalled);
 }
 
 @Test
@@ -471,13 +469,13 @@ public void test_addSelectionListenerWidgetDefaultSelectedAdapterLorg_eclipse_sw
 	text.addSelectionListener(listener);
 	// cause StyledText to call the listener.
 	text.invokeAction(ST.SELECT_LINE_END);
-	assertFalse("Listener called unexpectedly", listener2Called);
+	assertFalse(listener2Called);
 
 	listener2Called = false;
 	text.removeSelectionListener(listener);
 	// cause StyledText to call the listener.
 	text.invokeAction(ST.SELECT_LINE_END);
-	assertFalse("Listener called unexpectedly", listener2Called);
+	assertFalse(listener2Called);
 }
 
 @Test
@@ -499,9 +497,9 @@ public void test_addVerifyListenerLorg_eclipse_swt_events_VerifyListener() {
 	final int textLength;
 	VerifyListener listener = event -> {
 		listenerCalled = true;
-		assertEquals("Verify event data invalid", 0, event.start);
-		assertEquals("Verify event data invalid", 0, event.end);
-		assertEquals("Verify event data invalid", line, event.text);
+		assertEquals(0, event.start);
+		assertEquals(0, event.end);
+		assertEquals(line, event.text);
 		event.start = 2;
 		event.end = 5;
 		event.text = newLine;
@@ -514,21 +512,21 @@ public void test_addVerifyListenerLorg_eclipse_swt_events_VerifyListener() {
 
 	listenerCalled = false;
 	text.append(line);
-	assertTrue("append does not send event", listenerCalled);
-	assertEquals("Listener failed", newLine, text.getText());
+	assertTrue(listenerCalled);
+	assertEquals(newLine, text.getText());
 
 	listenerCalled = false;
 	text.insert(line);
-	assertTrue("replaceTextRange does not send event", listenerCalled);
-	assertEquals("Listener failed", newLine + newLine, text.getText());
+	assertTrue(listenerCalled);
+	assertEquals(newLine + newLine, text.getText());
 
 	listenerCalled = false;
 	text.removeVerifyListener(listener);
 	listener = event -> {
 		listenerCalled = true;
-		assertEquals("Verify event data invalid", 0, event.start);
-		assertEquals("Verify event data invalid", 1, event.end);
-		assertEquals("Verify event data invalid", line, event.text);
+		assertEquals(0, event.start);
+		assertEquals(1, event.end);
+		assertEquals(line, event.text);
 		event.start = 2;
 		event.end = 5;
 		event.text = newLine;
@@ -536,51 +534,51 @@ public void test_addVerifyListenerLorg_eclipse_swt_events_VerifyListener() {
 	text.addVerifyListener(listener);
 	textLength = text.getCharCount() - 1 + newLine.length();
 	text.replaceTextRange(0, 1, line);
-	assertTrue("replaceTextRange does not send event", listenerCalled);
-	assertEquals("Listener failed", newLine + newLine.substring(1, newLine.length()) + newLine, text.getText());
+	assertTrue(listenerCalled);
+	assertEquals(newLine + newLine.substring(1, newLine.length()) + newLine, text.getText());
 
 	listenerCalled = false;
 	text.removeVerifyListener(listener);
 	listener = event -> {
 		listenerCalled = true;
-		assertEquals("Verify event data invalid", 0, event.start);
-		assertEquals("Verify event data invalid", textLength, event.end);
-		assertEquals("Verify event data invalid", line, event.text);
+		assertEquals(0, event.start);
+		assertEquals(textLength, event.end);
+		assertEquals(line, event.text);
 		event.start = 2;
 		event.end = 5;
 		event.text = newLine;
 	};
 	text.addVerifyListener(listener);
 	text.setText(line);
-	assertTrue("setText does not send event", listenerCalled);
-	assertEquals("Listener failed", newLine, text.getText());
+	assertTrue(listenerCalled);
+	assertEquals(newLine, text.getText());
 
 	text.removeVerifyListener(listener);
 
 	listenerCalled = false;
 	listener = event -> {
 		listenerCalled = true;
-		assertEquals("Verify event data invalid", 2, event.start);
-		assertEquals("Verify event data invalid", newLine.length(), event.end);
-		assertEquals("Verify event data invalid", line, event.text);
+		assertEquals(2, event.start);
+		assertEquals(newLine.length(), event.end);
+		assertEquals(line, event.text);
 		event.doit = false;
 	};
 	text.addVerifyListener(listener);
 	// cause StyledText to call the listener.
 	text.replaceTextRange(2, text.getCharCount() - 2, line);
-	assertTrue("Listener not called", listenerCalled);
-	assertEquals("Listener failed", newLine, text.getText());
+	assertTrue(listenerCalled);
+	assertEquals(newLine, text.getText());
 
 	listenerCalled = false;
 	text.removeVerifyListener(listener);
 	// cause StyledText to call the listener.
 	text.setText(line);
-	assertFalse("Listener not removed", listenerCalled);
+	assertFalse(listenerCalled);
 }
 
-@Test(expected=IllegalArgumentException.class)
+@Test
 public void test_addWordMovementListener_passingNullThrowsException() {
-	text.addWordMovementListener(null);
+	assertThrows(IllegalArgumentException.class, () -> text.addWordMovementListener(null));
 }
 
 @Test
@@ -591,8 +589,8 @@ public void test_addWordMovementListener_invokeActionSelectWordNextCallsGetNextO
 	text.setText("Word0 Word1 Word2");
 	text.addWordMovementListener(listener);
 	text.invokeAction(ST.SELECT_WORD_NEXT);
-	assertFalse("Listener unexpectantly called", listenerCalled);
-	assertTrue("Listener not called", listener2Called);
+	assertFalse(listenerCalled);
+	assertTrue(listener2Called);
 }
 
 @Test
@@ -603,8 +601,8 @@ public void test_addWordMovementListener_invokeActionSelectWordPreviousCallsGetP
 	text.setText("Word0 Word1 Word2");
 	text.addWordMovementListener(listener);
 	text.invokeAction(ST.SELECT_WORD_PREVIOUS);
-	assertTrue("Listener not called", listenerCalled);
-	assertFalse("Listener unexpectantly called", listener2Called);
+	assertTrue(listenerCalled);
+	assertFalse(listener2Called);
 }
 
 @Test
@@ -617,8 +615,8 @@ public void test_removeWordMovementListener_invokeActionSelectWordCallsNoMethods
 	text.removeWordMovementListener(listener);
 	text.invokeAction(ST.SELECT_WORD_NEXT);
 	text.invokeAction(ST.SELECT_WORD_PREVIOUS);
-	assertFalse("Listener unexpectantly called", listenerCalled);
-	assertFalse("Listener unexpectantly called", listener2Called);
+	assertFalse(listenerCalled);
+	assertFalse(listener2Called);
 }
 
 private class RecordingMovementListener implements MovementListener {
@@ -638,24 +636,24 @@ public void test_appendLjava_lang_String() {
 	String line = "Line1";
 
 	text.append(line);
-	assertEquals("append to empty text", line, text.getText());
+	assertEquals(line, text.getText());
 
-	assertThrows("append null string", IllegalArgumentException.class, () -> text.append(null));
+	assertThrows(IllegalArgumentException.class, () -> text.append(null));
 
 	text.append("");
-	assertEquals("append empty string", line, text.getText());
+	assertEquals(line, text.getText());
 
 	text.append(line);
-	assertEquals("append non-empty string", line + line, text.getText());
+	assertEquals(line + line, text.getText());
 
 	text.setText("");
 	String text2 = "line\r";
 	text.append(text2);
-	assertEquals("append string ending with line delimiter", text2, text.getText());
+	assertEquals(text2, text.getText());
 
 	String text3 = "line\r\nline3";
 	text.append(text3);
-	assertEquals("append multi line string", text2 + text3, text.getText());
+	assertEquals(text2 + text3, text.getText());
 }
 
 @Override
@@ -1307,19 +1305,19 @@ public void test_getLocationAtOffsetI(){
 	final int XINSET = isBidiCaret() ? 2 : 0;
 
 	assertEquals(new Point(XINSET, 0), text.getLocationAtOffset(0));
-	assertThrows("No exception thrown for offset == -1", IllegalArgumentException.class, () ->
-		text.getLocationAtOffset(-1));
+	assertThrows(IllegalArgumentException.class, () ->
+	text.getLocationAtOffset(-1));
 
-	assertThrows("No exception thrown for illegal offset argument", IllegalArgumentException.class, () ->
-		text.getLocationAtOffset(100));
+	assertThrows(IllegalArgumentException.class, () ->
+	text.getLocationAtOffset(100));
 
 	text.setText("Line0\r\nLine1");
 	assertTrue(text.getLocationAtOffset(4).x > 0 && text.getLocationAtOffset(4).y == 0);
 	assertTrue(text.getLocationAtOffset(6).x > 0 && text.getLocationAtOffset(6).y == 0);
 	// x location will == StyledText x inset on bidi platforms
 	assertTrue(text.getLocationAtOffset(7).x == XINSET && text.getLocationAtOffset(7).y > 0);
-	assertThrows("No exception thrown for illegal offset argument", IllegalArgumentException.class, () ->
-		text.getLocationAtOffset(13));
+	assertThrows(IllegalArgumentException.class, () ->
+	text.getLocationAtOffset(13));
 
 	text.setTopIndex(1);
 	assertTrue(text.getLocationAtOffset(4).x > 0 && text.getLocationAtOffset(4).y < 0);
@@ -1414,14 +1412,14 @@ public void test_getOffsetAtPointLorg_eclipse_swt_graphics_Point() {
 }
 
 void testStyles (String msg, int[] resultRanges, int[] expectedRanges, StyleRange[] resultStyles, StyleRange[] expectedStyles) {
-	assertNotNull("resultRanges is null on: " + msg, resultRanges);
-	assertNotNull("expectedRanges is null on: " + msg, expectedRanges);
-	assertNotNull("resultStyles is null on: " + msg, resultStyles);
-	assertNotNull("expectedStyles is null on: " + msg, expectedStyles);
-	assertEquals("result ranges and styles length don't match on: " + msg, resultRanges.length, resultStyles.length * 2);
-	assertEquals("expected ranges and styles length don't match on: " + msg, expectedRanges.length, expectedStyles.length * 2);
-	assertArrayEquals("expected and result ranges are differnt on: " + msg, expectedRanges, resultRanges);
-	assertArrayEquals("expected and result styles are differnt on: " + msg, expectedStyles, resultStyles);
+	assertNotNull(resultRanges);
+	assertNotNull(expectedRanges);
+	assertNotNull(resultStyles);
+	assertNotNull(expectedStyles);
+	assertEquals(resultRanges.length, resultStyles.length * 2);
+	assertEquals(expectedRanges.length, expectedStyles.length * 2);
+	assertArrayEquals(expectedRanges, resultRanges);
+	assertArrayEquals(expectedStyles, resultStyles);
 }
 
 @Test
@@ -1800,12 +1798,11 @@ public void test_getStyleRangeAtOffsetI() {
 	int i;
 	StyleRange style = new StyleRange(styleStart, styleLength, BLUE, RED, SWT.BOLD);
 
-	assertThrows("offset out of range no text", IllegalArgumentException.class, () -> text.getStyleRangeAtOffset(0));
+	assertThrows(IllegalArgumentException.class, () -> text.getStyleRangeAtOffset(0));
 
 	text.setText(line);
-	assertThrows("offset out of range negative", IllegalArgumentException.class, () -> text.getStyleRangeAtOffset(-1));
-	assertThrows("offset out of range positive", IllegalArgumentException.class,
-			() -> text.getStyleRangeAtOffset(line.length()));
+	assertThrows(IllegalArgumentException.class, () -> text.getStyleRangeAtOffset(-1));
+	assertThrows(IllegalArgumentException.class, () -> text.getStyleRangeAtOffset(line.length()));
 
 	text.setStyleRange(style);
 	style.length = 1;
@@ -2063,8 +2060,7 @@ public void test_getWordWrap() {
 @Test
 public void test_insertLjava_lang_String(){
 	String delimiterString = "\n";
-	assertThrows("No exception thrown for string == null", IllegalArgumentException.class,
-		() -> text.insert(null));
+	assertThrows(IllegalArgumentException.class, () -> text.insert(null));
 	assertTrue(text.getText().isEmpty());
 	text.insert("");
 	assertTrue(text.getText().isEmpty());
@@ -2377,8 +2373,8 @@ public void test_printLorg_eclipse_swt_printing_Printer() {
 	// if there aren't any printers, don't do this test
 	if (Printer.getDefaultPrinterData() == null) return;
 
-	assertThrows("no exception thrown for print(null)", IllegalArgumentException.class, () ->
-		text.print((Printer) null));
+	assertThrows(IllegalArgumentException.class, () ->
+	text.print((Printer) null));
 
 	Printer printer = new Printer();
 	text.print(printer); // don't run the runnable, to save paper
@@ -4731,7 +4727,7 @@ public void test_verticalIndent_resetsCacheForAllLinesAssumingLowestLineHeight()
 		field = lineSize.getClass().getDeclaredField("height");
 		field.setAccessible(true);
 		int height = (int) field.get(lineSize);
-		assertEquals("resetCache is not called for line "+lineNr+" after setLineVerticalIndent",-1, height);
+		assertEquals(-1, height);
 	}
 }
 
@@ -4764,14 +4760,14 @@ public void test_verticalIndent_keepsCurrentCaretAndLinePosition() {
 	text.setLineVerticalIndent(line, INDENT);
 	assertEquals(caretLocation, text.getCaret().getLocation());
 	assertEquals(offsetLocation, text.getLocationAtOffset(offset));
-	assertEquals("vertical scroll should have been updated", initialTopPixel + INDENT, text.getTopPixel());
+	assertEquals(initialTopPixel + INDENT, text.getTopPixel());
 	assertEquals(scrollMini, scrollbar.getMinimum());
 	assertEquals(scrollMaxi + INDENT, scrollbar.getMaximum());
 	assertEquals(scrollOffset + INDENT, scrollbar.getSelection());
 	text.setLineVerticalIndent(line, 0);
 	assertEquals(caretLocation, text.getCaret().getLocation());
 	assertEquals(offsetLocation, text.getLocationAtOffset(offset));
-	assertEquals("vertical scroll should have been restored", initialTopPixel, text.getTopPixel());
+	assertEquals(initialTopPixel, text.getTopPixel());
 	assertEquals(scrollMini, scrollbar.getMinimum());
 	assertEquals(scrollMaxi, scrollbar.getMaximum());
 	assertEquals(scrollOffset, scrollbar.getSelection());
@@ -4780,14 +4776,14 @@ public void test_verticalIndent_keepsCurrentCaretAndLinePosition() {
 	text.setLineVerticalIndent(0, INDENT);
 	assertEquals(caretLocation, text.getCaret().getLocation());
 	assertEquals(offsetLocation, text.getLocationAtOffset(offset));
-	assertEquals("vertical scroll should have been updated", initialTopPixel + INDENT, text.getTopPixel());
+	assertEquals(initialTopPixel + INDENT, text.getTopPixel());
 	assertEquals(scrollMini, scrollbar.getMinimum());
 	assertEquals(scrollMaxi + INDENT, scrollbar.getMaximum());
 	assertEquals(scrollOffset + INDENT, scrollbar.getSelection());
 	text.setLineVerticalIndent(0, 0);
 	assertEquals(caretLocation, text.getCaret().getLocation());
 	assertEquals(offsetLocation, text.getLocationAtOffset(offset));
-	assertEquals("vertical scroll should have been updated", initialTopPixel, text.getTopPixel());
+	assertEquals(initialTopPixel, text.getTopPixel());
 	assertEquals(scrollMini, scrollbar.getMinimum());
 	assertEquals(scrollMaxi, scrollbar.getMaximum());
 	assertEquals(scrollOffset, scrollbar.getSelection());
@@ -4797,31 +4793,31 @@ public void test_verticalIndent_keepsCurrentCaretAndLinePosition() {
 	text.setLineVerticalIndent(nextInvisibleLine, INDENT);
 	assertEquals(caretLocation, text.getCaret().getLocation());
 	assertEquals(offsetLocation, text.getLocationAtOffset(offset));
-	assertEquals("Vertical scroll shouldn't be modified",initialTopPixel, text.getTopPixel());
+	assertEquals(initialTopPixel, text.getTopPixel());
 	text.setLineVerticalIndent(nextInvisibleLine, 0);
 	assertEquals(caretLocation, text.getCaret().getLocation());
 	assertEquals(offsetLocation, text.getLocationAtOffset(offset));
-	assertEquals("Vertical scroll shouldn't be modified",initialTopPixel, text.getTopPixel());
+	assertEquals(initialTopPixel, text.getTopPixel());
 
 	// above active line, in visible area
 	text.setLineVerticalIndent(line - 2, INDENT);
 	assertEquals(caretLocation, text.getCaret().getLocation());
 	assertEquals(offsetLocation, text.getLocationAtOffset(offset));
-	assertEquals("Vertical scroll should have been updated",initialTopPixel + INDENT, text.getTopPixel());
+	assertEquals(initialTopPixel + INDENT, text.getTopPixel());
 	text.setLineVerticalIndent(line - 2, 0);
 	assertEquals(caretLocation, text.getCaret().getLocation());
 	assertEquals(offsetLocation, text.getLocationAtOffset(offset));
-	assertEquals("Vertical scroll should have been restored",initialTopPixel, text.getTopPixel());
+	assertEquals(initialTopPixel, text.getTopPixel());
 
 	// below active line, in visible area
 	text.setLineVerticalIndent(line + 2, INDENT);
 	assertEquals(caretLocation, text.getCaret().getLocation());
 	assertEquals(offsetLocation, text.getLocationAtOffset(offset));
-	assertEquals("Vertical scroll shouldn't be modified",initialTopPixel, text.getTopPixel());
+	assertEquals(initialTopPixel, text.getTopPixel());
 	text.setLineVerticalIndent(line + 2, 0);
 	assertEquals(caretLocation, text.getCaret().getLocation());
 	assertEquals(offsetLocation, text.getLocationAtOffset(offset));
-	assertEquals("Vertical scroll shouldn't be modified",initialTopPixel, text.getTopPixel());
+	assertEquals(initialTopPixel, text.getTopPixel());
 }
 
 @Test
@@ -4842,8 +4838,8 @@ public void test_notFixedLineHeightDoesntChangeLinePixelIfUnnecessary() {
 	shell.setVisible(true);
 	shell.forceActive();
 	text.setVisible(true);
-	assertTrue("setFocus failed",text.setFocus());
-	assertTrue("text has not focus",text.isFocusControl());
+	assertTrue(text.setFocus());
+	assertTrue(text.isFocusControl());
 	text.replaceTextRange(0, 1, "X");
 	assertEquals(0, text.getTopIndex());
 	assertEquals(0, text.getLinePixel(0));
@@ -4947,7 +4943,7 @@ public void test_caretSizeAndPositionVariableGlyphMetrics() {
 	text.setCaretOffset(0);
 	assertEquals(text.getLineHeight(), text.getCaret().getSize().y);
 	// See https://github.com/eclipse-platform/eclipse.platform.swt/issues/294
-	assumeFalse("Test fails on Linux: expected:<87> but was:<174>", SwtTestUtil.isLinux);
+	assumeFalse(SwtTestUtil.isLinux, "Test fails on Linux: expected:<87> but was:<174>");
 	// +5: caret takes 5 more pixels
 	assertEquals(text.getLineHeight(0) - text.getCaret().getSize().y, text.getCaret().getBounds().y);
 	text.setCaretOffset(1);
@@ -5278,12 +5274,11 @@ public void test_cutTextInBlockSelection() {
 	text.setBlockSelectionBounds(0, 0, lowerRight.x, lowerRight.y + 1);
 	text.cut();
 
-	assertTrue(text.getText(),
-			text.getText()
-					.startsWith(" Test Selection" + System.lineSeparator()
-							+ " Test Selection" + System.lineSeparator()
-							+ " Test Selection" + System.lineSeparator()
-							+ "Sample Test Selection" + System.lineSeparator()));
+	assertTrue(text.getText()
+	.startsWith(" Test Selection" + System.lineSeparator()
+			+ " Test Selection" + System.lineSeparator()
+			+ " Test Selection" + System.lineSeparator()
+			+ "Sample Test Selection" + System.lineSeparator()));
 }
 
 @Test
@@ -5298,12 +5293,11 @@ public void test_pasteInsertsTextInBlockSelectionAsBlock() {
 	text.setCaretOffset(0);
 	text.paste();
 
-	assertTrue(text.getText(),
-			text.getText()
-					.startsWith("Sample" + blockSelectionTestTextOneLine()
-							+ "Sample" + blockSelectionTestTextOneLine()
-							+ "Sample" + blockSelectionTestTextOneLine()
-							+ blockSelectionTestTextOneLine()));
+	assertTrue(text.getText()
+	.startsWith("Sample" + blockSelectionTestTextOneLine()
+			+ "Sample" + blockSelectionTestTextOneLine()
+			+ "Sample" + blockSelectionTestTextOneLine()
+			+ blockSelectionTestTextOneLine()));
 }
 
 @Test
@@ -5316,12 +5310,11 @@ public void test_cutAndPasteInBlockSelection() {
 	text.cut();
 	text.paste();
 
-	assertTrue(text.getText(),
-			text.getText()
-					.startsWith(blockSelectionTestTextOneLine()
-							+ blockSelectionTestTextOneLine()
-							+ blockSelectionTestTextOneLine()
-							+ blockSelectionTestTextOneLine()));
+	assertTrue(text.getText()
+	.startsWith(blockSelectionTestTextOneLine()
+			+ blockSelectionTestTextOneLine()
+			+ blockSelectionTestTextOneLine()
+			+ blockSelectionTestTextOneLine()));
 }
 
 @Test
@@ -5384,15 +5377,15 @@ public void test_insertInBlockSelection() {
 	text.setSelection(6, 6 + blockSelectionTestTextOneLine().length());
 	text.insert("Foo" + System.lineSeparator() + "Foo" + System.lineSeparator());
 
-	assertTrue(text.getText(), text.getText()
-			.startsWith("SampleFoo Test Selection" + System.lineSeparator()
-					+ "SampleFoo Test Selection" + System.lineSeparator() + "Sample Test Selection"
-					+ System.lineSeparator()));
+	assertTrue(text.getText()
+	.startsWith("SampleFoo Test Selection" + System.lineSeparator()
+			+ "SampleFoo Test Selection" + System.lineSeparator() + "Sample Test Selection"
+			+ System.lineSeparator()));
 }
 
 @Test
 public void test_setStyleRanges_render() throws InterruptedException {
-	Assume.assumeFalse("Bug 553090 causes test to fail on Mac", SwtTestUtil.isCocoa);
+	assumeFalse(SwtTestUtil.isCocoa, "Bug 553090 prevents test to work on Mac");
 	shell.setVisible(true);
 	text.setText("abc");
 	text.setMargins(0, 0, 0, 0);
@@ -5422,7 +5415,7 @@ public void test_setStyleRanges_render() throws InterruptedException {
  */
 @Test
 public void test_lineStyleListener_styles_render() throws InterruptedException {
-	Assume.assumeFalse("Bug 536588 prevents test to work on Mac", SwtTestUtil.isCocoa);
+	assumeFalse(SwtTestUtil.isCocoa, "Bug 536588 prevents test to work on Mac");
 	final ArrayList<StyleRange> styles = new ArrayList<>();
 	styles.add(getStyle(0, 2, null, GREEN));
 	styles.add(getStyle(4, 1, null, GREEN));
@@ -5447,7 +5440,7 @@ public void test_lineStyleListener_styles_render() throws InterruptedException {
  */
 @Test
 public void test_lineStyleListener_stylesAndRanges_render() throws InterruptedException {
-	Assume.assumeFalse("Bug 536588 prevents test to work on Mac", SwtTestUtil.isCocoa);
+	assumeFalse(SwtTestUtil.isCocoa, "Bug 536588 prevents test to work on Mac");
 	LineStyleListener listener = (LineStyleEvent event) -> {
 		final StyleRange style = getStyle(0, 0, null, GREEN);
 		event.styles =  new StyleRange[] { style, style, style, style };
@@ -5473,7 +5466,7 @@ public void test_lineStyleListener_stylesAndRanges_render() throws InterruptedEx
  */
 @Test
 public void test_lineStyleListener_invalidStyles_render() throws InterruptedException {
-	Assume.assumeFalse("Bug 536588 prevents test to work on Mac", SwtTestUtil.isCocoa);
+	assumeFalse(SwtTestUtil.isCocoa, "Bug 536588 prevents test to work on Mac");
 	LineStyleListener listener = (LineStyleEvent event) -> {
 		event.styles = new StyleRange[] {
 			getStyle(-10, 4, null, GREEN),
@@ -5510,7 +5503,7 @@ private void testLineStyleListener(String content, LineStyleListener listener, B
 		text.setMargins(0, 0, 0, 0);
 		text.pack();
 		SwtTestUtil.processEvents(1000, evaluation);
-		assertTrue("Text not styled correctly.", evaluation.getAsBoolean());
+		assertTrue(evaluation.getAsBoolean());
 	} finally {
 		text.removeLineStyleListener(listener);
 	}
@@ -5616,16 +5609,16 @@ protected void rtfCopy() {
 	text.copy();
 
 	// The listener is invoked twice for each line, once for RTF and once for HTML.
-	assertEquals("not all lines tested for RTF & HTML copy", 2 * text.getLineCount(), linesCalled[0]);
+	assertEquals(2 * text.getLineCount(), linesCalled[0]);
 
 	Clipboard clipboard = new Clipboard(text.getDisplay());
 	RTFTransfer rtfTranfer = RTFTransfer.getInstance();
 	String clipboardText = (String) clipboard.getContents(rtfTranfer);
-	assertTrue("RTF copy failed", clipboardText.length() > 0);
+	assertTrue(clipboardText.length() > 0);
 
 	HTMLTransfer htmlTranfer = HTMLTransfer.getInstance();
 	clipboardText = (String) clipboard.getContents(htmlTranfer);
-	assertTrue("HTML copy failed", clipboardText.length() > 0);
+	assertTrue(clipboardText.length() > 0);
 
 	clipboard.dispose();
 	text.removeLineStyleListener(listener);
@@ -5656,7 +5649,7 @@ public void test_consistency_DragDetect () {
  */
 @Test
 public void test_GlyphMetricsOnTab_Bug549110() throws InterruptedException {
-	Assume.assumeFalse("Bug 536588 prevents test to work on Mac", SwtTestUtil.isCocoa);
+	assumeFalse(SwtTestUtil.isCocoa, "Bug 536588 prevents test to work on Mac");
 	shell.setVisible(true);
 	text.setText("ab\tcde");
 	text.setMargins(0, 0, 0, 0);
@@ -5678,8 +5671,8 @@ public void test_GlyphMetricsOnTab_Bug549110() throws InterruptedException {
 	text.replaceStyleRanges(0, text.getText().length(), new StyleRange[] { styleR, tabStyle, styleB });
 	text.pack();
 	SwtTestUtil.processEvents(1000, () -> hasPixel(text, RED) && hasPixel(text, BLUE));
-	assertTrue("Wrong style before tab", hasPixel(text, RED));
-	assertTrue("Wrong style after tab", hasPixel(text, BLUE));
+	assertTrue(hasPixel(text, RED));
+	assertTrue(hasPixel(text, BLUE));
 }
 
 @Test
@@ -5694,7 +5687,7 @@ public void test_GlyphMetricsOnTab() {
 	int tabWidthWithGlyphMetrics = text.getTextBounds(0, 0).width;
 	assertEquals(range.metrics.width, tabWidthWithGlyphMetrics);
 	Rectangle boundsWithGlyphMetrics = text.getTextBounds(0, text.getText().length() - 1);
-	assertEquals("Style should change text bounds", boundsWithoutGlyphMetrics.width - tabWidthWithoutGlyphMetrics + tabWidthWithGlyphMetrics, boundsWithGlyphMetrics.width);
+	assertEquals(boundsWithoutGlyphMetrics.width - tabWidthWithoutGlyphMetrics + tabWidthWithGlyphMetrics, boundsWithGlyphMetrics.width);
 }
 
 /**
@@ -5720,7 +5713,7 @@ public void test_InsertWhenDisabled() {
 	text.insert("[inserted]");
 	String actualText = text.getText();
 	String expectedText = "some [inserted] text";
-	assertEquals("Wrong insert in disabled StyledText", expectedText, actualText);
+	assertEquals(expectedText, actualText);
 }
 
 /**
@@ -5730,7 +5723,7 @@ public void test_InsertWhenDisabled() {
  */
 @Test
 public void test_bug551335_lostStyles() throws InterruptedException {
-	Assume.assumeFalse("Bug 536588 prevents test to work on Mac", SwtTestUtil.isCocoa);
+	assumeFalse(SwtTestUtil.isCocoa, "Bug 536588 prevents test to work on Mac");
 	shell.setVisible(true);
 	text.setText("012345678\n012345678\n0123456789");
 	text.setMargins(0, 0, 0, 0);
@@ -5820,7 +5813,7 @@ public void test_bug551335_lostStyles() throws InterruptedException {
  */
 @Test
 public void test_clipboardCarryover() {
-	assumeFalse("Disabled on Mac because similar clipboard tests are also disabled.", SwtTestUtil.isCocoa);
+	assumeFalse(SwtTestUtil.isCocoa, "Disabled on Mac because similar clipboard tests are also disabled.");
 
 	String content = "StyledText-" + Math.abs(new Random().nextInt());
 	text.setText(content);
@@ -5831,13 +5824,13 @@ public void test_clipboardCarryover() {
 	text = new StyledText(shell, SWT.NONE);
 	setWidget(text);
 	text.paste();
-	assertEquals("Lost clipboard content", content, text.getText());
-	assertEquals("Clipboard content got some unexpected styling", 0, text.getStyleRanges().length);
+	assertEquals(content, text.getText());
+	assertEquals(0, text.getStyleRanges().length);
 
 	Clipboard clipboard = new Clipboard(text.getDisplay());
 	RTFTransfer rtfTranfer = RTFTransfer.getInstance();
 	String clipboardText = (String) clipboard.getContents(rtfTranfer);
-	assertTrue("RTF copy failed", clipboardText.length() > 0);
+	assertTrue(clipboardText.length() > 0);
 }
 
 /**
@@ -5899,11 +5892,9 @@ public void test_arrowDownKeepsPositionAfterNewLine() {
  * Bug 565164 - SWT.BS event no longer working
  */
 @Test
-@EnabledIfEnvironmentVariable(named = "GITHUB_ACTIONS", matches = "true", disabledReason = "Display.post tests only run successfully on GitHub actions - see https://github.com/eclipse-platform/eclipse.platform.swt/issues/2571")
 public void test_backspaceAndDelete() throws InterruptedException {
-	assumeTrue(
-			"Display.post tests only run successfully on GitHub actions - see https://github.com/eclipse-platform/eclipse.platform.swt/issues/2571",
-			Boolean.parseBoolean(System.getenv("GITHUB_ACTIONS")));
+	assumeTrue(Boolean.parseBoolean(System.getenv("GITHUB_ACTIONS")),
+			"Display.post tests only run successfully on GitHub actions - see https://github.com/eclipse-platform/eclipse.platform.swt/issues/2571");
 	shell.open();
 	text.setSize(10, 50);
 	// The display.post needs to successfully obtain the focused window (at least on GTK3)
@@ -5938,14 +5929,11 @@ public void test_backspaceAndDelete() throws InterruptedException {
 @Test
 public void test_replaceTextRange_isInsideCRLF() {
 	text.setText("0123\r\n6789");
-	assertThrows("Exception shall be thrown when splitting CRLF", IllegalArgumentException.class,
-			() -> text.replaceTextRange(5, 0, "x"));
+	assertThrows(IllegalArgumentException.class, () -> text.replaceTextRange(5, 0, "x"));
 
-	assertThrows("Exception shall be thrown when splitting CRLF", IllegalArgumentException.class,
-			() -> text.replaceTextRange(0, 5, "x"));
+	assertThrows(IllegalArgumentException.class, () -> text.replaceTextRange(0, 5, "x"));
 
-	assertThrows("Exception shall be thrown when splitting CRLF", IllegalArgumentException.class,
-			() -> text.replaceTextRange(5, 5, "x"));
+	assertThrows(IllegalArgumentException.class, () -> text.replaceTextRange(5, 5, "x"));
 
 	// Shouldn't throw when CR/LF were already on different lines
 	text.setText("0\r2\n4");
@@ -5983,8 +5971,8 @@ public void test_rangeSelectionKeepsCaret() {
 	text.setSelection(initialOffset, initialOffset - 3);
 	assertEquals(13, text.getCaretOffset());
 	text.invokeAction(ST.SELECT_LINE_DOWN);
-	assertEquals("Selection does not start from caret", initialOffset, text.getSelection().x);
-	assertNotEquals("Selection is not left-to-right", text.getSelection().x, text.getCaretOffset());
+	assertEquals(initialOffset, text.getSelection().x);
+	assertNotEquals(text.getSelection().x, text.getCaretOffset());
 }
 
 @Test

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_custom_StyledText_VariableLineHeight.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_custom_StyledText_VariableLineHeight.java
@@ -13,6 +13,8 @@
  */
 package org.eclipse.swt.tests.junit;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.StyleRange;
 import org.eclipse.swt.custom.StyledText;
@@ -20,10 +22,9 @@ import org.eclipse.swt.graphics.Font;
 import org.eclipse.swt.graphics.FontData;
 import org.eclipse.swt.graphics.TextLayout;
 import org.eclipse.swt.widgets.Shell;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Automated Test Suite for class org.eclipse.swt.custom.StyledText to check there is no regression with Bug 530019
@@ -35,14 +36,14 @@ public class Test_org_eclipse_swt_custom_StyledText_VariableLineHeight {
 	Shell shell;
 	StyledText styledText;
 
-	@Before
+	@BeforeEach
 	public void setUp() {
 		shell = new Shell();
 		styledText = new StyledText(shell, SWT.NULL);
 		styledText.setLineSpacingProvider(l -> 0);
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() {
 		shell.dispose();
 	}
@@ -255,7 +256,7 @@ public class Test_org_eclipse_swt_custom_StyledText_VariableLineHeight {
 			layout.dispose();
 		}
 		int actual = styledText.getLinePixel(lineIndex + 1) - styledText.getLinePixel(lineIndex) - fontHeight;
-		Assert.assertEquals(expected, actual);
+		assertEquals(expected, actual);
 	}
 
 }

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_custom_StyledText_multiCaretsSelections.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_custom_StyledText_multiCaretsSelections.java
@@ -13,8 +13,9 @@
  *******************************************************************************/
 package org.eclipse.swt.tests.junit;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.ST;
@@ -25,11 +26,13 @@ import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Layout;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.test.Screenshots;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TestWatcher;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.AfterTestExecutionCallback;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.opentest4j.IncompleteExecutionException;
+
 
 /**
  * Automated Test Suite for class org.eclipse.swt.custom.StyledText with
@@ -43,19 +46,35 @@ public class Test_org_eclipse_swt_custom_StyledText_multiCaretsSelections {
 	StyledText text;
 	GC gc;
 
-	@Before
+	@BeforeEach
 	public void setUp() {
 		shell = new Shell();
 		text = new StyledText(shell, SWT.NULL);
 		gc = new GC(text);
 	}
 
-	@Rule
-	public TestWatcher screenshotRule = Screenshots.onFailure(() -> this.shell);
 
-	@After
+	@RegisterExtension
+	AfterTestExecutionCallback afterTestExecutionCallback = context -> {
+		context.getExecutionException().ifPresent((e) -> {
+			// If this is an assumption failed or otherwise
+			// skipped test, don't take a screenshot
+			if (!(e instanceof IncompleteExecutionException)) {
+				String screenshot = Screenshots.takeScreenshot(context.getTestClass().get(), context.getDisplayName());
+				e.addSuppressed((new Throwable("Screenshot written to " + screenshot)));
+			}
+		});
+	};
+
+	@AfterEach
 	public void tearDown() {
 		gc.dispose();
+		if (shell == null) {
+			return;
+		}
+		if (shell != null && !shell.isDisposed()) {
+			shell.dispose();
+		}
 	}
 	@Test
 	public void test_MultiSelectionEdit() {

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_dnd_Clipboard.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_dnd_Clipboard.java
@@ -149,7 +149,7 @@ public class Test_org_eclipse_swt_dnd_Clipboard {
 				"ClipboardTest$LocalHostOnlySocketFactory" //
 		).forEach((f) -> {
 			// extract the files and put them in the temp directory
-			SwtTestUtil.getPath("/clipboard/" + f + ".class",
+			SwtTestUtil.copyFile("/clipboard/" + f + ".class",
 					remoteClipboardTempDir.resolve("clipboard/" + f + ".class"));
 		});
 

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_Color.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_Color.java
@@ -14,11 +14,12 @@
  *******************************************************************************/
 package org.eclipse.swt.tests.junit;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.SWTException;
@@ -27,8 +28,8 @@ import org.eclipse.swt.graphics.Device;
 import org.eclipse.swt.graphics.RGB;
 import org.eclipse.swt.graphics.RGBA;
 import org.eclipse.swt.widgets.Display;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Automated Test Suite for class org.eclipse.swt.graphics.Color
@@ -40,7 +41,7 @@ import org.junit.Test;
  */
 public class Test_org_eclipse_swt_graphics_Color {
 
-@Before
+	@BeforeEach
 public void setUp() {
 	display = Display.getDefault();
 }
@@ -76,22 +77,22 @@ public void test_ConstructorLorg_eclipse_swt_graphics_DeviceIII() {
 	color = new Color(102, 255, 0, 0);
 
 	// illegal argument, rgb < 0
-	assertThrows("No exception thrown for rgb < 0", IllegalArgumentException.class, () -> new Color(-10, -10, -10));
+	assertThrows(IllegalArgumentException.class, () -> new Color(-10, -10, -10));
 
 	// illegal argument, alpha < 0
-	assertThrows("No exception thrown for rgba < 0", IllegalArgumentException.class, () -> new Color(0, 0, 0, -10));
+	assertThrows(IllegalArgumentException.class, () -> new Color(0, 0, 0, -10));
 
 	// illegal argument, rgb > 255
-	assertThrows("No exception thrown for rgb > 255", IllegalArgumentException.class, () -> new Color(1000, 2000, 3000));
+	assertThrows(IllegalArgumentException.class, () -> new Color(1000, 2000, 3000));
 
 	// illegal argument, rgba > 255
-	assertThrows("No exception thrown for rgba > 255", IllegalArgumentException.class, () -> new Color(1000, 2000, 3000, 4000));
+	assertThrows(IllegalArgumentException.class, () -> new Color(1000, 2000, 3000, 4000));
 
 	// illegal argument, blue > 255
-	assertThrows("No exception thrown for blue > 255", IllegalArgumentException.class, () -> new Color(10, 10, 256));
+	assertThrows(IllegalArgumentException.class, () -> new Color(10, 10, 256));
 
 	// illegal argument, alpha > 255
-	assertThrows("No exception thrown for alpha > 255", IllegalArgumentException.class, () -> new Color(10, 10, 10, 256));
+	assertThrows(IllegalArgumentException.class, () -> new Color(10, 10, 10, 256));
 }
 
 @Test
@@ -131,22 +132,22 @@ public void test_ConstructorLorg_eclipse_swt_graphics_DeviceIII_with_device() {
 	color = new Color(null, 0, 0, 0, 0);
 
 	// illegal argument, rgb < 0
-	assertThrows("No exception thrown for rgb < 0", IllegalArgumentException.class, () -> new Color(display, -10, -10, -10));
+	assertThrows(IllegalArgumentException.class, () -> new Color(display, -10, -10, -10));
 
 	// illegal argument, alpha < 0
-	assertThrows("No exception thrown for rgba < 0", IllegalArgumentException.class, () -> new Color(display, 0, 0, 0, -10));
+	assertThrows(IllegalArgumentException.class, () -> new Color(display, 0, 0, 0, -10));
 
 	// illegal argument, rgb > 255
-	assertThrows("No exception thrown for rgb > 255", IllegalArgumentException.class, () -> new Color(display, 1000, 2000, 3000));
+	assertThrows(IllegalArgumentException.class, () -> new Color(display, 1000, 2000, 3000));
 
 	// illegal argument, rgba > 255
-	assertThrows("No exception thrown for rgba > 355", IllegalArgumentException.class, () -> new Color(display, 1000, 2000, 3000, 4000));
+	assertThrows(IllegalArgumentException.class, () -> new Color(display, 1000, 2000, 3000, 4000));
 
 	// illegal argument, blue > 255
-	assertThrows("No exception thrown for blue > 255", IllegalArgumentException.class, () -> new Color(display, 10, 10, 256));
+	assertThrows(IllegalArgumentException.class, () -> new Color(display, 10, 10, 256));
 
 	// illegal argument, alpha > 255
-	assertThrows("No exception thrown for alpha > 255", IllegalArgumentException.class, () -> new Color(display, 10, 10, 10, 256));
+	assertThrows(IllegalArgumentException.class, () -> new Color(display, 10, 10, 10, 256));
 }
 
 @Test
@@ -180,25 +181,25 @@ public void test_ConstructorLorg_eclipse_swt_graphics_DeviceLorg_eclipse_swt_gra
 	color = new Color(new RGB(102, 255, 0), 0);
 
 	// illegal argument, rgb < 0
-	assertThrows("No exception thrown for rgb < 0", IllegalArgumentException.class, () -> new Color(new RGB(-10, -10, -10)));
+	assertThrows(IllegalArgumentException.class, () -> new Color(new RGB(-10, -10, -10)));
 
 	// illegal argument, alpha < 0
-	assertThrows("No exception thrown for rgba < 0", IllegalArgumentException.class, () -> new Color(new RGB(0, 0, 0), -10));
+	assertThrows(IllegalArgumentException.class, () -> new Color(new RGB(0, 0, 0), -10));
 
 	// illegal argument, rgb > 255
-	assertThrows("No exception thrown for rgb > 255", IllegalArgumentException.class, () -> new Color(new RGB(1000, 2000, 3000)));
+	assertThrows(IllegalArgumentException.class, () -> new Color(new RGB(1000, 2000, 3000)));
 
 	// illegal argument, rgba > 255
-	assertThrows("No exception thrown for rgba > 255", IllegalArgumentException.class, () -> new Color(new RGB(1000, 2000, 3000), 4000));
+	assertThrows(IllegalArgumentException.class, () -> new Color(new RGB(1000, 2000, 3000), 4000));
 
 	// illegal argument, blue > 255
-	assertThrows("No exception thrown for blue > 255", IllegalArgumentException.class, () -> new Color(new RGB(10, 10, 256)));
+	assertThrows(IllegalArgumentException.class, () -> new Color(new RGB(10, 10, 256)));
 
 	// illegal argument, alpha > 255
-	assertThrows("No exception thrown for alpha > 255", IllegalArgumentException.class, () -> new Color(new RGB(10, 10, 10), 256));
+	assertThrows(IllegalArgumentException.class, () -> new Color(new RGB(10, 10, 10), 256));
 
 	// illegal argument, rgb == null with alpha
-	assertThrows("No exception thrown for rgb == null with alpha", IllegalArgumentException.class, () -> new Color(null, 0));
+	assertThrows(IllegalArgumentException.class, () -> new Color(null, 0));
 }
 
 @Test
@@ -238,25 +239,25 @@ public void test_ConstructorLorg_eclipse_swt_graphics_DeviceLorg_eclipse_swt_gra
 	color = new Color(null, new RGB(0, 0, 0), 0);
 
 	// illegal argument, rgb < 0
-	assertThrows("No exception thrown for rgb < 0", IllegalArgumentException.class, () -> new Color(display, new RGB(-10, -10, -10)));
+	assertThrows(IllegalArgumentException.class, () -> new Color(display, new RGB(-10, -10, -10)));
 
 	// illegal argument, alpha < 0
-	assertThrows("No exception thrown for rgba < 0", IllegalArgumentException.class, () -> new Color(display, new RGB(0, 0, 0), -10));
+	assertThrows(IllegalArgumentException.class, () -> new Color(display, new RGB(0, 0, 0), -10));
 
 	// illegal argument, rgb > 255
-	assertThrows("No exception thrown for rgb > 255", IllegalArgumentException.class, () -> new Color(display, new RGB(1000, 2000, 3000)));
+	assertThrows(IllegalArgumentException.class, () -> new Color(display, new RGB(1000, 2000, 3000)));
 
 	// illegal argument, rgba > 255
-	assertThrows("No exception thrown for rgba > 255", IllegalArgumentException.class, () -> new Color(display, new RGB(1000, 2000, 3000), 4000));
+	assertThrows(IllegalArgumentException.class, () -> new Color(display, new RGB(1000, 2000, 3000), 4000));
 
 	// illegal argument, blue > 255
-	assertThrows("No exception thrown for blue > 255", IllegalArgumentException.class, () -> new Color(display, new RGB(10, 10, 256)));
+	assertThrows(IllegalArgumentException.class, () -> new Color(display, new RGB(10, 10, 256)));
 
 	// illegal argument, alpha > 255
-	assertThrows("No exception thrown for alpha > 255", IllegalArgumentException.class, () -> new Color(display, new RGB(10, 10, 10), 256));
+	assertThrows(IllegalArgumentException.class, () -> new Color(display, new RGB(10, 10, 10), 256));
 
 	// illegal argument, rgb == null with alpha
-	assertThrows("No exception thrown for rgb == null with alpha", IllegalArgumentException.class, () -> new Color(display, null, 0));
+	assertThrows(IllegalArgumentException.class, () -> new Color(display, null, 0));
 }
 
 @Test
@@ -290,19 +291,19 @@ public void test_ConstructorLorg_eclipse_swt_graphics_DeviceLorg_eclipse_swt_gra
 	color = new Color(new RGBA(102, 255, 0, 0));
 
 	// illegal argument, rgba < 0
-	assertThrows("No exception thrown for rgba < 0", IllegalArgumentException.class, () -> new Color(new RGBA(-10, -10, -10, -10)));
+	assertThrows(IllegalArgumentException.class, () -> new Color(new RGBA(-10, -10, -10, -10)));
 
 	// illegal argument, alpha < 0
-	assertThrows("No exception thrown for alpha < 0", IllegalArgumentException.class, () -> new Color(new RGBA(0, 0, 0, -10)));
+	assertThrows(IllegalArgumentException.class, () -> new Color(new RGBA(0, 0, 0, -10)));
 
 	// illegal argument, rgba > 255
-	assertThrows("No exception thrown for rgba > 255", IllegalArgumentException.class, () -> new Color(new RGBA(1000, 2000, 3000, 4000)));
+	assertThrows(IllegalArgumentException.class, () -> new Color(new RGBA(1000, 2000, 3000, 4000)));
 
 	// illegal argument, blue > 255
-	assertThrows("No exception thrown for blue > 255", IllegalArgumentException.class, () -> new Color(new RGBA(10, 10, 256, 10)));
+	assertThrows(IllegalArgumentException.class, () -> new Color(new RGBA(10, 10, 256, 10)));
 
 	// illegal argument, alpha > 255
-	assertThrows("No exception thrown for alpha > 255", IllegalArgumentException.class, () -> new Color(new RGBA(10, 10, 10, 256)));
+	assertThrows(IllegalArgumentException.class, () -> new Color(new RGBA(10, 10, 10, 256)));
 }
 
 @Test
@@ -342,19 +343,19 @@ public void test_ConstructorLorg_eclipse_swt_graphics_DeviceLorg_eclipse_swt_gra
 	color = new Color(null, new RGBA(0, 0, 0, 0));
 
 	// illegal argument, rgba < 0
-	assertThrows("No exception thrown for rgba < 0", IllegalArgumentException.class, () -> new Color(display, new RGBA(-10, -10, -10, -10)));
+	assertThrows(IllegalArgumentException.class, () -> new Color(display, new RGBA(-10, -10, -10, -10)));
 
 	// illegal argument, alpha < 0
-	assertThrows("No exception thrown for alpha < 0", IllegalArgumentException.class, () -> new Color(display, new RGBA(0, 0, 0, -10)));
+	assertThrows(IllegalArgumentException.class, () -> new Color(display, new RGBA(0, 0, 0, -10)));
 
 	// illegal argument, rgba > 255
-	assertThrows("No exception thrown for rgba > 255", IllegalArgumentException.class, () -> new Color(display, new RGBA(1000, 2000, 3000, 4000)));
+	assertThrows(IllegalArgumentException.class, () -> new Color(display, new RGBA(1000, 2000, 3000, 4000)));
 
 	// illegal argument, blue > 255
-	assertThrows("No exception thrown for blue > 255", IllegalArgumentException.class, () -> new Color(display, new RGBA(10, 10, 256, 10)));
+	assertThrows(IllegalArgumentException.class, () -> new Color(display, new RGBA(10, 10, 256, 10)));
 
 	// illegal argument, alpha > 255
-	assertThrows("No exception thrown for alpha > 255", IllegalArgumentException.class, () -> new Color(display, new RGBA(10, 10, 10, 256)));
+	assertThrows(IllegalArgumentException.class, () -> new Color(display, new RGBA(10, 10, 10, 256)));
 }
 
 @Test
@@ -367,14 +368,14 @@ public void test_equalsLjava_lang_Object() {
 	Color disposedColor2 = new Color(5, 6, 7);
 
 	// Test Color.equals(Object)
-	assertFalse("!color.equals((Object)null)", color.equals((Object)null));
+	assertFalse(color.equals((Object)null));
 
 	// Test Color.equals(Color)
-	assertFalse("!color.equals((Color)null)", color.equals((Color)null));
-	assertTrue("color.equals(color)", color.equals(color));
-	assertTrue("color.equals(sameColor)", color.equals(sameColor));
-	assertTrue("color.equals(sameColor2)", color.equals(sameColor2));
-	assertFalse("!color.equals(otherColor)", color.equals(otherColor));
+	assertFalse(color.equals((Color)null));
+	assertTrue(color.equals(color));
+	assertTrue(color.equals(sameColor));
+	assertTrue(color.equals(sameColor2));
+	assertFalse(color.equals(otherColor));
 
 	// With alpha
 	color = new Color(1, 2, 3, 0);
@@ -382,20 +383,20 @@ public void test_equalsLjava_lang_Object() {
 	sameColor2 = new Color(new RGB(1, 2, 3), 0);
 	otherColor = new Color(5, 6, 7, 0);
 	// Test Color.equals(Object)
-	assertFalse("!color.equals((Object)null)", color.equals((Object)null));
+	assertFalse(color.equals((Object)null));
 
 	// Test Color.equals(Color)
-	assertFalse("!color.equals((Color)null)", color.equals((Color)null));
-	assertTrue("color.equals(color)", color.equals(color));
-	assertTrue("color.equals(sameColor)", color.equals(sameColor));
-	assertTrue("color.equals(sameColor2)", color.equals(sameColor2));
-	assertFalse("!color.equals(otherColor)", color.equals(otherColor));
+	assertFalse(color.equals((Color)null));
+	assertTrue(color.equals(color));
+	assertTrue(color.equals(sameColor));
+	assertTrue(color.equals(sameColor2));
+	assertFalse(color.equals(otherColor));
 
 	// Test Color.equals(Color)
-	assertFalse("!color.equals(disposedColor)", color.equals(disposedColor));
-	assertFalse("!disposedColor.equals(color)", disposedColor.equals(color));
-	assertFalse("!disposedColor.equals(disposedColor2)", disposedColor.equals(disposedColor2));
-	assertFalse("!disposedColor2.equals(disposedColor)", disposedColor2.equals(disposedColor));
+	assertFalse(color.equals(disposedColor));
+	assertFalse(disposedColor.equals(color));
+	assertFalse(disposedColor.equals(disposedColor2));
+	assertFalse(disposedColor2.equals(disposedColor));
 }
 
 @Test
@@ -405,14 +406,14 @@ public void test_equalsLjava_lang_Object_with_device() {
 	Color sameColor2 = new Color(display, new RGB(1, 2, 3));
 	Color otherColor = new Color(display, 5, 6, 7);
 	// Test Color.equals(Object)
-	assertFalse("!color.equals((Object)null)", color.equals((Object)null));
+	assertFalse(color.equals((Object)null));
 
 	// Test Color.equals(Color)
-	assertFalse("!color.equals((Color)null)", color.equals((Color)null));
-	assertTrue("color.equals(color)", color.equals(color));
-	assertTrue("color.equals(sameColor)", color.equals(sameColor));
-	assertTrue("color.equals(sameColor2)", color.equals(sameColor2));
-	assertFalse("!color.equals(otherColor)", color.equals(otherColor));
+	assertFalse(color.equals((Color)null));
+	assertTrue(color.equals(color));
+	assertTrue(color.equals(sameColor));
+	assertTrue(color.equals(sameColor2));
+	assertFalse(color.equals(otherColor));
 
 	// With alpha
 	color = new Color(display, 1, 2, 3, 0);
@@ -420,14 +421,14 @@ public void test_equalsLjava_lang_Object_with_device() {
 	sameColor2 = new Color(display, new RGB(1, 2, 3), 0);
 	otherColor = new Color(display, 5, 6, 7, 0);
 	// Test Color.equals(Object)
-	assertFalse("!color.equals((Object)null)", color.equals((Object)null));
+	assertFalse(color.equals((Object)null));
 
 	// Test Color.equals(Color)
-	assertFalse("!color.equals((Color)null)", color.equals((Color)null));
-	assertTrue("color.equals(color)", color.equals(color));
-	assertTrue("color.equals(sameColor)", color.equals(sameColor));
-	assertTrue("color.equals(sameColor2)", color.equals(sameColor2));
-	assertFalse("!color.equals(otherColor)", color.equals(otherColor));
+	assertFalse(color.equals((Color)null));
+	assertTrue(color.equals(color));
+	assertTrue(color.equals(sameColor));
+	assertTrue(color.equals(sameColor2));
+	assertFalse(color.equals(otherColor));
 }
 
 @Test
@@ -436,48 +437,48 @@ public void test_equalsLjava_lang_Object_mix() {
 	Color sameColorNoDevice = new Color(1, 2, 3);
 	Color otherColorNoDevice = new Color(5, 6, 7);
 	// Test Color.equals(Color)
-	assertTrue("color.equals(sameColor)", color.equals(sameColorNoDevice));
-	assertFalse("!color.equals(otherColor)", color.equals(otherColorNoDevice));
-	assertTrue("color.equals(sameColor)", sameColorNoDevice.equals(color));
-	assertFalse("!color.equals(otherColor)", otherColorNoDevice.equals(color));
+	assertTrue(color.equals(sameColorNoDevice));
+	assertFalse(color.equals(otherColorNoDevice));
+	assertTrue(sameColorNoDevice.equals(color));
+	assertFalse(otherColorNoDevice.equals(color));
 
 	// With alpha
 	color = new Color(display, 1, 2, 3, 0);
 	sameColorNoDevice = new Color(1, 2, 3, 0);
 	otherColorNoDevice = new Color(5, 6, 7, 0);
 	// Test Color.equals(Color)
-	assertTrue("color.equals(sameColor)", color.equals(sameColorNoDevice));
-	assertFalse("!color.equals(otherColor)", color.equals(otherColorNoDevice));
-	assertTrue("color.equals(sameColor)", sameColorNoDevice.equals(color));
-	assertFalse("!color.equals(otherColor)", otherColorNoDevice.equals(color));
+	assertTrue(color.equals(sameColorNoDevice));
+	assertFalse(color.equals(otherColorNoDevice));
+	assertTrue(sameColorNoDevice.equals(color));
+	assertFalse(otherColorNoDevice.equals(color));
 }
 
 @Test
 public void test_getBlue() {
 	// Test Color.getBlue()
 	Color color = new Color(0, 0, 255);
-	assertEquals("color.getBlue()", color.getBlue(), 255);
+	assertEquals(color.getBlue(), 255);
 }
 
 @Test
 public void test_getBlue_with_device() {
 	// Test Color.getBlue()
 	Color color = new Color(display, 0, 0, 255);
-	assertEquals("color.getBlue()", color.getBlue(), 255);
+	assertEquals(color.getBlue(), 255);
 }
 
 @Test
 public void test_getGreen() {
 	// Test Color.getGreen()
 	Color color = new Color(0, 255, 0);
-	assertEquals("color.getGreen()", color.getGreen(), 255);
+	assertEquals(color.getGreen(), 255);
 }
 
 @Test
 public void test_getGreen_with_device() {
 	// Test Color.getGreen()
 	Color color = new Color(display, 0, 255, 0);
-	assertEquals("color.getGreen()", color.getGreen(), 255);
+	assertEquals(color.getGreen(), 255);
 }
 
 @Test
@@ -498,28 +499,28 @@ public void test_getRGB_with_device() {
 public void test_getRed() {
 	// Test Color.getRed()
 	Color color = new Color(255, 0, 0);
-	assertEquals("color.getRed()", color.getRed(), 255);
+	assertEquals(color.getRed(), 255);
 }
 
 @Test
 public void test_getRed_with_device() {
 	// Test Color.getRed()
 	Color color = new Color(display, 255, 0, 0);
-	assertEquals("color.getRed()", color.getRed(), 255);
+	assertEquals(color.getRed(), 255);
 }
 
 @Test
 public void test_getAlpha() {
 	// Test Color.getRed()
 	Color color = new Color(255, 0, 0, 0);
-	assertEquals("color.getAlpha()", color.getAlpha(), 0);
+	assertEquals(color.getAlpha(), 0);
 }
 
 @Test
 public void test_getAlpha_with_device() {
 	// Test Color.getRed()
 	Color color = new Color(display, 255, 0, 0, 0);
-	assertEquals("color.getAlpha()", color.getAlpha(), 0);
+	assertEquals(color.getAlpha(), 0);
 }
 
 @Test
@@ -527,7 +528,7 @@ public void test_hashCode() {
 	Color color = new Color(12, 34, 56, 0);
 	Color otherColor = new Color(12, 34, 56, 0);
 	if (color.equals(otherColor)) {
-		assertEquals("Hash codes of equal objects should be equal", color.hashCode(), otherColor.hashCode());
+		assertEquals(color.hashCode(), otherColor.hashCode());
 	}
 }
 
@@ -536,7 +537,7 @@ public void test_hashCode_with_device() {
 	Color color = new Color(display, 12, 34, 56, 0);
 	Color otherColor = new Color(display, 12, 34, 56, 0);
 	if (color.equals(otherColor)) {
-		assertEquals("Hash codes of equal objects should be equal", color.hashCode(), otherColor.hashCode());
+		assertEquals(color.hashCode(), otherColor.hashCode());
 	}
 }
 
@@ -548,20 +549,20 @@ public void test_hashCode_with_device() {
 public void test_isDisposed() {
 	// Test Color.isDisposed() false
 	Color color = new Color(34, 67, 98, 0);
-	assertFalse("Color should not be disposed", color.isDisposed());
+	assertFalse(color.isDisposed());
 	// Test Color.isDisposed() true
 	color.dispose();
-	assertTrue("Color should be disposed", color.isDisposed());
+	assertTrue(color.isDisposed());
 }
 
 @Test
 public void test_isDisposed_with_device() {
 	// Test Color.isDisposed() false
 	Color color = new Color(display, 34, 67, 98, 0);
-	assertFalse("Color should not be disposed", color.isDisposed());
+	assertFalse(color.isDisposed());
 	// Test Color.isDisposed() true
 	color.dispose();
-	assertTrue("Color should be disposed", color.isDisposed());
+	assertTrue(color.isDisposed());
 }
 
 @Test
@@ -584,29 +585,29 @@ public void test_toString_with_device() {
 public void test_getDevice() {
 	Color color = new Color(0, 0, 255, 255);
 	Device device = color.getDevice();
-	assertEquals("The existing display should have been returned", display, device);
+	assertEquals(display, device);
 
 
 	// see test_isDisposed - we need to keep dispose semantics
-	SWTException e = assertThrows("No exception thrown for getDevice on disposed Color", SWTException.class, () -> {
+	SWTException e = assertThrows(SWTException.class, () -> {
 		Color color1 = new Color(0, 0, 255, 255);
 		color1.dispose();
 		color1.getDevice();
 	});
-	assertEquals("Color should have thrown device disposed on getDevice", SWT.ERROR_GRAPHIC_DISPOSED, e.code);
+	assertEquals(SWT.ERROR_GRAPHIC_DISPOSED, e.code);
 }
 
 @Test
 public void test_getDevice_with_device() {
 	Color color = new Color(display, 0, 0, 255, 255);
-	assertEquals("Color should return device as constructed", display, color.getDevice());
+	assertEquals(display, color.getDevice());
 
-	SWTException e = assertThrows("No exception thrown for getDevice on disposed Color", SWTException.class, () -> {
+	SWTException e = assertThrows(SWTException.class, () -> {
 		Color color1 = new Color(0, 0, 255, 255);
 		color1.dispose();
 		color1.getDevice();
 	});
-	assertEquals("Color should have thrown device disposed on getDevice", SWT.ERROR_GRAPHIC_DISPOSED, e.code);
+	assertEquals(SWT.ERROR_GRAPHIC_DISPOSED, e.code);
 }
 
 /* custom */

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_Cursor.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_Cursor.java
@@ -15,9 +15,10 @@
 package org.eclipse.swt.tests.junit;
 
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -31,8 +32,8 @@ import org.eclipse.swt.graphics.ImageLoader;
 import org.eclipse.swt.graphics.PaletteData;
 import org.eclipse.swt.graphics.RGB;
 import org.eclipse.swt.widgets.Display;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Automated Test Suite for class org.eclipse.swt.graphics.Cursor
@@ -41,7 +42,8 @@ import org.junit.Test;
  */
 public class Test_org_eclipse_swt_graphics_Cursor {
 
-@Before
+
+@BeforeEach
 public void setUp() {
 	display = Display.getDefault();
 }
@@ -122,12 +124,10 @@ public void test_ConstructorLorg_eclipse_swt_graphics_DeviceI() {
 	cursor.dispose();
 
 	// illegal argument, style > SWT.CURSOR_HAND (21)
-	assertThrows("No exception thrown for style > SWT.CURSOR_HAND (21)",
-			IllegalArgumentException.class, () -> new Cursor(display, 100));
+	assertThrows(IllegalArgumentException.class, () -> new Cursor(display, 100));
 
 	// illegal argument, style < 0
-	assertThrows("No exception thrown for style < 0",
-			IllegalArgumentException.class, () -> new Cursor(display, -100));
+	assertThrows(IllegalArgumentException.class, () -> new Cursor(display, -100));
 }
 
 @Test
@@ -161,8 +161,7 @@ public void test_ConstructorWithImageDataProvider() {
 	cursor.dispose();
 	sourceImage.dispose();
 
-	assertThrows("No exception thrown when ImageDataProvider is null",
-			IllegalArgumentException.class, () -> new Cursor(display, (ImageDataProvider) null, 0, 0));
+	assertThrows(IllegalArgumentException.class, () -> new Cursor(display, (ImageDataProvider) null, 0, 0));
 }
 
 @Test
@@ -170,63 +169,56 @@ public void test_InvalidArgumentsForAllConstructors() {
 	ImageData source = new ImageData(16, 16, 1, new PaletteData(new RGB[] { new RGB(0, 0, 0) }));
 	ImageData mask = new ImageData(16, 16, 1, new PaletteData(new RGB[] { new RGB(0, 0, 0) }));
 
-	assertThrows("When wrong style was provided", IllegalArgumentException.class,
-			() -> {
-				Cursor cursor = new Cursor(Display.getDefault(), -99);
-				cursor.dispose();
-			});
+	assertThrows(IllegalArgumentException.class, () -> {
+		Cursor cursor = new Cursor(Display.getDefault(), -99);
+		cursor.dispose();
+	});
 
-	assertThrows("When source is null", IllegalArgumentException.class, () -> {
+	assertThrows(IllegalArgumentException.class, () -> {
 		@SuppressWarnings("deprecation")
 		Cursor cursorFromImageAndMask = new Cursor(Display.getDefault(), null, mask, 0, 0);
 		cursorFromImageAndMask.dispose();
 	});
 
-	assertThrows("When mask is null and source doesn't heve a mask",
-			IllegalArgumentException.class, () -> {
-				@SuppressWarnings("deprecation")
-				Cursor cursorFromImageAndMask = new Cursor(Display.getDefault(), source, null, 0, 0);
-				cursorFromImageAndMask.dispose();
-			});
+	assertThrows(IllegalArgumentException.class, () -> {
+		@SuppressWarnings("deprecation")
+		Cursor cursorFromImageAndMask = new Cursor(Display.getDefault(), source, null, 0, 0);
+		cursorFromImageAndMask.dispose();
+	});
 
-	assertThrows("When source and the mask are not the same size",
-			IllegalArgumentException.class, () -> {
-				ImageData source32 = new ImageData(32, 32, 1, new PaletteData(new RGB[] { new RGB(0, 0, 0) }));
-				ImageData mask16 = new ImageData(16, 16, 1, new PaletteData(new RGB[] { new RGB(0, 0, 0) }));
+	assertThrows(IllegalArgumentException.class, () -> {
+		ImageData source32 = new ImageData(32, 32, 1, new PaletteData(new RGB[] { new RGB(0, 0, 0) }));
+		ImageData mask16 = new ImageData(16, 16, 1, new PaletteData(new RGB[] { new RGB(0, 0, 0) }));
 
-				@SuppressWarnings("deprecation")
-				Cursor cursorFromImageAndMask = new Cursor(Display.getDefault(), source32, mask16, 0, 0);
-				cursorFromImageAndMask.dispose();
-			});
+		@SuppressWarnings("deprecation")
+		Cursor cursorFromImageAndMask = new Cursor(Display.getDefault(), source32, mask16, 0, 0);
+		cursorFromImageAndMask.dispose();
+	});
 
-	assertThrows("When hotspot is outside the bounds of the image",
-			IllegalArgumentException.class, () -> {
-				@SuppressWarnings("deprecation")
-				Cursor cursorFromImageAndMask = new Cursor(Display.getDefault(), source, mask, 18, 18);
-				cursorFromImageAndMask.dispose();
-			});
+	assertThrows(IllegalArgumentException.class, () -> {
+		@SuppressWarnings("deprecation")
+		Cursor cursorFromImageAndMask = new Cursor(Display.getDefault(), source, mask, 18, 18);
+		cursorFromImageAndMask.dispose();
+	});
 
-	assertThrows("When source image data is null", IllegalArgumentException.class,
-			() -> {
-				ImageData nullImageData = null;
-				Cursor cursorFromSourceOnly = new Cursor(Display.getDefault(), nullImageData, 0, 0);
-				cursorFromSourceOnly.dispose();
-			});
+	assertThrows(IllegalArgumentException.class, () -> {
+		ImageData nullImageData = null;
+		Cursor cursorFromSourceOnly = new Cursor(Display.getDefault(), nullImageData, 0, 0);
+		cursorFromSourceOnly.dispose();
+	});
 
-	assertThrows("When ImageDataProvider is null", IllegalArgumentException.class,
-			() -> {
-				ImageDataProvider provider = null;
-				Cursor cursorFromProvider = new Cursor(Display.getDefault(), provider, 0, 0);
-				cursorFromProvider.dispose();
-			});
+	assertThrows(IllegalArgumentException.class, () -> {
+		ImageDataProvider provider = null;
+		Cursor cursorFromProvider = new Cursor(Display.getDefault(), provider, 0, 0);
+		cursorFromProvider.dispose();
+	});
 
-	assertThrows("When source in ImageDataProvider is null",
-			IllegalArgumentException.class, () -> {
-				ImageData nullSource = null;
-				ImageDataProvider provider = zoom -> nullSource;
-				Cursor cursorFromProvider = new Cursor(Display.getDefault(), provider, 0, 0);
-				cursorFromProvider.dispose();
-			});
+	assertThrows(IllegalArgumentException.class, () -> {
+		ImageData nullSource = null;
+		ImageDataProvider provider = zoom -> nullSource;
+		Cursor cursorFromProvider = new Cursor(Display.getDefault(), provider, 0, 0);
+		cursorFromProvider.dispose();
+	});
 }
 
 @Test
@@ -239,12 +231,12 @@ public void test_equalsLjava_lang_Object() {
 	Cursor otherCursor = new Cursor(display, SWT.CURSOR_CROSS);
 	try {
 		// Test Cursor.equals(Object)
-		assertTrue("!cursor.equals((Object)null)", !cursor.equals((Object)null));
+		assertTrue(!cursor.equals((Object)null));
 
 		// Test Cursor.equals(Cursor)
-		assertTrue("!cursor.equals((Cursor)null)", !cursor.equals((Cursor)null));
-		assertTrue("cursor.equals(cursor)", cursor.equals(cursor));
-		assertTrue("!cursor.equals(otherCursor)", !cursor.equals(otherCursor));
+		assertTrue(!cursor.equals((Cursor)null));
+		assertTrue(cursor.equals(cursor));
+		assertTrue(!cursor.equals(otherCursor));
 	} finally {
 		cursor.dispose();
 		otherCursor.dispose();
@@ -256,11 +248,11 @@ public void test_isDisposed() {
 	// Test Cursor.isDisposed() false
 	Cursor cursor = new Cursor(display, SWT.CURSOR_WAIT);
 	try {
-		assertTrue("Cursor should not be disposed", !cursor.isDisposed());
+		assertTrue(!cursor.isDisposed());
 	} finally {
 		// Test Cursor.isDisposed() true
 		cursor.dispose();
-		assertTrue("Cursor should be disposed", cursor.isDisposed());
+		assertTrue(cursor.isDisposed());
 	}
 }
 

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_DeviceData.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_DeviceData.java
@@ -16,7 +16,7 @@ package org.eclipse.swt.tests.junit;
 
 
 import org.eclipse.swt.graphics.DeviceData;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Automated Test Suite for class org.eclipse.swt.graphics.DeviceData

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_GC.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_GC.java
@@ -15,9 +15,6 @@
 package org.eclipse.swt.tests.junit;
 
 import static org.eclipse.swt.tests.junit.SwtTestUtil.assertSWTProblem;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -839,8 +836,8 @@ public void test_drawLine_noSingularitiesIn45DregreeRotation() {
 		gc.setTransform(rotation);
 		gc.drawLine(centerPixel, centerPixel, centerPixel + 1, centerPixel);
 
-		assertThat("line is not drawn with 45 degree rotation",
-				image.getImageData().getPixel(centerPixel, centerPixel), not(is(-1)));
+		assertNotEquals(-1,
+				image.getImageData().getPixel(centerPixel, centerPixel), "line is not drawn with 45 degree rotation");
 	} finally {
 		rotation.dispose();
 		gc.dispose();

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_Image.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_Image.java
@@ -16,15 +16,15 @@ package org.eclipse.swt.tests.junit;
 
 
 import static org.eclipse.swt.tests.junit.SwtTestUtil.assertSWTProblem;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assume.assumeFalse;
-import static org.junit.Assume.assumeTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -50,10 +50,10 @@ import org.eclipse.swt.graphics.RGB;
 import org.eclipse.swt.graphics.Rectangle;
 import org.eclipse.swt.internal.DPIUtil;
 import org.eclipse.swt.widgets.Display;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
 
 /**
  * Automated Test Suite for class org.eclipse.swt.graphics.Image
@@ -63,8 +63,8 @@ import org.junit.rules.TemporaryFolder;
 @SuppressWarnings("restriction")
 public class Test_org_eclipse_swt_graphics_Image {
 
-	@ClassRule
-	public static TemporaryFolder tempFolder = new TemporaryFolder();
+	@TempDir
+	static Path tempFolder;
 
 	private static String getPath(String fileName) {
 		return SwtTestUtil.getPath(fileName, tempFolder).toString();
@@ -96,7 +96,7 @@ public class Test_org_eclipse_swt_graphics_Image {
 	};
 ImageGcDrawer imageGcDrawer = (gc, width, height) -> {};
 
-@Before
+@BeforeEach
 public void setUp() {
 	display = Display.getDefault();
 }
@@ -584,7 +584,6 @@ public void test_getBounds() {
 	image.dispose();
 	assertEquals(bounds, bounds1);
 }
-
 @SuppressWarnings("removal")
 @Test
 public void test_getBoundsInPixels() {
@@ -600,8 +599,8 @@ public void test_getBoundsInPixels() {
 	Rectangle boundsInPixels = image.getBoundsInPixels();
 	Rectangle bounds = image.getBounds();
 	image.dispose();
-	assertEquals("Image.getBounds method doesn't return original bounds.", initialBounds, bounds);
-	assertEquals("Image.getBoundsInPixels method doesn't return bounds in Pixel values.", initialBounds, boundsInPixels);
+	assertEquals(initialBounds, bounds);
+	assertEquals(initialBounds, boundsInPixels);
 
 	// create icon image
 	ImageData imageData = new ImageData(initialBounds.width, initialBounds.height, 1, new PaletteData(new RGB[] {new RGB(0, 0, 0)}));
@@ -609,30 +608,30 @@ public void test_getBoundsInPixels() {
 	boundsInPixels = image.getBoundsInPixels();
 	bounds = image.getBounds();
 	image.dispose();
-	assertEquals("Image.getBounds method doesn't return original bounds.", initialBounds, bounds);
-	assertEquals("Image.getBoundsInPixels method doesn't return bounds in Pixel values.", initialBounds, boundsInPixels);
+	assertEquals(initialBounds, bounds);
+	assertEquals(initialBounds, boundsInPixels);
 
 	// create image with FileNameProvider
 	image = new Image(display, imageFileNameProvider);
 	boundsInPixels = image.getBoundsInPixels();
 	bounds = image.getBounds();
 	image.dispose();
-	assertEquals("Image.getBoundsInPixels method doesn't return bounds in Pixel values.", bounds, boundsInPixels);
+	assertEquals(bounds, boundsInPixels);
 
 	// create image with ImageDataProvider
 	image = new Image(display, imageDataProvider);
 	boundsInPixels = image.getBoundsInPixels();
 	bounds = image.getBounds();
 	image.dispose();
-	assertEquals("Image.getBoundsInPixels method doesn't return bounds in Pixel values.", bounds, boundsInPixels);
+	assertEquals(bounds, boundsInPixels);
 
 	// create image with ImageGcDrawer
 	image = new Image(display, imageGcDrawer, initialBounds.width, initialBounds.height);
 	boundsInPixels = image.getBoundsInPixels();
 	bounds = image.getBounds();
 	image.dispose();
-	assertEquals("Image.getBounds method doesn't return original bounds.", initialBounds, bounds);
-	assertEquals("Image.getBoundsInPixels method doesn't return bounds in Pixel values for ImageGcDrawer.", initialBounds, boundsInPixels);
+	assertEquals(initialBounds, bounds);
+	assertEquals(initialBounds, boundsInPixels);
 }
 
 @SuppressWarnings("removal")
@@ -650,7 +649,7 @@ public void test_getImageDataCurrentZoom() {
 	ImageData imageDataAtCurrentZoom = image.getImageDataAtCurrentZoom();
 	image.dispose();
 	Rectangle boundsAtCurrentZoom = new Rectangle(0, 0, imageDataAtCurrentZoom.width, imageDataAtCurrentZoom.height);
-	assertEquals(":a: Size of ImageData returned from Image.getImageDataAtCurrentZoom method doesn't return matches with bounds in Pixel values.", boundsAtCurrentZoom, bounds);
+	assertEquals(boundsAtCurrentZoom, bounds);
 
 	// create icon image and compare size of imageData
 	ImageData imageData = new ImageData(bounds.width, bounds.height, 1, new PaletteData(new RGB[] {new RGB(0, 0, 0)}));
@@ -658,7 +657,7 @@ public void test_getImageDataCurrentZoom() {
 	imageDataAtCurrentZoom = image.getImageDataAtCurrentZoom();
 	image.dispose();
 	boundsAtCurrentZoom = new Rectangle(0, 0, imageDataAtCurrentZoom.width, imageDataAtCurrentZoom.height);
-	assertEquals(":b: Size of ImageData returned from Image.getImageDataAtCurrentZoom method doesn't return matches with bounds in Pixel values.", boundsAtCurrentZoom, bounds);
+	assertEquals(boundsAtCurrentZoom, bounds);
 
 	// create image with FileNameProvider
 	image = new Image(display, imageFileNameProvider);
@@ -666,7 +665,7 @@ public void test_getImageDataCurrentZoom() {
 	boundsAtCurrentZoom = new Rectangle(0, 0, imageDataAtCurrentZoom.width, imageDataAtCurrentZoom.height);
 	bounds = image.getBounds();
 	image.dispose();
-	assertEquals(":c: Size of ImageData returned from Image.getImageDataAtCurrentZoom method doesn't return matches with bounds in Pixel values.", boundsAtCurrentZoom, bounds);
+	assertEquals(boundsAtCurrentZoom, bounds);
 
 	// create image with ImageDataProvider
 	image = new Image(display, imageDataProvider);
@@ -674,7 +673,7 @@ public void test_getImageDataCurrentZoom() {
 	boundsAtCurrentZoom = new Rectangle(0, 0, imageDataAtCurrentZoom.width, imageDataAtCurrentZoom.height);
 	bounds = image.getBounds();
 	image.dispose();
-	assertEquals(":d: Size of ImageData returned from Image.getImageDataAtCurrentZoom method doesn't return matches with bounds in Pixel values.", boundsAtCurrentZoom, bounds);
+	assertEquals(boundsAtCurrentZoom, bounds);
 }
 
 @Test
@@ -730,7 +729,7 @@ void getImageData_int(int zoom) {
 	ImageData imageDataAtZoom = image.getImageData(zoom);
 	image.dispose();
 	Rectangle boundsAtZoom = new Rectangle(0, 0, imageDataAtZoom.width, imageDataAtZoom.height);
-	assertEquals(":a: Size of ImageData returned from Image.getImageData(int) method doesn't return matches with bounds in Pixel values.", scaleBounds(bounds, zoom, 100), boundsAtZoom);
+	assertEquals(scaleBounds(bounds, zoom, 100), boundsAtZoom);
 
 	// creates second bitmap image and compare size of imageData
 	image = new Image(display, bounds.width, bounds.height);
@@ -738,14 +737,14 @@ void getImageData_int(int zoom) {
 	boundsAtZoom = new Rectangle(0, 0, imageDataAtZoom.width, imageDataAtZoom.height);
 	bounds = image.getBounds();
 	image.dispose();
-	assertEquals(":a: Size of ImageData returned from Image.getImageData(int) method doesn't return matches with bounds in Pixel values.", scaleBounds(bounds, zoom, 100), boundsAtZoom);
+	assertEquals(scaleBounds(bounds, zoom, 100), boundsAtZoom);
 
 	// creates bitmap image with GCDrawer and compare size of imageData
 	image = new Image(display, (gc, width, height) -> {}, bounds.width, bounds.height);
 	imageDataAtZoom = image.getImageData(zoom);
 	image.dispose();
 	boundsAtZoom = new Rectangle(0, 0, imageDataAtZoom.width, imageDataAtZoom.height);
-	assertEquals(":a: Size of ImageData returned from Image.getImageData(int) method doesn't return matches with bounds in Pixel values.", scaleBounds(bounds, zoom, 100), boundsAtZoom);
+	assertEquals(scaleBounds(bounds, zoom, 100), boundsAtZoom);
 
 	// create icon image and compare size of imageData
 	ImageData imageData = new ImageData(bounds.width, bounds.height, 1, new PaletteData(new RGB[] {new RGB(0, 0, 0)}));
@@ -753,7 +752,7 @@ void getImageData_int(int zoom) {
 	imageDataAtZoom = image.getImageData(zoom);
 	image.dispose();
 	boundsAtZoom = new Rectangle(0, 0, imageDataAtZoom.width, imageDataAtZoom.height);
-	assertEquals(":b: Size of ImageData returned from Image.getImageData(int) method doesn't return matches with bounds in Pixel values.", scaleBounds(bounds, zoom, 100), boundsAtZoom);
+	assertEquals(scaleBounds(bounds, zoom, 100), boundsAtZoom);
 
 	// create image with FileNameProvider
 	image = new Image(display, imageFileNameProvider);
@@ -761,7 +760,7 @@ void getImageData_int(int zoom) {
 	boundsAtZoom = new Rectangle(0, 0, imageDataAtZoom.width, imageDataAtZoom.height);
 	bounds = image.getBounds();
 	image.dispose();
-	assertEquals(":c: Size of ImageData returned from Image.getImageData(int) method doesn't return matches with bounds in Pixel values.", scaleBounds(bounds, zoom, 100), boundsAtZoom);
+	assertEquals(scaleBounds(bounds, zoom, 100), boundsAtZoom);
 
 	// create image with ImageDataProvider
 	image = new Image(display, imageDataProvider);
@@ -769,7 +768,7 @@ void getImageData_int(int zoom) {
 	boundsAtZoom = new Rectangle(0, 0, imageDataAtZoom.width, imageDataAtZoom.height);
 	bounds = image.getBounds();
 	image.dispose();
-	assertEquals(":d: Size of ImageData returned from Image.getImageData(int) method doesn't return matches with bounds in Pixel values.", scaleBounds(bounds, zoom, 100), boundsAtZoom);
+	assertEquals(scaleBounds(bounds, zoom, 100), boundsAtZoom);
 
 	// create image with ImageDataProvider that only has 1x data
 	image = new Image(display, imageDataProvider1xOnly);
@@ -777,7 +776,7 @@ void getImageData_int(int zoom) {
 	boundsAtZoom = new Rectangle(0, 0, imageDataAtZoom.width, imageDataAtZoom.height);
 	bounds = image.getBounds();
 	image.dispose();
-	assertEquals(":d: Size of ImageData returned from Image.getImageData(int) method doesn't return matches with bounds in Pixel values.", scaleBounds(bounds, zoom, 100), boundsAtZoom);
+	assertEquals(scaleBounds(bounds, zoom, 100), boundsAtZoom);
 }
 
 public static Rectangle scaleBounds (Rectangle rect, int targetZoom, int currentZoom) {
@@ -853,9 +852,8 @@ public void test_isDisposed() {
 
 @Test
 public void test_setBackgroundLorg_eclipse_swt_graphics_Color() {
-	assumeFalse(
-			"Excluded test_setBackgroundLorg_eclipse_swt_graphics_Color(org.eclipse.swt.tests.junit.Test_org_eclipse_swt_graphics_Image)",
-			SwtTestUtil.isGTK);
+	assumeFalse(SwtTestUtil.isGTK,
+			"Excluded test_setBackgroundLorg_eclipse_swt_graphics_Color(org.eclipse.swt.tests.junit.Test_org_eclipse_swt_graphics_Image)");
 	// TODO Fix GTK failure.
 	ImageGcDrawer noOpGcDrawer = (gc, width, height) -> {};
 	Image image1 = new Image(display, noOpGcDrawer, 10, 10);
@@ -884,7 +882,7 @@ public void test_setBackgroundLorg_eclipse_swt_graphics_Color() {
 	Image image4 = new Image(display, noOpGcDrawer, 10, 10);
 	image4.setBackground(display.getSystemColor(SWT.COLOR_GREEN));
 	Color color4 = image4.getBackground();
-	assertNull("background color should be null for non-transparent image", color4);
+	assertNull(color4);
 	image4.dispose();
 
 	// create an image with transparency and then set the background color
@@ -894,7 +892,7 @@ public void test_setBackgroundLorg_eclipse_swt_graphics_Color() {
 	Image image5 = new Image(display, imageData);
 	image5.setBackground(display.getSystemColor(SWT.COLOR_GREEN));
 	Color color5 = image5.getBackground();
-	assertEquals("background color should have been set to green", display.getSystemColor(SWT.COLOR_GREEN), color5);
+	assertEquals(display.getSystemColor(SWT.COLOR_GREEN), color5);
 	image5.dispose();
 }
 
@@ -924,8 +922,8 @@ public void test_getImageData_fromFiles() {
 			Image image = new Image(display, data1);
 			ImageData data2 = image.getImageData();
 			image.dispose();
-			assertEquals("Image width should be the same", data1.width, data2.width);
-			assertEquals("Image height should be the same", data1.height, data2.height);
+			assertEquals(data1.width, data2.width);
+			assertEquals(data1.height, data2.height);
 		} catch (IOException e) {
 			// continue;
 		}
@@ -979,7 +977,7 @@ private static PaletteData assertAllPixelsHaveColor(ImageData imageData, Color e
 		for (int y = 0; y < imageData.height; y++) {
 			int pixel = imageData.getPixel(x, y);
 			RGB rgb = newPalette.getRGB(pixel);
-			assertEquals("pixel at x=" + x + " y=" + y + " does not have expected color", expectedColor.getRGB(), rgb);
+			assertEquals(expectedColor.getRGB(), rgb);
 		}
 	}
 	return newPalette;
@@ -1052,11 +1050,11 @@ public void test_updateWidthHeightAfterDPIChange() {
 		Image baseImage = new Image(display, noOpGcDrawer, imageSize.width, imageSize.height);
 		GC gc = new GC(display);
 		gc.drawImage(baseImage, 10, 10);
-		assertEquals("Base image size differs unexpectedly", imageSize, baseImage.getBounds());
+		assertEquals(imageSize, baseImage.getBounds());
 
 		DPIUtil.setDeviceZoom(deviceZoom * 2);
 		gc.drawImage(baseImage, 10, 10);
-		assertEquals("Image size at 100% must always stay the same despite the zoom factor", imageSize, baseImage.getBounds());
+		assertEquals(imageSize, baseImage.getBounds());
 		gc.dispose();
 		baseImage.dispose();
 	} finally {
@@ -1066,7 +1064,7 @@ public void test_updateWidthHeightAfterDPIChange() {
 
 @Test
 public void test_imageDataIsCached() {
-	assumeTrue("On-demand image creation only implemented for Windows", SwtTestUtil.isWindows);
+	assumeTrue(SwtTestUtil.isWindows, "On-demand image creation only implemented for Windows");
 	String imagePath = getPath("collapseall.png");
 	AtomicInteger callCount = new AtomicInteger();
 	ImageFileNameProvider imageFileNameProvider = __ -> {
@@ -1083,7 +1081,7 @@ public void test_imageDataIsCached() {
 
 @Test
 public void test_imageDataSameViaDifferentProviders() {
-	assumeFalse("Cocoa generates inconsistent image data", SwtTestUtil.isCocoa);
+	assumeFalse(SwtTestUtil.isCocoa, "Cocoa generates inconsistent image data");
 	String imagePath = getPath("collapseall.png");
 	ImageFileNameProvider imageFileNameProvider = zoom -> {
 		return (zoom == 100) ? imagePath : null;
@@ -1109,7 +1107,7 @@ public void test_imageDataSameViaDifferentProviders() {
 
 @Test
 public void test_imageDataSameViaProviderAndSimpleData() {
-	assumeFalse("Cocoa generates inconsistent image data", SwtTestUtil.isCocoa);
+	assumeFalse(SwtTestUtil.isCocoa, "Cocoa generates inconsistent image data");
 	String imagePath = getPath("collapseall.png");
 	ImageFileNameProvider imageFileNameProvider = __ -> {
 		return imagePath;

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_ImageData.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_ImageData.java
@@ -18,12 +18,12 @@ package org.eclipse.swt.tests.junit;
 import static org.eclipse.swt.tests.graphics.ImageDataTestHelper.LSB_FIRST;
 import static org.eclipse.swt.tests.graphics.ImageDataTestHelper.MSB_FIRST;
 import static org.eclipse.swt.tests.junit.SwtTestUtil.assertSWTProblem;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -39,8 +39,8 @@ import org.eclipse.swt.graphics.RGB;
 import org.eclipse.swt.tests.graphics.ImageDataTestHelper;
 import org.eclipse.swt.tests.graphics.ImageDataTestHelper.BlitTestInfo;
 import org.eclipse.swt.widgets.Display;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Automated Test Suite for class org.eclipse.swt.graphics.ImageData
@@ -51,7 +51,7 @@ public class Test_org_eclipse_swt_graphics_ImageData {
 	static int[] indexedDepths = {1, 2, 4, 8, 16};
 	static int[] directDepths  = {8, 16, 24, 32};
 
-@Before
+@BeforeEach
 public void setUp() {
 	imageData = new ImageData(IMAGE_DIMENSION, IMAGE_DIMENSION, 32, new PaletteData(0xFF0000, 0xFF00, 0xFF));
 }
@@ -149,17 +149,13 @@ public void test_blit_MsbLsb() throws Exception {
 
 @Test
 public void test_ConstructorIIILorg_eclipse_swt_graphics_PaletteData() {
-	assertThrows("No exception thrown for width < 0", IllegalArgumentException.class,
-			() -> new ImageData(-1, 1, 1, new PaletteData(new RGB(0, 0, 0))));
+	assertThrows(IllegalArgumentException.class, () -> new ImageData(-1, 1, 1, new PaletteData(new RGB(0, 0, 0))));
 
-	assertThrows("No exception thrown for height < 0", IllegalArgumentException.class,
-			() -> new ImageData(1, -1, 1, new PaletteData(new RGB(0, 0, 0))));
+	assertThrows(IllegalArgumentException.class, () -> new ImageData(1, -1, 1, new PaletteData(new RGB(0, 0, 0))));
 
-	assertThrows("No exception thrown for paletteData == null", IllegalArgumentException.class,
-			() -> new ImageData(1, 1, 1, null, 0, new byte[] { 0, 0x4f, 0x4f, 0 }));
+	assertThrows(IllegalArgumentException.class, () -> new ImageData(1, 1, 1, null, 0, new byte[] { 0, 0x4f, 0x4f, 0 }));
 
-	assertThrows("No exception thrown for unsupported depth", IllegalArgumentException.class,
-			() -> new ImageData(1, 1, 3, new PaletteData(new RGB(0, 0, 0))));
+	assertThrows(IllegalArgumentException.class, () -> new ImageData(1, 1, 3, new PaletteData(new RGB(0, 0, 0))));
 
 	int[] validDepths = {1, 2, 4, 8, 16, 24, 32};
 	for (int validDepth : validDepths) {
@@ -171,32 +167,23 @@ public void test_ConstructorIIILorg_eclipse_swt_graphics_PaletteData() {
 public void test_ConstructorIIILorg_eclipse_swt_graphics_PaletteDataI$B() {
 	byte[] validData = {0, 0x4f, 0x4f, 0};
 
-	assertThrows("No exception thrown for width < 0", IllegalArgumentException.class,
-		() -> new ImageData(-1, 1, 1, new PaletteData(new RGB(0, 0, 0)), 1, validData));
+	assertThrows(IllegalArgumentException.class, () -> new ImageData(-1, 1, 1, new PaletteData(new RGB(0, 0, 0)), 1, validData));
 
-	assertThrows("No exception thrown for height < 0", IllegalArgumentException.class,
-		() -> new ImageData(1, -1, 1, new PaletteData(new RGB(0, 0, 0)), 1, validData));
+	assertThrows(IllegalArgumentException.class, () -> new ImageData(1, -1, 1, new PaletteData(new RGB(0, 0, 0)), 1, validData));
 
-	assertThrows("No exception thrown for paletteData == null", IllegalArgumentException.class,
-		() -> new ImageData(1, 1, 1, null, 0, validData));
+	assertThrows(IllegalArgumentException.class, () -> new ImageData(1, 1, 1, null, 0, validData));
 
-	assertThrows("No exception thrown for data == null", IllegalArgumentException.class,
-		() -> new ImageData(1, 1, 1, new PaletteData(new RGB(0, 0, 0)), 1, null));
+	assertThrows(IllegalArgumentException.class, () -> new ImageData(1, 1, 1, new PaletteData(new RGB(0, 0, 0)), 1, null));
 
-	assertThrows("No exception thrown for data array too small", IllegalArgumentException.class,
-		() ->new ImageData(1, 1, 1, new PaletteData(new RGB(0, 0, 0)), 1, new byte[] {}));
+	assertThrows(IllegalArgumentException.class, () ->new ImageData(1, 1, 1, new PaletteData(new RGB(0, 0, 0)), 1, new byte[] {}));
 
-	assertThrows("No exception thrown for data array too small", IllegalArgumentException.class,
-		() -> new ImageData(1, 1, 16, new PaletteData(new RGB(0, 0, 0)), 1, new byte[] {0x4f}));
+	assertThrows(IllegalArgumentException.class, () -> new ImageData(1, 1, 16, new PaletteData(new RGB(0, 0, 0)), 1, new byte[] {0x4f}));
 
-	assertThrows("No exception thrown for data array too small", IllegalArgumentException.class,
-		() -> new ImageData(1, 1, 32, new PaletteData(new RGB(0, 0, 0)), 1, new byte[] {0x4f, 0x4f}));
+	assertThrows(IllegalArgumentException.class, () -> new ImageData(1, 1, 32, new PaletteData(new RGB(0, 0, 0)), 1, new byte[] {0x4f, 0x4f}));
 
-	assertThrows("No exception thrown for data array too small", IllegalArgumentException.class,
-		() ->new ImageData(2, 2, 8, new PaletteData(new RGB(0, 0, 0)), 1, new byte[] {0x4f, 0x4f, 0x4f}));
+	assertThrows(IllegalArgumentException.class, () ->new ImageData(2, 2, 8, new PaletteData(new RGB(0, 0, 0)), 1, new byte[] {0x4f, 0x4f, 0x4f}));
 
-	assertThrows("No exception thrown for unsupported depth", IllegalArgumentException.class,
-		() -> new ImageData(1, 1, 3, new PaletteData(new RGB(0, 0, 0)), 1, validData));
+	assertThrows(IllegalArgumentException.class, () -> new ImageData(1, 1, 3, new PaletteData(new RGB(0, 0, 0)), 1, validData));
 
 	// verify all valid depths
 	int[] validDepths = {1, 2, 4, 8, 16, 24, 32};
@@ -205,18 +192,16 @@ public void test_ConstructorIIILorg_eclipse_swt_graphics_PaletteDataI$B() {
 	}
 
 	// verify no divide by zero exception if scanlinePad == 0
-	assertThrows("No exception thrown for scanlinePad == 0", IllegalArgumentException.class,
-		() -> new ImageData(1, 1, 8, new PaletteData(new RGB(0, 0, 0)), 0, validData));
+	assertThrows(IllegalArgumentException.class, () -> new ImageData(1, 1, 8, new PaletteData(new RGB(0, 0, 0)), 0, validData));
 }
 
 @Test
 public void test_ConstructorLjava_io_InputStream() throws IOException {
 		InputStream stream = null;
-		assertThrows("No exception thrown for InputStream == null", IllegalArgumentException.class,
-				() -> new ImageData(stream));
+		assertThrows(IllegalArgumentException.class, () -> new ImageData(stream));
 
 		try (InputStream stream1 = SwtTestUtil.class.getResourceAsStream("empty.txt")){
-			assertThrows("No exception thrown for invalid InputStream", SWTException.class, () ->new ImageData(stream1));
+			assertThrows(SWTException.class, () ->new ImageData(stream1));
 		}
 
 		String fileName = SwtTestUtil.imageFilenames[0];
@@ -230,8 +215,7 @@ public void test_ConstructorLjava_io_InputStream() throws IOException {
 @Test
 public void test_ConstructorLjava_lang_String() {
 	String filename = null;
-	assertThrows("No exception thrown for filename == null", IllegalArgumentException.class,
-			() -> new ImageData(filename));
+	assertThrows(IllegalArgumentException.class, () -> new ImageData(filename));
 }
 
 @Test
@@ -240,23 +224,23 @@ public void test_clone() throws IOException {
 		ImageData data1 = new ImageData(stream);
 		ImageData data2 = (ImageData) data1.clone();
 		// imageData does not implement an equals(Object) method
-		assertEquals(":a:", data1.alpha, data2.alpha);
-		assertArrayEquals(":b:", data1.alphaData, data2.alphaData);
-		assertEquals(":c:", data1.bytesPerLine, data2.bytesPerLine);
-		assertArrayEquals(":d:", data1.data, data2.data);
-		assertEquals(":e:", data1.delayTime, data2.delayTime);
-		assertEquals(":f:", data1.depth, data2.depth);
-		assertEquals(":g:", data1.disposalMethod, data2.disposalMethod);
-		assertEquals(":h:", data1.height, data2.height);
-		assertArrayEquals(":i:", data1.maskData, data2.maskData);
-		assertEquals(":j:", data1.maskPad, data2.maskPad);
-		assertEquals(":k:", data1.palette, data2.palette);
-		assertEquals(":l:", data1.scanlinePad, data2.scanlinePad);
-		assertEquals(":m:", data1.transparentPixel, data2.transparentPixel);
-		assertEquals(":n:", data1.type, data2.type);
-		assertEquals(":o:", data1.width, data2.width);
-		assertEquals(":p:", data1.x, data2.x);
-		assertEquals(":q:", data1.y, data2.y);
+		assertEquals(data1.alpha, data2.alpha);
+		assertArrayEquals(data1.alphaData, data2.alphaData);
+		assertEquals(data1.bytesPerLine, data2.bytesPerLine);
+		assertArrayEquals(data1.data, data2.data);
+		assertEquals(data1.delayTime, data2.delayTime);
+		assertEquals(data1.depth, data2.depth);
+		assertEquals(data1.disposalMethod, data2.disposalMethod);
+		assertEquals(data1.height, data2.height);
+		assertArrayEquals(data1.maskData, data2.maskData);
+		assertEquals(data1.maskPad, data2.maskPad);
+		assertEquals(data1.palette, data2.palette);
+		assertEquals(data1.scanlinePad, data2.scanlinePad);
+		assertEquals(data1.transparentPixel, data2.transparentPixel);
+		assertEquals(data1.type, data2.type);
+		assertEquals(data1.width, data2.width);
+		assertEquals(data1.x, data2.x);
+		assertEquals(data1.y, data2.y);
 	}
 }
 
@@ -264,23 +248,19 @@ public void test_clone() throws IOException {
 public void test_getAlphaII() {
 	int value;
 
-	assertEquals(":a:", 255, imageData.getAlpha(0, 0));
+	assertEquals(255, imageData.getAlpha(0, 0));
 	value = 0xAA;
 	imageData.setAlpha(0, 0, value);
-	assertEquals(":b:", value, imageData.getAlpha(0, 0));
+	assertEquals(value, imageData.getAlpha(0, 0));
 
 	// exception cases
-	IllegalArgumentException ex = assertThrows("No exception thrown for x out of bounds",
-			IllegalArgumentException.class, () -> imageData.getAlpha(-1, 1));
+	IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () -> imageData.getAlpha(-1, 1));
 	assertSWTProblem("Incorrect exception thrown for x out of bounds", SWT.ERROR_INVALID_ARGUMENT, ex);
-	ex = assertThrows("No exception thrown for x out of bounds", IllegalArgumentException.class,
-			() -> imageData.getAlpha(IMAGE_DIMENSION, 1));
+	ex = assertThrows(IllegalArgumentException.class, () -> imageData.getAlpha(IMAGE_DIMENSION, 1));
 	assertSWTProblem("Incorrect exception thrown for x out of bounds", SWT.ERROR_INVALID_ARGUMENT, ex);
-	ex = assertThrows("No exception thrown for y out of bounds",
-			IllegalArgumentException.class, () -> imageData.getAlpha(0, -1));
+	ex = assertThrows(IllegalArgumentException.class, () -> imageData.getAlpha(0, -1));
 	assertSWTProblem("Incorrect exception thrown for y out of bounds", SWT.ERROR_INVALID_ARGUMENT, ex);
-	ex = assertThrows("No exception thrown for y out of bounds", IllegalArgumentException.class,
-			() -> imageData.getAlpha(0, IMAGE_DIMENSION));
+	ex = assertThrows(IllegalArgumentException.class, () -> imageData.getAlpha(0, IMAGE_DIMENSION));
 	assertSWTProblem("Incorrect exception thrown for y out of bounds", SWT.ERROR_INVALID_ARGUMENT, ex);
 }
 
@@ -295,9 +275,9 @@ public void test_getAlphasIII$BI() {
 	imageData.getAlphas(0, 1, GET_WIDTH, alphaData, OFFSET);
 	for (int i = 0; i < alphaData.length; i ++) {
 		if (i < OFFSET) {
-			assertEquals(":a:", 0, alphaData[i]);
+			assertEquals(0, alphaData[i]);
 		} else {
-			assertEquals(":b:", (byte) 255, alphaData[i]);
+			assertEquals((byte) 255, alphaData[i]);
 		}
 	}
 
@@ -307,34 +287,27 @@ public void test_getAlphasIII$BI() {
 	imageData.getAlphas(0, 1, GET_WIDTH, alphaData, OFFSET);
 	for (int i = 0; i < alphaData.length; i++) {
 		if (i < OFFSET) {
-			assertEquals(":c:", 0, alphaData[i]);
+			assertEquals(0, alphaData[i]);
 		} else if (i < OFFSET + values.length) {
-			assertEquals(":d:", values[i-OFFSET], alphaData[i]);
+			assertEquals(values[i-OFFSET], alphaData[i]);
 		} else if (i < OFFSET+GET_WIDTH) {
-			assertEquals(":e:", 0, alphaData[i]);
+			assertEquals(0, alphaData[i]);
 		}
 	}
 
 	// exception cases
-	assertThrows("No exception thrown for getWidth out of bounds", IndexOutOfBoundsException.class,
-		() -> imageData.getAlphas(0, 1, GET_WIDTH*GET_WIDTH, alphaData, OFFSET));
-	IllegalArgumentException ex = assertThrows("No exception thrown for alphas == null", IllegalArgumentException.class,
-			() -> imageData.getAlphas(0, 1, GET_WIDTH, (byte[]) null, OFFSET));
+	assertThrows(IndexOutOfBoundsException.class, () -> imageData.getAlphas(0, 1, GET_WIDTH*GET_WIDTH, alphaData, OFFSET));
+	IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () -> imageData.getAlphas(0, 1, GET_WIDTH, (byte[]) null, OFFSET));
 	assertSWTProblem("Incorrect exception thrown for alphas == null", SWT.ERROR_NULL_ARGUMENT, ex);
-	ex = assertThrows("No exception thrown for x out of bounds", IllegalArgumentException.class,
-		() -> imageData.getAlphas(-1, 1, GET_WIDTH, alphaData, OFFSET));
+	ex = assertThrows(IllegalArgumentException.class, () -> imageData.getAlphas(-1, 1, GET_WIDTH, alphaData, OFFSET));
 	assertSWTProblem("Incorrect exception thrown for x out of bounds", SWT.ERROR_INVALID_ARGUMENT, ex);
-	ex = assertThrows("No exception thrown for x out of bounds", IllegalArgumentException.class,
-		() ->imageData.getAlphas(IMAGE_DIMENSION, 1, GET_WIDTH, alphaData, OFFSET));
+	ex = assertThrows(IllegalArgumentException.class, () ->imageData.getAlphas(IMAGE_DIMENSION, 1, GET_WIDTH, alphaData, OFFSET));
 	assertSWTProblem("Incorrect exception thrown for x out of bounds", SWT.ERROR_INVALID_ARGUMENT, ex);
-	ex = assertThrows("No exception thrown for y out of bounds", IllegalArgumentException.class,
-		() -> imageData.getAlphas(0, -1, GET_WIDTH, alphaData, OFFSET));
+	ex = assertThrows(IllegalArgumentException.class, () -> imageData.getAlphas(0, -1, GET_WIDTH, alphaData, OFFSET));
 	assertSWTProblem("Incorrect exception thrown for y out of bounds", SWT.ERROR_INVALID_ARGUMENT, ex);
-	ex = assertThrows("No exception thrown for y out of bounds", IllegalArgumentException.class,
-		() -> imageData.getAlphas(0, IMAGE_DIMENSION, GET_WIDTH, alphaData, OFFSET));
+	ex = assertThrows(IllegalArgumentException.class, () -> imageData.getAlphas(0, IMAGE_DIMENSION, GET_WIDTH, alphaData, OFFSET));
 		assertSWTProblem("Incorrect exception thrown for y out of bounds", SWT.ERROR_INVALID_ARGUMENT, ex);
-	ex = assertThrows("No exception thrown for getWidth < 0", IllegalArgumentException.class,
-			() -> imageData.getAlphas(0, 1, -1, alphaData, OFFSET));
+	ex = assertThrows(IllegalArgumentException.class, () -> imageData.getAlphas(0, 1, -1, alphaData, OFFSET));
 	assertSWTProblem("Incorrect exception thrown for getWidth < 0", SWT.ERROR_INVALID_ARGUMENT, ex);
 }
 
@@ -342,23 +315,19 @@ public void test_getAlphasIII$BI() {
 public void test_getPixelII() {
 	int value;
 
-	assertEquals(":a:", 0, imageData.getPixel(0, 0));
+	assertEquals(0, imageData.getPixel(0, 0));
 	value = 0xAA;
 	imageData.setPixel(0, 0, value);
-	assertEquals(":b:", value, imageData.getPixel(0, 0));
+	assertEquals(value, imageData.getPixel(0, 0));
 
 	// exception cases
-	IllegalArgumentException ex = assertThrows("No exception thrown for x out of bounds", IllegalArgumentException.class,
-		() -> imageData.getPixel(-1, 1));
+	IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () -> imageData.getPixel(-1, 1));
 	assertSWTProblem("Incorrect exception thrown for x out of bounds", SWT.ERROR_INVALID_ARGUMENT, ex);
-	ex = assertThrows("No exception thrown for x out of bounds", IllegalArgumentException.class,
-		() ->imageData.getPixel(IMAGE_DIMENSION, 1));
+	ex = assertThrows(IllegalArgumentException.class, () ->imageData.getPixel(IMAGE_DIMENSION, 1));
 	assertSWTProblem("Incorrect exception thrown for x out of bounds", SWT.ERROR_INVALID_ARGUMENT, ex);
-	ex = assertThrows("No exception thrown for y out of bounds", IllegalArgumentException.class,
-		() -> imageData.getPixel(0, -1));
+	ex = assertThrows(IllegalArgumentException.class, () -> imageData.getPixel(0, -1));
 	assertSWTProblem("Incorrect exception thrown for y out of bounds", SWT.ERROR_INVALID_ARGUMENT, ex);
-	ex = assertThrows("No exception thrown for y out of bounds", IllegalArgumentException.class,
-		() -> imageData.getPixel(0, IMAGE_DIMENSION));
+	ex = assertThrows(IllegalArgumentException.class, () -> imageData.getPixel(0, IMAGE_DIMENSION));
 	assertSWTProblem("Incorrect exception thrown for y out of bounds", SWT.ERROR_INVALID_ARGUMENT, ex);
 	int width = 3;
 	int height = 3;
@@ -369,7 +338,7 @@ public void test_getPixelII() {
 	for (int y = 0; y < height; y++) {
 		for (int x = 0; x < width; x++) {
 			int pixel = imageData.getPixel(x, y);
-			assertEquals("Bad pixel data", pixelValue, pixel);
+			assertEquals(pixelValue, pixel);
 		}
 	}
 }
@@ -385,7 +354,7 @@ public void test_getPixelsIII$BI() {
 	imageData = new ImageData(IMAGE_DIMENSION, IMAGE_DIMENSION, 1, new PaletteData(new RGB(0, 0, 0), new RGB(255, 255, 255)));
 	imageData.getPixels(0, 1, GET_WIDTH, pixelData, OFFSET);
 	for (byte b : pixelData) {
-		assertEquals(":a:", 0, b);
+		assertEquals(0, b);
 	}
 
 	byte[] values = new byte[]{0x1, 0x1, 0x1, 0x1, 0x1};
@@ -393,11 +362,11 @@ public void test_getPixelsIII$BI() {
 	imageData.getPixels(0, 1, GET_WIDTH, pixelData, OFFSET);
 	for (int i = 0; i < pixelData.length; i++) {
 		if (i < OFFSET) {
-			assertEquals(":b:", 0, pixelData[i]);
+			assertEquals(0, pixelData[i]);
 		} else if (i < OFFSET + values.length) {
-			assertEquals(":c:", values[i-OFFSET], pixelData[i]);
+			assertEquals(values[i-OFFSET], pixelData[i]);
 		} else if (i < OFFSET+GET_WIDTH) {
-			assertEquals(":d:", 0, pixelData[i]);
+			assertEquals(0, pixelData[i]);
 		}
 	}
 
@@ -405,7 +374,7 @@ public void test_getPixelsIII$BI() {
 	imageData = new ImageData(IMAGE_DIMENSION, IMAGE_DIMENSION, 2, new PaletteData(new RGB(0, 0, 0), new RGB(255, 255, 255)));
 	imageData.getPixels(0, 1, GET_WIDTH, pixelData, OFFSET);
 	for (byte b : pixelData) {
-		assertEquals(":e:", 0, b);
+		assertEquals(0, b);
 	}
 
 	values = new byte[]{0x1, 0x2, 0x3, 0x2, 0x1};
@@ -413,11 +382,11 @@ public void test_getPixelsIII$BI() {
 	imageData.getPixels(0, 1, GET_WIDTH, pixelData, OFFSET);
 	for (int i = 0; i < pixelData.length; i++) {
 		if (i < OFFSET) {
-			assertEquals(":f:", 0, pixelData[i]);
+			assertEquals(0, pixelData[i]);
 		} else if (i < OFFSET + values.length) {
-			assertEquals(":g:", values[i-OFFSET], pixelData[i]);
+			assertEquals(values[i-OFFSET], pixelData[i]);
 		} else if (i < OFFSET+GET_WIDTH) {
-			assertEquals(":h:", 0, pixelData[i]);
+			assertEquals(0, pixelData[i]);
 		}
 	}
 
@@ -425,7 +394,7 @@ public void test_getPixelsIII$BI() {
 	imageData = new ImageData(IMAGE_DIMENSION, IMAGE_DIMENSION, 4, new PaletteData(new RGB(0, 0, 0), new RGB(255, 255, 255)));
 	imageData.getPixels(0, 1, GET_WIDTH, pixelData, OFFSET);
 	for (byte b : pixelData) {
-		assertEquals(":i:", 0, b);
+		assertEquals(0, b);
 	}
 
 	values = new byte[]{0x1, 0x2, 0x3, 0x4, 0xF};
@@ -433,11 +402,11 @@ public void test_getPixelsIII$BI() {
 	imageData.getPixels(0, 1, GET_WIDTH, pixelData, OFFSET);
 	for (int i = 0; i < pixelData.length; i++) {
 		if (i < OFFSET) {
-			assertEquals(":j:", 0, pixelData[i]);
+			assertEquals(0, pixelData[i]);
 		} else if (i < OFFSET + values.length) {
-			assertEquals(":k:", values[i-OFFSET], pixelData[i]);
+			assertEquals(values[i-OFFSET], pixelData[i]);
 		} else if (i < OFFSET+GET_WIDTH) {
-			assertEquals(":l:", 0, pixelData[i]);
+			assertEquals(0, pixelData[i]);
 		}
 	}
 
@@ -445,7 +414,7 @@ public void test_getPixelsIII$BI() {
 	imageData = new ImageData(IMAGE_DIMENSION, IMAGE_DIMENSION, 8, new PaletteData(new RGB(0, 0, 0), new RGB(255, 255, 255)));
 	imageData.getPixels(0, 1, GET_WIDTH, pixelData, OFFSET);
 	for (byte b : pixelData) {
-		assertEquals(":m:", 0, b);
+		assertEquals(0, b);
 	}
 
 	values = new byte[]{0x1, 0x2, 0x3, 0xF, (byte)0xFF};
@@ -453,38 +422,30 @@ public void test_getPixelsIII$BI() {
 	imageData.getPixels(0, 1, GET_WIDTH, pixelData, OFFSET);
 	for (int i = 0; i < pixelData.length; i++) {
 		if (i < OFFSET) {
-			assertEquals(":n:", 0, pixelData[i]);
+			assertEquals(0, pixelData[i]);
 		} else if (i < OFFSET + values.length) {
-			assertEquals(":o:", values[i-OFFSET], pixelData[i]);
+			assertEquals(values[i-OFFSET], pixelData[i]);
 		} else if (i < OFFSET+GET_WIDTH) {
-			assertEquals(":p:", 0, pixelData[i]);
+			assertEquals(0, pixelData[i]);
 		}
 	}
 
 	// exception cases
-	assertThrows("No exception thrown for getWidth out of bounds", IndexOutOfBoundsException.class,
-		() -> imageData.getPixels(0, 1, GET_WIDTH*GET_WIDTH, pixelData, OFFSET));
-	IllegalArgumentException ex = assertThrows("No exception thrown for pixels == null", IllegalArgumentException.class,
-		() -> imageData.getPixels(0, 1, GET_WIDTH, (byte[]) null, OFFSET));
+	assertThrows(IndexOutOfBoundsException.class, () -> imageData.getPixels(0, 1, GET_WIDTH*GET_WIDTH, pixelData, OFFSET));
+	IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () -> imageData.getPixels(0, 1, GET_WIDTH, (byte[]) null, OFFSET));
 	assertSWTProblem("Incorrect exception thrown for pixels == null", SWT.ERROR_NULL_ARGUMENT, ex);
-	ex = assertThrows("No exception thrown for x out of bounds", IllegalArgumentException.class,
-		()->imageData.getPixels(-1, 1, GET_WIDTH, pixelData, OFFSET));
+	ex = assertThrows(IllegalArgumentException.class, ()->imageData.getPixels(-1, 1, GET_WIDTH, pixelData, OFFSET));
 	assertSWTProblem("Incorrect exception thrown for x out of bounds", SWT.ERROR_INVALID_ARGUMENT, ex);
-	ex = assertThrows("No exception thrown for x out of bounds", IllegalArgumentException.class,
-		() -> imageData.getPixels(IMAGE_DIMENSION, 1, GET_WIDTH, pixelData, OFFSET));
+	ex = assertThrows(IllegalArgumentException.class, () -> imageData.getPixels(IMAGE_DIMENSION, 1, GET_WIDTH, pixelData, OFFSET));
 	assertSWTProblem("Incorrect exception thrown for x out of bounds", SWT.ERROR_INVALID_ARGUMENT, ex);
-	ex = assertThrows("No exception thrown for y out of bounds", IllegalArgumentException.class,
-		() -> imageData.getPixels(0, -1, GET_WIDTH, pixelData, OFFSET));
+	ex = assertThrows(IllegalArgumentException.class, () -> imageData.getPixels(0, -1, GET_WIDTH, pixelData, OFFSET));
 	assertSWTProblem("Incorrect exception thrown for y out of bounds", SWT.ERROR_INVALID_ARGUMENT, ex);
-	ex = assertThrows("No exception thrown for y out of bounds", IllegalArgumentException.class,
-		() -> imageData.getPixels(0, IMAGE_DIMENSION, GET_WIDTH, pixelData, OFFSET));
+	ex = assertThrows(IllegalArgumentException.class, () -> imageData.getPixels(0, IMAGE_DIMENSION, GET_WIDTH, pixelData, OFFSET));
 	assertSWTProblem("Incorrect exception thrown for y out of bounds", SWT.ERROR_INVALID_ARGUMENT, ex);
-	ex = assertThrows("No exception thrown for getWidth < 0", IllegalArgumentException.class,
-		() -> imageData.getPixels(0, 1, -1, pixelData, OFFSET));
+	ex = assertThrows(IllegalArgumentException.class, () -> imageData.getPixels(0, 1, -1, pixelData, OFFSET));
 	assertSWTProblem("Incorrect exception thrown for getWidth < 0", SWT.ERROR_INVALID_ARGUMENT, ex);
 	imageData = new ImageData(IMAGE_DIMENSION, IMAGE_DIMENSION, 32, new PaletteData(0xFF0000, 0xFF00, 0xFF));
-	SWTException swtEx = assertThrows("No exception thrown for invalid depth", SWTException.class,
-		() -> imageData.getPixels(0, 1, GET_WIDTH, pixelData, OFFSET));
+	SWTException swtEx = assertThrows(SWTException.class, () -> imageData.getPixels(0, 1, GET_WIDTH, pixelData, OFFSET));
 	assertSWTProblem("Incorrect exception thrown for invalid depth", SWT.ERROR_UNSUPPORTED_DEPTH, swtEx);
 }
 
@@ -499,7 +460,7 @@ public void test_getPixelsIII$II() {
 	imageData = new ImageData(IMAGE_DIMENSION, IMAGE_DIMENSION, 1, new PaletteData(new RGB(0, 0, 0), new RGB(255, 255, 255)));
 	imageData.getPixels(0, 1, GET_WIDTH, pixelData, OFFSET);
 	for (int data : pixelData) {
-		assertEquals(":a:", 0, data);
+		assertEquals(0, data);
 	}
 
 	int[] values = new int[]{0x1, 0x1, 0x1, 0x1, 0x1};
@@ -507,11 +468,11 @@ public void test_getPixelsIII$II() {
 	imageData.getPixels(0, 1, GET_WIDTH, pixelData, OFFSET);
 	for (int i = 0; i < pixelData.length; i++) {
 		if (i < OFFSET) {
-			assertEquals(":b:", 0, pixelData[i]);
+			assertEquals(0, pixelData[i]);
 		} else if (i < OFFSET + values.length) {
-			assertEquals(":c:", values[i-OFFSET], pixelData[i]);
+			assertEquals(values[i-OFFSET], pixelData[i]);
 		} else if (i < OFFSET+GET_WIDTH) {
-			assertEquals(":d:", 0, pixelData[i]);
+			assertEquals(0, pixelData[i]);
 		}
 	}
 
@@ -519,7 +480,7 @@ public void test_getPixelsIII$II() {
 	imageData = new ImageData(IMAGE_DIMENSION, IMAGE_DIMENSION, 2, new PaletteData(new RGB(0, 0, 0), new RGB(255, 255, 255)));
 	imageData.getPixels(0, 1, GET_WIDTH, pixelData, OFFSET);
 	for (int data : pixelData) {
-		assertEquals(":e:", 0, data);
+		assertEquals(0, data);
 	}
 
 	values = new int[]{0x1, 0x2, 0x3, 0x2, 0x1};
@@ -527,11 +488,11 @@ public void test_getPixelsIII$II() {
 	imageData.getPixels(0, 1, GET_WIDTH, pixelData, OFFSET);
 	for (int i = 0; i < pixelData.length; i++) {
 		if (i < OFFSET) {
-			assertEquals(":f:", 0, pixelData[i]);
+			assertEquals(0, pixelData[i]);
 		} else if (i < OFFSET + values.length) {
-			assertEquals(":g:", values[i-OFFSET], pixelData[i]);
+			assertEquals(values[i-OFFSET], pixelData[i]);
 		} else if (i < OFFSET+GET_WIDTH) {
-			assertEquals(":h:", 0, pixelData[i]);
+			assertEquals(0, pixelData[i]);
 		}
 	}
 
@@ -539,7 +500,7 @@ public void test_getPixelsIII$II() {
 	imageData = new ImageData(IMAGE_DIMENSION, IMAGE_DIMENSION, 4, new PaletteData(new RGB(0, 0, 0), new RGB(255, 255, 255)));
 	imageData.getPixels(0, 1, GET_WIDTH, pixelData, OFFSET);
 	for (int data : pixelData) {
-		assertEquals(":i:", 0, data);
+		assertEquals(0, data);
 	}
 
 	values = new int[]{0x1, 0x2, 0x3, 0x4, 0xF};
@@ -547,11 +508,11 @@ public void test_getPixelsIII$II() {
 	imageData.getPixels(0, 1, GET_WIDTH, pixelData, OFFSET);
 	for (int i = 0; i < pixelData.length; i++) {
 		if (i < OFFSET) {
-			assertEquals(":j:", 0, pixelData[i]);
+			assertEquals(0, pixelData[i]);
 		} else if (i < OFFSET + values.length) {
-			assertEquals(":k:", values[i-OFFSET], pixelData[i]);
+			assertEquals(values[i-OFFSET], pixelData[i]);
 		} else if (i < OFFSET+GET_WIDTH) {
-			assertEquals(":l:", 0, pixelData[i]);
+			assertEquals(0, pixelData[i]);
 		}
 	}
 
@@ -559,7 +520,7 @@ public void test_getPixelsIII$II() {
 	imageData = new ImageData(IMAGE_DIMENSION, IMAGE_DIMENSION, 8, new PaletteData(new RGB(0, 0, 0), new RGB(255, 255, 255)));
 	imageData.getPixels(0, 1, GET_WIDTH, pixelData, OFFSET);
 	for (int data : pixelData) {
-		assertEquals(":m:", 0, data);
+		assertEquals(0, data);
 	}
 
 	values = new int[]{0x1, 0x2, 0x3, 0xF, 0xFF};
@@ -567,11 +528,11 @@ public void test_getPixelsIII$II() {
 	imageData.getPixels(0, 1, GET_WIDTH, pixelData, OFFSET);
 	for (int i = 0; i < pixelData.length; i++) {
 		if (i < OFFSET) {
-			assertEquals(":n:", 0, pixelData[i]);
+			assertEquals(0, pixelData[i]);
 		} else if (i < OFFSET + values.length) {
-			assertEquals(":o:", values[i-OFFSET], pixelData[i]);
+			assertEquals(values[i-OFFSET], pixelData[i]);
 		} else if (i < OFFSET+GET_WIDTH) {
-			assertEquals(":p:", 0, pixelData[i]);
+			assertEquals(0, pixelData[i]);
 		}
 	}
 
@@ -579,7 +540,7 @@ public void test_getPixelsIII$II() {
 	imageData = new ImageData(IMAGE_DIMENSION, IMAGE_DIMENSION, 16, new PaletteData(0xF800, 0x7E0, 0x1F));
 	imageData.getPixels(0, 1, GET_WIDTH, pixelData, OFFSET);
 	for (int data : pixelData) {
-		assertEquals(":q:", 0, data);
+		assertEquals(0, data);
 	}
 
 	values = new int[]{0, 0x2, 0xF, 0xFF, 0xFFAA};
@@ -587,11 +548,11 @@ public void test_getPixelsIII$II() {
 	imageData.getPixels(0, 1, GET_WIDTH, pixelData, OFFSET);
 	for (int i = 0; i < pixelData.length; i++) {
 		if (i < OFFSET) {
-			assertEquals(":r:", 0, pixelData[i]);
+			assertEquals(0, pixelData[i]);
 		} else if (i < OFFSET + values.length) {
-			assertEquals(":s:", values[i-OFFSET], pixelData[i]);
+			assertEquals(values[i-OFFSET], pixelData[i]);
 		} else if (i < OFFSET+GET_WIDTH) {
-			assertEquals(":t:", 0, pixelData[i]);
+			assertEquals(0, pixelData[i]);
 		}
 	}
 
@@ -599,7 +560,7 @@ public void test_getPixelsIII$II() {
 	imageData = new ImageData(IMAGE_DIMENSION, IMAGE_DIMENSION, 24, new PaletteData(0xFF0000, 0xFF00, 0xFF));
 	imageData.getPixels(0, 1, GET_WIDTH, pixelData, OFFSET);
 	for (int data : pixelData) {
-		assertEquals(":u:", 0, data);
+		assertEquals(0, data);
 	}
 
 	values = new int[]{0, 0xFF, 0xFFAA, 0xFF00AA};
@@ -607,11 +568,11 @@ public void test_getPixelsIII$II() {
 	imageData.getPixels(0, 1, GET_WIDTH, pixelData, OFFSET);
 	for (int i = 0; i < pixelData.length; i++) {
 		if (i < OFFSET) {
-			assertEquals(":v:", 0, pixelData[i]);
+			assertEquals(0, pixelData[i]);
 		} else if (i < OFFSET + values.length) {
-			assertEquals(":w:", values[i-OFFSET], pixelData[i]);
+			assertEquals(values[i-OFFSET], pixelData[i]);
 		} else if (i < OFFSET+GET_WIDTH) {
-			assertEquals(":x:", 0, pixelData[i]);
+			assertEquals(0, pixelData[i]);
 		}
 	}
 
@@ -619,7 +580,7 @@ public void test_getPixelsIII$II() {
 	imageData = new ImageData(IMAGE_DIMENSION, IMAGE_DIMENSION, 32, new PaletteData(0xFF000000, 0xFF00, 0xFF));
 	imageData.getPixels(0, 1, GET_WIDTH, pixelData, OFFSET);
 	for (int data : pixelData) {
-		assertEquals(":y:", 0, data);
+		assertEquals(0, data);
 	}
 
 	values = new int[]{0, 0xFF, 0xFFAA, 0xFF00AA00};
@@ -627,43 +588,36 @@ public void test_getPixelsIII$II() {
 	imageData.getPixels(0, 1, GET_WIDTH, pixelData, OFFSET);
 	for (int i = 0; i < pixelData.length; i++) {
 		if (i < OFFSET) {
-			assertEquals(":z:", 0, pixelData[i]);
+			assertEquals(0, pixelData[i]);
 		} else if (i < OFFSET + values.length) {
-			assertEquals(":aa:", values[i-OFFSET], pixelData[i]);
+			assertEquals(values[i-OFFSET], pixelData[i]);
 		} else if (i < OFFSET+GET_WIDTH) {
-			assertEquals(":ab:", 0, pixelData[i]);
+			assertEquals(0, pixelData[i]);
 		}
 	}
 
 	// exception cases
-	assertThrows("No exception thrown for getWidth out of bounds", IndexOutOfBoundsException.class,
-		() -> imageData.getPixels(0, 1, GET_WIDTH*GET_WIDTH, pixelData, OFFSET));
-	IllegalArgumentException ex = assertThrows("No exception thrown for pixels == null", IllegalArgumentException.class,
-		() -> imageData.getPixels(0, 1, GET_WIDTH, (int[]) null, OFFSET));
+	assertThrows(IndexOutOfBoundsException.class, () -> imageData.getPixels(0, 1, GET_WIDTH*GET_WIDTH, pixelData, OFFSET));
+	IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () -> imageData.getPixels(0, 1, GET_WIDTH, (int[]) null, OFFSET));
 	assertSWTProblem("Incorrect exception thrown for pixels == null", SWT.ERROR_NULL_ARGUMENT, ex);
-	ex = assertThrows("No exception thrown for x out of bounds", IllegalArgumentException.class,
-		() -> imageData.getPixels(-1, 1, GET_WIDTH, pixelData, OFFSET));
+	ex = assertThrows(IllegalArgumentException.class, () -> imageData.getPixels(-1, 1, GET_WIDTH, pixelData, OFFSET));
 	assertSWTProblem("Incorrect exception thrown for x out of bounds", SWT.ERROR_INVALID_ARGUMENT, ex);
-	ex = assertThrows("No exception thrown for x out of bounds", IllegalArgumentException.class,
-		() -> imageData.getPixels(IMAGE_DIMENSION, 1, GET_WIDTH, pixelData, OFFSET));
+	ex = assertThrows(IllegalArgumentException.class, () -> imageData.getPixels(IMAGE_DIMENSION, 1, GET_WIDTH, pixelData, OFFSET));
 		assertSWTProblem("Incorrect exception thrown for x out of bounds", SWT.ERROR_INVALID_ARGUMENT, ex);
-	ex = assertThrows("No exception thrown for y out of bounds", IllegalArgumentException.class,
-		()-> imageData.getPixels(0, -1, GET_WIDTH, pixelData, OFFSET));
+	ex = assertThrows(IllegalArgumentException.class, ()-> imageData.getPixels(0, -1, GET_WIDTH, pixelData, OFFSET));
 	assertSWTProblem("Incorrect exception thrown for y out of bounds", SWT.ERROR_INVALID_ARGUMENT, ex);
-	ex = assertThrows("No exception thrown for y out of bounds", IllegalArgumentException.class,
-		() -> imageData.getPixels(0, IMAGE_DIMENSION, GET_WIDTH, pixelData, OFFSET));
+	ex = assertThrows(IllegalArgumentException.class, () -> imageData.getPixels(0, IMAGE_DIMENSION, GET_WIDTH, pixelData, OFFSET));
 	assertSWTProblem("Incorrect exception thrown for y out of bounds", SWT.ERROR_INVALID_ARGUMENT, ex);
-	ex = assertThrows("No exception thrown for getWidth < 0", IllegalArgumentException.class,
-		() -> imageData.getPixels(0, 1, -1, pixelData, OFFSET));
+	ex = assertThrows(IllegalArgumentException.class, () -> imageData.getPixels(0, 1, -1, pixelData, OFFSET));
 	assertSWTProblem("Incorrect exception thrown for getWidth < 0", SWT.ERROR_INVALID_ARGUMENT, ex);
 }
 
 @Test
 public void test_getRGBs() {
-	assertNull(":a:", imageData.getRGBs());
+	assertNull(imageData.getRGBs());
 	RGB[] rgbs = new RGB[]{new RGB(0, 0, 0), new RGB(255, 255, 255)};
 	imageData = new ImageData(IMAGE_DIMENSION, IMAGE_DIMENSION, 8, new PaletteData(rgbs));
-	assertArrayEquals(":b:", rgbs, imageData.getRGBs());
+	assertArrayEquals(rgbs, imageData.getRGBs());
 }
 
 @Test
@@ -675,7 +629,7 @@ public void test_getTransparencyMask() throws IOException {
 		Image image = new Image(Display.getDefault(), stream);
 		imageData = image.getImageData();
 		ImageData maskData = imageData.getTransparencyMask();
-		assertNotNull(":b:", maskData);
+		assertNotNull(maskData);
 		image.dispose();
 	}
 
@@ -689,19 +643,19 @@ public void test_getTransparencyMask() throws IOException {
 
 @Test
 public void test_getTransparencyType() throws IOException {
-	assertEquals(":a:", SWT.TRANSPARENCY_NONE, imageData.getTransparencyType());
+	assertEquals(SWT.TRANSPARENCY_NONE, imageData.getTransparencyType());
 
 	try (InputStream stream = getClass().getResourceAsStream(SwtTestUtil.transparentImageFilenames[0])) {
 		Image image = new Image(Display.getDefault(), stream);
 		imageData = image.getImageData();
-		assertNotEquals(":b:", SWT.TRANSPARENCY_NONE, imageData.getTransparencyType());
+		assertNotEquals(SWT.TRANSPARENCY_NONE, imageData.getTransparencyType());
 		image.dispose();
 	}
 
 	try (InputStream stream = getClass().getResourceAsStream(SwtTestUtil.imageFilenames[0] + '.' + SwtTestUtil.imageFormats[SwtTestUtil.imageFormats.length-1])) {
 		Image image = new Image(Display.getDefault(), stream);
 		imageData = image.getImageData();
-		assertEquals(":c:", SWT.TRANSPARENCY_NONE, imageData.getTransparencyType());
+		assertEquals(SWT.TRANSPARENCY_NONE, imageData.getTransparencyType());
 		image.dispose();
 	}
 }
@@ -719,19 +673,19 @@ public void test_scaledToII() {
 	byte[] scaledPixelData = new byte[imageDimension];
 	scaledImageData.getPixels(0, imageDimension - 1, scaledPixelData.length, scaledPixelData, 0);
 	byte[] expectedPixelData = new byte[] {0x1, 0x1, 0x1, 0x1, 0, 0, 0x1, 0};
-	assertArrayEquals(":a:", expectedPixelData, scaledPixelData);
+	assertArrayEquals(expectedPixelData, scaledPixelData);
 
 	scaledImageData = imageData.scaledTo(imageDimension * 10, imageDimension);
 	scaledPixelData = new byte[imageDimension * 10];
 	scaledImageData.getPixels(0, 0, scaledPixelData.length, scaledPixelData, 0);
-	assertEquals(":b:", 0, scaledPixelData[0]);
-	assertEquals(":c:", 0, scaledPixelData[1]);
+	assertEquals(0, scaledPixelData[0]);
+	assertEquals(0, scaledPixelData[1]);
 
 	scaledImageData = imageData.scaledTo(imageDimension, imageDimension * 10);
 	scaledPixelData = new byte[imageDimension];
 	scaledImageData.getPixels(0, 0, scaledPixelData.length, scaledPixelData, 0);
 	expectedPixelData = new byte[] {0, 0x1, 0, 0, 0x1, 0x1, 0x1, 0x1};
-	assertArrayEquals(":d:", expectedPixelData, scaledPixelData);
+	assertArrayEquals(expectedPixelData, scaledPixelData);
 }
 
 @Test
@@ -740,20 +694,16 @@ public void test_setAlphaIII() {
 
 	value = 0xAA;
 	imageData.setAlpha(0, 0, value);
-	assertEquals(":a:", value, imageData.getAlpha(0, 0));
+	assertEquals(value, imageData.getAlpha(0, 0));
 
 	// exception cases
-	IllegalArgumentException ex = assertThrows("No exception thrown for x out of bounds", IllegalArgumentException.class,
-		() -> imageData.setAlpha(-1, 1, value));
+	IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () -> imageData.setAlpha(-1, 1, value));
 	assertSWTProblem("Incorrect exception thrown for x out of bounds", SWT.ERROR_INVALID_ARGUMENT, ex);
-	ex = assertThrows("No exception thrown for x out of bounds", IllegalArgumentException.class,
-		() -> imageData.setAlpha(IMAGE_DIMENSION, 1, value));
+	ex = assertThrows(IllegalArgumentException.class, () -> imageData.setAlpha(IMAGE_DIMENSION, 1, value));
 	assertSWTProblem("Incorrect exception thrown for x out of bounds", SWT.ERROR_INVALID_ARGUMENT, ex);
-	ex = assertThrows("No exception thrown for y out of bounds", IllegalArgumentException.class,
-		() -> imageData.setAlpha(0, -1, value));
+	ex = assertThrows(IllegalArgumentException.class, () -> imageData.setAlpha(0, -1, value));
 	assertSWTProblem("Incorrect exception thrown for y out of bounds", SWT.ERROR_INVALID_ARGUMENT, ex);
-	ex = assertThrows("No exception thrown for y out of bounds", IllegalArgumentException.class,
-		() -> imageData.setAlpha(0, IMAGE_DIMENSION, value));
+	ex = assertThrows(IllegalArgumentException.class, () -> imageData.setAlpha(0, IMAGE_DIMENSION, value));
 	assertSWTProblem("Incorrect exception thrown for y out of bounds", SWT.ERROR_INVALID_ARGUMENT, ex);
 }
 
@@ -770,32 +720,25 @@ public void test_setAlphasIII$BI() {
 	imageData.getAlphas(0, 1, IMAGE_DIMENSION, alphaData, 0);
 	for (int i = 0; i < alphaData.length; i++) {
 		if (i + OFFSET < values.length) {
-			assertEquals(":a:", values[i + OFFSET], alphaData[i]);
+			assertEquals(values[i + OFFSET], alphaData[i]);
 		} else {
-			assertEquals(":b:", 0, alphaData[i]);
+			assertEquals(0, alphaData[i]);
 		}
 	}
 
 	// exception cases
-	assertThrows("No exception thrown for putWidth out of bounds", IndexOutOfBoundsException.class,
-		() -> imageData.setAlphas(0, 1, IMAGE_DIMENSION*IMAGE_DIMENSION, alphaData, OFFSET));
-	IllegalArgumentException ex = assertThrows("No exception thrown for alphas == null", IllegalArgumentException.class,
-		() -> imageData.setAlphas(0, 1, IMAGE_DIMENSION, (byte[]) null, OFFSET));
+	assertThrows(IndexOutOfBoundsException.class, () -> imageData.setAlphas(0, 1, IMAGE_DIMENSION*IMAGE_DIMENSION, alphaData, OFFSET));
+	IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () -> imageData.setAlphas(0, 1, IMAGE_DIMENSION, (byte[]) null, OFFSET));
 	assertSWTProblem("Incorrect exception thrown for alphas == null", SWT.ERROR_NULL_ARGUMENT, ex);
-	ex = assertThrows("No exception thrown for x out of bounds", IllegalArgumentException.class,
-		() -> imageData.setAlphas(-1, 1, IMAGE_DIMENSION, alphaData, OFFSET));
+	ex = assertThrows(IllegalArgumentException.class, () -> imageData.setAlphas(-1, 1, IMAGE_DIMENSION, alphaData, OFFSET));
 	assertSWTProblem("Incorrect exception thrown for x out of bounds", SWT.ERROR_INVALID_ARGUMENT, ex);
-	ex = assertThrows("No exception thrown for x out of bounds", IllegalArgumentException.class,
-		() -> imageData.setAlphas(IMAGE_DIMENSION, 1, IMAGE_DIMENSION, alphaData, OFFSET));
+	ex = assertThrows(IllegalArgumentException.class, () -> imageData.setAlphas(IMAGE_DIMENSION, 1, IMAGE_DIMENSION, alphaData, OFFSET));
 	assertSWTProblem("Incorrect exception thrown for x out of bounds", SWT.ERROR_INVALID_ARGUMENT, ex);
-	ex = assertThrows("No exception thrown for y out of bounds", IllegalArgumentException.class,
-		() -> imageData.setAlphas(0, -1, IMAGE_DIMENSION, alphaData, OFFSET));
+	ex = assertThrows(IllegalArgumentException.class, () -> imageData.setAlphas(0, -1, IMAGE_DIMENSION, alphaData, OFFSET));
 	assertSWTProblem("Incorrect exception thrown for y out of bounds", SWT.ERROR_INVALID_ARGUMENT, ex);
-	ex = assertThrows("No exception thrown for y out of bounds", IllegalArgumentException.class,
-		() -> imageData.setAlphas(0, IMAGE_DIMENSION, IMAGE_DIMENSION, alphaData, OFFSET));
+	ex = assertThrows(IllegalArgumentException.class, () -> imageData.setAlphas(0, IMAGE_DIMENSION, IMAGE_DIMENSION, alphaData, OFFSET));
 	assertSWTProblem("Incorrect exception thrown for y out of bounds", SWT.ERROR_INVALID_ARGUMENT, ex);
-	ex = assertThrows("No exception thrown for putWidth < 0", IllegalArgumentException.class,
-		() -> imageData.setAlphas(0, 1, -1, alphaData, OFFSET));
+	ex = assertThrows(IllegalArgumentException.class, () -> imageData.setAlphas(0, 1, -1, alphaData, OFFSET));
 	assertSWTProblem("Incorrect exception thrown for putWidth < 0", SWT.ERROR_INVALID_ARGUMENT, ex);
 }
 
@@ -805,20 +748,16 @@ public void test_setPixelIII() {
 
 	value = 0xAA;
 	imageData.setPixel(0, 0, value);
-	assertEquals(":a:", value, imageData.getPixel(0, 0));
+	assertEquals(value, imageData.getPixel(0, 0));
 
 	// exception cases
-	IllegalArgumentException ex = assertThrows("No exception thrown for x out of bounds", IllegalArgumentException.class,
-		() -> imageData.setPixel(-1, 1, value));
+	IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () -> imageData.setPixel(-1, 1, value));
 	assertSWTProblem("Incorrect exception thrown for x out of bounds", SWT.ERROR_INVALID_ARGUMENT, ex);
-	ex = assertThrows("No exception thrown for x out of bounds", IllegalArgumentException.class,
-		() -> imageData.setPixel(IMAGE_DIMENSION, 1, value));
+	ex = assertThrows(IllegalArgumentException.class, () -> imageData.setPixel(IMAGE_DIMENSION, 1, value));
 	assertSWTProblem("Incorrect exception thrown for x out of bounds", SWT.ERROR_INVALID_ARGUMENT, ex);
-	ex = assertThrows("No exception thrown for y out of bounds", IllegalArgumentException.class,
-		() -> imageData.setPixel(0, -1, value));
+	ex = assertThrows(IllegalArgumentException.class, () -> imageData.setPixel(0, -1, value));
 	assertSWTProblem("Incorrect exception thrown for y out of bounds", SWT.ERROR_INVALID_ARGUMENT, ex);
-	ex = assertThrows("No exception thrown for x out of bounds", IllegalArgumentException.class,
-		() -> imageData.setPixel(0, IMAGE_DIMENSION, value));
+	ex = assertThrows(IllegalArgumentException.class, () -> imageData.setPixel(0, IMAGE_DIMENSION, value));
 	assertSWTProblem("Incorrect exception thrown for y out of bounds", SWT.ERROR_INVALID_ARGUMENT, ex);
 }
 
@@ -835,9 +774,9 @@ public void test_setPixelsIII$BI() {
 	imageData.getPixels(0, 1, IMAGE_DIMENSION, pixelData, 0);
 	for (int i = 0; i < pixelData.length; i++) {
 		if (i + OFFSET < values.length) {
-			assertEquals(":a:", values[i + OFFSET], pixelData[i]);
+			assertEquals(values[i + OFFSET], pixelData[i]);
 		} else {
-			assertEquals(":b:", 0, pixelData[i]);
+			assertEquals(0, pixelData[i]);
 		}
 	}
 
@@ -848,9 +787,9 @@ public void test_setPixelsIII$BI() {
 	imageData.getPixels(0, 1, IMAGE_DIMENSION, pixelData, 0);
 	for (int i = 0; i < pixelData.length; i++) {
 		if (i + OFFSET < values.length) {
-			assertEquals(":c:", values[i + OFFSET], pixelData[i]);
+			assertEquals(values[i + OFFSET], pixelData[i]);
 		} else {
-			assertEquals(":d:", 0, pixelData[i]);
+			assertEquals(0, pixelData[i]);
 		}
 	}
 
@@ -861,9 +800,9 @@ public void test_setPixelsIII$BI() {
 	imageData.getPixels(0, 1, IMAGE_DIMENSION, pixelData, 0);
 	for (int i = 0; i < pixelData.length; i++) {
 		if (i + OFFSET < values.length) {
-			assertEquals(":e:", values[i + OFFSET], pixelData[i]);
+			assertEquals(values[i + OFFSET], pixelData[i]);
 		} else {
-			assertEquals(":f:", 0, pixelData[i]);
+			assertEquals(0, pixelData[i]);
 		}
 	}
 
@@ -874,36 +813,28 @@ public void test_setPixelsIII$BI() {
 	imageData.getPixels(0, 1, IMAGE_DIMENSION, pixelData, 0);
 	for (int i = 0; i < pixelData.length; i++) {
 		if (i + OFFSET < values.length) {
-			assertEquals(":g:", values[i + OFFSET], pixelData[i]);
+			assertEquals(values[i + OFFSET], pixelData[i]);
 		} else {
-			assertEquals(":h:", 0, pixelData[i]);
+			assertEquals(0, pixelData[i]);
 		}
 	}
 
 	// exception cases
-	assertThrows("No exception thrown for putWidth out of bounds", IndexOutOfBoundsException.class,
-		() -> imageData.setPixels(0, 1, IMAGE_DIMENSION*IMAGE_DIMENSION, pixelData, OFFSET));
-	IllegalArgumentException ex = assertThrows("No exception thrown for pixels == null", IllegalArgumentException.class,
-		() -> imageData.setPixels(0, 1, IMAGE_DIMENSION, (byte[]) null, OFFSET));
+	assertThrows(IndexOutOfBoundsException.class, () -> imageData.setPixels(0, 1, IMAGE_DIMENSION*IMAGE_DIMENSION, pixelData, OFFSET));
+	IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () -> imageData.setPixels(0, 1, IMAGE_DIMENSION, (byte[]) null, OFFSET));
 	assertSWTProblem("Incorrect exception thrown for pixels == null", SWT.ERROR_NULL_ARGUMENT, ex);
-	ex = assertThrows("No exception thrown for x out of bounds", IllegalArgumentException.class,
-		() -> imageData.setPixels(-1, 1, IMAGE_DIMENSION, pixelData, OFFSET));
+	ex = assertThrows(IllegalArgumentException.class, () -> imageData.setPixels(-1, 1, IMAGE_DIMENSION, pixelData, OFFSET));
 	assertSWTProblem("Incorrect exception thrown for x out of bounds", SWT.ERROR_INVALID_ARGUMENT, ex);
-	ex = assertThrows("No exception thrown for x out of bounds", IllegalArgumentException.class,
-		() -> imageData.setPixels(IMAGE_DIMENSION, 1, IMAGE_DIMENSION, pixelData, OFFSET));
+	ex = assertThrows(IllegalArgumentException.class, () -> imageData.setPixels(IMAGE_DIMENSION, 1, IMAGE_DIMENSION, pixelData, OFFSET));
 	assertSWTProblem("Incorrect exception thrown for x out of bounds", SWT.ERROR_INVALID_ARGUMENT, ex);
-	ex = assertThrows("No exception thrown for y out of bounds", IllegalArgumentException.class,
-		() -> imageData.setPixels(0, -1, IMAGE_DIMENSION, pixelData, OFFSET));
+	ex = assertThrows(IllegalArgumentException.class, () -> imageData.setPixels(0, -1, IMAGE_DIMENSION, pixelData, OFFSET));
 	assertSWTProblem("Incorrect exception thrown for y out of bounds", SWT.ERROR_INVALID_ARGUMENT, ex);
-	ex = assertThrows("No exception thrown for y out of bounds", IllegalArgumentException.class,
-		() -> imageData.setPixels(0, IMAGE_DIMENSION, IMAGE_DIMENSION, pixelData, OFFSET));
+	ex = assertThrows(IllegalArgumentException.class, () -> imageData.setPixels(0, IMAGE_DIMENSION, IMAGE_DIMENSION, pixelData, OFFSET));
 	assertSWTProblem("Incorrect exception thrown for y out of bounds", SWT.ERROR_INVALID_ARGUMENT, ex);
-	ex = assertThrows("No exception thrown for putWidth < 0", IllegalArgumentException.class,
-		() -> imageData.setPixels(0, 1, -1, pixelData, OFFSET));
+	ex = assertThrows(IllegalArgumentException.class, () -> imageData.setPixels(0, 1, -1, pixelData, OFFSET));
 	assertSWTProblem("Incorrect exception thrown for putWidth < 0", SWT.ERROR_INVALID_ARGUMENT, ex);
 	imageData = new ImageData(IMAGE_DIMENSION, IMAGE_DIMENSION, 32, new PaletteData(0xFF0000, 0xFF00, 0xFF));
-	SWTException swtEx = assertThrows("No exception thrown for invalid depth", SWTException.class,
-		() -> imageData.setPixels(0, 1, IMAGE_DIMENSION, pixelData, OFFSET));
+	SWTException swtEx = assertThrows(SWTException.class, () -> imageData.setPixels(0, 1, IMAGE_DIMENSION, pixelData, OFFSET));
 	assertSWTProblem("Incorrect exception thrown for invalid depth", SWT.ERROR_UNSUPPORTED_DEPTH, swtEx);
 }
 
@@ -920,9 +851,9 @@ public void test_setPixelsIII$II() {
 	imageData.getPixels(0, 1, IMAGE_DIMENSION, pixelData, 0);
 	for (int i = 0; i < pixelData.length; i++) {
 		if (i + OFFSET < values.length) {
-			assertEquals(":a:", values[i + OFFSET], pixelData[i]);
+			assertEquals(values[i + OFFSET], pixelData[i]);
 		} else {
-			assertEquals(":b:", 0, pixelData[i]);
+			assertEquals(0, pixelData[i]);
 		}
 	}
 
@@ -933,9 +864,9 @@ public void test_setPixelsIII$II() {
 	imageData.getPixels(0, 1, IMAGE_DIMENSION, pixelData, 0);
 	for (int i = 0; i < pixelData.length; i++) {
 		if (i + OFFSET < values.length) {
-			assertEquals(":c:", values[i + OFFSET], pixelData[i]);
+			assertEquals(values[i + OFFSET], pixelData[i]);
 		} else {
-			assertEquals(":d:", 0, pixelData[i]);
+			assertEquals(0, pixelData[i]);
 		}
 	}
 
@@ -946,9 +877,9 @@ public void test_setPixelsIII$II() {
 	imageData.getPixels(0, 1, IMAGE_DIMENSION, pixelData, 0);
 	for (int i = 0; i < pixelData.length; i++) {
 		if (i + OFFSET < values.length) {
-			assertEquals(":e:", values[i + OFFSET], pixelData[i]);
+			assertEquals(values[i + OFFSET], pixelData[i]);
 		} else {
-			assertEquals(":f:", 0, pixelData[i]);
+			assertEquals(0, pixelData[i]);
 		}
 	}
 
@@ -959,9 +890,9 @@ public void test_setPixelsIII$II() {
 	imageData.getPixels(0, 1, IMAGE_DIMENSION, pixelData, 0);
 	for (int i = 0; i < pixelData.length; i++) {
 		if (i + OFFSET < values.length) {
-			assertEquals(":g:", values[i + OFFSET], pixelData[i]);
+			assertEquals(values[i + OFFSET], pixelData[i]);
 		} else {
-			assertEquals(":h:", 0, pixelData[i]);
+			assertEquals(0, pixelData[i]);
 		}
 	}
 
@@ -972,9 +903,9 @@ public void test_setPixelsIII$II() {
 	imageData.getPixels(0, 1, IMAGE_DIMENSION, pixelData, 0);
 	for (int i = 0; i < pixelData.length; i++) {
 		if (i + OFFSET < values.length) {
-			assertEquals(":i:", values[i + OFFSET], pixelData[i]);
+			assertEquals(values[i + OFFSET], pixelData[i]);
 		} else {
-			assertEquals(":j:", 0, pixelData[i]);
+			assertEquals(0, pixelData[i]);
 		}
 	}
 
@@ -985,9 +916,9 @@ public void test_setPixelsIII$II() {
 	imageData.getPixels(0, 1, IMAGE_DIMENSION, pixelData, 0);
 	for (int i = 0; i < pixelData.length; i++) {
 		if (i + OFFSET < values.length) {
-			assertEquals(":k:", values[i + OFFSET], pixelData[i]);
+			assertEquals(values[i + OFFSET], pixelData[i]);
 		} else {
-			assertEquals(":l:", 0, pixelData[i]);
+			assertEquals(0, pixelData[i]);
 		}
 	}
 
@@ -998,32 +929,25 @@ public void test_setPixelsIII$II() {
 	imageData.getPixels(0, 1, IMAGE_DIMENSION, pixelData, 0);
 	for (int i = 0; i < pixelData.length; i++) {
 		if (i + OFFSET < values.length) {
-			assertEquals(":m:", values[i + OFFSET], pixelData[i]);
+			assertEquals(values[i + OFFSET], pixelData[i]);
 		} else {
-			assertEquals(":n:", 0, pixelData[i]);
+			assertEquals(0, pixelData[i]);
 		}
 	}
 
 	// exception cases
-	assertThrows("No exception thrown for putWidth out of bounds", IndexOutOfBoundsException.class,
-		() -> imageData.setPixels(0, 1, IMAGE_DIMENSION*IMAGE_DIMENSION, pixelData, OFFSET));
-	IllegalArgumentException ex = assertThrows("No exception thrown for pixels == null", IllegalArgumentException.class,
-		() -> imageData.setPixels(0, 1, IMAGE_DIMENSION, (int[]) null, OFFSET));
+	assertThrows(IndexOutOfBoundsException.class, () -> imageData.setPixels(0, 1, IMAGE_DIMENSION*IMAGE_DIMENSION, pixelData, OFFSET));
+	IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () -> imageData.setPixels(0, 1, IMAGE_DIMENSION, (int[]) null, OFFSET));
 	assertSWTProblem("Incorrect exception thrown for pixels == null", SWT.ERROR_NULL_ARGUMENT, ex);
-	ex = assertThrows("No exception thrown for x out of bounds", IllegalArgumentException.class,
-		() -> imageData.setPixels(-1, 1, IMAGE_DIMENSION, pixelData, OFFSET));
+	ex = assertThrows(IllegalArgumentException.class, () -> imageData.setPixels(-1, 1, IMAGE_DIMENSION, pixelData, OFFSET));
 	assertSWTProblem("Incorrect exception thrown for x out of bounds", SWT.ERROR_INVALID_ARGUMENT, ex);
-	ex = assertThrows("No exception thrown for x out of bounds", IllegalArgumentException.class,
-		() -> imageData.setPixels(IMAGE_DIMENSION, 1, IMAGE_DIMENSION, pixelData, OFFSET));
+	ex = assertThrows(IllegalArgumentException.class, () -> imageData.setPixels(IMAGE_DIMENSION, 1, IMAGE_DIMENSION, pixelData, OFFSET));
 	assertSWTProblem("Incorrect exception thrown for x out of bounds", SWT.ERROR_INVALID_ARGUMENT, ex);
-	ex = assertThrows("No exception thrown for y out of bounds", IllegalArgumentException.class,
-		() -> imageData.setPixels(0, -1, IMAGE_DIMENSION, pixelData, OFFSET));
+	ex = assertThrows(IllegalArgumentException.class, () -> imageData.setPixels(0, -1, IMAGE_DIMENSION, pixelData, OFFSET));
 	assertSWTProblem("Incorrect exception thrown for y out of bounds", SWT.ERROR_INVALID_ARGUMENT, ex);
-	ex = assertThrows("No exception thrown for y out of bounds", IllegalArgumentException.class,
-		() -> imageData.setPixels(0, IMAGE_DIMENSION, IMAGE_DIMENSION, pixelData, OFFSET));
+	ex = assertThrows(IllegalArgumentException.class, () -> imageData.setPixels(0, IMAGE_DIMENSION, IMAGE_DIMENSION, pixelData, OFFSET));
 	assertSWTProblem("Incorrect exception thrown for y out of bounds", SWT.ERROR_INVALID_ARGUMENT, ex);
-	ex = assertThrows("No exception thrown for putWidth < 0", IllegalArgumentException.class,
-		() -> imageData.setPixels(0, 1, -1, pixelData, OFFSET));
+	ex = assertThrows(IllegalArgumentException.class, () -> imageData.setPixels(0, 1, -1, pixelData, OFFSET));
 	assertSWTProblem("Incorrect exception thrown for putWidth < 0", SWT.ERROR_INVALID_ARGUMENT, ex);
 }
 /* custom */

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_ImageLoader.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_ImageLoader.java
@@ -15,11 +15,11 @@
 package org.eclipse.swt.tests.junit;
 
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -36,7 +36,7 @@ import org.eclipse.swt.graphics.ImageLoaderEvent;
 import org.eclipse.swt.graphics.ImageLoaderListener;
 import org.eclipse.swt.graphics.PaletteData;
 import org.eclipse.swt.widgets.Display;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Automated Test Suite for class org.eclipse.swt.graphics.ImageLoader
@@ -57,28 +57,28 @@ public void test_addImageLoaderListenerLorg_eclipse_swt_graphics_ImageLoaderList
 
 	assertThrows(IllegalArgumentException.class, () -> loader.addImageLoaderListener(null),
 			"No exception thrown for addImageLoaderListener with null argument");
-	assertFalse(":a:", loader.hasListeners());
+	assertFalse(loader.hasListeners());
 	loader.addImageLoaderListener(loaderListener);
-	assertTrue(":b:", loader.hasListeners());
+	assertTrue(loader.hasListeners());
 
 	loaderListenerCalled = false;
 	try (InputStream stream = SwtTestUtil.class.getResourceAsStream("interlaced_target.png")) {
 		loader.load(stream);
 	}
-	assertTrue(":c:", loaderListenerCalled);
+	assertTrue(loaderListenerCalled);
 
 	loaderListenerCalled = false;
 	try (InputStream stream = SwtTestUtil.class.getResourceAsStream("target.png")) {
 		loader.load(stream);
 	}
-	assertFalse(":d:", loaderListenerCalled);
+	assertFalse(loaderListenerCalled);
 
 	loaderListenerCalled = false;
 	loader.notifyListeners(new ImageLoaderEvent(loader, loader.data[0], 0, true));
-	assertTrue(":e:", loaderListenerCalled);
+	assertTrue(loaderListenerCalled);
 
 	loader.removeImageLoaderListener(loaderListener);
-	assertFalse(":f:", loader.hasListeners());
+	assertFalse(loader.hasListeners());
 }
 
 @Test
@@ -204,7 +204,7 @@ public void test_bug547529() {
 		ImageLoader loader = new ImageLoader();
 		loader.load(inputStream);
 		ImageData[] loadedData = loader.data;
-		assertEquals("ImageLoader loaded incorrect number of ImageData objects", 1, loadedData.length);
+		assertEquals(1, loadedData.length);
 		byte[] loadedBytes = loadedData[0].data;
 		assertArrayEquals(savedBytes, loadedBytes);
 	} finally {

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_ImageLoaderEvent.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_ImageLoaderEvent.java
@@ -15,13 +15,13 @@
 package org.eclipse.swt.tests.junit;
 
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import org.eclipse.swt.graphics.ImageLoader;
 import org.eclipse.swt.graphics.ImageLoaderEvent;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Automated Test Suite for class org.eclipse.swt.graphics.ImageLoaderEvent

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_Region.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_Region.java
@@ -14,15 +14,15 @@
  *******************************************************************************/
 package org.eclipse.swt.tests.junit;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import org.eclipse.swt.SWTException;
 import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.graphics.Rectangle;
 import org.eclipse.swt.graphics.Region;
 import org.eclipse.swt.widgets.Display;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Automated Test Suite for class org.eclipse.swt.graphics.Region
@@ -31,7 +31,7 @@ import org.junit.Test;
  */
 public class Test_org_eclipse_swt_graphics_Region {
 
-@Before
+@BeforeEach
 public void setUp() {
 	display = Display.getDefault();
 }

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_TextLayout.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_TextLayout.java
@@ -14,12 +14,12 @@
  *******************************************************************************/
 package org.eclipse.swt.tests.junit;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays;
 
@@ -33,14 +33,14 @@ import org.eclipse.swt.graphics.Rectangle;
 import org.eclipse.swt.graphics.TextLayout;
 import org.eclipse.swt.graphics.TextStyle;
 import org.eclipse.swt.widgets.Display;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 
 public class Test_org_eclipse_swt_graphics_TextLayout {
 	Display display;
 
-@Before
+@BeforeEach
 public void setUp() {
 	display = Display.getDefault();
 }
@@ -56,11 +56,11 @@ public void test_getLevel() {
 //	assertEquals(0, layout.getLevel(4)); //bug in windows (uniscribe)
 	assertEquals(1, layout.getLevel(5));
 	assertEquals(1, layout.getLevel(6));
-	if (!SwtTestUtil.isWindows) assertEquals(2, layout.getLevel(7));  // skipping windows due to fix for bug 565526
+	if (!SwtTestUtil.isWindows)
+		assertEquals(2, layout.getLevel(7));  // skipping windows due to fix for bug 565526
 	assertEquals(0, layout.getLevel(9));
-	assertThrows("invalid range expection expected", IllegalArgumentException.class, () -> layout.getLevel(-1));
-	assertThrows("invalid range expection expected", IllegalArgumentException.class,
-			() -> layout.getLevel(text.length() + 1));
+	assertThrows(IllegalArgumentException.class, () -> layout.getLevel(-1));
+	assertThrows(IllegalArgumentException.class, () -> layout.getLevel(text.length() + 1));
 	layout.dispose();
 }
 
@@ -73,12 +73,12 @@ public void test_getSegments() {
 	for (int i = 0; i < segments.length; i++) {
 		String m = messages[i];
 		layout.setSegments(segments[i]);
-		assertEquals(m, 1, layout.getNextOffset(0, SWT.MOVEMENT_CLUSTER));
-		assertEquals(m, 2, layout.getNextOffset(1, SWT.MOVEMENT_CLUSTER));
-		assertEquals(m, 2, layout.getNextOffset(2, SWT.MOVEMENT_CLUSTER));
-		assertEquals(m, 1, layout.getPreviousOffset(2, SWT.MOVEMENT_CLUSTER));
-		assertEquals(m, 0, layout.getPreviousOffset(1, SWT.MOVEMENT_CLUSTER));
-		assertEquals(m, 0, layout.getPreviousOffset(0, SWT.MOVEMENT_CLUSTER));
+		assertEquals(1, layout.getNextOffset(0, SWT.MOVEMENT_CLUSTER), m);
+		assertEquals(2, layout.getNextOffset(1, SWT.MOVEMENT_CLUSTER), m);
+		assertEquals(2, layout.getNextOffset(2, SWT.MOVEMENT_CLUSTER), m);
+		assertEquals(1, layout.getPreviousOffset(2, SWT.MOVEMENT_CLUSTER), m);
+		assertEquals(0, layout.getPreviousOffset(1, SWT.MOVEMENT_CLUSTER), m);
+		assertEquals(0, layout.getPreviousOffset(0, SWT.MOVEMENT_CLUSTER), m);
 	}
 
 	// Bug 295513
@@ -162,15 +162,15 @@ public void test_getSegments() {
 		layout.setSegments(new int[] { length});
 		trailing = new int [1];
 		int width = layout.getBounds().width + 20;
-		assertEquals("hit test to the left", 0, layout.getOffset(0, 0, trailing));
-		assertEquals("hit test to the left (trailing)", 0, trailing[0]);
-		assertEquals("hit test to the right", length - 1, layout.getOffset(width, 0, trailing));
-		assertEquals("hit test to the right (trailing)", 1, trailing[0]);
+		assertEquals(0, layout.getOffset(0, 0, trailing));
+		assertEquals(0, trailing[0]);
+		assertEquals(length - 1, layout.getOffset(width, 0, trailing));
+		assertEquals(1, trailing[0]);
 		layout.setSegmentsChars(new char[] { '*' });
-		assertEquals("hit test to the left", 0, layout.getOffset(0, 0, trailing));
-		assertEquals("hit test to the left (trailing)", 0, trailing[0]);
-		assertEquals("hit test to the right", length - 1, layout.getOffset(width, 0, trailing));
-		assertEquals("hit test to the right (trailing)", 1, trailing[0]);
+		assertEquals(0, layout.getOffset(0, 0, trailing));
+		assertEquals(0, trailing[0]);
+		assertEquals(length - 1, layout.getOffset(width, 0, trailing));
+		assertEquals(1, trailing[0]);
 	}
 
 	/* wrong: internal testing */
@@ -265,9 +265,9 @@ public void test_getSegmentsChars() {
 	for (int i = 0; i < segments.length; i++) {
 		layout.setSegments(segments[i]);
 		layout.setSegmentsChars(chars[i]);
-		assertArrayEquals("Test line offsets" + ": group: " + i, offsets, layout.getLineOffsets());
+		assertArrayEquals(offsets, layout.getLineOffsets(), messages[i]);
 		for (int j = 0; j < textLength; j++) {
-			assertEquals(messages[i] + ": group: " + i + ", index: " + j, levels[i][j], layout.getLevel(j));
+			assertEquals(levels[i][j], layout.getLevel(j), messages[i]);
 		}
 	}
 	layout.dispose();
@@ -330,9 +330,9 @@ public void test_getLineIndex() {
 	assertEquals(1, layout.getLineIndex(12));
 	assertEquals(1, layout.getLineIndex(14));
 	assertEquals(2, layout.getLineIndex(15));
-	assertThrows("invalid range expection expected", IllegalArgumentException.class, ()-> layout.getLineIndex(-1));
-	assertThrows("invalid range expection expected", IllegalArgumentException.class, ()->
-		layout.getLineIndex(text.length() + 1));
+	assertThrows(IllegalArgumentException.class, ()-> layout.getLineIndex(-1));
+	assertThrows(IllegalArgumentException.class, ()->
+	layout.getLineIndex(text.length() + 1));
 	layout.dispose();
 }
 
@@ -371,8 +371,8 @@ public void test_getLineBounds() {
 	assertEquals(100, newRect1.x);
 	assertEquals(bounds.height, rect0.height + rect1.height + rect2.height);
 
-	assertThrows("invalid range expection expected", IllegalArgumentException.class, () -> layout.getLineBounds(-1));
-	assertThrows("invalid range expection expected", IllegalArgumentException.class, () -> layout.getLineBounds(3));
+	assertThrows(IllegalArgumentException.class, () -> layout.getLineBounds(-1));
+	assertThrows(IllegalArgumentException.class, () -> layout.getLineBounds(3));
 	layout.dispose();
 }
 
@@ -762,12 +762,12 @@ public void test_getNextOffset2() {
 	for (int i = 0; i < segments.length; i++) {
 		String m = messages[i];
 		layout.setSegments(segments[i]);
-		assertEquals(m, 1, layout.getNextOffset(0, SWT.MOVEMENT_CLUSTER));
-		assertEquals(m, 4, layout.getNextOffset(1, SWT.MOVEMENT_CLUSTER));
-		assertEquals(m, 5, layout.getNextOffset(4, SWT.MOVEMENT_CLUSTER));
-		assertEquals(m, 4, layout.getPreviousOffset(5, SWT.MOVEMENT_CLUSTER));
-		assertEquals(m, 1, layout.getPreviousOffset(4, SWT.MOVEMENT_CLUSTER));
-		assertEquals(m, 0, layout.getPreviousOffset(1, SWT.MOVEMENT_CLUSTER));
+		assertEquals(1, layout.getNextOffset(0, SWT.MOVEMENT_CLUSTER), m);
+		assertEquals(4, layout.getNextOffset(1, SWT.MOVEMENT_CLUSTER), m);
+		assertEquals(5, layout.getNextOffset(4, SWT.MOVEMENT_CLUSTER), m);
+		assertEquals(4, layout.getPreviousOffset(5, SWT.MOVEMENT_CLUSTER), m);
+		assertEquals(1, layout.getPreviousOffset(4, SWT.MOVEMENT_CLUSTER), m);
+		assertEquals(0, layout.getPreviousOffset(1, SWT.MOVEMENT_CLUSTER), m);
 	}
 	layout.dispose();
 }
@@ -781,7 +781,7 @@ public void test_getLineSpacing() {
 	assertEquals(Short.MAX_VALUE, layout.getSpacing());
 	layout.setSpacing(50);
 	assertEquals(50, layout.getSpacing());
-	assertThrows("invalid range expection expected", IllegalArgumentException.class, ()->layout.setSpacing(-1));
+	assertThrows(IllegalArgumentException.class, ()->layout.setSpacing(-1));
 	assertEquals(50, layout.getSpacing());
 	layout.setSpacing(0);
 	assertEquals(0, layout.getSpacing());
@@ -858,7 +858,8 @@ public void test_getOffset() {
 	assertEquals(1, trailing[0]);
 	point = layout.getLocation(4, true);
 	assertEquals(2, layout.getOffset(point.x - 1, 0, trailing));
-	if (!isCocoa) assertEquals(1, trailing[0]);
+	if (!isCocoa)
+		assertEquals(1, trailing[0]);
 	point = layout.getLocation(4, false);
 	assertEquals(3, layout.getOffset(point.x + 1, 0, trailing));
 	assertEquals(1, trailing[0]);
@@ -919,12 +920,10 @@ public void test_getTextDirection() {
 				layout.setTextDirection(direction);
 			}
 			if (direction == SWT.NONE || direction == -1) {
-				assertEquals("orientation: " + orientation + ", text direction: " + direction,
-						layout.getTextDirection(), prevDirection);
+				assertEquals(layout.getTextDirection(), prevDirection);
 			} else {
 				prevDirection = direction;
-				assertEquals("orientation: " + orientation + ", text direction: " + direction,
-						layout.getTextDirection(), direction);
+				assertEquals(layout.getTextDirection(), direction);
 			}
 		}
 	}
@@ -981,14 +980,14 @@ public void test_bug568740_multilineTextStyle() {
 		Rectangle searchRangeStrike = new Rectangle(0, 0, image.getBounds().width, offset + (int)(firstLineBounds.height * 1.0));
 		Rectangle searchRangeUnder = new Rectangle(0, 0, image.getBounds().width, offset + (int)(firstLineBounds.height * 1.3));
 
-		assertFalse("Invalid test range for border test. Fix test!", SwtTestUtil.hasPixel(image, display.getSystemColor(SWT.COLOR_DARK_BLUE), searchRangeBorder));
-		assertTrue("Found no border style in first line", SwtTestUtil.hasPixel(image, display.getSystemColor(SWT.COLOR_BLUE), searchRangeBorder));
+		assertFalse(SwtTestUtil.hasPixel(image, display.getSystemColor(SWT.COLOR_DARK_BLUE), searchRangeBorder));
+		assertTrue(SwtTestUtil.hasPixel(image, display.getSystemColor(SWT.COLOR_BLUE), searchRangeBorder));
 
-		assertFalse("Invalid test range for strikeout test. Fix test!", SwtTestUtil.hasPixel(image, display.getSystemColor(SWT.COLOR_DARK_RED), searchRangeStrike));
-		assertTrue("Found no strikeout style in first line", SwtTestUtil.hasPixel(image, display.getSystemColor(SWT.COLOR_RED), searchRangeStrike));
+		assertFalse(SwtTestUtil.hasPixel(image, display.getSystemColor(SWT.COLOR_DARK_RED), searchRangeStrike));
+		assertTrue(SwtTestUtil.hasPixel(image, display.getSystemColor(SWT.COLOR_RED), searchRangeStrike));
 
-		assertFalse("Invalid test range for underline test. Fix test!", SwtTestUtil.hasPixel(image, display.getSystemColor(SWT.COLOR_DARK_GREEN), searchRangeUnder));
-		assertTrue("Found no underline style in first line", SwtTestUtil.hasPixel(image, display.getSystemColor(SWT.COLOR_GREEN), searchRangeUnder));
+		assertFalse(SwtTestUtil.hasPixel(image, display.getSystemColor(SWT.COLOR_DARK_GREEN), searchRangeUnder));
+		assertTrue(SwtTestUtil.hasPixel(image, display.getSystemColor(SWT.COLOR_GREEN), searchRangeUnder));
 	} finally {
 		if (layout != null)
 			layout.dispose();
@@ -1035,8 +1034,7 @@ private int[][] draw(String input, int antialias) {
 		layout.setText(input);
 		image = draw(layout, antialias);
 //		SwtTestUtil.debugDisplayImage(image);
-		assertTrue("Found no drawn pixels, nothing at all was drawn!",
-		SwtTestUtil.hasPixelNotMatching(image, display.getSystemColor(SWT.COLOR_WHITE), image.getBounds()));
+		assertTrue(SwtTestUtil.hasPixelNotMatching(image, display.getSystemColor(SWT.COLOR_WHITE), image.getBounds()));
 		return SwtTestUtil.getAllPixels(image);
 
 	} finally {

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_Transform.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_Transform.java
@@ -13,13 +13,13 @@
  *******************************************************************************/
 package org.eclipse.swt.tests.junit;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import org.eclipse.swt.graphics.Transform;
 import org.eclipse.swt.widgets.Display;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Automated Test Suite for class org.eclipse.swt.graphics.Transform
@@ -27,10 +27,9 @@ import org.junit.Test;
  * @see org.eclipse.swt.graphics.Transform
  */
 public class Test_org_eclipse_swt_graphics_Transform {
-
 	private Display display;
 
-	@Before
+	@BeforeEach
 	public void setUp() {
 		display = Display.getDefault();
 	}
@@ -56,7 +55,7 @@ public class Test_org_eclipse_swt_graphics_Transform {
 		transformDisposed.dispose();
 		float [] elements = new float[6];
 		transform.getElements(elements);
-		assertEquals("Multiply of transforms failed.", 30, elements[4], 0.01);
+		assertEquals(30, elements[4], 0.01);
 		transform.dispose();
 	}
 

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_internal_SVGRasterizer.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_internal_SVGRasterizer.java
@@ -15,6 +15,8 @@ package org.eclipse.swt.tests.junit;
 import static org.eclipse.swt.tests.junit.SwtTestUtil.assertSWTProblem;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.nio.file.Path;
+
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.SWTException;
 import org.eclipse.swt.graphics.Image;
@@ -22,9 +24,9 @@ import org.eclipse.swt.graphics.ImageData;
 import org.eclipse.swt.graphics.ImageDataProvider;
 import org.eclipse.swt.graphics.ImageFileNameProvider;
 import org.eclipse.swt.widgets.Display;
-import org.junit.ClassRule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
 
 /**
  * When executed locally (outside Tycho build), this tests needs to be run as
@@ -33,8 +35,8 @@ import org.junit.rules.TemporaryFolder;
  */
 public class Test_org_eclipse_swt_internal_SVGRasterizer {
 
-	@ClassRule
-	public static TemporaryFolder tempFolder = new TemporaryFolder();
+	@TempDir
+	static Path tempFolder;
 
 	private static String getPath(String fileName) {
 		return SwtTestUtil.getPath(fileName, tempFolder).toString();

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_layout_BorderLayout.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_layout_BorderLayout.java
@@ -13,8 +13,8 @@
  *******************************************************************************/
 package org.eclipse.swt.tests.junit;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Point;
@@ -25,17 +25,16 @@ import org.eclipse.swt.widgets.Canvas;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Automated Test Suite for class {@link BorderLayout}
  */
 public class Test_org_eclipse_swt_layout_BorderLayout {
-
 	Display display;
 
-	@Before
+	@BeforeEach
 	public void setUp() {
 		display = Display.getDefault();
 	}

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_layout_FormAttachment.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_layout_FormAttachment.java
@@ -14,15 +14,16 @@
  *******************************************************************************/
 package org.eclipse.swt.tests.junit;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.layout.FormAttachment;
 import org.eclipse.swt.widgets.Shell;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Automated Test Suite for class org.eclipse.swt.layout.FormAttachment
@@ -31,12 +32,13 @@ import org.junit.Test;
  */
 public class Test_org_eclipse_swt_layout_FormAttachment {
 
-@Before
+
+@BeforeEach
 public void setUp() {
 	shell = new Shell();
 }
 
-@After
+@AfterEach
 public void tearDown() {
 	shell.dispose();
 }

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_layout_GridData.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_layout_GridData.java
@@ -14,15 +14,14 @@
  *******************************************************************************/
 package org.eclipse.swt.tests.junit;
 
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.layout.GridData;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Automated Test Suite for class org.eclipse.swt.layout.GridData

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Button.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Button.java
@@ -13,14 +13,14 @@
  *******************************************************************************/
 package org.eclipse.swt.tests.junit;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-import static org.junit.Assume.assumeFalse;
-import static org.junit.Assume.assumeTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.FocusAdapter;
@@ -36,9 +36,9 @@ import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Text;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 /**
  * Automated Test Suite for class org.eclipse.swt.widgets.Button
@@ -46,11 +46,10 @@ import org.junit.Test;
  * @see org.eclipse.swt.widgets.Button
  */
 public class Test_org_eclipse_swt_widgets_Button extends Test_org_eclipse_swt_widgets_Control {
-
-Button button;
+	Button button;
 
 @Override
-@Before
+@BeforeEach
 public void setUp() {
 	super.setUp();
 	button = new Button(shell, SWT.PUSH);
@@ -223,27 +222,21 @@ public void test_setBackgroundCheckButton() {
 	Button checkButton = new Button(shell, SWT.CHECK);
 	Color color = new Color(255, 0, 0);
 	checkButton.setBackground(color);
-	assertEquals("getBackground not equal after setBackground for SWT.CHECK Button",
-			color, checkButton.getBackground());
+	assertEquals(color, checkButton.getBackground());
 	checkButton.setBackground(null);
-	assertNotEquals("getBackground unchanged after setBackground(null) for SWT.CHECK Button",
-			color, checkButton.getBackground());
+	assertNotEquals(color, checkButton.getBackground());
 
 	color = new Color(255, 0, 0, 0);
 	checkButton.setBackground(color);
-	assertEquals("getBackground not equal after setBackground with 0 alpha for SWT.CHECK Button",
-			color, checkButton.getBackground());
+	assertEquals(color, checkButton.getBackground());
 	checkButton.setBackground(null);
-	assertNotEquals("getBackground unchanged after setBackground(null) with 0 alpha for SWT.CHECK Button",
-			color, checkButton.getBackground());
+	assertNotEquals(color, checkButton.getBackground());
 	if ("gtk".equals(SWT.getPlatform ())) {
 		Color fg = new Color(0, 255, 0);
 		checkButton.setBackground(color);
 		checkButton.setForeground(fg);
-		assertEquals("Setting a foreground disrupted the background color for SWT.CHECK Button",
-				color, checkButton.getBackground());
-		assertEquals("Setting a foreground onto an SWT.CHECK Button with a background failed",
-				fg, checkButton.getForeground());
+		assertEquals(color, checkButton.getBackground());
+		assertEquals(fg, checkButton.getForeground());
 	}
 	checkButton.dispose();
 }
@@ -265,26 +258,20 @@ public void test_setBackgroundRadioButton() {
 	Button radioButton = new Button(shell, SWT.RADIO);
 	Color color = new Color(255, 0, 0);
 	radioButton.setBackground(color);
-	assertEquals("getBackground not equal after setBackground for SWT.RADIO Button",
-			color, radioButton.getBackground());
+	assertEquals(color, radioButton.getBackground());
 	radioButton.setBackground(null);
-	assertNotEquals("getBackground unchanged after setBackground(null) for SWT.RADIO Button",
-			color, radioButton.getBackground());
+	assertNotEquals(color, radioButton.getBackground());
 	color = new Color(255, 0, 0, 0);
 	radioButton.setBackground(color);
-	assertEquals("getBackground not equal after setBackground with 0 alpha for SWT.RADIO Button",
-			color, radioButton.getBackground());
+	assertEquals(color, radioButton.getBackground());
 	radioButton.setBackground(null);
-	assertNotEquals("getBackground unchanged after setBackground(null) with 0 alpha for SWT.RADIO Button",
-			color, radioButton.getBackground());
+	assertNotEquals(color, radioButton.getBackground());
 	if ("gtk".equals(SWT.getPlatform ())) {
 		Color fg = new Color(0, 255, 0);
 		radioButton.setBackground(color);
 		radioButton.setForeground(fg);
-		assertEquals("Setting a foreground disrupted the background color for SWT.RADIO Button",
-				color, radioButton.getBackground());
-		assertEquals("Setting a foreground onto an SWT.RADIO Button with a background failed",
-				fg, radioButton.getForeground());
+		assertEquals(color, radioButton.getBackground());
+		assertEquals(fg, radioButton.getForeground());
 	}
 	radioButton.dispose();
 }
@@ -320,10 +307,8 @@ public void test_setForegroundCheckButton() {
 		Color bg = new Color(0, 255, 0);
 		checkButton.setForeground(color);
 		checkButton.setBackground(bg);
-		assertEquals("Setting a background disrupted the foreground color for SWT.CHECK Button",
-				color, checkButton.getForeground());
-		assertEquals("Setting a background onto an SWT.CHECK Button with a foreground failed",
-				bg, checkButton.getBackground());
+		assertEquals(color, checkButton.getForeground());
+		assertEquals(bg, checkButton.getBackground());
 	}
         checkButton.dispose();
 }
@@ -331,8 +316,7 @@ public void test_setForegroundCheckButton() {
 @Test
 public void test_setForegroundAlphaCheckButton() {
 	Button checkButton = new Button(shell, SWT.CHECK);
-	assumeTrue("Alpha support for foreground colors does not exist on Win32",
-			SwtTestUtil.isCocoa || SwtTestUtil.isGTK);
+	assumeTrue(SwtTestUtil.isCocoa || SwtTestUtil.isGTK, "Alpha support for foreground colors does not exist on Win32");
 	Color color = new Color (255, 0, 0, 0);
 	checkButton.setForeground(color);
 	assertEquals(color, checkButton.getForeground());
@@ -354,10 +338,8 @@ public void test_setForegroundRadioButton() {
 		Color bg = new Color(0, 255, 0);
 		radioButton.setForeground(color);
 		radioButton.setBackground(bg);
-		assertEquals("Setting a background disrupted the foreground color for SWT.RADIO Button",
-				color, radioButton.getForeground());
-		assertEquals("Setting a background onto an SWT.RADIO Button with a foreground failed",
-				bg, radioButton.getBackground());
+		assertEquals(color, radioButton.getForeground());
+		assertEquals(bg, radioButton.getBackground());
 	}
 	radioButton.dispose();
 }
@@ -365,8 +347,7 @@ public void test_setForegroundRadioButton() {
 @Test
 public void test_setForegroundAlphaRadiokButton() {
 	Button radioButton = new Button(shell, SWT.RADIO);
-	assumeTrue("Alpha support for foreground colors does not exist Win32",
-			SwtTestUtil.isCocoa || SwtTestUtil.isGTK);
+	assumeTrue(SwtTestUtil.isCocoa || SwtTestUtil.isGTK, "Alpha support for foreground colors does not exist Win32");
 	Color color = new Color (255, 0, 0, 0);
 	radioButton.setForeground(color);
 	assertEquals(color, radioButton.getForeground());
@@ -448,7 +429,7 @@ public void test_setTextLjava_lang_String() {
 	int goodCases = 4;
 	for (int i=0; i<goodCases; i++){
 		button.setText(cases[i]);
-		assertEquals("good case: " + String.valueOf(i), cases[i], button.getText());
+		assertEquals(cases[i], button.getText());
 	}
 
 	try {
@@ -463,8 +444,8 @@ public void test_setTextLjava_lang_String() {
 
 @Test
 public void test_traverseCheckButton() {
-	assumeFalse("Mnemonic not applicable on Cocoa", SwtTestUtil.isCocoa);
-	assumeFalse("getSelection() checks below fail on Linux", SwtTestUtil.isGTK);
+	assumeFalse(SwtTestUtil.isCocoa, "Mnemonic not applicable on Cocoa");
+	assumeFalse(SwtTestUtil.isGTK, "getSelection() checks below fail on Linux");
     Composite composite = new Composite(shell, SWT.NONE);
     composite.setLayout(new GridLayout ());
 
@@ -604,7 +585,7 @@ public void test_consistency_DragDetect () {
 }
 
 /** Test for Bug 381668 - NPE when disposing radio buttons right before they should gain focus */
-@Ignore(value = "Test works fine locally but fails to get correct focus on automated builds.")
+@Disabled(value = "Test works fine locally but fails to get correct focus on automated builds.")
 @Test
 public void test_Bug381668() throws InterruptedException {
 	button.dispose();

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Canvas.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Canvas.java
@@ -14,9 +14,9 @@
 package org.eclipse.swt.tests.junit;
 
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Font;
@@ -24,8 +24,8 @@ import org.eclipse.swt.graphics.FontData;
 import org.eclipse.swt.widgets.Canvas;
 import org.eclipse.swt.widgets.Caret;
 import org.eclipse.swt.widgets.Widget;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Automated Test Suite for class org.eclipse.swt.widgets.Canvas
@@ -37,7 +37,7 @@ public class Test_org_eclipse_swt_widgets_Canvas extends Test_org_eclipse_swt_wi
 Canvas canvas;
 
 @Override
-@Before
+@BeforeEach
 public void setUp() {
 	super.setUp();
 	canvas = new Canvas(shell, 0);
@@ -90,11 +90,11 @@ public void test_setCaretLorg_eclipse_swt_widgets_Caret() {
 	}
 	for (int i = 0; i < number; i++) {
 		canvas.setCaret(carets[i]);
-		assertEquals("Caret # " + i + "not set properly", canvas.getCaret(), carets[i]);
+		assertEquals(canvas.getCaret(), carets[i]);
 	}
 
 	canvas.setCaret(null);
-	assertNull("Caret should be null" , canvas.getCaret());
+	assertNull(canvas.getCaret());
 }
 
 @Override
@@ -103,7 +103,7 @@ public void test_setFontLorg_eclipse_swt_graphics_Font() {
 	FontData fontData = canvas.getFont().getFontData()[0];
 	Font font = new Font(canvas.getDisplay(), fontData.getName(), 8, fontData.getStyle());
 	canvas.setFont(font);
-	assertEquals(":a:", font, canvas.getFont());
+	assertEquals(font, canvas.getFont());
 	canvas.setFont(null);
 	font.dispose();
 }

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Caret.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Caret.java
@@ -14,13 +14,13 @@
 package org.eclipse.swt.tests.junit;
 
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Font;
@@ -29,8 +29,8 @@ import org.eclipse.swt.graphics.ImageGcDrawer;
 import org.eclipse.swt.graphics.Rectangle;
 import org.eclipse.swt.widgets.Canvas;
 import org.eclipse.swt.widgets.Caret;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Automated Test Suite for class org.eclipse.swt.widgets.Caret
@@ -43,7 +43,7 @@ Canvas canvas;
 Caret caret;
 
 @Override
-@Before
+@BeforeEach
 public void setUp() {
 	super.setUp();
 	canvas = new Canvas(shell, SWT.NULL);
@@ -53,7 +53,7 @@ public void setUp() {
 
 @Test
 public void test_ConstructorLorg_eclipse_swt_widgets_CanvasI() {
-	assertThrows("No exception thrown for null parent", IllegalArgumentException.class, () -> new Caret(null, 0));
+	assertThrows(IllegalArgumentException.class, () -> new Caret(null, 0));
 }
 
 @Test
@@ -106,7 +106,7 @@ public void test_setBoundsIIII() {
 public void test_setBoundsLorg_eclipse_swt_graphics_Rectangle() {
 	caret.setBounds(new Rectangle(0, 0, 30, 30));
 
-	assertThrows("No exception thrown for bounds == null", IllegalArgumentException.class, () -> caret.setBounds(null));
+	assertThrows(IllegalArgumentException.class, () -> caret.setBounds(null));
 }
 
 @Test
@@ -122,7 +122,7 @@ public void test_setFontLorg_eclipse_swt_graphics_Font() {
 
 	caret.setFont(null);
 	font.dispose();
-	assertThrows("No exception thrown for disposed font", IllegalArgumentException.class, () -> caret.setFont(font));
+	assertThrows(IllegalArgumentException.class, () -> caret.setFont(font));
 	caret.setFont(null);
 }
 
@@ -142,16 +142,16 @@ public void test_setImageLorg_eclipse_swt_graphics_Image() {
 
 	caret.setImage(null);
 	image.dispose();
-	assertThrows("No exception thrown for disposed image", IllegalArgumentException.class, () -> caret.setImage(image));
+	assertThrows(IllegalArgumentException.class, () -> caret.setImage(image));
 	caret.setImage(null);
 }
 
 @Test
 public void test_setVisibleZ() {
 	caret.setVisible(true);
-	assertTrue("Caret should be visible", caret.getVisible());
+	assertTrue(caret.getVisible());
 
 	caret.setVisible(false);
-	assertFalse("Caret should not be visible", caret.getVisible());
+	assertFalse(caret.getVisible());
 }
 }

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Combo.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Combo.java
@@ -14,14 +14,14 @@
 package org.eclipse.swt.tests.junit;
 
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-import static org.junit.Assume.assumeTrue;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -35,8 +35,8 @@ import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.graphics.Rectangle;
 import org.eclipse.swt.widgets.Combo;
 import org.eclipse.swt.widgets.Display;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Automated Test Suite for class org.eclipse.swt.widgets.Combo
@@ -48,7 +48,7 @@ public class Test_org_eclipse_swt_widgets_Combo extends Test_org_eclipse_swt_wid
 	Combo combo;
 
 @Override
-@Before
+@BeforeEach
 public void setUp() {
 	super.setUp();
 	combo = new Combo(shell, 0);
@@ -58,19 +58,19 @@ public void setUp() {
 @Override
 @Test
 public void test_ConstructorLorg_eclipse_swt_widgets_CompositeI() {
-	assertThrows("No exception thrown for parent == null", IllegalArgumentException.class, () ->
+	assertThrows(IllegalArgumentException.class, () ->
 		combo = new Combo(null, 0));
 
 	int[] cases = {SWT.DROP_DOWN, SWT.SIMPLE};
 	for (int i = 0; i < cases.length; i++) {
 		combo = new Combo(shell, cases[i]);
-		assertEquals(String.valueOf(i), cases[i], (combo.getStyle() & cases[i]));
+		assertEquals(cases[i], (combo.getStyle() & cases[i]));
 	}
 }
 
 @Test
 public void test_addLjava_lang_String() {
-	assertThrows("No exception thrown for item == null", IllegalArgumentException.class, () ->
+	assertThrows(IllegalArgumentException.class, () ->
 		combo.add(null));
 
 	combo.add("");
@@ -84,41 +84,41 @@ public void test_addLjava_lang_String() {
 
 @Test
 public void test_addLjava_lang_StringI() {
-	assertThrows("No exception thrown for index == null", IllegalArgumentException.class, () ->
+	assertThrows(IllegalArgumentException.class, () ->
 		combo.add(null, 0));
 
-	assertThrows("No exception thrown for index < 0", IllegalArgumentException.class, () ->
+	assertThrows(IllegalArgumentException.class, () ->
 		combo.add("string", -1));
 
 	combo.add("string0", 0);
-	assertThrows("No exception thrown for index > size", IllegalArgumentException.class, () ->
+	assertThrows(IllegalArgumentException.class, () ->
 		combo.add("string1", 2));
 	combo.removeAll();
 
 	combo.add("fred", 0);
-	assertArrayEquals("fred", new String[]{"fred"}, combo.getItems());
+	assertArrayEquals(new String[]{"fred"}, combo.getItems());
 	combo.add("fred", 0);
-	assertArrayEquals("fred fred", new String[]{"fred", "fred"}, combo.getItems());
+	assertArrayEquals(new String[]{"fred", "fred"}, combo.getItems());
 	combo.add("fred");
-	assertArrayEquals("fred fred fred", new String[]{"fred", "fred", "fred"}, combo.getItems());
+	assertArrayEquals(new String[]{"fred", "fred", "fred"}, combo.getItems());
 	combo.removeAll();
 
 	int number = 3;
 	for (int i = 0; i < number; i++)
 		combo.add("fred" + i);
 	combo.add("fred", number);
-	assertArrayEquals("fred0 fred1 fred2 fred", new String[]{"fred0", "fred1", "fred2", "fred"}, combo.getItems());
+	assertArrayEquals(new String[]{"fred0", "fred1", "fred2", "fred"}, combo.getItems());
 
 	combo.removeAll();
 	number = 3;
 	for (int i = 0; i < number; i++)
 		combo.add("fred" + i);
 	combo.add("fred", 1);
-	assertArrayEquals("fred0 fred fred1 fred2", new String[]{"fred0", "fred", "fred1", "fred2"}, combo.getItems());
+	assertArrayEquals(new String[]{"fred0", "fred", "fred1", "fred2"}, combo.getItems());
 	combo.add("fred", 0);
-	assertArrayEquals("fred fred0 fred fred1 fred2", new String[]{"fred", "fred0", "fred", "fred1", "fred2"}, combo.getItems());
+	assertArrayEquals(new String[]{"fred", "fred0", "fred", "fred1", "fred2"}, combo.getItems());
 	combo.add("fred", 4);
-	assertArrayEquals("fred fred0 fred fred1 fred fred2", new String[]{"fred", "fred0", "fred", "fred1", "fred", "fred2"}, combo.getItems());
+	assertArrayEquals(new String[]{"fred", "fred0", "fred", "fred1", "fred", "fred2"}, combo.getItems());
 }
 
 @Test
@@ -130,7 +130,7 @@ public void test_addModifyListenerLorg_eclipse_swt_events_ModifyListener() {
 	combo.addModifyListener(listener);
 	listenerCalled = false;
 	combo.setText("new text");
-	assertTrue("setText does not send event", listenerCalled);
+	assertTrue(listenerCalled);
 
 	if (SwtTestUtil.isCocoa) {
 		// TODO Fix Cocoa failure.
@@ -145,7 +145,7 @@ public void test_addModifyListenerLorg_eclipse_swt_events_ModifyListener() {
 		combo.select(0);
 		listenerCalled = false;
 		combo.remove(0);
-		assertTrue("remove(int index) for last item:", listenerCalled);
+		assertTrue(listenerCalled);
 
 		combo.removeAll();
 		combo.add("one");
@@ -153,14 +153,14 @@ public void test_addModifyListenerLorg_eclipse_swt_events_ModifyListener() {
 		combo.select(0);
 		listenerCalled = false;
 		combo.remove(0, 1);
-		assertTrue("remove(int start, int end) for all items:", listenerCalled);
+		assertTrue(listenerCalled);
 	}
 
 	listenerCalled = false;
 	combo.removeModifyListener(listener);
 	// cause to call the listener.
 	combo.setText("line");
-	assertFalse("Listener not removed", listenerCalled);
+	assertFalse(listenerCalled);
 	assertThrows(IllegalArgumentException.class, () ->
 		combo.removeModifyListener(null));
 }
@@ -288,9 +288,9 @@ public void test_deselectI() {
 		combo.add("fred" + i);
 	for (int i = 0; i < number; i++) {
 		combo.select(i);
-		assertEquals("index "+i,i, combo.getSelectionIndex());
+		assertEquals(i, combo.getSelectionIndex());
 		combo.deselect(i);
-		assertEquals("index "+i,-1, combo.getSelectionIndex());
+		assertEquals(-1, combo.getSelectionIndex());
 	}
 }
 
@@ -304,13 +304,13 @@ public void test_getChildren() {
 public void test_getItemCount() {
 	int number = 10;
 	for (int i = 0; i < number; i++) {
-		assertEquals("index "+i,i,  combo.getItemCount());
+		assertEquals(i,  combo.getItemCount());
 		combo.add("fred" + i);
 	}
 	assertEquals(number, combo.getItemCount());
 
 	for (int i = 0; i < number; i++) {
-		assertEquals("index "+i, number-i, combo.getItemCount());
+		assertEquals(number-i, combo.getItemCount());
 		combo.remove(0);
 	}
 	combo.removeAll();
@@ -409,7 +409,7 @@ public void test_getText() {
 	String[] cases = {"", "fred", "fredfred"};
 	for (int i = 0; i < cases.length; i++) {
 		combo.setText(cases[i]);
-		assertEquals(String.valueOf(i), cases[i], combo.getText());
+		assertEquals(cases[i], combo.getText());
 	}
 }
 
@@ -478,18 +478,18 @@ public void test_indexOfLjava_lang_StringI() {
 	for (int i = 0; i < number; i++)
 		combo.add("fred" + i);
 	for (int i = 0; i < number; i++)
-		assertEquals("index " + i, i, combo.indexOf("fred" + i, 0));
+		assertEquals(i, combo.indexOf("fred" + i, 0));
 	for (int i = 0; i < number; i++)
-		assertEquals("index " + i, -1, combo.indexOf("fred" + i, i + 1));
+		assertEquals(-1, combo.indexOf("fred" + i, i + 1));
 
 	for (int i = 0; i < number; i++)
 		combo.add("fred" + i);
 	for (int i = 0; i < 3; i++)
-		assertEquals("index " + i, i, combo.indexOf("fred" + i, 0));
+		assertEquals(i, combo.indexOf("fred" + i, 0));
 	for (int i = 3; i < number; i++)
-		assertEquals("index " + i, i, combo.indexOf("fred" + i, 3));
+		assertEquals(i, combo.indexOf("fred" + i, 3));
 	for (int i = 0; i < number; i++)
-		assertEquals("index " + i, i, combo.indexOf("fred" + i, i));
+		assertEquals(i, combo.indexOf("fred" + i, i));
 }
 
 @Test
@@ -538,7 +538,7 @@ public void test_removeI() {
 		combo.add("fred" + i);
 	}
 	for (int i = 0; i < number; i++) {
-		assertEquals("Wrong number of items", number - i, combo.getItemCount());
+		assertEquals(number - i, combo.getItemCount());
 		combo.remove(0);
 	}
 
@@ -546,7 +546,7 @@ public void test_removeI() {
 		combo.add("fred");  // all items the same
 	}
 	for (int i = 0; i < number; i++) {
-		assertEquals("Wrong number of items", number - i, combo.getItemCount());
+		assertEquals(number - i, combo.getItemCount());
 		combo.remove(0);
 	}
 
@@ -554,23 +554,23 @@ public void test_removeI() {
 		combo.add("fred" + i); // different items
 	}
 	for (int i = 0; i < number; i++) {
-		assertEquals("index " + i, number - i, combo.getItemCount());
+		assertEquals(number - i, combo.getItemCount());
 		combo.select(0);
-		assertEquals("index " + i, 0, combo.getSelectionIndex());
+		assertEquals(0, combo.getSelectionIndex());
 		combo.remove(0);
 		if (SwtTestUtil.isWindows || SwtTestUtil.isGTK ) {
 			// The behavior on Windows and GTK when the selected item is removed
 			// is to simply say that no items are selected.
-			assertEquals("index " + i, -1, combo.getSelectionIndex());
+			assertEquals(-1, combo.getSelectionIndex());
 		} else {
 			// The behavior on other platforms when the selected item is removed
 			// is to select the item that is now at the same index, and send a
 			// selection event. If there is no item at the selected index, then
 			// the platform says that no items are selected.
 			if (i < number - 1) {
-				assertEquals("index " + i, 0, combo.getSelectionIndex());
+				assertEquals(0, combo.getSelectionIndex());
 			} else {
-				assertEquals("index " + i, -1, combo.getSelectionIndex());
+				assertEquals(-1, combo.getSelectionIndex());
 			}
 		}
 	}
@@ -578,7 +578,7 @@ public void test_removeI() {
 	for (int i = 0; i < number; i++)
 		combo.add("fred" + i); // different items
 	for (int i = 0; i < number; i++) {
-		assertEquals("index " + i, number - i, combo.getItemCount());
+		assertEquals(number - i, combo.getItemCount());
 		combo.remove(number-i-1);
 	}
 }
@@ -664,13 +664,13 @@ public void test_removeLjava_lang_String() {
 
 	for (int i = 0; i < number; i++)
 		combo.add("fred");
-	assertThrows("No exception thrown for item == null", IllegalArgumentException.class,
+	assertThrows(IllegalArgumentException.class,
 			() ->	combo.remove(null));
 
 	combo.removeAll();
 	for (int i = 0; i < number; i++)
 		combo.add("fred" + i);
-	assertThrows("No exception thrown for item not found", IllegalArgumentException.class,
+	assertThrows(IllegalArgumentException.class,
 			() -> combo.remove("fred"));
 
 	assertEquals(number, combo.getItemCount());
@@ -694,25 +694,25 @@ public void test_setBackgroundDropDownCombo() {
 	Combo dropDown = new Combo(shell, SWT.DROP_DOWN);
 	Color color = new Color(255, 0, 0);
 	dropDown.setBackground(color);
-	assertEquals("getBackground not equal after setBackground for SWT.DROP_DOWN Combo",
+	assertEquals(
 			color, dropDown.getBackground());
 	dropDown.setBackground(null);
-	assertNotEquals("getBackground unchanged after setBackground(null) for SWT.DROP_DOWN Combo", color,
+	assertNotEquals(color,
 			dropDown.getBackground());
 	color = new Color(255, 0, 0, 0);
 	dropDown.setBackground(color);
-	assertEquals("getBackground not equal after setBackground with 0 alpha for SWT.DROP_DOWN Combo",
+	assertEquals(
 			color, dropDown.getBackground());
 	dropDown.setBackground(null);
-	assertNotEquals("getBackground unchanged after setBackground(null) with 0 alpha for SWT.DROP_DOWN Combo", color,
+	assertNotEquals(color,
 			dropDown.getBackground());
 	if ("gtk".equals(SWT.getPlatform ())) {
 		Color fg = new Color(0, 255, 0);
 		dropDown.setBackground(color);
 		dropDown.setForeground(fg);
-		assertEquals("Setting a foreground disrupted the background color for SWT.DROP_DOWN Combo",
+		assertEquals(
 				color, dropDown.getBackground());
-		assertEquals("Setting a foreground onto an SWT.DROP_DOWN Combo with a background failed",
+		assertEquals(
 				fg, dropDown.getForeground());
 	}
 	dropDown.dispose();
@@ -735,25 +735,25 @@ public void test_setBackgroundSimpleCombo() {
 	Combo simple = new Combo(shell, SWT.SIMPLE);
 	Color color = new Color(255, 0, 0);
 	simple.setBackground(color);
-	assertEquals("getBackground not equal after setBackground for SWT.SIMPLE Combo",
+	assertEquals(
 			color, simple.getBackground());
 	simple.setBackground(null);
-	assertNotEquals("getBackground unchanged after setBackground(null) for SWT.SIMPLE Combo",
+	assertNotEquals(
 			color, simple.getBackground());
 	color = new Color(255, 0, 0, 0);
 	simple.setBackground(color);
-	assertEquals("getBackground not equal after setBackground with 0 alpha for SWT.SIMPLE Combo",
+	assertEquals(
 			color, simple.getBackground());
 	simple.setBackground(null);
-	assertNotEquals("getBackground unchanged after setBackground(null) with 0 alpha for SWT.SIMPLE Combo",
+	assertNotEquals(
 			color, simple.getBackground());
 	if ("gtk".equals(SWT.getPlatform ())) {
 		Color fg = new Color(0, 255, 0);
 		simple.setBackground(color);
 		simple.setForeground(fg);
-		assertEquals("Setting a foreground disrupted the background color for SWT.SIMPLE Combo",
+		assertEquals(
 				color, simple.getBackground());
-		assertEquals("Setting a foreground onto an SWT.SIMPLE Combo with a background failed",
+		assertEquals(
 				fg, simple.getForeground());
 	}
 	simple.dispose();
@@ -783,9 +783,9 @@ public void test_setForegroundDropDownCombo() {
 		Color bg = new Color(0, 255, 0);
 		dropDown.setForeground(color);
 		dropDown.setBackground(bg);
-		assertEquals("Setting a background disrupted the foreground color for SWT.DROP_DOWN Combo",
+		assertEquals(
 				color, dropDown.getForeground());
-		assertEquals("Setting a background onto an SWT.DROP_DOWN Combo with a foreground failed",
+		assertEquals(
 				bg, dropDown.getBackground());
 	}
 	dropDown.dispose();
@@ -794,8 +794,8 @@ public void test_setForegroundDropDownCombo() {
 @Test
 public void test_setForegroundAlphaDropDownCombo() {
 	Combo dropDown = new Combo(shell, SWT.DROP_DOWN);
-	assumeTrue("Alpha support for foreground colors does not exist on Win32",
-			SwtTestUtil.isCocoa || SwtTestUtil.isGTK);
+	assumeTrue(SwtTestUtil.isCocoa || SwtTestUtil.isGTK,
+			"Alpha support for foreground colors does not exist on Win32");
 	Color color = new Color (255, 0, 0, 0);
 	dropDown.setForeground(color);
 	assertEquals(color, dropDown.getForeground());
@@ -817,9 +817,9 @@ public void test_setForegroundSimpleCombo() {
 		Color bg = new Color(0, 255, 0);
 		simple.setForeground(color);
 		simple.setBackground(bg);
-		assertEquals("Setting a background disrupted the foreground color for SWT.SIMPLE Combo",
+		assertEquals(
 				color, simple.getForeground());
-		assertEquals("Setting a background onto an SWT.SIMPLE Combo with a foreground failed",
+		assertEquals(
 				bg, simple.getBackground());
 	}
 	simple.dispose();
@@ -828,8 +828,8 @@ public void test_setForegroundSimpleCombo() {
 @Test
 public void test_setForegroundAlphaSimpleCombo() {
 	Combo simple = new Combo(shell, SWT.SIMPLE);
-	assumeTrue("Alpha support for foreground colors does not exist on Win32",
-			SwtTestUtil.isCocoa || SwtTestUtil.isGTK);
+	assumeTrue(SwtTestUtil.isCocoa || SwtTestUtil.isGTK,
+			"Alpha support for foreground colors does not exist on Win32");
 	Color color = new Color (255, 0, 0, 0);
 	simple.setForeground(color);
 	assertEquals(color, simple.getForeground());
@@ -841,7 +841,7 @@ public void test_setForegroundAlphaSimpleCombo() {
 
 @Test
 public void test_setItemILjava_lang_String() {
-	assertThrows("No exception thrown for item == null", IllegalArgumentException.class,
+	assertThrows(IllegalArgumentException.class,
 		() -> combo.setItem(0, null));
 
 	assertThrows(IllegalArgumentException.class, () -> combo.setItem(3, null));
@@ -849,17 +849,17 @@ public void test_setItemILjava_lang_String() {
 	assertThrows(IllegalArgumentException.class, () -> combo.setItem(0, "fred"));
 
 	combo.add("string0");
-	assertThrows("No exception thrown for item == null", IllegalArgumentException.class, () ->
+	assertThrows(IllegalArgumentException.class, () ->
 		combo.setItem(0, null));
 
-	assertThrows("No exception thrown for index < 0", IllegalArgumentException.class, () ->
+	assertThrows(IllegalArgumentException.class, () ->
 		combo.setItem(-1, "new value"));
 
 	combo.add("joe");
 	combo.setItem(0, "fred");
-	assertEquals("fred", "fred", combo.getItem(0));
+	assertEquals("fred", combo.getItem(0));
 
-	assertThrows("No exception thrown for index < 0", IllegalArgumentException.class, () ->
+	assertThrows(IllegalArgumentException.class, () ->
 		combo.setItem(4, "fred"));
 
 	combo.removeAll();
@@ -873,14 +873,14 @@ public void test_setItemILjava_lang_String() {
 
 @Test
 public void test_setItems$Ljava_lang_String() {
-	assertThrows("No exception thrown for items == null", IllegalArgumentException.class, () ->
+	assertThrows(IllegalArgumentException.class, () ->
 		combo.setItems((String [])null));
 
 	String[][] items = {{}, {""}, {"", ""}, {"fred"}, {"fred0", "fred0"}, {"fred", "fred"}};
 
 	for (int i = 0 ; i< items.length; i++){
 		combo.setItems(items[i]);
-		assertArrayEquals("index" + i, items[i], combo.getItems());}
+		assertArrayEquals(items[i], combo.getItems());}
 }
 
 @Test
@@ -895,7 +895,7 @@ public void test_setOrientationI() {
 
 @Test
 public void test_setSelectionLorg_eclipse_swt_graphics_Point() {
-	assertThrows("No exception thrown for point == null", IllegalArgumentException.class, () ->
+	assertThrows(IllegalArgumentException.class, () ->
 		combo.setSelection(null));
 
 	int number = 5;
@@ -910,7 +910,7 @@ public void test_setSelectionLorg_eclipse_swt_graphics_Point() {
 
 @Test
 public void test_setTextLimitI() {
-	assertThrows("No exception thrown for limit == 0", IllegalArgumentException.class, () ->
+	assertThrows(IllegalArgumentException.class, () ->
 		combo.setTextLimit(0));
 
 	combo.setTextLimit(3);
@@ -919,27 +919,27 @@ public void test_setTextLimitI() {
 
 @Test
 public void test_setTextLjava_lang_String() {
-	assertThrows("No exception thrown for text == null", IllegalArgumentException.class, () ->
+	assertThrows(IllegalArgumentException.class, () ->
 		combo.setText(null));
 
 	String[] cases = {"", "fred", "fred0"};
 	for (int i = 0; i < cases.length; i++) {
 		combo.setText(cases[i]);
-		assertEquals("index" + i, cases[i], combo.getText());
+		assertEquals(cases[i], combo.getText());
 	}
 	for (int i = 0; i < 5; i++) {
 		combo.add("fred");
 	}
 	for (int i = 0; i < cases.length; i++) {
 		combo.setText(cases[i]);
-		assertEquals("index" + i,cases[i], combo.getText());
+		assertEquals(cases[i], combo.getText());
 	}
 	for (int i = 0; i < 5; i++) {
 		combo.add("fred" + i);
 	}
 	for (int i = 0; i < cases.length; i++) {
 		combo.setText(cases[i]);
-		assertEquals("index" + i, cases[i], combo.getText());
+		assertEquals(cases[i], combo.getText());
 	}
 }
 

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Composite.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Composite.java
@@ -13,11 +13,10 @@
  *******************************************************************************/
 package org.eclipse.swt.tests.junit;
 
-
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -31,8 +30,9 @@ import org.eclipse.swt.widgets.List;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.Text;
 import org.eclipse.swt.widgets.Widget;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
 
 /**
  * Automated Test Suite for class org.eclipse.swt.widgets.Composite
@@ -44,7 +44,7 @@ public class Test_org_eclipse_swt_widgets_Composite extends Test_org_eclipse_swt
 Composite composite;
 
 @Override
-@Before
+@BeforeEach
 public void setUp() {
 	super.setUp();
 	composite = new Composite(shell, 0);
@@ -68,24 +68,24 @@ public void test_ConstructorLorg_eclipse_swt_widgets_CompositeI() {
 
 @Test
 public void test_getChildren() {
-	assertArrayEquals(":a:", new Control[]{}, composite.getChildren());
+	assertArrayEquals(new Control[]{}, composite.getChildren());
 	Composite c1 = new Composite(composite, 0);
-	assertArrayEquals(":b:", new Control[]{c1}, composite.getChildren());
+	assertArrayEquals(new Control[]{c1}, composite.getChildren());
 
 	List c2 = new List(composite, 0);
-	assertArrayEquals(":c:", new Control[]{c1, c2}, composite.getChildren());
+	assertArrayEquals(new Control[]{c1, c2}, composite.getChildren());
 
 	Button c3 = new Button(composite, 0);
-	assertArrayEquals(":d:", new Control[]{c1, c2, c3}, composite.getChildren());
+	assertArrayEquals(new Control[]{c1, c2, c3}, composite.getChildren());
 
 	c2.dispose();
-	assertArrayEquals(":e:", new Control[]{c1, c3}, composite.getChildren());
+	assertArrayEquals(new Control[]{c1, c3}, composite.getChildren());
 
 	Control[] children = composite.getChildren();
 	for (Control element : children)
 		element.dispose();
 
-	assertArrayEquals(":f:", new Control[]{}, composite.getChildren());
+	assertArrayEquals(new Control[]{}, composite.getChildren());
 }
 
 
@@ -115,8 +115,7 @@ public void test_setVisibility_and_sizing() {
 //    System.out.println("Button size: " + button.getSize().toString());			  // >> 500,463
 
 	Point compSize = visibilityComposite.getSize();
-	assertTrue("Composite should be aprox 500 by 463 px, but instead it is: " + compSize.toString(),
-			compSize.x > 100 && compSize.y > 100); // If this is 1x1 or 0x0 then there was some fault in layout.
+	assertTrue(compSize.x > 100 && compSize.y > 100); // If this is 1x1 or 0x0 then there was some fault in layout.
 	visibilityShell.dispose();
 }
 
@@ -132,7 +131,7 @@ public void test_setFocus_toChild_afterOpen() {
 	Text focusChild = new Text(composite, SWT.NONE);
 	SwtTestUtil.waitShellActivate(shell::open, shell);
 	composite.setFocus();
-	assertTrue("First child widget should have focus", focusChild.isFocusControl());
+	assertTrue(focusChild.isFocusControl());
 }
 
 @Test
@@ -147,7 +146,7 @@ public void test_setFocus_toChild_beforeOpen() {
 	Text focusChild = new Text(composite, SWT.NONE);
 	composite.setFocus();
 	SwtTestUtil.waitShellActivate(shell::open, shell);
-	assertTrue("First child widget should have focus", focusChild.isFocusControl());
+	assertTrue(focusChild.isFocusControl());
 }
 
 @Test
@@ -164,7 +163,7 @@ public void test_setFocus_withInvisibleChild() {
 	SwtTestUtil.waitShellActivate(shell::open, shell);
 
 	composite.setFocus();
-	assertFalse("Composite should not try to set focus on invisible child", wasSetFocusCalledOnInvisibleChildWidget.get());
+	assertFalse(wasSetFocusCalledOnInvisibleChildWidget.get());
 }
 
 @Test
@@ -182,8 +181,8 @@ public void test_setFocus_withVisibleAndInvisibleChild() {
 	SwtTestUtil.waitShellActivate(shell::open, shell);
 
 	composite.setFocus();
-	assertFalse("Composite should not try to set focus on invisible child", wasSetFocusCalledOnInvisibleChildWidget.get());
-	assertTrue("Visible child widget should have focus", getElementExpectedToHaveFocusAfterSetFocusOnParent(visibleChildWidget).isFocusControl());
+	assertFalse(wasSetFocusCalledOnInvisibleChildWidget.get());
+	assertTrue(getElementExpectedToHaveFocusAfterSetFocusOnParent(visibleChildWidget).isFocusControl());
 }
 
 @Test

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Control.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Control.java
@@ -13,16 +13,16 @@
  *******************************************************************************/
 package org.eclipse.swt.tests.junit;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-import static org.junit.Assume.assumeTrue;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -59,8 +59,7 @@ import org.eclipse.swt.widgets.Menu;
 import org.eclipse.swt.widgets.Monitor;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.Widget;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Base Test for widgets of type org.eclipse.swt.widgets.Control
@@ -478,7 +477,7 @@ public void test_computeSizeIIZ() {
 @Test
 public void test_getAccessible() {
 	Accessible accessible = control.getAccessible();
-	assertNotNull(":a:", accessible);
+	assertNotNull(accessible);
 }
 @Test
 public void test_getBorderWidth() {
@@ -533,11 +532,11 @@ public void test_isFocusControl() {
 	assertFalse(control.isFocusControl());
 	SwtTestUtil.waitShellActivate(shell::open, shell);
 	assertEquals(shell, shell.getDisplay().getActiveShell());
-	assertEquals("Unexpected focus", control.forceFocus(), control.isFocusControl());
+	assertEquals(control.forceFocus(), control.isFocusControl());
 }
 @Test
 public void test_isReparentable() {
-	assertTrue ("isReparentable", control.isReparentable());
+	assertTrue(control.isReparentable());
 }
 @Test
 public void test_isVisible() {
@@ -549,9 +548,9 @@ public void test_isVisible() {
 
 	control.setVisible(true);
 	shell.setVisible(true);
-	assertTrue("Window should be visible", control.isVisible());
+	assertTrue(control.isVisible());
 	shell.setVisible(false);
-	assertFalse("Window should not be visible", control.isVisible());
+	assertFalse(control.isVisible());
 }
 @Test
 public void test_moveAboveLorg_eclipse_swt_widgets_Control() {
@@ -608,23 +607,23 @@ public void test_requestLayoutL() {
 public void test_setBackgroundLorg_eclipse_swt_graphics_Color() {
 	Color color = new Color(255, 0, 0);
 	control.setBackground(color);
-	assertEquals("getBackground not equal color after setBackground(color) for " + control, color, control.getBackground());
+	assertEquals(color, control.getBackground());
 	control.setBackground(null);
-	assertNotEquals("getBackground unchanged after setBackground(null) for" + control,
+	assertNotEquals(
 			color, control.getBackground());
 	color = new Color(255, 0, 0, 0);
 	control.setBackground(color);
-	assertEquals("getBackground not equal color after setBackground(color) with 0 alpha for " + control + " " + control.getBackground(), color, control.getBackground());
+	assertEquals(color, control.getBackground());
 	control.setBackground(null);
-	assertNotEquals("getBackground unchanged after setBackground(null) alpha for " + control + " " + control.getBackground() + " " + control,
+	assertNotEquals(
 			color, control.getBackground());
 	if ("gtk".equals(SWT.getPlatform ())) {
 		Color fg = new Color(0, 255, 0);
 		control.setBackground(color);
 		control.setForeground(fg);
-		assertEquals("Setting a foreground disrupted the background color for " + control,
+		assertEquals(
 				color, control.getBackground());
-		assertEquals("Setting a foreground onto a widget with a background failed for " + control,
+		assertEquals(
 				fg, control.getForeground());
 	}
 }
@@ -641,7 +640,7 @@ public void test_setBackgroundAlphaLorg_eclipse_swt_graphics_Color() {
 public void test_setBackgroundDisposedColorLorg_eclipse_swt_graphics_Color() {
 	Color color = new Color(255, 0, 0);
 	color.dispose();
-	assertThrows("setting a disposed color object with Control.setBackground(Color) should throw an exception",
+	assertThrows(
 			IllegalArgumentException.class, () -> control.setBackground(color));
 }
 @Test
@@ -662,7 +661,7 @@ public void test_setBoundsLorg_eclipse_swt_graphics_Rectangle() {
 	control.setBounds(new Rectangle(20, 30, 40, 50));
 	assertNotEquals(new Rectangle(10, 20, 30, 40), control.getBounds());
 
-	assertThrows("No exception thrown for rectangle == null", IllegalArgumentException.class,
+	assertThrows(IllegalArgumentException.class,
 			() -> control.setBounds(null));
 
 	control.setBounds(new Rectangle(10, 20, 30, 40));
@@ -707,8 +706,7 @@ public void test_setTextDirection() {
 		expectedDirections[2] = control.getOrientation ();
 		for (int j = directions.length; j-- > 0;) {
 			control.setTextDirection (directions [j]);
-			assertEquals("orientation: " + orientations [i] + ", text direction: " + directions [j],
-					control.getTextDirection(), expectedDirections [j]);
+			assertEquals(control.getTextDirection(), expectedDirections [j]);
 		}
 	}
 }
@@ -729,7 +727,7 @@ public void test_setFontLorg_eclipse_swt_graphics_Font() {
 	control.setFont(null);
 	font.dispose();
 	Font f = font;
-	assertThrows("No exception thrown for disposed font", IllegalArgumentException.class, () -> control.setFont(f));
+	assertThrows(IllegalArgumentException.class, () -> control.setFont(f));
 	control.setFont(null);
 }
 @Test
@@ -743,16 +741,15 @@ public void test_setForegroundLorg_eclipse_swt_graphics_Color() {
 		Color bg = new Color(0, 255, 0);
 		control.setForeground(color);
 		control.setBackground(bg);
-		assertEquals("Setting a background disrupted the foreground color for " + control,
+		assertEquals(
 				color, control.getForeground());
-		assertEquals("Setting a background onto a widget with a foreground failed for " + control,
+		assertEquals(
 				bg, control.getBackground());
 	}
 }
 @Test
 public void test_setForegroundAlphaLorg_eclipse_swt_graphics_Color() {
-	assumeTrue("Alpha support for foreground colors does not exist on Win32",
-			SwtTestUtil.isCocoa || SwtTestUtil.isGTK);
+	assumeTrue(SwtTestUtil.isCocoa || SwtTestUtil.isGTK, "Alpha support for foreground colors does not exist on Win32");
 	Color color = new Color (255, 0, 0, 0);
 	control.setForeground(color);
 	assertEquals(color, control.getForeground());
@@ -765,7 +762,7 @@ public void test_setForegroundAlphaLorg_eclipse_swt_graphics_Color() {
 public void test_setForegroundDisposedColorLorg_eclipse_swt_graphics_Color() {
 	Color color = new Color(255, 0, 0);
 	color.dispose();
-	assertThrows("setting a disposed color object with Control.setForeground(Color) should throw an exception",
+	assertThrows(
 			IllegalArgumentException.class, () -> control.setForeground(color));
 }
 @Test
@@ -794,7 +791,7 @@ public void test_setLocationII() {
 }
 @Test
 public void test_setLocationLorg_eclipse_swt_graphics_Point() {
-	assertThrows("No exception thrown for location == null", IllegalArgumentException.class,
+	assertThrows(IllegalArgumentException.class,
 			() -> control.setLocation(null));
 
 	Point loc = new Point(30, 40);
@@ -863,7 +860,7 @@ public void test_setSizeLorg_eclipse_swt_graphics_Point() {
 	control.setSize(new Point(30, 40));
 	assertEquals(new Point(30, 40), control.getSize());
 
-	assertThrows("No exception thrown for size == null", IllegalArgumentException.class, () -> control.setSize(null));
+	assertThrows(IllegalArgumentException.class, () -> control.setSize(null));
 
 	control.setSize(new Point(0, 0));
 
@@ -898,7 +895,7 @@ public void test_toControlII() {
 public void test_toControlLorg_eclipse_swt_graphics_Point() {
 	Point controlCoords = control.toControl(new Point(0, 0));
 	assertEquals(new Point(0, 0), control.toDisplay(controlCoords));
-	assertThrows("No exception thrown for point == null", IllegalArgumentException.class,
+	assertThrows(IllegalArgumentException.class,
 			() -> control.toControl(null));
 }
 @Test
@@ -910,7 +907,7 @@ public void test_toDisplayII() {
 public void test_toDisplayLorg_eclipse_swt_graphics_Point() {
 	Point displayCoords = control.toDisplay(new Point(0, 0));
 	assertEquals(new Point(0, 0), control.toControl(displayCoords));
-	assertThrows("No exception thrown for display == null", IllegalArgumentException.class,
+	assertThrows(IllegalArgumentException.class,
 			() -> control.toDisplay(null));
 }
 @Test
@@ -1006,38 +1003,38 @@ protected void consistencyEvent(final int paramA, final int paramB,
 				display.wake();
 				switch(method) {
 					case ConsistencyUtility.MOUSE_CLICK:
-						Assert.assertTrue(test,
+						assertTrue(
 							ConsistencyUtility.postClick(display, pt[0], paramC));
 						if(paramD == ConsistencyUtility.ESCAPE_MENU) {
-							Assert.assertTrue(test,
+							assertTrue(
 								ConsistencyUtility.postClick(display, pt[1], 1));
 						}
 						break;
 					case ConsistencyUtility.MOUSE_DOUBLECLICK:
-						Assert.assertTrue(test,
+						assertTrue(
 								ConsistencyUtility.postDoubleClick(display, pt[0], paramC));
 						break;
 					case ConsistencyUtility.KEY_PRESS:
-						Assert.assertTrue(test,
+						assertTrue(
 							ConsistencyUtility.postKeyPress(display, paramA, paramB));
 						break;
 					case ConsistencyUtility.DOUBLE_KEY_PRESS:
-						Assert.assertTrue(test,
+						assertTrue(
 							ConsistencyUtility.postDoubleKeyPress(display, paramA, paramB, paramC, paramD));
 						break;
 					case ConsistencyUtility.MOUSE_DRAG:
-						Assert.assertTrue(test,
+						assertTrue(
 							ConsistencyUtility.postDrag(display,
 									pt[0], pt[1]));
 						break;
 					case ConsistencyUtility.SELECTION:
 
-						Assert.assertTrue(test,
+						assertTrue(
 							ConsistencyUtility.postSelection(display,
 									pt[0], pt[1]));
 						break;
 					case ConsistencyUtility.SHELL_ICONIFY:
-						Assert.assertTrue(test,
+						assertTrue(
 							ConsistencyUtility.postShellIconify(display, pt[1], paramA));
 						if(control instanceof Shell) {
 							display.syncExec(() -> ((Shell)control).setMinimized(false));
@@ -1055,7 +1052,7 @@ protected void consistencyEvent(final int paramA, final int paramB,
 		setUp();
 		String[] results = new String[events.size()];
 		results = events.toArray(results);
-		assertArrayEquals(test + " event ordering", expectedEvents, results);
+		assertArrayEquals(expectedEvents, results);
 	}
 }
 

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_CoolBar.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_CoolBar.java
@@ -28,8 +28,8 @@ import org.eclipse.swt.widgets.Menu;
 import org.eclipse.swt.widgets.MenuItem;
 import org.eclipse.swt.widgets.ToolBar;
 import org.eclipse.swt.widgets.ToolItem;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 
 /**
@@ -40,7 +40,7 @@ import org.junit.Test;
 public class Test_org_eclipse_swt_widgets_CoolBar extends Test_org_eclipse_swt_widgets_Composite {
 
 @Override
-@Before
+@BeforeEach
 public void setUp() {
 	super.setUp();
 	coolBar = new CoolBar(shell, 0);

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_CoolItem.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_CoolItem.java
@@ -14,10 +14,10 @@
 package org.eclipse.swt.tests.junit;
 
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Point;
@@ -26,8 +26,9 @@ import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.CoolBar;
 import org.eclipse.swt.widgets.CoolItem;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
 
 /**
  * Automated Test Suite for class org.eclipse.swt.widgets.CoolItem
@@ -37,7 +38,7 @@ import org.junit.Test;
 public class Test_org_eclipse_swt_widgets_CoolItem extends Test_org_eclipse_swt_widgets_Item {
 
 @Override
-@Before
+@BeforeEach
 public void setUp() {
 	super.setUp();
 	CoolBar coolBar = new CoolBar(shell, 0);

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_DateTime.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_DateTime.java
@@ -13,15 +13,13 @@
  *******************************************************************************/
 package org.eclipse.swt.tests.junit;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assume.assumeTrue;
 
-import java.util.Arrays;
-import java.util.Collection;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.SelectionEvent;
@@ -29,40 +27,32 @@ import org.eclipse.swt.events.SelectionListener;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.widgets.DateTime;
 import org.eclipse.swt.widgets.Event;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
 
 /**
  * Automated Test Suite for class org.eclipse.swt.widgets.DateTime
  *
  * @see org.eclipse.swt.widgets.DateTime
  */
-@RunWith(value = Parameterized.class)
-public class Test_org_eclipse_swt_widgets_DateTime extends Test_org_eclipse_swt_widgets_Control {
+public abstract class Test_org_eclipse_swt_widgets_DateTime extends Test_org_eclipse_swt_widgets_Control {
 	static final int JAN = 0, FEB = 1, AUG = 7, NOV = 10;
 	DateTime datetime;
-	int style = SWT.DATE;
-
-	@Parameters
-	public static Collection<Object[]> data() {
-		Object[][] data = new Object[][] { { SWT.DATE }, { SWT.TIME}, { SWT.CALENDAR }};
-		return Arrays.asList(data);
-	}
+	private int style;
 
 public Test_org_eclipse_swt_widgets_DateTime(int style) {
 	this.style = style;
 }
 
 @Override
-@Before
+@BeforeEach
 public void setUp() {
 	super.setUp();
 	datetime = new DateTime(shell, style);
 	setWidget(datetime);
 }
+
 
 @Override
 @Test
@@ -95,7 +85,7 @@ public void test_ConstructorLorg_eclipse_swt_widgets_CompositeI() {
 
 	new DateTime(shell, SWT.DROP_DOWN);
 
-	assertThrows("No exception thrown for parent == null", IllegalArgumentException.class, () -> new DateTime(null, 0));
+	assertThrows(IllegalArgumentException.class, () -> new DateTime(null, 0));
 }
 
 @Test
@@ -112,15 +102,13 @@ public void test_addSelectionListenerLorg_eclipse_swt_events_SelectionListener()
 		}
 	};
 
-	assertThrows("No exception thrown for addSelectionListener with null argument", IllegalArgumentException.class,
-			() -> datetime.addSelectionListener(null));
+	assertThrows(IllegalArgumentException.class, () -> datetime.addSelectionListener(null));
 
 	datetime.addSelectionListener(listener);
 	datetime.notifyListeners(SWT.Selection, new Event());
 	assertTrue(listenerCalled);
 
-	assertThrows("No exception thrown for removeSelectionListener with null argument", IllegalArgumentException.class,
-			() -> datetime.removeSelectionListener(null));
+	assertThrows(IllegalArgumentException.class, () -> datetime.removeSelectionListener(null));
 
 	listenerCalled = false;
 	datetime.removeSelectionListener(listener);
@@ -148,26 +136,20 @@ public void test_setBackgroundCalendarDateTime() {
 	DateTime calendar = new DateTime(shell, SWT.CALENDAR);
 	Color color = new Color(255, 0, 0);
 	calendar.setBackground(color);
-	assertEquals("getBackground not equal after setBackground for SWT.CALENDAR DateTime",
-			color, calendar.getBackground());
+	assertEquals(color, calendar.getBackground());
 	calendar.setBackground(null);
-	assertNotEquals("getBackground unchanged after setBackground(null) for SWT.CALENDAR DateTime",
-			color, calendar.getBackground());
+	assertNotEquals(color, calendar.getBackground());
 	color = new Color(255, 0, 0, 0);
 	calendar.setBackground(color);
-	assertEquals("getBackground not equal after setBackground with 0 alpha for SWT.CALENDAR DateTime",
-			color, calendar.getBackground());
+	assertEquals(color, calendar.getBackground());
 	calendar.setBackground(null);
-	assertNotEquals("getBackground unchanged after setBackground(null) with 0 alpha for SWT.CALENDAR DateTime",
-			color, calendar.getBackground());
+	assertNotEquals(color, calendar.getBackground());
 	if ("gtk".equals(SWT.getPlatform ())) {
 		Color fg = new Color(0, 255, 0);
 		calendar.setBackground(color);
 		calendar.setForeground(fg);
-		assertEquals("Setting a foreground disrupted the background color for SWT.CALENDAR DateTime",
-				color, calendar.getBackground());
-		assertEquals("Setting a foreground onto an SWT.CALENDAR DateTime with a background failed",
-				fg, calendar.getForeground());
+		assertEquals(color, calendar.getBackground());
+		assertEquals(fg, calendar.getForeground());
 	}
 	calendar.dispose();
 }
@@ -189,26 +171,20 @@ public void test_setBackgroundTimeDateTime() {
 	DateTime time = new DateTime(shell, SWT.TIME);
 	Color color = new Color(255, 0, 0);
 	time.setBackground(color);
-	assertEquals("getBackground not equal after setBackground for SWT.TIME DateTime",
-			color, time.getBackground());
+	assertEquals(color, time.getBackground());
 	time.setBackground(null);
-	assertNotEquals("getBackground unchanged after setBackground(null) for SWT.TIME DateTime",
-			color, time.getBackground());
+	assertNotEquals(color, time.getBackground());
 	color = new Color(255, 0, 0, 0);
 	time.setBackground(color);
-	assertEquals("getBackground not equal after setBackground with 0 alpha for SWT.TIME DateTime",
-			color, time.getBackground());
+	assertEquals(color, time.getBackground());
 	time.setBackground(null);
-	assertNotEquals("getBackground unchanged after setBackground(null) with 0 alpha for SWT.TIME DateTime",
-			color, time.getBackground());
+	assertNotEquals(color, time.getBackground());
 	if ("gtk".equals(SWT.getPlatform ())) {
 		Color fg = new Color(0, 255, 0);
 		time.setBackground(color);
 		time.setForeground(fg);
-		assertEquals("Setting a foreground disrupted the background color for SWT.TIME DateTime",
-				color, time.getBackground());
-		assertEquals("Setting a foreground onto an SWT.TIME DateTime with a background failed",
-				fg, time.getForeground());
+		assertEquals(color, time.getBackground());
+		assertEquals(fg, time.getForeground());
 	}
 	time.dispose();
 }
@@ -230,26 +206,20 @@ public void test_setBackgroundDateDateTime() {
 	DateTime date = new DateTime(shell, SWT.DATE);
 	Color color = new Color(255, 0, 0);
 	date.setBackground(color);
-	assertEquals("getBackground not equal after setBackground for SWT.DATE DateTime",
-			color, date.getBackground());
+	assertEquals(color, date.getBackground());
 	date.setBackground(null);
-	assertNotEquals("getBackground unchanged after setBackground(null) for SWT.DATE DateTime",
-			color, date.getBackground());
+	assertNotEquals(color, date.getBackground());
 	color = new Color(255, 0, 0, 0);
 	date.setBackground(color);
-	assertEquals("getBackground not equal after setBackground with 0 alpha for SWT.DATE DateTime",
-			color, date.getBackground());
+	assertEquals(color, date.getBackground());
 	date.setBackground(null);
-	assertNotEquals("getBackground unchanged after setBackground(null) with 0 alpha for SWT.DATE DateTime",
-			color, date.getBackground());
+	assertNotEquals(color, date.getBackground());
 	if ("gtk".equals(SWT.getPlatform ())) {
 		Color fg = new Color(0, 255, 0);
 		date.setBackground(color);
 		date.setForeground(fg);
-		assertEquals("Setting a foreground disrupted the background color for SWT.DATE DateTime",
-				color, date.getBackground());
-		assertEquals("Setting a foreground onto an SWT.DATE DateTime with a background failed",
-				fg, date.getForeground());
+		assertEquals(color, date.getBackground());
+		assertEquals(fg, date.getForeground());
 	}
 	date.dispose();
 }
@@ -404,10 +374,8 @@ public void test_setForegroundCalendarDateTime() {
 		Color bg = new Color(0, 255, 0);
 		calendar.setForeground(color);
 		calendar.setBackground(bg);
-		assertEquals("Setting a background disrupted the foreground color for SWT.CALENDAR DateTime",
-				color, calendar.getForeground());
-		assertEquals("Setting a background onto an SWT.CALENDAR DateTime with a foreground failed",
-				bg, calendar.getBackground());
+		assertEquals(color, calendar.getForeground());
+		assertEquals(bg, calendar.getBackground());
 	}
 	calendar.dispose();
 }
@@ -415,8 +383,8 @@ public void test_setForegroundCalendarDateTime() {
 @Test
 public void test_setForegroundAlphaCalendarDateTime() {
 	DateTime calendar = new DateTime(shell, SWT.CALENDAR);
-	assumeTrue("Alpha support for foreground colors does not exist on Win32",
-			SwtTestUtil.isCocoa || SwtTestUtil.isGTK);
+	assumeTrue(SwtTestUtil.isCocoa || SwtTestUtil.isGTK,
+			"Alpha support for foreground colors does not exist on Win32");
 	Color color = new Color (255, 0, 0, 0);
 	calendar.setForeground(color);
 	assertEquals(color, calendar.getForeground());
@@ -438,10 +406,8 @@ public void test_setForegroundTimeDateTime() {
 		Color bg = new Color(0, 255, 0);
 		time.setForeground(color);
 		time.setBackground(bg);
-		assertEquals("Setting a background disrupted the foreground color for SWT.TIME DateTime",
-				color, time.getForeground());
-		assertEquals("Setting a background onto an SWT.TIME DateTime with a foreground failed",
-				bg, time.getBackground());
+		assertEquals(color, time.getForeground());
+		assertEquals(bg, time.getBackground());
 	}
 	time.dispose();
 }
@@ -449,8 +415,8 @@ public void test_setForegroundTimeDateTime() {
 @Test
 public void test_setForegroundAlphaTimeDateTime() {
 	DateTime time = new DateTime(shell, SWT.TIME);
-	assumeTrue("Alpha support for foreground colors does not exist Win32",
-			SwtTestUtil.isCocoa || SwtTestUtil.isGTK);
+	assumeTrue(SwtTestUtil.isCocoa || SwtTestUtil.isGTK,
+			"Alpha support for foreground colors does not exist on Win32");
 	Color color = new Color (255, 0, 0, 0);
 	time.setForeground(color);
 	assertEquals(color, time.getForeground());
@@ -472,10 +438,8 @@ public void test_setForegroundDateDateTime() {
 		Color bg = new Color(0, 255, 0);
 		date.setForeground(color);
 		date.setBackground(bg);
-		assertEquals("Setting a background disrupted the foreground color for SWT.DATE DateTime",
-				color, date.getForeground());
-		assertEquals("Setting a background onto an SWT.DATE DateTime with a foreground failed",
-				bg, date.getBackground());
+		assertEquals(color, date.getForeground());
+		assertEquals(bg, date.getBackground());
 	}
 	date.dispose();
 }
@@ -483,8 +447,8 @@ public void test_setForegroundDateDateTime() {
 @Test
 public void test_setForegroundAlphaDateDateTime() {
 	DateTime date = new DateTime(shell, SWT.DATE);
-	assumeTrue("Alpha support for foreground colors does not exist on Win32",
-			SwtTestUtil.isCocoa || SwtTestUtil.isGTK);
+	assumeTrue(SwtTestUtil.isCocoa || SwtTestUtil.isGTK,
+			"Alpha support for foreground colors does not exist on Win32");
 	Color color = new Color (255, 0, 0, 0);
 	date.setForeground(color);
 	assertEquals(color, date.getForeground());

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_DateTime_Style_CALENDAR.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_DateTime_Style_CALENDAR.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2015 IBM Corporation and others.
+ * Copyright (c) 2025 Kichwa Coders Canada, Inc.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -7,20 +7,15 @@
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package org.eclipse.swt.tests.junit;
 
+import org.eclipse.swt.SWT;
 
-import org.junit.platform.suite.api.SelectClasses;
-import org.junit.platform.suite.api.Suite;
+public class Test_org_eclipse_swt_widgets_DateTime_Style_CALENDAR extends Test_org_eclipse_swt_widgets_DateTime {
 
-@Suite
-@SelectClasses({
-	Test_org_eclipse_swt_browser_Browser.class,
-	Test_org_eclipse_swt_browser_Browser_IE.class
-})
-public class AllBrowserTests {
+
+	public Test_org_eclipse_swt_widgets_DateTime_Style_CALENDAR() {
+		super(SWT.CALENDAR);
+	}
 }

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_DateTime_Style_DATE.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_DateTime_Style_DATE.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2015 IBM Corporation and others.
+ * Copyright (c) 2025 Kichwa Coders Canada, Inc.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -7,20 +7,14 @@
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package org.eclipse.swt.tests.junit;
 
+import org.eclipse.swt.SWT;
 
-import org.junit.platform.suite.api.SelectClasses;
-import org.junit.platform.suite.api.Suite;
+public class Test_org_eclipse_swt_widgets_DateTime_Style_DATE extends Test_org_eclipse_swt_widgets_DateTime {
 
-@Suite
-@SelectClasses({
-	Test_org_eclipse_swt_browser_Browser.class,
-	Test_org_eclipse_swt_browser_Browser_IE.class
-})
-public class AllBrowserTests {
+	public Test_org_eclipse_swt_widgets_DateTime_Style_DATE() {
+		super(SWT.DATE);
+	}
 }

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_DateTime_Style_TIME.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_DateTime_Style_TIME.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2015 IBM Corporation and others.
+ * Copyright (c) 2025 Kichwa Coders Canada, Inc.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -7,20 +7,14 @@
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package org.eclipse.swt.tests.junit;
 
+import org.eclipse.swt.SWT;
 
-import org.junit.platform.suite.api.SelectClasses;
-import org.junit.platform.suite.api.Suite;
+public class Test_org_eclipse_swt_widgets_DateTime_Style_TIME extends Test_org_eclipse_swt_widgets_DateTime {
 
-@Suite
-@SelectClasses({
-	Test_org_eclipse_swt_browser_Browser.class,
-	Test_org_eclipse_swt_browser_Browser_IE.class
-})
-public class AllBrowserTests {
+	public Test_org_eclipse_swt_widgets_DateTime_Style_TIME() {
+		super(SWT.TIME);
+	}
 }

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Decorations.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Decorations.java
@@ -13,11 +13,11 @@
  *******************************************************************************/
 package org.eclipse.swt.tests.junit;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -32,7 +32,7 @@ import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Decorations;
 import org.eclipse.swt.widgets.Menu;
 import org.eclipse.swt.widgets.Widget;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Automated Test Suite for class org.eclipse.swt.widgets.Decorations
@@ -59,15 +59,15 @@ public void test_computeTrimIIII() {
 @Test
 public void test_getClientArea() {
 	Rectangle rect = decorations.getClientArea();
-	assertTrue(":a:", rect.height >= 0);
-	assertTrue(":b:", rect.width >= 0);
+	assertTrue(rect.height >= 0);
+	assertTrue(rect.width >= 0);
 }
 
 @Test
 public void test_getDefaultButton() {
 	Button button = new Button(decorations, SWT.PUSH);
 	decorations.setDefaultButton(button);
-	assertTrue(":a:", decorations.getDefaultButton() == button);
+	assertTrue(decorations.getDefaultButton() == button);
 }
 
 @Test
@@ -86,22 +86,22 @@ public void test_getImage() {
 @Test
 public void test_getLocation() {
 	decorations.setLocation(10,15);
-	assertEquals(":a:", 10, decorations.getLocation().x);
-	assertEquals(":b:", 15, decorations.getLocation().y);
+	assertEquals(10, decorations.getLocation().x);
+	assertEquals(15, decorations.getLocation().y);
 }
 
 @Test
 public void test_getMenuBar() {
-	assertNull(":a:", decorations.getMenuBar());
+	assertNull(decorations.getMenuBar());
 	Menu bar = new Menu (decorations, SWT.BAR);
 	decorations.setMenuBar (bar);
-	assertTrue(":b:", decorations.getMenuBar() == bar);
+	assertTrue(decorations.getMenuBar() == bar);
 }
 
 @Test
 public void test_getText() {
 	decorations.setText("test");
-	assertEquals(":a:", "test", decorations.getText());
+	assertEquals("test", decorations.getText());
 }
 
 @Override
@@ -116,7 +116,7 @@ public void test_setDefaultButtonLorg_eclipse_swt_widgets_Button() {
 	assertNull(decorations.getDefaultButton());
 	Button button = new Button(decorations, SWT.NULL);
 	decorations.setDefaultButton(button);
-	assertTrue("button not default", decorations.getDefaultButton() == button);
+	assertTrue(decorations.getDefaultButton() == button);
 	if (SwtTestUtil.fCheckBogusTestCases) {
 		decorations.setDefaultButton(null);
 		assertNull(decorations.getDefaultButton());
@@ -125,23 +125,23 @@ public void test_setDefaultButtonLorg_eclipse_swt_widgets_Button() {
 
 @Test
 public void test_setImageLorg_eclipse_swt_graphics_Image() {
-	assertNull(":a:", decorations.getImage());
+	assertNull(decorations.getImage());
 	loadImages();
 	decorations.setImage(images.get(0));
-	assertTrue(":b:", images.get(0) == decorations.getImage());
-	assertTrue(":c:", images.get(1) != decorations.getImage());
+	assertTrue(images.get(0) == decorations.getImage());
+	assertTrue(images.get(1) != decorations.getImage());
 	decorations.setImage(null);
-	assertNull(":d:", decorations.getImage());
+	assertNull(decorations.getImage());
 	freeImages();
 }
 
 @Test
 public void test_setMaximizedZ() {
 	decorations.setMaximized(false);
-	assertFalse(":1:", decorations.getMaximized());
+	assertFalse(decorations.getMaximized());
 	decorations.setMaximized(true);
-	assertTrue(":2:", decorations.getMaximized());
-	assertFalse(":3:", decorations.getMinimized());
+	assertTrue(decorations.getMaximized());
+	assertFalse(decorations.getMinimized());
 }
 
 @Test
@@ -149,7 +149,7 @@ public void test_setMenuBarLorg_eclipse_swt_widgets_Menu() {
 	assertNull(decorations.getMenu());
 	Menu testMenu = new Menu(decorations);
 	decorations.setMenu(testMenu);
-	assertTrue("Incorrect menu", decorations.getMenu() == testMenu);
+	assertTrue(decorations.getMenu() == testMenu);
 	decorations.setMenu(null);
 	assertNull(decorations.getMenu());
 }
@@ -157,10 +157,10 @@ public void test_setMenuBarLorg_eclipse_swt_widgets_Menu() {
 @Test
 public void test_setMinimizedZ() {
 	decorations.setMinimized(false);
-	assertFalse(":1:", decorations.getMinimized());
+	assertFalse(decorations.getMinimized());
 	decorations.setMinimized(true);
-	assertTrue(":2:", decorations.getMinimized());
-	assertFalse(":3:", decorations.getMaximized());
+	assertTrue(decorations.getMinimized());
+	assertFalse(decorations.getMaximized());
 }
 
 @Test
@@ -174,9 +174,9 @@ public void test_setTextLjava_lang_String() {
 
 	String testStr = "test string";
 	decorations.setText(testStr);
-	assertEquals("a", testStr, decorations.getText());
+	assertEquals(testStr, decorations.getText());
 	decorations.setText("");
-	assertTrue("b", decorations.getText().isEmpty());
+	assertTrue(decorations.getText().isEmpty());
 	try {
 		decorations.setText(null);
 		fail("No exception thrown for string == null");

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Event.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Event.java
@@ -14,12 +14,11 @@
  *******************************************************************************/
 package org.eclipse.swt.tests.junit;
 
-
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.swt.widgets.Event;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Automated Test Suite for class org.eclipse.swt.widgets.Event

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_ExpandBar.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_ExpandBar.java
@@ -13,11 +13,11 @@
  *******************************************************************************/
 package org.eclipse.swt.tests.junit;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -28,8 +28,8 @@ import org.eclipse.swt.events.ExpandListener;
 import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.ExpandBar;
 import org.eclipse.swt.widgets.ExpandItem;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Automated Test Suite for class org.eclipse.swt.widgets.ExpandBar
@@ -39,7 +39,7 @@ import org.junit.Test;
 public class Test_org_eclipse_swt_widgets_ExpandBar extends Test_org_eclipse_swt_widgets_Composite {
 
 @Override
-@Before
+@BeforeEach
 public void setUp() {
 	super.setUp();
 	expandBar = new ExpandBar(shell, 0);
@@ -68,11 +68,11 @@ public void test_addExpandListenerLorg_eclipse_swt_events_ExpandListener() {
 
 	expandBar.addExpandListener(expandListener);
 	expandBar.notifyListeners(SWT.Expand, new Event());
-	assertTrue(":a:", listenerCalled[0]);
+	assertTrue(listenerCalled[0]);
 
 	listenerCalled[0] = false;
 	expandBar.notifyListeners(SWT.Collapse, new Event());
-	assertTrue(":b:", listenerCalled[0]);
+	assertTrue(listenerCalled[0]);
 
 	try {
 		expandBar.removeExpandListener(null);
@@ -149,7 +149,7 @@ public void test_ConstructorLorg_eclipse_swt_widgets_CompositeI() {
 public void test_getItemCount() {
 	int number = 10;
 	for (int i = 0; i < number; i++) {
-		assertEquals(":a:" + i, i, expandBar.getItemCount());
+		assertEquals(i, expandBar.getItemCount());
 		new ExpandItem(expandBar, 0);
 	}
 }
@@ -162,7 +162,7 @@ public void test_getItemI() {
 		items[i] = new ExpandItem(expandBar, 0);
 	}
 	for (int i = 0; i<number ; i++){
-		assertTrue(":a:", expandBar.getItem(i)==items[i]);
+		assertTrue(expandBar.getItem(i)==items[i]);
 	}
 
 	expandBar = new ExpandBar(shell, 0);
@@ -206,7 +206,7 @@ public void test_indexOfLorg_eclipse_swt_widgets_ExpandItem() {
 		items[i] = new ExpandItem(expandBar, 0);
 	}
 	for (int i = 0; i < number; i++) {
-		assertTrue(":a:" + i, expandBar.indexOf(items[i] ) == i);
+		assertTrue(expandBar.indexOf(items[i] ) == i);
 	}
 
 	items = new ExpandItem[number];

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_ExpandItem.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_ExpandItem.java
@@ -12,19 +12,19 @@
  *******************************************************************************/
 package org.eclipse.swt.tests.junit;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.ExpandBar;
 import org.eclipse.swt.widgets.ExpandItem;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Automated Test Suite for class org.eclipse.swt.widgets.ToolItem
@@ -34,7 +34,7 @@ import org.junit.Test;
 public class Test_org_eclipse_swt_widgets_ExpandItem extends Test_org_eclipse_swt_widgets_Item {
 
 @Override
-@Before
+@BeforeEach
 public void setUp() {
 	super.setUp();
 	expandBar = new ExpandBar(shell, 0);

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Group.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Group.java
@@ -13,13 +13,13 @@
  *******************************************************************************/
 package org.eclipse.swt.tests.junit;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Group;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Automated Test Suite for class org.eclipse.swt.widgets.Group
@@ -29,7 +29,7 @@ import org.junit.Test;
 public class Test_org_eclipse_swt_widgets_Group extends Test_org_eclipse_swt_widgets_Composite {
 
 @Override
-@Before
+@BeforeEach
 public void setUp() {
 	super.setUp();
 	group = new Group(shell, 0);
@@ -66,7 +66,7 @@ public void test_setTextLjava_lang_String() {
 	String[] cases = {"", "some text", "ldkashdoehufweovcnhslvhregojebckreavbkuhxbiufvcyhbifuyewvbiureyd.,cmnesljliewjfchvbwoifivbeworixuieurvbiuvbohflksjeahfcliureafgyciabelitvyrwtlicuyrtliureybcliuyreuceyvbliureybct"};
 	for (int i = 0; i < cases.length; i++) {
 		group.setText(cases[i]);
-		assertEquals("case: " + String.valueOf(i), cases[i], group.getText());
+		assertEquals(cases[i], group.getText());
 	}
 }
 

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Item.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Item.java
@@ -13,10 +13,10 @@
  *******************************************************************************/
 package org.eclipse.swt.tests.junit;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -24,9 +24,9 @@ import java.io.InputStream;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.widgets.Item;
 import org.eclipse.swt.widgets.Widget;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Automated Test Suite for class org.eclipse.swt.widgets.Item
@@ -36,14 +36,14 @@ import org.junit.Test;
 public abstract class Test_org_eclipse_swt_widgets_Item extends Test_org_eclipse_swt_widgets_Widget {
 
 @Override
-@Before
+@BeforeEach
 public void setUp() {
 	super.setUp();
 	loadImages();
 }
 
 @Override
-@After
+@AfterEach
 public void tearDown() {
 	super.tearDown();
 	freeImages();
@@ -63,10 +63,10 @@ public void test_setImageLorg_eclipse_swt_graphics_Image() {
 public void test_setTextLjava_lang_String() {
 	String testStr = "test string";
 	item.setText(testStr);
-	assertEquals("a", testStr, item.getText());
+	assertEquals(testStr, item.getText());
 	item.setText("");
-	assertTrue("b", item.getText().isEmpty());
-	assertThrows("No exception thrown for string == null", IllegalArgumentException.class, () -> item.setText(null));
+	assertTrue(item.getText().isEmpty());
+	assertThrows(IllegalArgumentException.class, () -> item.setText(null));
 }
 
 /* custom */

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Label.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Label.java
@@ -13,15 +13,15 @@
  *******************************************************************************/
 package org.eclipse.swt.tests.junit;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.graphics.ImageGcDrawer;
 import org.eclipse.swt.widgets.Label;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Automated Test Suite for class org.eclipse.swt.widgets.Label
@@ -31,7 +31,7 @@ import org.junit.Test;
 public class Test_org_eclipse_swt_widgets_Label extends Test_org_eclipse_swt_widgets_Control {
 
 @Override
-@Before
+@BeforeEach
 public void setUp() {
 	super.setUp();
 	label = new Label(shell, 0);

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Link.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Link.java
@@ -13,12 +13,12 @@
  *******************************************************************************/
 package org.eclipse.swt.tests.junit;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.SelectionEvent;
@@ -26,8 +26,9 @@ import org.eclipse.swt.events.SelectionListener;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Link;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
 
 /**
  * Automated Test Suite for class org.eclipse.swt.widgets.Link
@@ -39,7 +40,7 @@ public class Test_org_eclipse_swt_widgets_Link extends Test_org_eclipse_swt_widg
 	Link link;
 
 @Override
-@Before
+@BeforeEach
 public void setUp() {
 	super.setUp();
 	link = new Link(shell, SWT.NONE);

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_List.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_List.java
@@ -13,11 +13,11 @@
  *******************************************************************************/
 package org.eclipse.swt.tests.junit;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.SWTError;
@@ -27,8 +27,8 @@ import org.eclipse.swt.events.SelectionListener;
 import org.eclipse.swt.graphics.Font;
 import org.eclipse.swt.graphics.FontData;
 import org.eclipse.swt.widgets.List;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Automated Test Suite for class org.eclipse.swt.widgets.List
@@ -38,7 +38,7 @@ import org.junit.Test;
 public class Test_org_eclipse_swt_widgets_List extends Test_org_eclipse_swt_widgets_Scrollable {
 
 @Override
-@Before
+@BeforeEach
 public void setUp() {
 	super.setUp();
 	list = new List(shell, SWT.MULTI);
@@ -75,11 +75,11 @@ public void test_addLjava_lang_String() {
 	} catch (IllegalArgumentException e) {
 	}
 	list.add("");
-	assertArrayEquals(":a:", new String[] {""}, list.getItems());
+	assertArrayEquals(new String[] {""}, list.getItems());
 	list.add("some \n text");
-	assertArrayEquals(":b:", new String[] {"", "some \n text"}, list.getItems());
+	assertArrayEquals(new String[] {"", "some \n text"}, list.getItems());
 	list.add("some text");
-	assertArrayEquals(":c:", new String[] {"", "some \n text", "some text"}, list.getItems());
+	assertArrayEquals(new String[] {"", "some \n text", "some text"}, list.getItems());
 
 	// test single-selection list
 
@@ -92,11 +92,11 @@ public void test_addLjava_lang_String() {
 	}
 
 	list.add("");
-	assertArrayEquals(":a:", new String[] {""}, list.getItems());
+	assertArrayEquals(new String[] {""}, list.getItems());
 	list.add("some \n text");
-	assertArrayEquals(":b:", new String[] {"", "some \n text"}, list.getItems());
+	assertArrayEquals(new String[] {"", "some \n text"}, list.getItems());
 	list.add("some text");
-	assertArrayEquals(":c:", new String[] {"", "some \n text", "some text"}, list.getItems());
+	assertArrayEquals(new String[] {"", "some \n text", "some text"}, list.getItems());
 }
 
 @Test
@@ -109,11 +109,11 @@ public void test_addLjava_lang_StringI() {
 	assertEquals(0, list.getItemCount());
 
 	list.add("", 0);
-	assertArrayEquals(":a:", new String[] {""}, list.getItems());
+	assertArrayEquals(new String[] {""}, list.getItems());
 	list.add("some \n text", 1);
-	assertArrayEquals(":b:", new String[] {"", "some \n text"}, list.getItems());
+	assertArrayEquals(new String[] {"", "some \n text"}, list.getItems());
 	list.add("some text", 0);
-	assertArrayEquals(":c:", new String[] {"some text", "", "some \n text" }, list.getItems());
+	assertArrayEquals(new String[] {"some text", "", "some \n text" }, list.getItems());
 
 	try {
 		list.add(null, 0);
@@ -140,11 +140,11 @@ public void test_addLjava_lang_StringI() {
 	assertEquals(0, list.getItemCount());
 
 	list.add("", 0);
-	assertArrayEquals(":a:", new String[] {""}, list.getItems());
+	assertArrayEquals(new String[] {""}, list.getItems());
 	list.add("some \n text", 1);
-	assertArrayEquals(":b:", new String[] {"", "some \n text"}, list.getItems());
+	assertArrayEquals(new String[] {"", "some \n text"}, list.getItems());
 	list.add("some text", 0);
-	assertArrayEquals(":c:", new String[] {"some text", "", "some \n text" }, list.getItems());
+	assertArrayEquals(new String[] {"some text", "", "some \n text" }, list.getItems());
 
 	try {
 		list.add(null, 0);
@@ -178,11 +178,11 @@ public void test_addSelectionListenerLorg_eclipse_swt_events_SelectionListener()
 	catch (IllegalArgumentException e) {
 		exceptionThrown = true;
 	}
-	assertTrue("Expected exception not thrown for listener == null", exceptionThrown);
+	assertTrue(exceptionThrown);
 
 	list.addSelectionListener(listener);
 	list.select(0);
-	assertFalse(":a:", listenerCalled);
+	assertFalse(listenerCalled);
 	list.removeSelectionListener(listener);
 	exceptionThrown = false;
 	try {
@@ -191,7 +191,7 @@ public void test_addSelectionListenerLorg_eclipse_swt_events_SelectionListener()
 	catch (IllegalArgumentException e) {
 		exceptionThrown = true;
 	}
-	assertTrue("Expected exception not thrown for listener == null", exceptionThrown);
+	assertTrue(exceptionThrown);
 
 	// test single-selection list
 
@@ -205,11 +205,11 @@ public void test_addSelectionListenerLorg_eclipse_swt_events_SelectionListener()
 	catch (IllegalArgumentException e) {
 		exceptionThrown = true;
 	}
-	assertTrue("Expected exception not thrown for listener == null", exceptionThrown);
+	assertTrue(exceptionThrown);
 
 	list.addSelectionListener(listener);
 	list.select(0);
-	assertFalse(":a:", listenerCalled);
+	assertFalse(listenerCalled);
 	list.removeSelectionListener(listener);
 	exceptionThrown = false;
 	try {
@@ -218,7 +218,7 @@ public void test_addSelectionListenerLorg_eclipse_swt_events_SelectionListener()
 	catch (IllegalArgumentException e) {
 		exceptionThrown = true;
 	}
-	assertTrue("Expected exception not thrown for listener == null", exceptionThrown);
+	assertTrue(exceptionThrown);
 }
 
 @Test
@@ -228,7 +228,7 @@ public void test_addSelectionListenerWidgetSelectedAdapterLorg_eclipse_swt_event
 
 	list.addSelectionListener(listener);
 	list.select(0);
-	assertFalse(":a:", listenerCalled);
+	assertFalse(listenerCalled);
 	list.removeSelectionListener(listener);
 
 	// test single-selection list
@@ -237,7 +237,7 @@ public void test_addSelectionListenerWidgetSelectedAdapterLorg_eclipse_swt_event
 
 	list.addSelectionListener(listener);
 	list.select(0);
-	assertFalse(":a:", listenerCalled);
+	assertFalse(listenerCalled);
 	list.removeSelectionListener(listener);
 }
 
@@ -252,7 +252,7 @@ public void test_deselect$I() {
 	String[] items = { "item0", "item1", "item2", "item3" };
 	list.setItems(items);
 	list.setSelection(items);
-	assertArrayEquals(":a:", list.getSelection(), items);
+	assertArrayEquals(list.getSelection(), items);
 	try {
 		list.deselect(null);
 		fail("No exception thrown");
@@ -385,23 +385,21 @@ public void test_deselectII() {
 	String[] items2 = { "item0", "item1", "item2", "item3" };
 	list.setItems(items2);
 	list.setSelection(items2);
-	assertArrayEquals(":a:", items2, list.getSelection());
+	assertArrayEquals(items2, list.getSelection());
 	list.deselect(0, 0);
-	assertArrayEquals(":b:", list.getSelectionIndices(), new int[] { 1, 2, 3 });
+	assertArrayEquals(list.getSelectionIndices(), new int[] { 1, 2, 3 });
 	list.deselect(0, 0);
-	assertArrayEquals(":bbb:", list.getSelectionIndices(), new int[] { 1, 2, 3 });
+	assertArrayEquals(list.getSelectionIndices(), new int[] { 1, 2, 3 });
 	list.deselect(2, 3);
-	assertArrayEquals(":bb:", list.getSelectionIndices(), new int[] { 1 });
+	assertArrayEquals(list.getSelectionIndices(), new int[] { 1 });
 
 	list.setSelection(items2);
 	list.deselect(0, 2);
-	assertArrayEquals(":dddd:", list.getSelectionIndices(), new int[] { 3 });
+	assertArrayEquals(list.getSelectionIndices(), new int[] { 3 });
 
 	list.setSelection(items2);
 	list.deselect(2, 0);
-	assertArrayEquals(
-		":ddddd:",
-		list.getSelectionIndices(), new int[] { 0, 1, 2, 3 });
+	assertArrayEquals(list.getSelectionIndices(), new int[] { 0, 1, 2, 3 });
 
 
 	setSingleList();
@@ -418,7 +416,7 @@ public void test_deselectII() {
 	assertArrayEquals(list.getSelectionIndices(), new int[] { 0 });
 
 	list.deselect(-1, -1);
-	assertArrayEquals(":e:", list.getSelectionIndices(), new int[] { 0 });
+	assertArrayEquals(list.getSelectionIndices(), new int[] { 0 });
 
 
 	list.setSelection(new String[] { "item3" });
@@ -501,7 +499,7 @@ public void test_getItemHeight() {
 	font = new Font(list.getDisplay(), fontData.getName(), 24, fontData.getStyle());
 	list.setFont(font);
 	int newLineHeight = list.getItemHeight();
-	assertTrue(":a:", newLineHeight > lineHeight);
+	assertTrue(newLineHeight > lineHeight);
 	list.setFont(null);
 	font.dispose();
 }
@@ -554,7 +552,7 @@ public void test_getItems() {
 	};
 	for (int i = 0; i < cases.length; i++) {
 		list.setItems(cases[i]);
-		assertArrayEquals("case: " + i, cases[i], list.getItems());
+		assertArrayEquals(cases[i], list.getItems());
 	}
 }
 
@@ -572,15 +570,13 @@ public void test_getSelection() {
 		list.setSelection(cases[i]);
 		//		System.out.println("list:" + list.getSelection());
 		//		System.out.println("case:" + i + cases[i]);
-		assertArrayEquals("case: " + i, cases[i], list.getSelection());
+		assertArrayEquals(cases[i], list.getSelection());
 	}
 
 	for (int i = 1; i < cases.length; i++) {
 		list.setItems(cases[i]);
 		list.setSelection(0);
-		assertArrayEquals(
-			"case: " + String.valueOf(i),
-			list.getSelection(), new String[] { cases[i][0] });
+		assertArrayEquals(list.getSelection(), new String[] { cases[i][0] });
 	}
 
 	String[] items = { "text1", "text2", "text3" };
@@ -899,14 +895,14 @@ public void test_remove$I() {
 		fail("No exception thrown");
 	} catch (IllegalArgumentException e) {
 	}
-	assertArrayEquals(":a:", list.getItems(), items);
+	assertArrayEquals(list.getItems(), items);
 
 	try {
 		list.remove(new int[] { 3, 1, -1 });
 		fail("No exception thrown");
 	} catch (IllegalArgumentException e) {
 	}
-	assertArrayEquals(":a:", list.getItems(), items);
+	assertArrayEquals(list.getItems(), items);
 
 	list.setItems(items);
 	assertEquals(list.getItemCount(), 4);
@@ -916,28 +912,26 @@ public void test_remove$I() {
 		fail("No exception thrown");
 	} catch (IllegalArgumentException e) {
 	}
-	assertArrayEquals(":b:", list.getItems(), items);
+	assertArrayEquals(list.getItems(), items);
 
 	try {
 		list.remove(new int[] { -2, -1 });
 		fail("No exception thrown");
 	} catch (IllegalArgumentException e) {
 	}
-	assertArrayEquals(":c:", list.getItems(), items);
+	assertArrayEquals(list.getItems(), items);
 
 	list.setItems(items);
 	assertEquals(list.getItemCount(), 4);
 
 	list.remove(new int[] { 1, 1, 1 });
-	assertArrayEquals(
-		":d:",
-		list.getItems(), new String[] { "text0", "text2", "text3" });
+	assertArrayEquals(list.getItems(), new String[] { "text0", "text2", "text3" });
 
 	list.setItems(items);
 	assertEquals(list.getItemCount(), 4);
 
 	list.remove(new int[] { 1, 3 });
-	assertArrayEquals(":e:", list.getItems(), new String[] { "text0", "text2" });
+	assertArrayEquals(list.getItems(), new String[] { "text0", "text2" });
 
 
 	setSingleList();
@@ -953,14 +947,14 @@ public void test_remove$I() {
 	assertEquals(4, list.getItemCount());
 
 	list.remove(new int[] { 1, 3 });
-	assertArrayEquals(":f:", list.getItems(), new String[] { "text0", "text2" });
+	assertArrayEquals(list.getItems(), new String[] { "text0", "text2" });
 
 
 	list.setItems(items);
 	assertEquals(4, list.getItemCount());
 
 	list.remove(new int[] { 3, 1 });
-	assertArrayEquals(":g:", list.getItems(), new String[] { "text0", "text2" });
+	assertArrayEquals(list.getItems(), new String[] { "text0", "text2" });
 
 
 	list.setItems(items);
@@ -972,14 +966,14 @@ public void test_remove$I() {
 		fail("No exception thrown");
 	} catch (IllegalArgumentException e) {
 	}
-	assertArrayEquals(":h:", list.getItems(), items);
+	assertArrayEquals(list.getItems(), items);
 
 	try {
 		list.remove(new int[] { 3, 1, -1 });
 		fail("No exception thrown");
 	} catch (IllegalArgumentException e) {
 	}
-	assertArrayEquals(":h:", list.getItems(), items);
+	assertArrayEquals(list.getItems(), items);
 
 
 	list.setItems(items);
@@ -991,14 +985,13 @@ public void test_remove$I() {
 	} catch (IllegalArgumentException e) {
 	}
 
-	assertArrayEquals(":i:", items, list.getItems());
+	assertArrayEquals(items, list.getItems());
 
 
 	assertEquals(4, list.getItemCount());
 
 	list.remove(new int[] { 1, 1, 1 });
-	assertArrayEquals(":j:",
-		new String[] { "text0", "text2", "text3" }, list.getItems());
+	assertArrayEquals(new String[] { "text0", "text2", "text3" }, list.getItems());
 
 }
 
@@ -1419,36 +1412,32 @@ public void test_selectI() {
 	list.setItems(items);
 
 	list.select(2);
-	assertArrayEquals("select(2):", list.getSelectionIndices(), new int[] { 2 });
+	assertArrayEquals(list.getSelectionIndices(), new int[] { 2 });
 
 	list.select(1);
-	assertArrayEquals("select(1):", list.getSelectionIndices(), new int[] { 1, 2 });
+	assertArrayEquals(list.getSelectionIndices(), new int[] { 1, 2 });
 
 	list.select(3);
-	assertArrayEquals(
-		"select(3):",
-		list.getSelectionIndices(), new int[] { 1, 2, 3 });
+	assertArrayEquals(list.getSelectionIndices(), new int[] { 1, 2, 3 });
 
 	list.select(5);
-	assertArrayEquals(
-		"select(5):",
-		list.getSelectionIndices(), new int[] { 1, 2, 3 });
+	assertArrayEquals(list.getSelectionIndices(), new int[] { 1, 2, 3 });
 
 	list.deselectAll();
 	list.select(0);
-	assertArrayEquals("select(0):", list.getSelectionIndices(), new int[] { 0 });
+	assertArrayEquals(list.getSelectionIndices(), new int[] { 0 });
 
 	list.deselectAll();
 	list.select(-1);
-	assertArrayEquals("select(-1):", list.getSelectionIndices(), new int[] {});
+	assertArrayEquals(list.getSelectionIndices(), new int[] {});
 
 	list.deselectAll();
 	list.select(-2);
-	assertArrayEquals("select(-2):", list.getSelectionIndices(), new int[] {});
+	assertArrayEquals(list.getSelectionIndices(), new int[] {});
 
 	list.deselectAll();
 	list.select(4);
-	assertArrayEquals("select(4):", list.getSelectionIndices(), new int[] {});
+	assertArrayEquals(list.getSelectionIndices(), new int[] {});
 
 	setSingleList();
 	list.setItems(items);
@@ -1467,31 +1456,31 @@ public void test_selectI() {
 
 	list.deselectAll();
 	list.select(0);
-	assertArrayEquals("select(0):", list.getSelectionIndices(), new int[] { 0 });
+	assertArrayEquals(list.getSelectionIndices(), new int[] { 0 });
 
 	list.deselectAll();
 	list.select(-1);
-	assertArrayEquals("select(-1):", list.getSelectionIndices(), new int[] {});
+	assertArrayEquals(list.getSelectionIndices(), new int[] {});
 
 	list.deselectAll();
 	list.select(-2);
-	assertArrayEquals("select(-2):", list.getSelectionIndices(), new int[] {});
+	assertArrayEquals(list.getSelectionIndices(), new int[] {});
 
 	list.deselectAll();
 	list.select(4);
-	assertArrayEquals("select(4):", list.getSelectionIndices(), new int[] {});
+	assertArrayEquals(list.getSelectionIndices(), new int[] {});
 }
 
 @Test
 public void test_selectII() {
 	list.select(0, 0);
-	assertArrayEquals("empty list", list.getSelectionIndices(), new int[] {});
+	assertArrayEquals(list.getSelectionIndices(), new int[] {});
 
 	list.select(0, 1);
-	assertArrayEquals("empty list", list.getSelectionIndices(), new int[] {});
+	assertArrayEquals(list.getSelectionIndices(), new int[] {});
 
 	list.select(-1, 0);
-	assertArrayEquals("empty list", list.getSelectionIndices(), new int[] {});
+	assertArrayEquals(list.getSelectionIndices(), new int[] {});
 
 	int number = 5;
 
@@ -1539,13 +1528,13 @@ public void test_selectII() {
 
 	setSingleList();
 	list.select(0, 0);
-	assertArrayEquals("empty list", list.getSelectionIndices(), new int[] {});
+	assertArrayEquals(list.getSelectionIndices(), new int[] {});
 
 	list.select(0, 1);
-	assertArrayEquals("empty list", list.getSelectionIndices(), new int[] {});
+	assertArrayEquals(list.getSelectionIndices(), new int[] {});
 
 	list.select(-1, 0);
-	assertArrayEquals("empty list", list.getSelectionIndices(), new int[] {});
+	assertArrayEquals(list.getSelectionIndices(), new int[] {});
 
 	list.setItems(items);
 	list.select(0);
@@ -1626,7 +1615,7 @@ public void test_setFontLorg_eclipse_swt_graphics_Font() {
 	font = new Font(list.getDisplay(), fontData.getName(), 24, fontData.getStyle());
 	list.setFont(font);
 	assertEquals(font, list.getFont());
-	assertTrue("itemHeight=" + list.getItemHeight() + ", lineHeight=" + lineHeight, list.getItemHeight() > lineHeight);
+	assertTrue(list.getItemHeight() > lineHeight);
 	list.setFont(null);
 	font.dispose();
 }
@@ -1753,7 +1742,7 @@ public void test_setItems$Ljava_lang_String() {
 	setSingleList();
 	for (int i = 0; i < itemArr.length; i++) {
 		list.setItems(itemArr[i]);
-		assertArrayEquals("case:" + i, itemArr[i], list.getItems());
+		assertArrayEquals(itemArr[i], list.getItems());
 	}
 
 
@@ -1771,7 +1760,7 @@ public void test_setSelection$I() {
 		list.add("fred" + i);
 
 	list.setSelection(new int [0]);
-	assertArrayEquals("MULTI: setSelection(new int [0])", list.getSelectionIndices(), new int[0]);
+	assertArrayEquals(list.getSelectionIndices(), new int[0]);
 
 	try {
 		list.setSelection((int[]) null);
@@ -1780,56 +1769,56 @@ public void test_setSelection$I() {
 	}
 
 	list.setSelection(new int [] {2});
-	assertArrayEquals("MULTI: setSelection(new int [] {2})", list.getSelectionIndices(), new int[] {2});
-	assertEquals("MULTI: setSelection(new int [] {2}) getFocusIndex()", list.getFocusIndex(), 2);
+	assertArrayEquals(list.getSelectionIndices(), new int[] {2});
+	assertEquals(list.getFocusIndex(), 2);
 
 	list.setSelection(new int [] {number});
-	assertArrayEquals("MULTI: setSelection(new int [] {number})", list.getSelectionIndices(), new int[0]);
+	assertArrayEquals(list.getSelectionIndices(), new int[0]);
 
 	list.setSelection(new int [] {3, 1, 5, 2});
-	assertArrayEquals("MULTI: setSelection(new int [] {3, 1, 5, 2})", list.getSelectionIndices(), new int[] {1, 2, 3, 5});
+	assertArrayEquals(list.getSelectionIndices(), new int[] {1, 2, 3, 5});
 
 	list.setSelection(new int [] {1, 0});
-	assertArrayEquals("MULTI: setSelection(new int [] {1, 0})", list.getSelectionIndices(), new int[] {0, 1});
+	assertArrayEquals(list.getSelectionIndices(), new int[] {0, 1});
 
 	list.setSelection(new int [] {-1, number});
-	assertArrayEquals("MULTI: setSelection(new int [] {-1, number})", list.getSelectionIndices(), new int[0]);
+	assertArrayEquals(list.getSelectionIndices(), new int[0]);
 
 	list.setSelection(new int [] {number - 1, number});
-	assertArrayEquals("MULTI: setSelection(new int [] {number - 1, number})", list.getSelectionIndices(), new int[] {number - 1});
-	assertEquals("MULTI: setSelection(new int [] {number - 1, number}) getFocusIndex()", list.getFocusIndex(), number - 1);
+	assertArrayEquals(list.getSelectionIndices(), new int[] {number - 1});
+	assertEquals(list.getFocusIndex(), number - 1);
 
 	list.setSelection(new int [] {-1, 0});
-	assertArrayEquals("MULTI: setSelection(new int [] {-1, 0})", list.getSelectionIndices(), new int[] {0});
+	assertArrayEquals(list.getSelectionIndices(), new int[] {0});
 
 	list.setSelection(new int [] {0, 1, 2, 3, 5});
-	assertArrayEquals("MULTI: setSelection(new int [] {0, 1, 2, 3, 5})", list.getSelectionIndices(), new int [] {0, 1, 2, 3, 5});
+	assertArrayEquals(list.getSelectionIndices(), new int [] {0, 1, 2, 3, 5});
 
 	int[] indices = new int [number];
 	for (int i = 0; i < number; i++) {
 		indices[i] = i;
 	}
 	list.setSelection(indices);
-	assertArrayEquals("MULTI: setSelection(indices)", indices, list.getSelectionIndices());
+	assertArrayEquals(indices, list.getSelectionIndices());
 
 	list.setSelection(new int [] {number, number});
-	assertArrayEquals("MULTI: setSelection(new int [] {number, number})", new int[0], list.getSelectionIndices());
+	assertArrayEquals(new int[0], list.getSelectionIndices());
 
 	list.setSelection(new int [] {number - 1, number - 1});
-	assertArrayEquals("MULTI: setSelection(new int [] {number - 1, number - 1})", list.getSelectionIndices(), new int[] {number - 1});
-	assertEquals("MULTI: setSelection(new int [] {number - 1, number - 1}) getFocusIndex()", list.getFocusIndex(), number - 1);
+	assertArrayEquals(list.getSelectionIndices(), new int[] {number - 1});
+	assertEquals(list.getFocusIndex(), number - 1);
 
 	list.setSelection(new int [] {0, number, 1});
-	assertArrayEquals("MULTI: setSelection(new int [] {0, number, 1})", list.getSelectionIndices(), new int[] {0, 1});
+	assertArrayEquals(list.getSelectionIndices(), new int[] {0, 1});
 
 	list.setSelection(new int [] {number - 1, 0, number - 2});
-	assertArrayEquals("MULTI: setSelection(new int [] {number - 1, 0, number - 2})", list.getSelectionIndices(), new int[] {0, number - 2, number - 1});
+	assertArrayEquals(list.getSelectionIndices(), new int[] {0, number - 2, number - 1});
 
 	list.removeAll();
 
 	list.setSelection(new int [0]);
-	assertArrayEquals("EMPTY MULTI: setSelection(new int [0])", list.getSelectionIndices(), new int[0]);
-	assertEquals("EMPTY MULTI: setSelection(new int [0]) getFocusIndex()", list.getFocusIndex(), -1);
+	assertArrayEquals(list.getSelectionIndices(), new int[0]);
+	assertEquals(list.getFocusIndex(), -1);
 
 	try {
 		list.setSelection((int[]) null);
@@ -1838,24 +1827,24 @@ public void test_setSelection$I() {
 	}
 
 	list.setSelection(new int [] {0});
-	assertArrayEquals("EMPTY MULTI: setSelection(new int [] {0})", list.getSelectionIndices(), new int[0]);
-	assertEquals("EMPTY MULTI: setSelection(new int [] {0}) getFocusIndex()", list.getFocusIndex(), -1);
+	assertArrayEquals(list.getSelectionIndices(), new int[0]);
+	assertEquals(list.getFocusIndex(), -1);
 
 	list.setSelection(new int [] {-1});
-	assertArrayEquals("EMPTY MULTI: setSelection(new int [] {-1})", list.getSelectionIndices(), new int[0]);
-	assertEquals("EMPTY MULTI: setSelection(new int [] {-1}) getFocusIndex()", list.getFocusIndex(), -1);
+	assertArrayEquals(list.getSelectionIndices(), new int[0]);
+	assertEquals(list.getFocusIndex(), -1);
 
 	list.setSelection(new int [] {0, 0});
-	assertArrayEquals("EMPTY MULTI: setSelection(new int [] {0, 0})", list.getSelectionIndices(), new int[0]);
-	assertEquals("EMPTY MULTI: setSelection(new int [] {0, 0}) getFocusIndex()", list.getFocusIndex(), -1);
+	assertArrayEquals(list.getSelectionIndices(), new int[0]);
+	assertEquals(list.getFocusIndex(), -1);
 
 	list.setSelection(new int [] {-1, 0});
-	assertArrayEquals("EMPTY MULTI: setSelection(new int [] {-1, 0})", list.getSelectionIndices(), new int[0]);
-	assertEquals("EMPTY MULTI: setSelection(new int [] {-1, 0}) getFocusIndex()", list.getFocusIndex(), -1);
+	assertArrayEquals(list.getSelectionIndices(), new int[0]);
+	assertEquals(list.getFocusIndex(), -1);
 
 	list.setSelection(new int [] {0, -1});
-	assertArrayEquals("EMPTY MULTI: setSelection(new int [] {0, -1})", list.getSelectionIndices(), new int[0]);
-	assertEquals("EMPTY MULTI: setSelection(new int [] {0, -1}) getFocusIndex()", list.getFocusIndex(), -1);
+	assertArrayEquals(list.getSelectionIndices(), new int[0]);
+	assertEquals(list.getFocusIndex(), -1);
 
 
 	setSingleList();
@@ -1863,7 +1852,7 @@ public void test_setSelection$I() {
 		list.add("fred" + i);
 
 	list.setSelection(new int [0]);
-	assertArrayEquals("SINGLE: setSelection(new int [0])", list.getSelectionIndices(), new int[0]);
+	assertArrayEquals(list.getSelectionIndices(), new int[0]);
 
 	try {
 		list.setSelection((int[]) null);
@@ -1872,51 +1861,51 @@ public void test_setSelection$I() {
 	}
 
 	list.setSelection(new int [] {2});
-	assertArrayEquals("SINGLE: setSelection(new int [] {2})", list.getSelectionIndices(), new int[] {2});
-	assertEquals("SINGLE: setSelection(new int [] {2}) getFocusIndex()", list.getFocusIndex(), 2);
+	assertArrayEquals(list.getSelectionIndices(), new int[] {2});
+	assertEquals(list.getFocusIndex(), 2);
 
 	list.setSelection(new int [] {number});
-	assertArrayEquals("SINGLE: setSelection(new int [] {number})", list.getSelectionIndices(), new int[0]);
+	assertArrayEquals(list.getSelectionIndices(), new int[0]);
 
 	list.setSelection(new int [] {1, 0});
-	assertArrayEquals("SINGLE: setSelection(new int [] {1, 0})", list.getSelectionIndices(), new int[] {});
+	assertArrayEquals(list.getSelectionIndices(), new int[] {});
 
 	list.setSelection(new int [] {0, 1, 2, 3, 5});
-	assertArrayEquals("SINGLE: setSelection(new int [] {0, 1, 2, 3, 5})", list.getSelectionIndices(), new int [] {});
+	assertArrayEquals(list.getSelectionIndices(), new int [] {});
 
 	list.setSelection(new int [] {-1, number});
-	assertArrayEquals("SINGLE: setSelection(new int [] {-1, number})", list.getSelectionIndices(), new int[0]);
+	assertArrayEquals(list.getSelectionIndices(), new int[0]);
 
 	list.setSelection(new int [] {number - 1, number});
-	assertArrayEquals("SINGLE: setSelection(new int [] {number - 1, number})", list.getSelectionIndices(), new int[] {});
+	assertArrayEquals(list.getSelectionIndices(), new int[] {});
 
 	list.setSelection(new int [] {-1, 0});
-	assertArrayEquals("SINGLE: setSelection(new int [] {-1, 0})", list.getSelectionIndices(), new int[] {});
+	assertArrayEquals(list.getSelectionIndices(), new int[] {});
 
 	indices = new int [number];
 	for (int i = 0; i < number; i++) {
 		indices[i] = i;
 	}
 	list.setSelection(indices);
-	assertArrayEquals("SINGLE: setSelection(indices)", list.getSelectionIndices(), new int[] {});
+	assertArrayEquals(list.getSelectionIndices(), new int[] {});
 
 	list.setSelection(new int [] {number, number});
-	assertArrayEquals("SINGLE: setSelection(new int [] {number, number})", list.getSelectionIndices(), new int[0]);
+	assertArrayEquals(list.getSelectionIndices(), new int[0]);
 
 	list.setSelection(new int [] {number - 1, number - 1});
-	assertArrayEquals("SINGLE: setSelection(new int [] {number - 1, number - 1})", list.getSelectionIndices(), new int[] {});
+	assertArrayEquals(list.getSelectionIndices(), new int[] {});
 
 	list.setSelection(new int [] {0, number, 1});
-	assertArrayEquals("SINGLE: setSelection(new int [] {0, number, 1})", list.getSelectionIndices(), new int[] {});
+	assertArrayEquals(list.getSelectionIndices(), new int[] {});
 
 	list.setSelection(new int [] {number - 1, 0, number - 2});
-	assertArrayEquals("SINGLE: setSelection(new int [] {number - 1, 0, number - 2})", list.getSelectionIndices(), new int[] {});
+	assertArrayEquals(list.getSelectionIndices(), new int[] {});
 
 	list.removeAll();
 
 	list.setSelection(new int [0]);
-	assertArrayEquals("EMPTY SINGLE: setSelection(new int [0])", list.getSelectionIndices(), new int[0]);
-	assertEquals("EMPTY SINGLE: setSelection(new int [0]) getFocusIndex()", list.getFocusIndex(), -1);
+	assertArrayEquals(list.getSelectionIndices(), new int[0]);
+	assertEquals(list.getFocusIndex(), -1);
 
 	try {
 		list.setSelection((int[]) null);
@@ -1925,24 +1914,24 @@ public void test_setSelection$I() {
 	}
 
 	list.setSelection(new int [] {0});
-	assertArrayEquals("EMPTY SINGLE: setSelection(new int [] {0})", list.getSelectionIndices(), new int[0]);
-	assertEquals("EMPTY SINGLE: setSelection(new int [] {0}) getFocusIndex()", list.getFocusIndex(), -1);
+	assertArrayEquals(list.getSelectionIndices(), new int[0]);
+	assertEquals(list.getFocusIndex(), -1);
 
 	list.setSelection(new int [] {-1});
-	assertArrayEquals("EMPTY SINGLE: setSelection(new int [] {-1})", list.getSelectionIndices(), new int[0]);
-	assertEquals("EMPTY SINGLE: setSelection(new int [] {-1}) getFocusIndex()", list.getFocusIndex(), -1);
+	assertArrayEquals(list.getSelectionIndices(), new int[0]);
+	assertEquals(list.getFocusIndex(), -1);
 
 	list.setSelection(new int [] {0, 0});
-	assertArrayEquals("EMPTY SINGLE: setSelection(new int [] {0, 0})", list.getSelectionIndices(), new int[0]);
-	assertEquals("EMPTY SINGLE: setSelection(new int [] {0, 0}) getFocusIndex()", list.getFocusIndex(), -1);
+	assertArrayEquals(list.getSelectionIndices(), new int[0]);
+	assertEquals(list.getFocusIndex(), -1);
 
 	list.setSelection(new int [] {-1, 0});
-	assertArrayEquals("EMPTY SINGLE: setSelection(new int [] {-1, 0})", list.getSelectionIndices(), new int[0]);
-	assertEquals("EMPTY SINGLE: setSelection(new int [] {-1, 0}) getFocusIndex()", list.getFocusIndex(), -1);
+	assertArrayEquals(list.getSelectionIndices(), new int[0]);
+	assertEquals(list.getFocusIndex(), -1);
 
 	list.setSelection(new int [] {0, -1});
-	assertArrayEquals("EMPTY SINGLE: setSelection(new int [] {0, -1})", list.getSelectionIndices(), new int[0]);
-	assertEquals("EMPTY SINGLE: setSelection(new int [] {0, -1}) getFocusIndex()", list.getFocusIndex(), -1);
+	assertArrayEquals(list.getSelectionIndices(), new int[0]);
+	assertEquals(list.getFocusIndex(), -1);
 }
 
 @Test
@@ -2302,23 +2291,23 @@ public void test_setTopIndexI() {
 		return;
 	}
 	list.setTopIndex(3);
-	assertEquals("MULTI: setTopIndex(3) in empty list", 0, list.getTopIndex());
+	assertEquals(0, list.getTopIndex());
 	String[] items = { "item0", "item1", "item2", "item3" };
 	list.setItems(items);
 	for (int i = 0; i < items.length; i++) {
 		list.setTopIndex(i);
-		assertEquals("MULTI: setTopIndex(i=" + i + ")", i, list.getTopIndex());
+		assertEquals(i, list.getTopIndex());
 	}
 
 
 	setSingleList();
 	list.setTopIndex(3);
-	assertEquals("SINGLE: setTopIndex(3) in empty list", 0, list.getTopIndex());
+	assertEquals(0, list.getTopIndex());
 
 	list.setItems(items);
 	for (int i = 0; i < items.length; i++) {
 		list.setTopIndex(i);
-		assertEquals("SINGLE: setTopIndex(i=" + i + ")", i, list.getTopIndex());
+		assertEquals(i, list.getTopIndex());
 	}
 
 }
@@ -2353,21 +2342,17 @@ protected void deselectII_helper(
 	list.setSelection(items);
 
 	list.deselect(start, end);
-	assertArrayEquals(
-		":(" + start + ", " + end + "):",
-		expectedIndices, list.getSelectionIndices());
+	assertArrayEquals(expectedIndices, list.getSelectionIndices());
 
 	list.setSelection(items);
 	if ( 0 != (list.getStyle() & SWT.MULTI) ) {
-		assertArrayEquals("setSelection(items):", items, list.getSelection());
+		assertArrayEquals(items, list.getSelection());
 	}
 
 	for (int i = start; i <= end; ++i) {
 		list.deselect(i);
 	}
-	assertArrayEquals(
-		":(" + start + ", " + end + "):",
-		expectedIndices, list.getSelectionIndices());
+	assertArrayEquals(expectedIndices, list.getSelectionIndices());
 
 	list.deselectAll();
 }
@@ -2391,18 +2376,15 @@ protected void selectII_helper(
 	int[] expectedIndices) {
 	list.setItems(items);
 	list.select(start, end);
-	assertArrayEquals(
-		":(" + start + ", " + end + "):",
-		expectedIndices, list.getSelectionIndices());
+	assertArrayEquals(expectedIndices, list.getSelectionIndices());
 
 	list.deselectAll();
-	assertArrayEquals("deselectAll:", list.getSelectionIndices(), new int[] {});
+	assertArrayEquals(list.getSelectionIndices(), new int[] {});
 
 	for (int i = start; i <= end; i++) // <= on purpose
 		list.select(i);
 
-	assertArrayEquals(":(" + start + ", " + end + "):",
-		expectedIndices, list.getSelectionIndices());
+	assertArrayEquals(expectedIndices, list.getSelectionIndices());
 
 	list.deselectAll();
 }
@@ -2422,19 +2404,15 @@ protected void select$I_helper(
 
 	list.select(selection);
 
-	assertArrayEquals(
-		":(" + start + ", " + end + "):",
-		expectedIndices, list.getSelectionIndices());
+	assertArrayEquals(expectedIndices, list.getSelectionIndices());
 
 	list.deselectAll();
-	assertArrayEquals("deselectAll:", list.getSelectionIndices(), new int[] {});
+	assertArrayEquals(list.getSelectionIndices(), new int[] {});
 
 	for (int i = start; i <= end; i++) // <= on purpose
 		list.select(i);
 
-	assertArrayEquals(
-		":(" + start + ", " + end + "):",
-		expectedIndices, list.getSelectionIndices());
+	assertArrayEquals(expectedIndices, list.getSelectionIndices());
 
 	list.deselectAll();
 }

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Menu.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Menu.java
@@ -13,12 +13,12 @@
  *******************************************************************************/
 package org.eclipse.swt.tests.junit;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.HelpListener;
@@ -30,8 +30,8 @@ import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Menu;
 import org.eclipse.swt.widgets.MenuItem;
 import org.eclipse.swt.widgets.Shell;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Automated Test Suite for class org.eclipse.swt.widgets.Menu
@@ -41,7 +41,7 @@ import org.junit.Test;
 public class Test_org_eclipse_swt_widgets_Menu extends Test_org_eclipse_swt_widgets_Widget {
 
 @Override
-@Before
+@BeforeEach
 public void setUp() {
 	super.setUp();
 	menu = new Menu(shell);
@@ -138,11 +138,11 @@ public void test_addMenuListenerLorg_eclipse_swt_events_MenuListener() {
 
 	menu.addMenuListener(menuListener);
 	menu.notifyListeners(SWT.Show, new Event());
-	assertTrue(":a:", listenerCalled);
+	assertTrue(listenerCalled);
 
 	listenerCalled = false;
 	menu.notifyListeners(SWT.Hide, new Event());
-	assertTrue(":b:", listenerCalled);
+	assertTrue(listenerCalled);
 
 	try {
 		menu.removeMenuListener(null);
@@ -229,16 +229,16 @@ public void test_getItems() {
 	for (int i = 0; i<number ; i++){
 		items[i] = new MenuItem(menu, 0);
 	}
-	assertArrayEquals(":a:", items, menu.getItems());
+	assertArrayEquals(items, menu.getItems());
 
 	menu.getItems()[0].dispose();
-	assertArrayEquals(":b:", new MenuItem[]{items[1], items[2], items[3], items[4]}, menu.getItems());
+	assertArrayEquals(new MenuItem[]{items[1], items[2], items[3], items[4]}, menu.getItems());
 
 	menu.getItems()[3].dispose();
-	assertArrayEquals(":c:", new MenuItem[]{items[1], items[2], items[3]}, menu.getItems());
+	assertArrayEquals(new MenuItem[]{items[1], items[2], items[3]}, menu.getItems());
 
 	menu.getItems()[1].dispose();
-	assertArrayEquals(":d:", new MenuItem[]{items[1], items[3]}, menu.getItems());
+	assertArrayEquals(new MenuItem[]{items[1], items[3]}, menu.getItems());
 }
 
 @Test
@@ -296,10 +296,10 @@ public void test_setDefaultItemLorg_eclipse_swt_widgets_MenuItem() {
 	MenuItem mItem1 = new MenuItem(menu, SWT.NULL);
 	menu.setDefaultItem(mItem0);
 	assertEquals(menu.getDefaultItem(), mItem0);
-	assertTrue("After setDefaultItem(mItem0):", menu.getDefaultItem() != mItem1);
+	assertTrue(menu.getDefaultItem() != mItem1);
 	menu.setDefaultItem(mItem1);
 	assertEquals(menu.getDefaultItem(), mItem1);
-	assertTrue("After setDefaultItem(mItem1):", menu.getDefaultItem() != mItem0);
+	assertTrue(menu.getDefaultItem() != mItem0);
 }
 
 @Test

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_MenuItem.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_MenuItem.java
@@ -13,12 +13,12 @@
  *******************************************************************************/
 package org.eclipse.swt.tests.junit;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.ArmListener;
@@ -28,8 +28,8 @@ import org.eclipse.swt.events.SelectionListener;
 import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Menu;
 import org.eclipse.swt.widgets.MenuItem;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Automated Test Suite for class org.eclipse.swt.widgets.MenuItem
@@ -39,7 +39,7 @@ import org.junit.Test;
 public class Test_org_eclipse_swt_widgets_MenuItem extends Test_org_eclipse_swt_widgets_Item {
 
 @Override
-@Before
+@BeforeEach
 public void setUp() {
 	super.setUp();
 	menu = new Menu(shell);
@@ -85,15 +85,13 @@ public void test_addArmListenerLorg_eclipse_swt_events_ArmListener() {
 	listenerCalled = false;
 	ArmListener listener = e -> listenerCalled = true;
 
-	assertThrows("No exception thrown for addArmListener with null argument", IllegalArgumentException.class,
-			() -> menuItem.addArmListener(null));
+	assertThrows(IllegalArgumentException.class, () -> menuItem.addArmListener(null));
 
 	menuItem.addArmListener(listener);
 	menuItem.notifyListeners(SWT.Arm, new Event());
 	assertTrue(listenerCalled);
 
-	assertThrows("No exception thrown for removeArmListener with null argument", IllegalArgumentException.class,
-			() -> menuItem.removeArmListener(null));
+	assertThrows(IllegalArgumentException.class, () -> menuItem.removeArmListener(null));
 	listenerCalled = false;
 	menuItem.removeArmListener(listener);
 	menuItem.notifyListeners(SWT.Arm, new Event());
@@ -105,15 +103,13 @@ public void test_addHelpListenerLorg_eclipse_swt_events_HelpListener() {
 	listenerCalled = false;
 	HelpListener listener = e -> listenerCalled = true;
 
-	assertThrows("No exception thrown for addHelpListener with null argument", IllegalArgumentException.class,
-			() -> menuItem.addHelpListener(null));
+	assertThrows(IllegalArgumentException.class, () -> menuItem.addHelpListener(null));
 
 	menuItem.addHelpListener(listener);
 	menuItem.notifyListeners(SWT.Help, new Event());
 	assertTrue(listenerCalled);
 
-	assertThrows("No exception thrown for removeHelpListener with null argument", IllegalArgumentException.class,
-			() -> menuItem.removeHelpListener(null));
+	assertThrows(IllegalArgumentException.class, () -> menuItem.removeHelpListener(null));
 	listenerCalled = false;
 	menuItem.removeHelpListener(listener);
 	menuItem.notifyListeners(SWT.Help, new Event());
@@ -133,15 +129,13 @@ public void test_addSelectionListenerLorg_eclipse_swt_events_SelectionListener()
 		}
 	};
 
-	assertThrows("No exception thrown for addSelectionListener with null argument", IllegalArgumentException.class,
-			() -> menuItem.addSelectionListener(null));
+	assertThrows(IllegalArgumentException.class, () -> menuItem.addSelectionListener(null));
 
 	menuItem.addSelectionListener(listener);
 	menuItem.notifyListeners(SWT.Selection, new Event());
 	assertTrue(listenerCalled);
 
-	assertThrows("No exception thrown for removeSelectionListener with null argument", IllegalArgumentException.class,
-			() -> menuItem.removeSelectionListener(null));
+	assertThrows(IllegalArgumentException.class, () -> menuItem.removeSelectionListener(null));
 	listenerCalled = false;
 	menuItem.removeSelectionListener(listener);
 	menuItem.notifyListeners(SWT.Selection, new Event());

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Monitor.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Monitor.java
@@ -14,16 +14,18 @@
  *******************************************************************************/
 package org.eclipse.swt.tests.junit;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import org.eclipse.swt.graphics.Rectangle;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Monitor;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
 
 /**
  * Automated Test Suite for class org.eclipse.swt.widgets.Monitor
@@ -32,7 +34,7 @@ import org.junit.Test;
  */
 public class Test_org_eclipse_swt_widgets_Monitor {
 
-@Before
+@BeforeEach
 public void setUp() {
 	display = Display.getDefault();
 	monitors = display.getMonitors();

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_ProgressBar.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_ProgressBar.java
@@ -13,13 +13,13 @@
  *******************************************************************************/
 package org.eclipse.swt.tests.junit;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.ProgressBar;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Automated Test Suite for class org.eclipse.swt.widgets.ProgressBar
@@ -29,7 +29,7 @@ import org.junit.Test;
 public class Test_org_eclipse_swt_widgets_ProgressBar extends Test_org_eclipse_swt_widgets_Control {
 
 @Override
-@Before
+@BeforeEach
 public void setUp() {
 	super.setUp();
 	progressBar = new ProgressBar(shell, 0);

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Sash.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Sash.java
@@ -13,13 +13,14 @@
  *******************************************************************************/
 package org.eclipse.swt.tests.junit;
 
-import static org.junit.Assert.fail;
+
+import static org.junit.jupiter.api.Assertions.fail;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Sash;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Automated Test Suite for class org.eclipse.swt.widgets.Sash
@@ -29,7 +30,7 @@ import org.junit.Test;
 public class Test_org_eclipse_swt_widgets_Sash extends Test_org_eclipse_swt_widgets_Control {
 
 @Override
-@Before
+@BeforeEach
 public void setUp() {
 	super.setUp();
 	sash = new Sash(shell, 0);

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Scale.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Scale.java
@@ -14,13 +14,14 @@
 package org.eclipse.swt.tests.junit;
 
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Scale;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
 
 /**
  * Automated Test Suite for class org.eclipse.swt.widgets.Scale
@@ -30,7 +31,7 @@ import org.junit.Test;
 public class Test_org_eclipse_swt_widgets_Scale extends Test_org_eclipse_swt_widgets_Control {
 
 @Override
-@Before
+@BeforeEach
 public void setUp() {
 	super.setUp();
 	scale = new Scale(shell, 0);

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_ScrollBar.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_ScrollBar.java
@@ -13,17 +13,17 @@
  *******************************************************************************/
 package org.eclipse.swt.tests.junit;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.events.SelectionListener;
 import org.eclipse.swt.widgets.Canvas;
 import org.eclipse.swt.widgets.ScrollBar;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Automated Test Suite for class org.eclipse.swt.widgets.ScrollBar
@@ -33,7 +33,7 @@ import org.junit.Test;
 public class Test_org_eclipse_swt_widgets_ScrollBar extends Test_org_eclipse_swt_widgets_Widget {
 
 @Override
-@Before
+@BeforeEach
 public void setUp() {
 	super.setUp();
 	canvas = new Canvas(shell, SWT.H_SCROLL);
@@ -63,7 +63,7 @@ public void test_addSelectionListenerLorg_eclipse_swt_events_SelectionListener()
 	assertThrows(IllegalArgumentException.class, () ->scrollBar.addSelectionListener(null));
 	scrollBar.addSelectionListener(listener);
 	scrollBar.setSelection(100);
-	assertEquals(":a:", false, listenerCalled);
+	assertEquals(false, listenerCalled);
 	scrollBar.removeSelectionListener(listener);
 	assertThrows(IllegalArgumentException.class, () ->scrollBar.removeSelectionListener(null));
 }
@@ -75,7 +75,7 @@ public void test_addSelectionListenerWidgetSelectedAdapterLorg_eclipse_swt_event
 
 	scrollBar.addSelectionListener(listener);
 	scrollBar.setSelection(100);
-	assertEquals(":a:", false, listenerCalled);
+	assertEquals(false, listenerCalled);
 	scrollBar.removeSelectionListener(listener);
 }
 
@@ -191,12 +191,12 @@ public void test_setThumbI(){
 @Test
 public void test_setValuesIIIIII() {
 	scrollBar.setValues(10, 10, 50, 2, 5, 10);
-	assertEquals(":a:", 10, scrollBar.getSelection());
-	assertEquals(":b:", 10, scrollBar.getMinimum());
-	assertEquals(":c:", 50, scrollBar.getMaximum());
-	assertEquals(":d:", 2, scrollBar.getThumb());
-	assertEquals(":e:", 5, scrollBar.getIncrement());
-	assertEquals(":f:", 10, scrollBar.getPageIncrement());
+	assertEquals(10, scrollBar.getSelection());
+	assertEquals(10, scrollBar.getMinimum());
+	assertEquals(50, scrollBar.getMaximum());
+	assertEquals(2, scrollBar.getThumb());
+	assertEquals(5, scrollBar.getIncrement());
+	assertEquals(10, scrollBar.getPageIncrement());
 }
 
 @Test
@@ -232,10 +232,10 @@ private void report(String call, int set, int minExpected, int maxExpected, int 
 }
 // this method must be private or protected so the auto-gen tool keeps it
 private void check(String call, int minExpected, int maxExpected, int selectionExpected, int thumbExpected) {
-	assertEquals(call+" max ", maxExpected, scrollBar.getMaximum());
-	assertEquals(call+" min ", minExpected, scrollBar.getMinimum());
-	assertEquals(call+" sel ", selectionExpected, scrollBar.getSelection());
-	assertEquals(call+" thmb ", thumbExpected, scrollBar.getThumb());
+	assertEquals(maxExpected, scrollBar.getMaximum());
+	assertEquals(minExpected, scrollBar.getMinimum());
+	assertEquals(selectionExpected, scrollBar.getSelection());
+	assertEquals(thumbExpected, scrollBar.getThumb());
 }
 // this method must be private or protected so the auto-gen tool keeps it
 private int[][] getSetThumbValues() {

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Scrollable.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Scrollable.java
@@ -15,7 +15,7 @@ package org.eclipse.swt.tests.junit;
 
 import org.eclipse.swt.widgets.Scrollable;
 import org.eclipse.swt.widgets.Widget;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Automated Test Suite for class org.eclipse.swt.widgets.Scrollable

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_ScrolledComposite.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_ScrolledComposite.java
@@ -14,24 +14,24 @@
  *******************************************************************************/
 package org.eclipse.swt.tests.junit;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.ScrolledComposite;
 import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.widgets.Composite;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class Test_org_eclipse_swt_widgets_ScrolledComposite extends Test_org_eclipse_swt_widgets_Composite {
 
 	ScrolledComposite scrolledComposite;
 
 	@Override
-	@Before
+	@BeforeEach
 	public void setUp() {
 		super.setUp();
 		scrolledComposite = new ScrolledComposite(shell, 0);

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Shell.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Shell.java
@@ -13,14 +13,15 @@
  *******************************************************************************/
 package org.eclipse.swt.tests.junit;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -41,9 +42,8 @@ import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.Text;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Automated Test Suite for class org.eclipse.swt.widgets.Shell
@@ -55,7 +55,7 @@ public class Test_org_eclipse_swt_widgets_Shell extends Test_org_eclipse_swt_wid
 private static final boolean IS_GTK_BUG_445900 = SwtTestUtil.isGTK;
 
 @Override
-@Before
+@BeforeEach
 public void setUp() {
 	super.setUp();
 	testShell = new Shell(shell, SWT.NULL);
@@ -66,7 +66,7 @@ public void setUp() {
 @Test
 public void test_Constructor() {
 	Shell newShell = new Shell();
-	assertNotNull("a: ", newShell.getDisplay());
+	assertNotNull(newShell.getDisplay());
 	newShell.dispose();
 }
 
@@ -78,7 +78,7 @@ public void test_ConstructorI() {
 	Shell newShell;
 	for (int i = 0; i < cases.length; i++) {
 		newShell = new Shell(cases[i]);
-		assertEquals("a " + i, shell.getDisplay(), newShell.getDisplay());
+		assertEquals(shell.getDisplay(), newShell.getDisplay());
 		assertNotEquals(0, newShell.getStyle() & cases[i]);
 		newShell.dispose();
 	}
@@ -88,7 +88,7 @@ public void test_ConstructorI() {
 public void test_ConstructorLorg_eclipse_swt_widgets_Display() {
 	Display display = shell.getDisplay();
 	Shell newShell = new Shell(display);
-	assertEquals("a: ", display, newShell.getDisplay());
+	assertEquals(display, newShell.getDisplay());
 	newShell.dispose();
 }
 
@@ -100,7 +100,7 @@ public void test_ConstructorLorg_eclipse_swt_widgets_DisplayI() {
 	Display display = shell.getDisplay();
 	for (int i = 0; i < cases.length; i++) {
 		newShell = new Shell(display, cases[i]);
-		assertEquals("a " + i, shell.getDisplay(), newShell.getDisplay());
+		assertEquals(shell.getDisplay(), newShell.getDisplay());
 		newShell.dispose();
 	}
 }
@@ -108,7 +108,7 @@ public void test_ConstructorLorg_eclipse_swt_widgets_DisplayI() {
 @Test
 public void test_ConstructorLorg_eclipse_swt_widgets_Shell() {
 	Shell newShell = new Shell(shell);
-	assertEquals("a: ", shell, newShell.getParent());
+	assertEquals(shell, newShell.getParent());
 	newShell.dispose();
 }
 
@@ -120,7 +120,7 @@ public void test_ConstructorLorg_eclipse_swt_widgets_ShellI() {
 	Shell newShell;
 	for (int i = 0; i < cases.length; i++) {
 		newShell = new Shell(shell, cases[i]);
-		assertEquals("a: " + i, shell, newShell.getParent());
+		assertEquals(shell, newShell.getParent());
 		newShell.dispose();
 	}
 }
@@ -153,7 +153,7 @@ public void test_addShellListenerLorg_eclipse_swt_events_ShellListener() {
 	catch (IllegalArgumentException e) {
 		exceptionThrown = true;
 	}
-	assertTrue("Expected exception not thrown", exceptionThrown);
+	assertTrue(exceptionThrown);
 	exceptionThrown = false;
 	shell.addShellListener(listener);
 	shell.forceActive();
@@ -171,7 +171,7 @@ public void test_addShellListenerLorg_eclipse_swt_events_ShellListener() {
 	catch (IllegalArgumentException e) {
 		exceptionThrown = true;
 	}
-	assertTrue("Expected exception not thrown", exceptionThrown);
+	assertTrue(exceptionThrown);
 }
 
 @Test
@@ -441,17 +441,17 @@ public void test_forceActive() {
 
 @Test
 public void test_getEnabled() {
-	assertTrue(":a0:", shell.getEnabled());
+	assertTrue(shell.getEnabled());
 	shell.setEnabled(false);
-	assertTrue(":a:", !shell.getEnabled());
+	assertTrue(!shell.getEnabled());
 	shell.setEnabled(true);
-	assertTrue(":b:", shell.getEnabled());
+	assertTrue(shell.getEnabled());
 }
 
 @Test
 public void test_getImeInputMode() {
 	int mode = shell.getImeInputMode();
-	assertTrue(":a:", mode >= 0);
+	assertTrue(mode >= 0);
 }
 
 @Override
@@ -462,46 +462,46 @@ public void test_getLocation() {
 		return;
 	}
 	shell.setLocation(10,15);
-	assertEquals(":a:", 10, shell.getLocation().x);
-	assertEquals(":b:", 15, shell.getLocation().y);
+	assertEquals(10, shell.getLocation().x);
+	assertEquals(15, shell.getLocation().y);
 }
 
 @Override
 @Test
 public void test_getShell() {
-	assertEquals(":a:", shell, shell.getShell());
+	assertEquals(shell, shell.getShell());
 	Shell shell_1 = new Shell(shell);
-	assertEquals(":b:", shell_1, shell_1.getShell());
+	assertEquals(shell_1, shell_1.getShell());
 	shell_1.dispose();
 }
 
 @Test
 public void test_getShells() {
 	int num = shell.getShells().length;
-	assertEquals(":a:", 1, num);
+	assertEquals(1, num);
 	Shell shell_1 = new Shell(shell);
 	num = shell.getShells().length;
-	assertEquals(":b:", 2, num);
+	assertEquals(2, num);
 	shell_1.dispose();
 	num = shell.getShells().length;
-	assertEquals(":c:", 1, num);
+	assertEquals(1, num);
 }
 
 @Override
 @Test
 public void test_isEnabled() {
-	assertTrue(":a:", shell.isEnabled());
+	assertTrue(shell.isEnabled());
 	shell.setEnabled(false);
-	assertTrue(":b:", !shell.isEnabled());
+	assertTrue(!shell.isEnabled());
 	if (SwtTestUtil.fCheckBogusTestCases)
-		assertTrue(":b1:", !testShell.isEnabled());
+		assertTrue(!testShell.isEnabled());
 	shell.setEnabled(true);
-	assertTrue(":c:", shell.isEnabled());
-	assertTrue(":a:", testShell.isEnabled());
+	assertTrue(shell.isEnabled());
+	assertTrue(testShell.isEnabled());
 	testShell.setEnabled(false);
-	assertTrue(":b:", !testShell.isEnabled());
+	assertTrue(!testShell.isEnabled());
 	testShell.setEnabled(true);
-	assertTrue(":c:", testShell.isEnabled());
+	assertTrue(testShell.isEnabled());
 }
 
 @Test
@@ -526,28 +526,28 @@ public void test_setActive() {
 	/* Test setActive for visible shell. */
 	shell.setVisible(true);
 	shell.setActive();
-	assertTrue("visible shell was not made active", shell.getDisplay().getActiveShell() == shell);
+	assertTrue(shell.getDisplay().getActiveShell() == shell);
 
 	/* Test setActive for visible dialog shell. */
 	shell2.setActive();
 	testShell.setBounds(shell.getBounds());
 	testShell.setVisible(true);
 	testShell.setActive();
-	assertTrue("visible dialog shell was not made active", testShell.getDisplay().getActiveShell() == testShell);
+	assertTrue(testShell.getDisplay().getActiveShell() == testShell);
 
 	/* Test setActive for non-visible shell. */
 	shell2.setActive();
 	shell.setVisible(false);
 	shell.setActive();
 	shell2.setText("Shell2: Not active");
-	assertTrue("non-visible shell was made active", shell.getDisplay().getActiveShell() != shell);
+	assertTrue(shell.getDisplay().getActiveShell() != shell);
 
 	/* Test setActive for non-visible dialog shell. */
 	shell2.setActive();
 	testShell.setVisible(false);
 	testShell.setActive();
 	shell2.setText("Shell2: Not active");
-	assertTrue("non-visible dialog shell was made active", testShell.getDisplay().getActiveShell() != testShell);
+	assertTrue(testShell.getDisplay().getActiveShell() != testShell);
 
 	shell2.dispose();
 }
@@ -561,16 +561,16 @@ public void test_setEnabledZ() {
 @Test
 public void test_setImeInputModeI() {
 	shell.setImeInputMode(SWT.NONE);
-	assertEquals(":a:", SWT.NONE, shell.getImeInputMode());
+	assertEquals(SWT.NONE, shell.getImeInputMode());
 }
 
 @Override
 @Test
 public void test_setVisibleZ() {
 	shell.setVisible(false);
-	assertTrue(":a:", !shell.isVisible());
+	assertTrue(!shell.isVisible());
 	shell.setVisible(true);
-	assertTrue(":b:", shell.isVisible());
+	assertTrue(shell.isVisible());
 }
 
 
@@ -586,11 +586,11 @@ public void test_getParent () {
 @Test
 public void test_getStyle() {
 	// overriding Widget.test_getStyle
-	assertTrue("testShell not modeless", (testShell.getStyle () & SWT.MODELESS) == SWT.MODELESS);
+	assertTrue((testShell.getStyle () & SWT.MODELESS) == SWT.MODELESS);
 	int[] cases = {SWT.MODELESS, SWT.PRIMARY_MODAL, SWT.APPLICATION_MODAL, SWT.SYSTEM_MODAL};
 	for (int i = 0; i < cases.length; i++) {
 		Shell testShell2 = new Shell(shell, cases[i]);
-		assertTrue("shell " + i, (testShell2.getStyle () & cases[i]) == cases[i]);
+		assertTrue((testShell2.getStyle () & cases[i]) == cases[i]);
 		testShell2.dispose();
 	}
 }
@@ -606,11 +606,11 @@ public void test_isVisible() {
 
 	testShell.setVisible(true);
 	shell.setVisible(true);
-	assertTrue("shell.isVisible() a:", shell.isVisible());
+	assertTrue(shell.isVisible());
 	shell.setVisible(false);
-	assertTrue("shell.isVisible() b:", !shell.isVisible());
+	assertTrue(!shell.isVisible());
 	if (SwtTestUtil.fCheckBogusTestCases)
-		assertTrue("testShell.isVisible() c:", !testShell.isVisible());
+		assertTrue(!testShell.isVisible());
 }
 
 @Override
@@ -704,7 +704,7 @@ public void test_setBounds() throws Exception {
 			}
 		}
 		if (log.length() > 0) {
-			Assert.fail(log.toString());
+			fail(log.toString());
 		}
 	}
 }
@@ -721,21 +721,21 @@ public void a_test_setRegion() {
 	Region region = new Region();
 	region.add(new Rectangle(10, 20, 100, 200));
 	// test shell without style SWT.NO_TRIM
-	assertNull(":a:", shell.getRegion());
+	assertNull(shell.getRegion());
 	shell.setRegion(region);
-	assertNull(":b:", shell.getRegion());
+	assertNull(shell.getRegion());
 	shell.setRegion(null);
-	assertNull(":c:", shell.getRegion());
+	assertNull(shell.getRegion());
 	// test shell with style SWT.NO_TRIM
 	Display display = shell.getDisplay();
 	Shell shell2 = new Shell(display, SWT.NO_TRIM);
-	assertNull(":d:", shell2.getRegion());
+	assertNull(shell2.getRegion());
 	shell2.setRegion(region);
-	assertEquals(":e:", region, shell2.getRegion());
+	assertEquals(region, shell2.getRegion());
 	region.dispose();
-	assertTrue(":f:", shell2.getRegion().isDisposed());
+	assertTrue(shell2.getRegion().isDisposed());
 	shell2.setRegion(null);
-	assertNull(":g:", shell2.getRegion());
+	assertNull(shell2.getRegion());
 }
 @Override
 @Test
@@ -842,7 +842,7 @@ public void test_consistency_Open() {
 		}
 		setUp();
 		String[] results = events.toArray(new String[events.size()]);
-		assertArrayEquals(getTestName() + " event ordering", temp, results);
+		assertArrayEquals(temp, results);
 	}
 }
 
@@ -952,24 +952,24 @@ public void test_Issue450_NoShellActivateOnSetFocus() {
 
 		// System.out.println("open 1st shell");
 		SwtTestUtil.waitShellActivate(shell1::open, shell1);
-		assertSame("expecting the 1st shell to be activated", display.getActiveShell(), shell1);
-		assertTrue("expecting the 1st text field to be focused in the 1st shell", text11.isFocusControl());
+		assertSame(display.getActiveShell(), shell1);
+		assertTrue(text11.isFocusControl());
 
 		// System.out.println("open 2nd shell");
 		SwtTestUtil.waitShellActivate(shell2::open, shell2);
-		assertSame("expecting the 2nd shell to be activated", display.getActiveShell(), shell2);
-		assertTrue("expecting the 1st text field in 2nd shell to be focused", text21.isFocusControl());
+		assertSame(display.getActiveShell(), shell2);
+		assertTrue(text21.isFocusControl());
 
 		// System.out.println("setting focus to 2nd text field in 1st (unactivated) shell");
 		text12.setFocus();
-		assertSame("expecting the 2nd shell to remain activated", display.getActiveShell(), shell2);
+		assertSame(display.getActiveShell(), shell2);
 
 		// System.out.println("activating 1st shell");
 		// Fails here for Linux (21.04+ or Manjaro starting ~July 2023)? Check Bug 575712
 		// workaround: set env-var GDK_BACKEND=x11
 		SwtTestUtil.waitShellActivate(shell1::setActive, shell1);
-		assertSame("expecting the 1st shell to be activated", display.getActiveShell(), shell1);
-		assertTrue("expecting the the 1st shell to have remembered the previous setFocus and with the shell activation setting it to the 2nd text field", text12.isFocusControl());
+		assertSame(display.getActiveShell(), shell1);
+		assertTrue(text12.isFocusControl());
 
 		// System.out.println("disposing 1st shell");
 		SwtTestUtil.waitShellActivate(
@@ -983,13 +983,13 @@ public void test_Issue450_NoShellActivateOnSetFocus() {
 			},
 			shell2
 		);
-		assertSame("expecting the 2nd shell to be activated after the 1st, active has been disposed", display.getActiveShell(), shell2);
-		assertTrue("expecting the 1st text field in the 2nd shell to still have the focus because it hasn't been changed", text21.isFocusControl());
+		assertSame(display.getActiveShell(), shell2);
+		assertTrue(text21.isFocusControl());
 
 		// System.out.println("setting the focus to the 2nd text field");
 		text22.setFocus();
-		assertSame("expecting the 2nd shell to remain activated", display.getActiveShell(), shell2);
-		assertTrue("expecting the 2nd text field to have received the focus", text22.isFocusControl());
+		assertSame(display.getActiveShell(), shell2);
+		assertTrue(text22.isFocusControl());
 
 		// System.out.println("disposing the 2nd shell, too");
 		shell2.dispose();
@@ -1004,6 +1004,7 @@ public void test_Issue450_NoShellActivateOnSetFocus() {
 	}
 }
 
+@Test
 @Override
 public void test_setLocationLorg_eclipse_swt_graphics_Point() {
 	//Setting location for Windows is not supported in GTK4
@@ -1013,6 +1014,7 @@ public void test_setLocationLorg_eclipse_swt_graphics_Point() {
 	super.test_setLocationLorg_eclipse_swt_graphics_Point();
 }
 
+@Test
 @Override
 public void test_setLocationII() {
 	//Setting location for Windows is not supported in GTK4

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Slider.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Slider.java
@@ -13,17 +13,17 @@
  *******************************************************************************/
 package org.eclipse.swt.tests.junit;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.events.SelectionListener;
 import org.eclipse.swt.widgets.Slider;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Automated Test Suite for class org.eclipse.swt.widgets.Slider
@@ -33,7 +33,7 @@ import org.junit.Test;
 public class Test_org_eclipse_swt_widgets_Slider extends Test_org_eclipse_swt_widgets_Control {
 
 @Override
-@Before
+@BeforeEach
 public void setUp() {
 	super.setUp();
 	slider = new Slider(shell, 0);
@@ -78,11 +78,11 @@ public void test_addSelectionListenerLorg_eclipse_swt_events_SelectionListener()
 	catch (IllegalArgumentException e) {
 		exceptionThrown = true;
 	}
-	assertTrue("Expected exception not thrown", exceptionThrown);
+	assertTrue(exceptionThrown);
 	exceptionThrown = false;
 	slider.addSelectionListener(listener);
 	slider.setSelection(0);
-	assertFalse(":a:", listenerCalled);
+	assertFalse(listenerCalled);
 	slider.removeSelectionListener(listener);
 	try {
 		slider.removeSelectionListener(null);
@@ -90,7 +90,7 @@ public void test_addSelectionListenerLorg_eclipse_swt_events_SelectionListener()
 	catch (IllegalArgumentException e) {
 		exceptionThrown = true;
 	}
-	assertTrue("Expected exception not thrown", exceptionThrown);
+	assertTrue(exceptionThrown);
 }
 
 @Test
@@ -100,7 +100,7 @@ public void test_addSelectionListenerWidgetSelectedAdapterLorg_eclipse_swt_event
 
 	slider.addSelectionListener(listener);
 	slider.setSelection(0);
-	assertFalse(":a:", listenerCalled);
+	assertFalse(listenerCalled);
 	slider.removeSelectionListener(listener);
 }
 
@@ -116,36 +116,36 @@ public void test_getIncrement() {
 	for (int i=0; i<cases.length; i++)
 	{
 		slider.setIncrement(cases[i]);
-		assertEquals("case:" + String.valueOf(i), cases[i], slider.getIncrement());
+		assertEquals(cases[i], slider.getIncrement());
 	}
 }
 
 @Test
 public void test_getMaximum() {
 	slider.setMaximum(2000);
-	assertEquals(":a:", 2000, slider.getMaximum());
+	assertEquals(2000, slider.getMaximum());
 	slider.setMaximum(20);
-	assertEquals(":b:", 20, slider.getMaximum());
+	assertEquals(20, slider.getMaximum());
 	slider.setMaximum(-1);
-	assertEquals(":c:", 20, slider.getMaximum());
+	assertEquals(20, slider.getMaximum());
 	slider.setMaximum(0);
-	assertEquals(":d:", 20, slider.getMaximum());
+	assertEquals(20, slider.getMaximum());
 	slider.setMaximum(10);
-	assertEquals(":d:", 10, slider.getMaximum());
+	assertEquals(10, slider.getMaximum());
 }
 
 @Test
 public void test_getMinimum() {
 	slider.setMinimum(5);
-	assertEquals(":a:", 5, slider.getMinimum());
+	assertEquals(5, slider.getMinimum());
 	slider.setMinimum(20);
-	assertEquals(":b:", 20, slider.getMinimum());
+	assertEquals(20, slider.getMinimum());
 	slider.setMinimum(-1);
-	assertEquals(":c:", 20, slider.getMinimum());
+	assertEquals(20, slider.getMinimum());
 	slider.setMinimum(0);
-	assertEquals(":d:", 0, slider.getMinimum());
+	assertEquals(0, slider.getMinimum());
 	slider.setMinimum(10);
-	assertEquals(":d:", 10, slider.getMinimum());
+	assertEquals(10, slider.getMinimum());
 }
 
 @Test
@@ -154,14 +154,14 @@ public void test_getPageIncrement() {
 	for (int i=0; i<cases.length; i++)
 	{
 		slider.setPageIncrement(cases[i]);
-		assertEquals("case: " + String.valueOf(i), cases[i], slider.getPageIncrement());
+		assertEquals(cases[i], slider.getPageIncrement());
 	}
 }
 
 @Test
 public void test_getSelection() {
 	slider.setSelection(10);
-	assertEquals(":a:", 10, slider.getSelection());
+	assertEquals(10, slider.getSelection());
 
 }
 
@@ -203,7 +203,7 @@ public void test_setMinimumI() {
 @Test
 public void test_setPageIncrementI() {
 	slider.setPageIncrement(3);
-	assertEquals(":a:", 3, slider.getPageIncrement());
+	assertEquals(3, slider.getPageIncrement());
 }
 
 @Test
@@ -233,12 +233,12 @@ public void test_setThumbI() {
 @Test
 public void test_setValuesIIIIII() {
 	slider.setValues(10, 10, 50, 2, 5, 10);
-	assertEquals(":a:", 10, slider.getSelection());
-	assertEquals(":b:", 10, slider.getMinimum());
-	assertEquals(":c:", 50, slider.getMaximum());
-	assertEquals(":d:", 2, slider.getThumb());
-	assertEquals(":e:", 5, slider.getIncrement());
-	assertEquals(":f:", 10, slider.getPageIncrement());
+	assertEquals(10, slider.getSelection());
+	assertEquals(10, slider.getMinimum());
+	assertEquals(50, slider.getMaximum());
+	assertEquals(2, slider.getThumb());
+	assertEquals(5, slider.getIncrement());
+	assertEquals(10, slider.getPageIncrement());
 }
 
 
@@ -272,10 +272,10 @@ private void report(String call, int set, int minExpected, int maxExpected, int 
 }
 // this method must be private or protected so the auto-gen tool keeps it
 private void check(String call, int minExpected, int maxExpected, int selectionExpected, int thumbExpected) {
-	assertEquals(call+" max ", maxExpected, slider.getMaximum());
-	assertEquals(call+" min ", minExpected, slider.getMinimum());
-	assertEquals(call+" sel ", selectionExpected, slider.getSelection());
-	assertEquals(call+" thmb ", thumbExpected, slider.getThumb());
+	assertEquals(maxExpected, slider.getMaximum());
+	assertEquals(minExpected, slider.getMinimum());
+	assertEquals(selectionExpected, slider.getSelection());
+	assertEquals(thumbExpected, slider.getThumb());
 }
 // this method must be private or protected so the auto-gen tool keeps it
 private int[][] getSetThumbValues() {

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Spinner.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Spinner.java
@@ -14,20 +14,20 @@
  *******************************************************************************/
 package org.eclipse.swt.tests.junit;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Spinner;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class Test_org_eclipse_swt_widgets_Spinner extends Test_org_eclipse_swt_widgets_Composite {
 
 	Spinner spinner;
 
 	@Override
-	@Before
+	@BeforeEach
 	public void setUp() {
 		super.setUp();
 		spinner = new Spinner(shell, 0);
@@ -37,8 +37,7 @@ public class Test_org_eclipse_swt_widgets_Spinner extends Test_org_eclipse_swt_w
 	@Override
 	@Test
 	public void test_ConstructorLorg_eclipse_swt_widgets_CompositeI() {
-		assertThrows("No exception thrown for parent == null", IllegalArgumentException.class,
-				() -> new Spinner(null, 0));
+		assertThrows(IllegalArgumentException.class, () -> new Spinner(null, 0));
 		int[] cases = { 0, SWT.READ_ONLY, SWT.WRAP };
 		for (int style : cases)
 			spinner = new Spinner(shell, style);
@@ -62,8 +61,7 @@ public class Test_org_eclipse_swt_widgets_Spinner extends Test_org_eclipse_swt_w
 			spinner.setDigits(digits);
 			assertEquals(digits, spinner.getDigits());
 		}
-		assertThrows("setDigits should have failed with illegal Argument", IllegalArgumentException.class,
-				() -> spinner.setDigits(-1));
+		assertThrows(IllegalArgumentException.class, () -> spinner.setDigits(-1));
 		assertEquals(cases[cases.length-1], spinner.getDigits());
 	}
 
@@ -118,8 +116,7 @@ public class Test_org_eclipse_swt_widgets_Spinner extends Test_org_eclipse_swt_w
 			spinner.setTextLimit(value);
 			assertEquals(value, spinner.getTextLimit());
 		}
-		assertThrows("setTextLimit should have caused an expection with value 0", IllegalArgumentException.class,
-				() -> spinner.setTextLimit(0));
+		assertThrows(IllegalArgumentException.class, () -> spinner.setTextLimit(0));
 	}
 
 	@Test
@@ -133,12 +130,12 @@ public class Test_org_eclipse_swt_widgets_Spinner extends Test_org_eclipse_swt_w
 		int [] pageIncrement = {50,5,6,100};
 		for (int i=0;i<cases;i++){
 			spinner.setValues(selection[i], minimum[i], maximum[i], digits[i], increment[i], pageIncrement[i]);
-			assertEquals("i=" + i, selection[i], spinner.getSelection());
-			assertEquals("i=" + i, minimum[i], spinner.getMinimum());
-			assertEquals("i=" + i, maximum[i], spinner.getMaximum());
-			assertEquals("i=" + i, digits[i], spinner.getDigits());
-			assertEquals("i=" + i, increment[i], spinner.getIncrement());
-			assertEquals("i=" + i, pageIncrement[i], spinner.getPageIncrement());
+			assertEquals(selection[i], spinner.getSelection());
+			assertEquals(minimum[i], spinner.getMinimum());
+			assertEquals(maximum[i], spinner.getMaximum());
+			assertEquals(digits[i], spinner.getDigits());
+			assertEquals(increment[i], spinner.getIncrement());
+			assertEquals(pageIncrement[i], spinner.getPageIncrement());
 		}
 
 		// set invalid values. The last values should be preserved

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_TabFolder.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_TabFolder.java
@@ -13,10 +13,10 @@
  *******************************************************************************/
 package org.eclipse.swt.tests.junit;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -28,8 +28,8 @@ import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.TabFolder;
 import org.eclipse.swt.widgets.TabItem;
 import org.eclipse.swt.widgets.Text;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Automated Test Suite for class org.eclipse.swt.widgets.TabFolder
@@ -39,7 +39,7 @@ import org.junit.Test;
 public class Test_org_eclipse_swt_widgets_TabFolder extends Test_org_eclipse_swt_widgets_Composite {
 
 @Override
-@Before
+@BeforeEach
 public void setUp() {
 	super.setUp();
 	makeCleanEnvironment();
@@ -92,7 +92,7 @@ public void test_getClientArea() {
 public void test_getItemCount() {
 	int number = 10;
 	for (int i = 0; i<number ; i++){
-		assertEquals(":a:" + i, i, tabFolder.getItemCount());
+		assertEquals(i, tabFolder.getItemCount());
 		new TabItem(tabFolder, 0);
 	}
 }
@@ -106,7 +106,7 @@ public void test_getItemI() {
 	}
 
 	for (int i = 0; i < number; i++) {
-		assertEquals(":a:" + String.valueOf(i), items[i], tabFolder.getItem(i));
+		assertEquals(items[i], tabFolder.getItem(i));
 	}
 	try {
 		tabFolder.getItem(number);
@@ -182,10 +182,10 @@ public void test_getSelection() {
 	for (int i = 0; i<number ; i++){
 		tis[i] = new TabItem(tabFolder, 0);
 	}
-	assertEquals(":a:", tis[0], tabFolder.getSelection()[0]);
+	assertEquals(tis[0], tabFolder.getSelection()[0]);
 	for (int i = 0; i<number ; i++){
 		tabFolder.setSelection(i);
-		assertEquals(":b:" + i, tis[i], tabFolder.getSelection()[0]);
+		assertEquals(tis[i], tabFolder.getSelection()[0]);
 	}
 }
 
@@ -196,16 +196,16 @@ public void test_getSelectionIndex() {
 	for (int i = 0; i < number; i++)
 		items[i] = new TabItem(tabFolder, 0);
 
-	assertEquals(":a:", 0, tabFolder.getSelectionIndex());
+	assertEquals(0, tabFolder.getSelectionIndex());
 
 	tabFolder.setSelection(new TabItem[]{items[2], items[number-1], items[10]});
-	assertEquals(":b:", 2, tabFolder.getSelectionIndex());
+	assertEquals(2, tabFolder.getSelectionIndex());
 
 	tabFolder.setSelection(items);
-	assertEquals(":c:", 0, tabFolder.getSelectionIndex());
+	assertEquals(0, tabFolder.getSelectionIndex());
 
 	tabFolder.setSelection(items[2]);
-	assertEquals(":d:", 2, tabFolder.getSelectionIndex());
+	assertEquals(2, tabFolder.getSelectionIndex());
 }
 
 @Test
@@ -216,7 +216,7 @@ public void test_indexOfLorg_eclipse_swt_widgets_TabItem() {
 		tis[i] = new TabItem(tabFolder, 0);
 	}
 	for (int i = 0; i<number ; i++){
-		assertTrue(":a:" + i, tabFolder.indexOf(tis[i])==i);
+		assertTrue(tabFolder.indexOf(tis[i])==i);
 	}
 
 	//
@@ -253,14 +253,14 @@ public void test_indexOfLorg_eclipse_swt_widgets_TabItem() {
 	}
 
 	for (int i = 0; i < number; i++) {
-		assertTrue(":a:" + String.valueOf(i), tabFolder.indexOf(items_2[i])==-1);
+		assertTrue(tabFolder.indexOf(items_2[i])==-1);
 	}
 
 	//
 	TabFolder tabFolder2 = new TabFolder(shell, SWT.NULL);
 	TabItem tabItem = new TabItem(tabFolder2, SWT.NULL);
 
-	assertTrue(":a:", tabFolder.indexOf(tabItem) == -1);
+	assertTrue(tabFolder.indexOf(tabItem) == -1);
 }
 
 @Test
@@ -302,7 +302,7 @@ public void test_setSelectionI() {
 
 	for (int i = 0; i<number ; i++){
 		new TabItem(tabFolder, 0);
-		assertEquals("i=" + i, 0, tabFolder.getSelectionIndex());
+		assertEquals(0, tabFolder.getSelectionIndex());
 	}
 
 	//

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_TabItem.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_TabItem.java
@@ -13,18 +13,17 @@
  *******************************************************************************/
 package org.eclipse.swt.tests.junit;
 
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.TabFolder;
 import org.eclipse.swt.widgets.TabItem;
 import org.eclipse.swt.widgets.Table;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Automated Test Suite for class org.eclipse.swt.widgets.TabItem
@@ -34,7 +33,7 @@ import org.junit.Test;
 public class Test_org_eclipse_swt_widgets_TabItem extends Test_org_eclipse_swt_widgets_Item {
 
 @Override
-@Before
+@BeforeEach
 public void setUp() {
 	super.setUp();
 	tabFolder = new TabFolder(shell, 0);
@@ -44,46 +43,46 @@ public void setUp() {
 
 @Test
 public void test_ConstructorLorg_eclipse_swt_widgets_TabFolderI() {
-	assertThrows("No exception thrown for parent == null",IllegalArgumentException.class, () -> new TabItem(null, SWT.NULL));
+	assertThrows(IllegalArgumentException.class, () -> new TabItem(null, SWT.NULL));
 }
 
 @Test
 public void test_ConstructorLorg_eclipse_swt_widgets_TabFolderII() {
 	TabItem tItem = new TabItem(tabFolder, SWT.NULL, 0);
 
-	assertEquals(":a:", tItem, tabFolder.getItems()[0]);
+	assertEquals(tItem, tabFolder.getItems()[0]);
 
 	tItem = new TabItem(tabFolder, SWT.NULL, 1);
-	assertEquals(":b:", tItem, tabFolder.getItems()[1]);
+	assertEquals(tItem, tabFolder.getItems()[1]);
 
 	tItem = new TabItem(tabFolder, SWT.NULL, 1);
-	assertEquals(":c:", tItem, tabFolder.getItems()[1]);
+	assertEquals(tItem, tabFolder.getItems()[1]);
 
-	assertThrows("No exception thrown",IllegalArgumentException.class, () -> new TabItem(tabFolder, SWT.NULL, -1));
-	assertEquals(":d:", tItem, tabFolder.getItems()[1]);
+	assertThrows(IllegalArgumentException.class, () -> new TabItem(tabFolder, SWT.NULL, -1));
+	assertEquals(tItem, tabFolder.getItems()[1]);
 
-	assertThrows("No exception thrown",IllegalArgumentException.class, () -> new TabItem(tabFolder, SWT.NULL, tabFolder.getItemCount() + 1));
-	assertEquals(":e:", tItem, tabFolder.getItems()[1]);
+	assertThrows(IllegalArgumentException.class, () -> new TabItem(tabFolder, SWT.NULL, tabFolder.getItemCount() + 1));
+	assertEquals(tItem, tabFolder.getItems()[1]);
 
-	assertThrows("No exception thrown",IllegalArgumentException.class, () -> new TabItem(null, SWT.NULL, 0));
+	assertThrows(IllegalArgumentException.class, () -> new TabItem(null, SWT.NULL, 0));
 }
 
 @Test
 public void test_getParent() {
-	assertEquals(":a: ", tabFolder, tabItem.getParent());
+	assertEquals(tabFolder, tabItem.getParent());
 }
 
 @Test
 public void test_setControlLorg_eclipse_swt_widgets_Control() {
 	Control control = new Table(tabFolder, SWT.NULL);
 
-	assertNull(":a: ", tabItem.getControl());
+	assertNull(tabItem.getControl());
 
 	tabItem.setControl(control);
-	assertEquals(":b: ", control, tabItem.getControl());
+	assertEquals(control, tabItem.getControl());
 
 	tabItem.setControl(null);
-	assertNull(":c: ", tabItem.getControl());
+	assertNull(tabItem.getControl());
 }
 
 @Override
@@ -99,11 +98,11 @@ public void test_setTextLjava_lang_String() {
 @Test
 public void test_setToolTipTextLjava_lang_String() {
 	tabItem.setToolTipText("fred");
-	assertEquals(":a:", "fred", tabItem.getToolTipText());
+	assertEquals("fred", tabItem.getToolTipText());
 	tabItem.setToolTipText("fredttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttt");
-	assertEquals(":b:", "fredttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttt", tabItem.getToolTipText());
+	assertEquals("fredttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttt", tabItem.getToolTipText());
 	tabItem.setToolTipText(null);
-	assertNull(":c: ", tabItem.getToolTipText());
+	assertNull(tabItem.getToolTipText());
 }
 
 /* custom */

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Table.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Table.java
@@ -14,12 +14,12 @@
 package org.eclipse.swt.tests.junit;
 
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -31,8 +31,8 @@ import org.eclipse.swt.layout.FillLayout;
 import org.eclipse.swt.widgets.Table;
 import org.eclipse.swt.widgets.TableColumn;
 import org.eclipse.swt.widgets.TableItem;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Automated Test Suite for class org.eclipse.swt.widgets.Table
@@ -42,7 +42,7 @@ import org.junit.Test;
 public class Test_org_eclipse_swt_widgets_Table extends Test_org_eclipse_swt_widgets_Composite {
 
 @Override
-@Before
+@BeforeEach
 public void setUp() {
 	super.setUp();
 	makeCleanEnvironment(false); // by default, use multi-select table.
@@ -341,7 +341,7 @@ public void test_getItemCount() {
 		for (int i = 0; i < cases[j]; i++) {
 			new TableItem(table, 0);
 		}
-		assertEquals("j="+ j, cases[j], table.getItemCount());
+		assertEquals(cases[j], table.getItemCount());
 		table.removeAll();
 	}
 
@@ -351,16 +351,16 @@ public void test_getItemCount() {
 		for (int i = 0; i < cases[j]; i++) {
 			new TableItem(table, 0);
 		}
-		assertEquals("j="+ j, cases[j], table.getItemCount());
+		assertEquals(cases[j], table.getItemCount());
 		table.removeAll();
 	}
 }
 
 @Test
 public void test_getItemHeight() {
-	assertTrue(":a: Item height <= 0", table.getItemHeight() > 0);
+	assertTrue(table.getItemHeight() > 0);
 	new TableItem(table, 0);
-	assertTrue(":b: Item height <= 0", table.getItemHeight() > 0);
+	assertTrue(table.getItemHeight() > 0);
 }
 
 @Test
@@ -371,7 +371,7 @@ public void test_getItemI() {
 		items[i] = new TableItem(table, 0);
 
 	for (int i = 0; i < number; i++)
-		assertEquals("i=" + i, items[i], table.getItem(i));
+		assertEquals(items[i], table.getItem(i));
 	try {
 		table.getItem(number);
 		fail("No exception thrown for illegal index argument");
@@ -392,7 +392,7 @@ public void test_getItemI() {
 	for (int i = 0; i < number; i++)
 		items[i] = new TableItem(table, 0);
 	for (int i = 0; i < number; i++) {
-		assertEquals("i=" + i, items[i], table.getItem(i));
+		assertEquals(items[i], table.getItem(i));
 	}
 	try {
 		table.getItem(number);
@@ -416,7 +416,7 @@ public void test_getItems() {
 		for (int i = 0; i < cases[j]; i++) {
 			new TableItem(table, 0);
 		}
-		assertEquals("j=" + j, cases[j], table.getItems().length);
+		assertEquals(cases[j], table.getItems().length);
 		table.removeAll();
 	}
 
@@ -427,7 +427,7 @@ public void test_getItems() {
 		}
 		TableItem[] items = table.getItems();
 		for (int i = 0; i < items.length; i++) {
-			assertEquals("j=" + j + ", i=" + i, String.valueOf(i), items[i].getText());
+			assertEquals(String.valueOf(i), items[i].getText());
 		}
 		table.removeAll();
 	}
@@ -439,7 +439,7 @@ public void test_getItems() {
 		for (int i = 0; i < cases[j]; i++) {
 			new TableItem(table, 0);
 		}
-		assertEquals("j=" + j, cases[j], table.getItems().length);
+		assertEquals(cases[j], table.getItems().length);
 		table.removeAll();
 	}
 
@@ -452,7 +452,7 @@ public void test_getItems() {
 		}
 		TableItem[] items = table.getItems();
 		for (int i = 0; i < items.length; i++) {
-			assertEquals("j=" + j + ", i=" + i, String.valueOf(i), items[i].getText());
+			assertEquals(String.valueOf(i), items[i].getText());
 		}
 		table.removeAll();
 	}
@@ -657,7 +657,7 @@ public void test_indexOfLorg_eclipse_swt_widgets_TableItem() {
 	}
 
 	for (int i = 0; i < number; i++) {
-		assertEquals("i=" + i, -1, table.indexOf(items_2[i]));
+		assertEquals(-1, table.indexOf(items_2[i]));
 	}
 
 	// note: SWT.SINGLE
@@ -707,7 +707,7 @@ public void test_indexOfLorg_eclipse_swt_widgets_TableItem() {
 	}
 
 	for (int i = 0; i < number; i++) {
-		assertEquals("i=" + i, -1, table.indexOf(items_2[i]));
+		assertEquals(-1, table.indexOf(items_2[i]));
 	}
 }
 
@@ -718,27 +718,27 @@ public void test_isSelectedI() {
 	for (int i = 0; i < number; i++)
 		items[i] = new TableItem(table, 0);
 	for (int i = 0; i < number; i++)
-		assertTrue(":a:" + i, !table.isSelected(i));
+		assertTrue(!table.isSelected(i));
 	table.setSelection(new TableItem[] {items[2], items[number-1], items[10]});
 	for (int i = 0; i < number; i++) {
 		if (i == 2 || i == number-1 || i == 10)
-			assertTrue(":b:" + i, table.isSelected(i));
+			assertTrue(table.isSelected(i));
 		else
-			assertTrue(":b:" + i, !table.isSelected(i));
+			assertTrue(!table.isSelected(i));
 	}
 
 	table.setSelection(items[0]);
 	for (int i = 0; i < number; i++) {
 		if (i == 0)
-			assertTrue(":b:" + i, table.isSelected(i));
+			assertTrue(table.isSelected(i));
 		else
-			assertTrue(":b:" + i, !table.isSelected(i));
+			assertTrue(!table.isSelected(i));
 	}
 
 
 	table.setSelection(items);
 	for (int i = 0; i < number; i++)
-		assertTrue(":c:" + i, table.isSelected(i));
+		assertTrue(table.isSelected(i));
 
 	// note: SWT.SINGLE
 	makeCleanEnvironment(true);
@@ -746,18 +746,18 @@ public void test_isSelectedI() {
 	for (int i = 0; i < number; i++)
 		items[i] = new TableItem(table, 0);
 	for (int i = 0; i < number; i++)
-		assertTrue(":d:" + i, !table.isSelected(i));
+		assertTrue(!table.isSelected(i));
 	table.setSelection(new TableItem[] {items[10]});
 	for (int i = 0; i < number; i++) {
 		if (i == 10)
-			assertTrue(":e:" + i, table.isSelected(i));
+			assertTrue(table.isSelected(i));
 		else
-			assertTrue(":e:" + i, !table.isSelected(i));
+			assertTrue(!table.isSelected(i));
 	}
 
 	table.setSelection(items);
 	for (int i = 0; i < number; i++){
-		assertTrue(":f:" + i, !table.isSelected(i));
+		assertTrue(!table.isSelected(i));
 	}
 }
 
@@ -795,24 +795,24 @@ public void test_remove$I() {
 	for (int i = 0; i < number; i++)
 		items[i] = new TableItem(table, 0);
 
-	assertTrue(":a:", !items[2].isDisposed());
+	assertTrue(!items[2].isDisposed());
 	table.remove(new int[] {2});
-	assertTrue(":b:", items[2].isDisposed());
+	assertTrue(items[2].isDisposed());
 	assertEquals(number-1, table.getItemCount());
 
-	assertTrue(":c:", !items[number-1].isDisposed());
+	assertTrue(!items[number-1].isDisposed());
 	table.remove(new int[] {number-2});
-	assertTrue(":d:", items[number-1].isDisposed());
+	assertTrue(items[number-1].isDisposed());
 	assertEquals(number-2, table.getItemCount());
 
-	assertTrue(":e:", !items[3].isDisposed());
+	assertTrue(!items[3].isDisposed());
 	table.remove(new int[] {2});
-	assertTrue(":f:", items[3].isDisposed());
+	assertTrue(items[3].isDisposed());
 	assertEquals(number-3, table.getItemCount());
 
-	assertTrue(":g:", !items[0].isDisposed());
+	assertTrue(!items[0].isDisposed());
 	table.remove(new int[] {0});
-	assertTrue(":h:", items[0].isDisposed());
+	assertTrue(items[0].isDisposed());
 	assertEquals(number-4, table.getItemCount());
 }
 
@@ -1893,8 +1893,7 @@ public void test_Virtual() {
 		}
 	}
 	// the "* 3" allows some surplus for platforms that pre-fetch items to improve scrolling performance:
-	assertTrue("SetData callback count not in range: " + dataCounter[0],
-			dataCounter[0] > visibleCount / 2 && dataCounter[0] <= visibleCount * 3);
+	assertTrue(dataCounter[0] > visibleCount / 2 && dataCounter[0] <= visibleCount * 3);
 }
 
 @Test

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_TableColumn.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_TableColumn.java
@@ -13,10 +13,10 @@
  *******************************************************************************/
 package org.eclipse.swt.tests.junit;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.SWTException;
@@ -26,8 +26,8 @@ import org.eclipse.swt.events.SelectionListener;
 import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Table;
 import org.eclipse.swt.widgets.TableColumn;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Automated Test Suite for class org.eclipse.swt.widgets.TableColumn
@@ -37,7 +37,7 @@ import org.junit.Test;
 public class Test_org_eclipse_swt_widgets_TableColumn extends Test_org_eclipse_swt_widgets_Item {
 
 @Override
-@Before
+@BeforeEach
 public void setUp() {
 	super.setUp();
 	table = new Table(shell, SWT.SINGLE);
@@ -120,13 +120,13 @@ public void test_getWidth() {
 //	}
 
 	tableColumn.setWidth(0);
-	assertEquals(":a: width=" + tableColumn.getWidth() + " should be=" + 0, 0, tableColumn.getWidth());
+	assertEquals(0, tableColumn.getWidth());
 
 	tableColumn.setWidth(testWidth);
-	assertEquals(":b: width=" + tableColumn.getWidth() + " should be=" + testWidth, testWidth, tableColumn.getWidth());
+	assertEquals(testWidth, tableColumn.getWidth());
 
 	tableColumn.setWidth(testWidth);
-	assertEquals(":c: width=" + tableColumn.getWidth() + " should be=" + testWidth, testWidth, tableColumn.getWidth());
+	assertEquals(testWidth, tableColumn.getWidth());
 }
 
 @Test
@@ -150,25 +150,23 @@ public void test_removeSelectionListenerLorg_eclipse_swt_events_SelectionListene
 public void test_setAlignmentI() {
 	TableColumn column2;
 
-	assertEquals(":a:", SWT.LEFT, tableColumn.getAlignment());
+	assertEquals(SWT.LEFT, tableColumn.getAlignment());
 
 	tableColumn.setAlignment(-1);
-	assertEquals(":b:", SWT.LEFT, tableColumn.getAlignment());
+	assertEquals(SWT.LEFT, tableColumn.getAlignment());
 
 	tableColumn.setAlignment(SWT.RIGHT);
-	assertEquals(
-			":c: Should not be allowed to set alignment of the first column",
-			SWT.LEFT, tableColumn.getAlignment());
+	assertEquals(SWT.LEFT, tableColumn.getAlignment());
 
 	column2 = new TableColumn(table, SWT.NULL);
 	column2.setAlignment(SWT.RIGHT);
-	assertEquals(":d:", SWT.RIGHT, column2.getAlignment());
+	assertEquals(SWT.RIGHT, column2.getAlignment());
 
 	column2.setAlignment(SWT.CENTER);
-	assertEquals(":e:", SWT.CENTER, column2.getAlignment());
+	assertEquals(SWT.CENTER, column2.getAlignment());
 
 	column2.setAlignment(SWT.LEFT);
-	assertEquals(":f:", SWT.LEFT, column2.getAlignment());
+	assertEquals(SWT.LEFT, column2.getAlignment());
 }
 
 @Override
@@ -178,16 +176,16 @@ public void test_setImageLorg_eclipse_swt_graphics_Image() {
 
 @Test
 public void test_setMoveableZ() {
-	assertFalse(":a:", tableColumn.getMoveable());
+	assertFalse(tableColumn.getMoveable());
 
 	tableColumn.setMoveable(true);
-	assertTrue(":b:", tableColumn.getMoveable());
+	assertTrue(tableColumn.getMoveable());
 
 	tableColumn.setMoveable(true);
-	assertTrue(":c:", tableColumn.getMoveable());
+	assertTrue(tableColumn.getMoveable());
 
 	tableColumn.setMoveable(false);
-	assertFalse(":d:", tableColumn.getMoveable());
+	assertFalse(tableColumn.getMoveable());
 
 	TableColumn tableColumn2 = new TableColumn(tableColumn.getParent(), SWT.NONE);
 	tableColumn2.dispose();
@@ -203,25 +201,25 @@ public void test_setMoveableZ() {
 
 @Test
 public void test_setResizableZ() {
-	assertTrue(":a:", tableColumn.getResizable());
+	assertTrue(tableColumn.getResizable());
 
 	tableColumn.setResizable(false);
-	assertFalse(":b:", tableColumn.getResizable());
+	assertFalse(tableColumn.getResizable());
 
 	tableColumn.setResizable(false);
-	assertFalse(":c:", tableColumn.getResizable());
+	assertFalse(tableColumn.getResizable());
 
 	tableColumn.setResizable(true);
-	assertTrue(":d:", tableColumn.getResizable());
+	assertTrue(tableColumn.getResizable());
 }
 
 @Override
 @Test
 public void test_setTextLjava_lang_String() {
-	assertEquals(":a:", tableColumn.getText(), "");
+	assertEquals(tableColumn.getText(), "");
 
 	tableColumn.setText("text");
-	assertEquals(":b:", tableColumn.getText(), "text");
+	assertEquals(tableColumn.getText(), "text");
 
 	try {
 		tableColumn.setText(null);

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_TableItem.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_TableItem.java
@@ -13,11 +13,11 @@
  *******************************************************************************/
 package org.eclipse.swt.tests.junit;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Color;
@@ -28,8 +28,8 @@ import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Table;
 import org.eclipse.swt.widgets.TableColumn;
 import org.eclipse.swt.widgets.TableItem;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Automated Test Suite for class org.eclipse.swt.widgets.TableItem
@@ -39,7 +39,7 @@ import org.junit.Test;
 public class Test_org_eclipse_swt_widgets_TableItem extends Test_org_eclipse_swt_widgets_Item {
 
 @Override
-@Before
+@BeforeEach
 public void setUp() {
 	super.setUp();
 	makeCleanEnvironment();
@@ -87,18 +87,18 @@ public void test_getBoundsI() {
 
 	// no columns
 	bounds = tableItem.getBounds(0);
-	assertTrue(":1a:", bounds.x > 0 && bounds.height > 0);
+	assertTrue(bounds.x > 0 && bounds.height > 0);
 	bounds = tableItem.getBounds(-1);
-	assertEquals(":1b:", new Rectangle(0, 0, 0, 0), bounds);
+	assertEquals(new Rectangle(0, 0, 0, 0), bounds);
 	bounds = tableItem.getBounds(1);
-	assertEquals(":1c:", new Rectangle(0, 0, 0, 0), bounds);
+	assertEquals(new Rectangle(0, 0, 0, 0), bounds);
 
 	tableItem.setText("hello");
 	bounds = tableItem.getBounds(0);
-	assertTrue(":1d:", bounds.x > 0 && bounds.height > 0 && bounds.width > 0);
+	assertTrue(bounds.x > 0 && bounds.height > 0 && bounds.width > 0);
 	tableItem.setText("");
 	bounds2 = tableItem.getBounds(0);
-	assertTrue(":1e:", bounds2.x > 0 && bounds2.height > 0);
+	assertTrue(bounds2.x > 0 && bounds2.height > 0);
 	//assertTrue(":1f:", bounds2.width < bounds.width); // TODO doesn't shrink?
 
 	//
@@ -106,10 +106,10 @@ public void test_getBoundsI() {
 
 	tableItem.setImage(image);
 	bounds = tableItem.getBounds(0);
-	assertTrue(":1g:", bounds.x > 0 && bounds.height > 0 && bounds.width > 0);
+	assertTrue(bounds.x > 0 && bounds.height > 0 && bounds.width > 0);
 	tableItem.setImage((Image)null);
 	bounds2 = tableItem.getBounds(0);
-	assertTrue(":1h:", bounds2.x > 0 && bounds2.height > 0);
+	assertTrue(bounds2.x > 0 && bounds2.height > 0);
 //	assertTrue(":1i:", bounds2.width > bounds.width); // TODO once an image is added the space for it is always there
 
 	//
@@ -119,26 +119,26 @@ public void test_getBoundsI() {
 	bounds = tableItem.getBounds(0);
 	tableItem.setImage(image);
 	bounds2 = tableItem.getBounds(0);
-	assertTrue(":1j:", bounds2.x > 0 && bounds2.height > 0);
-	assertTrue(":1k:", bounds2.width > bounds.width);
+	assertTrue(bounds2.x > 0 && bounds2.height > 0);
+	assertTrue(bounds2.width > bounds.width);
 
 	// no columns and CHECK style
 	Table table2 = new Table(shell, SWT.CHECK);
 	TableItem tableItem2 = new TableItem(table2, SWT.NONE);
 
 	bounds = tableItem2.getBounds(0);
-	assertTrue(":2a:", bounds.x > 0 && bounds.height > 0);
+	assertTrue(bounds.x > 0 && bounds.height > 0);
 	bounds = tableItem2.getBounds(-1);
-	assertEquals(":2b:", new Rectangle(0, 0, 0, 0), bounds);
+	assertEquals(new Rectangle(0, 0, 0, 0), bounds);
 	bounds = tableItem2.getBounds(1);
-	assertEquals(":2c:", new Rectangle(0, 0, 0, 0), bounds);
+	assertEquals(new Rectangle(0, 0, 0, 0), bounds);
 
 	tableItem2.setText("hello");
 	bounds = tableItem2.getBounds(0);
-	assertTrue(":2d:", bounds.x > 0 && bounds.height > 0 && bounds.width > 0);
+	assertTrue(bounds.x > 0 && bounds.height > 0 && bounds.width > 0);
 	tableItem2.setText("");
 	bounds2 = tableItem2.getBounds(0);
-	assertTrue(":2e:", bounds2.x > 0 && bounds2.height > 0);
+	assertTrue(bounds2.x > 0 && bounds2.height > 0);
 	//assertTrue(":2f:", bounds2.width < bounds.width); // TODO doesn't shrink?
 
 	table2.dispose();
@@ -147,10 +147,10 @@ public void test_getBoundsI() {
 
 	tableItem2.setImage(image);
 	bounds = tableItem2.getBounds(0);
-	assertTrue(":2g:", bounds.x > 0 && bounds.height > 0 && bounds.width > 0);
+	assertTrue(bounds.x > 0 && bounds.height > 0 && bounds.width > 0);
 	tableItem2.setImage((Image)null);
 	bounds2 = tableItem2.getBounds(0);
-	assertTrue(":2h:", bounds2.x > 0 && bounds2.height > 0);
+	assertTrue(bounds2.x > 0 && bounds2.height > 0);
 	//assertTrue(":2i:", bounds2.width < bounds.width);  // TODO once an image is added the space for it is always there
 
 	table2.dispose();
@@ -161,8 +161,8 @@ public void test_getBoundsI() {
 	bounds = tableItem2.getBounds(0);
 	tableItem2.setImage(image);
 	bounds2 = tableItem2.getBounds(0);
-	assertTrue(":2j:", bounds2.x > 0 && bounds2.height > 0);
-	assertTrue(":2k:", bounds2.width > bounds.width);
+	assertTrue(bounds2.x > 0 && bounds2.height > 0);
+	assertTrue(bounds2.width > bounds.width);
 
 	//
 	makeCleanEnvironment();
@@ -173,36 +173,36 @@ public void test_getBoundsI() {
 	TableColumn column1 = new TableColumn(table, SWT.CENTER);
 
 	bounds = tableItem.getBounds(0);
-	assertTrue(":3a:", bounds.x > 0 && bounds.height > 0 && bounds.width == 0);
+	assertTrue(bounds.x > 0 && bounds.height > 0 && bounds.width == 0);
 	bounds = tableItem.getBounds(1);
-	assertTrue(":3b:", /*bounds.x > 0 &&*/ bounds.height > 0 && bounds.width == 0); // TODO bounds.x == 0 Is this right?
+	assertTrue(bounds.height > 0 && bounds.width == 0); // TODO bounds.x == 0 Is this right?
 	bounds = tableItem.getBounds(-1);
-	assertEquals(":3c:", new Rectangle(0, 0, 0, 0), bounds);
+	assertEquals(new Rectangle(0, 0, 0, 0), bounds);
 	bounds = tableItem.getBounds(2);
-	assertEquals(":3d:", new Rectangle(0, 0, 0, 0), bounds);
+	assertEquals(new Rectangle(0, 0, 0, 0), bounds);
 
 	column0.setWidth(100);
 	bounds = tableItem.getBounds(0);
-	assertTrue(":3e:", bounds.x > 0 && bounds.height > 0 && bounds.width > 0 && bounds.width < 100);
+	assertTrue(bounds.x > 0 && bounds.height > 0 && bounds.width > 0 && bounds.width < 100);
 	bounds = tableItem.getBounds(1);
-	assertTrue(":3f:", bounds.x >= 100 && bounds.height > 0 && bounds.width == 0);
+	assertTrue(bounds.x >= 100 && bounds.height > 0 && bounds.width == 0);
 
 	column1.setWidth(200);
 	bounds = tableItem.getBounds(0);
-	assertTrue(":3g:", bounds.x > 0 && bounds.height > 0 && bounds.width > 0 && bounds.width < 100);
+	assertTrue(bounds.x > 0 && bounds.height > 0 && bounds.width > 0 && bounds.width < 100);
 	bounds = tableItem.getBounds(1);
-	assertTrue(":3h:", bounds.x >= 100 && bounds.height > 0 && bounds.width == 200);
+	assertTrue(bounds.x >= 100 && bounds.height > 0 && bounds.width == 200);
 
 	tableItem.setText(new String[] {"hello", "world"});
 	bounds = tableItem.getBounds(0);
-	assertTrue(":3i:", bounds.x > 0 && bounds.height > 0 && bounds.width > 0 && bounds.width < 100);
+	assertTrue(bounds.x > 0 && bounds.height > 0 && bounds.width > 0 && bounds.width < 100);
 	bounds = tableItem.getBounds(1);
-	assertTrue(":3j:", bounds.x >= 100 && bounds.height > 0 && bounds.width  == 200);
+	assertTrue(bounds.x >= 100 && bounds.height > 0 && bounds.width  == 200);
 	tableItem.setText(new String[] {"", ""});
 	bounds = tableItem.getBounds(0);
-	assertTrue(":3k:", bounds.x > 0 && bounds.height > 0 && bounds.width > 0 && bounds.width < 100);
+	assertTrue(bounds.x > 0 && bounds.height > 0 && bounds.width > 0 && bounds.width < 100);
 	bounds = tableItem.getBounds(1);
-	assertTrue(":3l:", bounds.x >= 100 && bounds.height > 0 && bounds.width  == 200);
+	assertTrue(bounds.x >= 100 && bounds.height > 0 && bounds.width  == 200);
 
 	//
 	makeCleanEnvironment();
@@ -213,14 +213,14 @@ public void test_getBoundsI() {
 
 	tableItem.setImage(new Image[] {image, image});
 	bounds = tableItem.getBounds(0);
-	assertTrue(":3m:", bounds.x > 0 && bounds.height > 0 && bounds.width > 0 && bounds.width < 100);
+	assertTrue(bounds.x > 0 && bounds.height > 0 && bounds.width > 0 && bounds.width < 100);
 	bounds = tableItem.getBounds(1);
-	assertTrue(":3n:", bounds.x >= 100 && bounds.height > 0 && bounds.width  == 200);
+	assertTrue(bounds.x >= 100 && bounds.height > 0 && bounds.width  == 200);
 	tableItem.setImage(new Image[] {null, null});
 	bounds = tableItem.getBounds(0);
-	assertTrue(":3o:", bounds.x > 0 && bounds.height > 0 && bounds.width > 0 && bounds.width < 100);
+	assertTrue(bounds.x > 0 && bounds.height > 0 && bounds.width > 0 && bounds.width < 100);
 	bounds = tableItem.getBounds(1);
-	assertTrue(":3p:", bounds.x >= 100 && bounds.height > 0 && bounds.width  == 200);
+	assertTrue(bounds.x >= 100 && bounds.height > 0 && bounds.width  == 200);
 
 	//
 	makeCleanEnvironment();
@@ -232,9 +232,9 @@ public void test_getBoundsI() {
 	tableItem.setText(new String[] {"hello", "world"});
 	tableItem.setImage(new Image[] {null, null});
 	bounds = tableItem.getBounds(0);
-	assertTrue(":3q:", bounds.x > 0 && bounds.height > 0 && bounds.width > 0 && bounds.width < 100);
+	assertTrue(bounds.x > 0 && bounds.height > 0 && bounds.width > 0 && bounds.width < 100);
 	bounds = tableItem.getBounds(1);
-	assertTrue(":3r:", bounds.x > 0 && bounds.height > 0 && bounds.width  == 200);
+	assertTrue(bounds.x > 0 && bounds.height > 0 && bounds.width  == 200);
 
 	//
 	makeCleanEnvironment();
@@ -242,7 +242,7 @@ public void test_getBoundsI() {
 	tableItem.setText("hello");
 	new TableColumn(table, SWT.RIGHT);
 	bounds = tableItem.getBounds(0);
-	assertTrue(":3s:", bounds.x > 0 && bounds.height > 0 && bounds.width  == 0);
+	assertTrue(bounds.x > 0 && bounds.height > 0 && bounds.width  == 0);
 
 	// with columns and CHECK style
 	table2.dispose();
@@ -252,36 +252,36 @@ public void test_getBoundsI() {
 	column1 = new TableColumn(table2, SWT.CENTER);
 
 	bounds = tableItem2.getBounds(0);
-	assertTrue(":4a:", bounds.x > 0 && bounds.height > 0 && bounds.width == 0);
+	assertTrue(bounds.x > 0 && bounds.height > 0 && bounds.width == 0);
 	bounds = tableItem2.getBounds(1);
-	assertTrue(":4b:", /*bounds.x > 0 &&*/ bounds.height > 0 && bounds.width == 0); // TODO bounds.x == 0 Is this right?
+	assertTrue(bounds.height > 0 && bounds.width == 0); // TODO bounds.x == 0 Is this right?
 	bounds = tableItem2.getBounds(-1);
-	assertEquals(":4c:", new Rectangle(0, 0, 0, 0), bounds);
+	assertEquals(new Rectangle(0, 0, 0, 0), bounds);
 	bounds = tableItem2.getBounds(2);
-	assertEquals(":4d:", new Rectangle(0, 0, 0, 0), bounds);
+	assertEquals(new Rectangle(0, 0, 0, 0), bounds);
 
 	column0.setWidth(100);
 	bounds = tableItem2.getBounds(0);
-	assertTrue(":4e:", bounds.x > 0 && bounds.height > 0 && bounds.width > 0 && bounds.width < 100);
+	assertTrue(bounds.x > 0 && bounds.height > 0 && bounds.width > 0 && bounds.width < 100);
 	bounds = tableItem2.getBounds(1);
-	assertTrue(":4f:", bounds.x >= 100 && bounds.height > 0 && bounds.width == 0);
+	assertTrue(bounds.x >= 100 && bounds.height > 0 && bounds.width == 0);
 
 	column1.setWidth(200);
 	bounds = tableItem2.getBounds(0);
-	assertTrue(":4g:", bounds.x > 0 && bounds.height > 0 && bounds.width > 0 && bounds.width < 100);
+	assertTrue(bounds.x > 0 && bounds.height > 0 && bounds.width > 0 && bounds.width < 100);
 	bounds = tableItem2.getBounds(1);
-	assertTrue(":4h:", bounds.x >= 100 && bounds.height > 0 && bounds.width == 200);
+	assertTrue(bounds.x >= 100 && bounds.height > 0 && bounds.width == 200);
 
 	tableItem2.setText(new String[] {"hello", "world"});
 	bounds = tableItem2.getBounds(0);
-	assertTrue(":4i:", bounds.x > 0 && bounds.height > 0 && bounds.width > 0 && bounds.width < 100);
+	assertTrue(bounds.x > 0 && bounds.height > 0 && bounds.width > 0 && bounds.width < 100);
 	bounds = tableItem2.getBounds(1);
-	assertTrue(":4j:", bounds.x >= 100 && bounds.height > 0 && bounds.width  == 200);
+	assertTrue(bounds.x >= 100 && bounds.height > 0 && bounds.width  == 200);
 	tableItem2.setText(new String[] {"", ""});
 	bounds = tableItem2.getBounds(0);
-	assertTrue(":4k:", bounds.x > 0 && bounds.height > 0 && bounds.width > 0 && bounds.width < 100);
+	assertTrue(bounds.x > 0 && bounds.height > 0 && bounds.width > 0 && bounds.width < 100);
 	bounds = tableItem2.getBounds(1);
-	assertTrue(":4l:", bounds.x >= 100 && bounds.height > 0 && bounds.width  == 200);
+	assertTrue(bounds.x >= 100 && bounds.height > 0 && bounds.width  == 200);
 
 	//
 	table2.dispose();
@@ -294,14 +294,14 @@ public void test_getBoundsI() {
 
 	tableItem2.setImage(new Image[] {image, image});
 	bounds = tableItem2.getBounds(0);
-	assertTrue(":4m:", bounds.x > 0 && bounds.height > 0 && bounds.width > 0 && bounds.width < 100);
+	assertTrue(bounds.x > 0 && bounds.height > 0 && bounds.width > 0 && bounds.width < 100);
 	bounds = tableItem2.getBounds(1);
-	assertTrue(":4n:", bounds.x >= 100 && bounds.height > 0 && bounds.width  == 200);
+	assertTrue(bounds.x >= 100 && bounds.height > 0 && bounds.width  == 200);
 	tableItem2.setImage(new Image[] {null, null});
 	bounds = tableItem2.getBounds(0);
-	assertTrue(":4o:", bounds.x > 0 && bounds.height > 0 && bounds.width > 0 && bounds.width < 100);
+	assertTrue(bounds.x > 0 && bounds.height > 0 && bounds.width > 0 && bounds.width < 100);
 	bounds = tableItem2.getBounds(1);
-	assertTrue(":4p:", bounds.x >= 100 && bounds.height > 0 && bounds.width  == 200);
+	assertTrue(bounds.x >= 100 && bounds.height > 0 && bounds.width  == 200);
 
 	//
 	table2.dispose();
@@ -315,9 +315,9 @@ public void test_getBoundsI() {
 	tableItem2.setText(new String[] {"hello", "world"});
 	tableItem2.setImage(new Image[] {null, null});
 	bounds = tableItem2.getBounds(0);
-	assertTrue(":4q:", bounds.x > 0 && bounds.height > 0 && bounds.width > 0 && bounds.width < 100);
+	assertTrue(bounds.x > 0 && bounds.height > 0 && bounds.width > 0 && bounds.width < 100);
 	bounds = tableItem2.getBounds(1);
-	assertTrue(":4r:", bounds.x >= 100 && bounds.height > 0 && bounds.width  == 200);
+	assertTrue(bounds.x >= 100 && bounds.height > 0 && bounds.width  == 200);
 
 	//
 	table2.dispose();
@@ -327,7 +327,7 @@ public void test_getBoundsI() {
 	tableItem2.setText("hello");
 	new TableColumn(table2, SWT.RIGHT);
 	bounds = tableItem2.getBounds(0);
-	assertTrue(":4s:", bounds.x > 0 && bounds.height > 0 && bounds.width  == 0);
+	assertTrue(bounds.x > 0 && bounds.height > 0 && bounds.width  == 0);
 }
 
 @Test
@@ -342,14 +342,14 @@ public void test_getImageBoundsI() {
 	assertEquals(new Rectangle(0, 0, 0, 0), tableItem.getImageBounds(-1));
 
 	bounds = tableItem.getImageBounds(0);
-	assertEquals(":b:", 0, bounds.width);
+	assertEquals(0, bounds.width);
 
 	assertEquals(new Rectangle(0, 0, 0, 0), tableItem.getImageBounds(1));
 
 	assertEquals(new Rectangle(0, 0, 0, 0), tableItem2.getImageBounds(-1));
 
 	bounds = tableItem2.getImageBounds(0);
-	assertEquals(":e:", 0, bounds.width);
+	assertEquals(0, bounds.width);
 
 	assertEquals(new Rectangle(0, 0, 0, 0), tableItem2.getImageBounds(1));
 	//

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Text.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Text.java
@@ -13,11 +13,11 @@
  *******************************************************************************/
 package org.eclipse.swt.tests.junit;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assume.assumeTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.ModifyListener;
@@ -34,8 +34,8 @@ import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Group;
 import org.eclipse.swt.widgets.Text;
 import org.eclipse.swt.widgets.Widget;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Automated Test Suite for class org.eclipse.swt.widgets.Text
@@ -45,7 +45,7 @@ import org.junit.Test;
 public class Test_org_eclipse_swt_widgets_Text extends Test_org_eclipse_swt_widgets_Scrollable {
 
 @Override
-@Before
+@BeforeEach
 public void setUp() {
 	super.setUp();
 	shell.pack();
@@ -56,7 +56,7 @@ public void setUp() {
 @Override
 @Test
 public void test_ConstructorLorg_eclipse_swt_widgets_CompositeI() {
-	assertThrows("No exception thrown for parent == null", IllegalArgumentException.class, () ->	text = new Text(null, 0));
+	assertThrows(IllegalArgumentException.class, () ->	text = new Text(null, 0));
 
 	int[] cases = {0, SWT.SINGLE, SWT.MULTI, SWT.MULTI | SWT.V_SCROLL, SWT.MULTI | SWT.H_SCROLL, SWT.MULTI | SWT.H_SCROLL | SWT.V_SCROLL,
 					SWT.WRAP};
@@ -67,20 +67,20 @@ public void test_ConstructorLorg_eclipse_swt_widgets_CompositeI() {
 @Test
 public void test_addModifyListenerLorg_eclipse_swt_events_ModifyListener() {
 	ModifyListener listener = event -> listenerCalled = true;
-	assertThrows("Expected exception not thrown", IllegalArgumentException.class, ()-> text.addModifyListener(null));
+	assertThrows(IllegalArgumentException.class, ()-> text.addModifyListener(null));
 
 	// test whether all content modifying API methods send a Modify event
 	text.addModifyListener(listener);
 	listenerCalled = false;
 	text.setText("new text");
-	assertTrue("setText does not send event", listenerCalled);
+	assertTrue(listenerCalled);
 
 	listenerCalled = false;
 	text.removeModifyListener(listener);
 	// cause to call the listener.
 	text.setText("line");
-	assertFalse("Listener not removed", listenerCalled);
-	assertThrows("Expected exception not thrown", IllegalArgumentException.class, ()-> text.removeModifyListener(null));
+	assertFalse(listenerCalled);
+	assertThrows(IllegalArgumentException.class, ()-> text.removeModifyListener(null));
 }
 
 @Test
@@ -126,61 +126,61 @@ public void test_addVerifyListenerLorg_eclipse_swt_events_VerifyListener() {
 	text.setText("");
 
 	// test null listener case
-	assertThrows("Expected exception not thrown", IllegalArgumentException.class, ()->	text.addVerifyListener(null));
+	assertThrows(IllegalArgumentException.class, ()->	text.addVerifyListener(null));
 
 	// test append case
 	VerifyListener listener = event -> {
 		listenerCalled = true;
-		assertEquals("Verify event data invalid", 0, event.start);
-		assertEquals("Verify event data invalid", 0, event.end);
-		assertEquals("Verify event data invalid", line, event.text);
+		assertEquals(0, event.start);
+		assertEquals(0, event.end);
+		assertEquals(line, event.text);
 		event.text = newLine;
 	};
 	text.addVerifyListener(listener);
 	listenerCalled = false;
 	text.append(line);
-	assertTrue("append does not send event", listenerCalled);
-	assertEquals("Listener failed", newLine, text.getText());
+	assertTrue(listenerCalled);
+	assertEquals(newLine, text.getText());
 	text.removeVerifyListener(listener);
 
 	// test insert case
 	listener = event -> {
 		listenerCalled = true;
-		assertEquals("Verify event data invalid", 8, event.start);
-		assertEquals("Verify event data invalid", 8, event.end);
-		assertEquals("Verify event data invalid", line, event.text);
+		assertEquals(8, event.start);
+		assertEquals(8, event.end);
+		assertEquals(line, event.text);
 		event.text = newLine;
 	};
 	text.addVerifyListener(listener);
 	listenerCalled = false;
 	text.insert(line);
-	assertTrue("insert does not send event", listenerCalled);
-	assertEquals("Listener failed", newLine + newLine, text.getText());
+	assertTrue(listenerCalled);
+	assertEquals(newLine + newLine, text.getText());
 	text.removeVerifyListener(listener);
 
 	// test setText case
 	listener = event -> {
 		listenerCalled = true;
-		assertEquals("Verify event data invalid", 0, event.start);
-		assertEquals("Verify event data invalid", 16, event.end);
-		assertEquals("Verify event data invalid", line, event.text);
+		assertEquals(0, event.start);
+		assertEquals(16, event.end);
+		assertEquals(line, event.text);
 		event.text = newLine;
 	};
 	text.addVerifyListener(listener);
 	text.setText(line);
-	assertTrue("setText does not send event", listenerCalled);
-	assertEquals("Listener failed", newLine, text.getText());
+	assertTrue(listenerCalled);
+	assertEquals(newLine, text.getText());
 
 	// test remove case
 	listenerCalled = false;
 	text.removeVerifyListener(listener);
 	text.setText(line);
-	assertFalse("Listener not removed", listenerCalled);
+	assertFalse(listenerCalled);
 }
 
 @Test
 public void test_appendLjava_lang_String() {
-	assertThrows("No exception thrown for string == null", IllegalArgumentException.class, ()->text.append(null));
+	assertThrows(IllegalArgumentException.class, ()->text.append(null));
 
 	text.setText("01");
 	text.append("23");
@@ -203,7 +203,7 @@ public void test_appendLjava_lang_String() {
 	// tests a SINGLE line text editor
 	makeCleanEnvironment(true);
 
-	assertThrows("No exception thrown for string == null", IllegalArgumentException.class, ()->text.append(null));
+	assertThrows(IllegalArgumentException.class, ()->text.append(null));
 
 	// tests a SINGLE line text editor
 	makeCleanEnvironment(true);
@@ -862,7 +862,7 @@ public void test_getTopPixel() {
 @Test
 public void test_insertLjava_lang_String() {
 	text.setBounds(0, 0, 500, 500);
-	assertThrows("No exception thrown for string == null", IllegalArgumentException.class, ()->text.insert(null));
+	assertThrows(IllegalArgumentException.class, ()->text.insert(null));
 
 	assertEquals("", text.getText());
 	text.insert("");
@@ -882,7 +882,7 @@ public void test_insertLjava_lang_String() {
 	// tests a SINGLE line text editor
 	makeCleanEnvironment(true);
 
-	assertThrows("No exception thrown for string == null", IllegalArgumentException.class, ()->text.insert(null));
+	assertThrows(IllegalArgumentException.class, ()->text.insert(null));
 
 	// tests a SINGLE line text editor
 	makeCleanEnvironment(true);
@@ -908,7 +908,7 @@ public void test_insertLjava_lang_String() {
 	// tests a SINGLE line text editor
 	makeCleanEnvironment(true);
 
-	assertThrows("No exception thrown for string == null", IllegalArgumentException.class, ()->text.insert(null));
+	assertThrows(IllegalArgumentException.class, ()->text.insert(null));
 }
 
 @Override
@@ -923,9 +923,9 @@ public void test_isVisible() {
 
 	control.setVisible(true);
 	shell.setVisible(true);
-	assertTrue("Window should be visible", control.isVisible());
+	assertTrue(control.isVisible());
 	shell.setVisible(false);
-	assertFalse("Window should not be visible", control.isVisible());
+	assertFalse(control.isVisible());
 }
 
 @Test
@@ -1188,7 +1188,7 @@ public void test_setSelectionII() {
 @Test
 public void test_setSelectionLorg_eclipse_swt_graphics_Point() {
 	text.setText("dsdsdasdslaasdas");
-	assertThrows("No exception thrown for selection == null", IllegalArgumentException.class, ()->text.setSelection((Point) null));
+	assertThrows(IllegalArgumentException.class, ()->text.setSelection((Point) null));
 
 	text.setText("01234567890");
 	text.setSelection(new Point(2, 2));
@@ -1211,7 +1211,7 @@ public void test_setSelectionLorg_eclipse_swt_graphics_Point() {
 	makeCleanEnvironment(true);
 
 	text.setText("dsdsdasdslaasdas");
-	assertThrows("No exception thrown for selection == null", IllegalArgumentException.class, ()->text.setSelection((Point) null));
+	assertThrows(IllegalArgumentException.class, ()->text.setSelection((Point) null));
 
 	// tests a SINGLE line text editor
 	makeCleanEnvironment(true);
@@ -1266,7 +1266,7 @@ public void test_setTextLimitI() {
 
 @Test
 public void test_setTextLjava_lang_String() {
-	assertThrows("No exception thrown for string == null", IllegalArgumentException.class,()->text.setText(null));
+	assertThrows(IllegalArgumentException.class, ()->text.setText(null));
 
 	text.setText("");
 
@@ -1449,7 +1449,7 @@ public void test_consistency_Segments () {
 		}
 		listenerCalled = true;
 	};
-	assertThrows("No exception thrown for addSegmentListener(null)", IllegalArgumentException.class,()->text.addSegmentListener(null));
+	assertThrows(IllegalArgumentException.class, ()->text.addSegmentListener(null));
 	boolean[] singleLine = {false, true};
 	for (int i = singleLine.length; i-- > 0;) {
 		makeCleanEnvironment(singleLine[i]);
@@ -1552,9 +1552,8 @@ private void doSegmentsTest (boolean isListening) {
  */
 @Test
 public void test_backspaceAndDelete() throws InterruptedException {
-	assumeTrue(
-			"Display.post tests only run successfully on GitHub actions - see https://github.com/eclipse-platform/eclipse.platform.swt/issues/2571",
-			Boolean.parseBoolean(System.getenv("GITHUB_ACTIONS")));
+	assumeTrue(Boolean.parseBoolean(System.getenv("GITHUB_ACTIONS")),
+			"Display.post tests only run successfully on GitHub actions - see https://github.com/eclipse-platform/eclipse.platform.swt/issues/2571");
 	shell.open();
 	text.setSize(10, 50);
 	// The display.post needs to successfully obtain the focused window (at least on GTK3)

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_ToolBar.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_ToolBar.java
@@ -13,10 +13,10 @@
  *******************************************************************************/
 package org.eclipse.swt.tests.junit;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -24,8 +24,8 @@ import java.util.List;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.ToolBar;
 import org.eclipse.swt.widgets.ToolItem;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Automated Test Suite for class org.eclipse.swt.widgets.ToolBar
@@ -35,7 +35,7 @@ import org.junit.Test;
 public class Test_org_eclipse_swt_widgets_ToolBar extends Test_org_eclipse_swt_widgets_Composite {
 
 @Override
-@Before
+@BeforeEach
 public void setUp() {
 	super.setUp();
 	toolBar = new ToolBar(shell, 0);
@@ -45,7 +45,7 @@ public void setUp() {
 @Override
 @Test
 public void test_ConstructorLorg_eclipse_swt_widgets_CompositeI() {
-	assertThrows("No exception thrown for parent == null", IllegalArgumentException.class, () -> new ToolBar(null, 0));
+	assertThrows(IllegalArgumentException.class, () -> new ToolBar(null, 0));
 }
 
 @Override
@@ -62,7 +62,7 @@ public void test_computeTrimIIII() {
 public void test_getItemCount() {
 	int number = 10;
 	for (int i = 0; i<number ; i++){
-		assertEquals(":a:" + i, i, toolBar.getItemCount());
+		assertEquals(i, toolBar.getItemCount());
 		new ToolItem(toolBar, 0);
 	}
 }
@@ -75,7 +75,7 @@ public void test_getItemI() {
 		items[i] = new ToolItem(toolBar, 0);
 	}
 	for (int i = 0; i<number ; i++){
-		assertTrue(":a:", toolBar.getItem(i)==items[i]);
+		assertTrue(toolBar.getItem(i)==items[i]);
 	}
 
 	toolBar = new ToolBar(shell, 0);
@@ -83,8 +83,8 @@ public void test_getItemI() {
 	for (int i = 0; i<number ; i++){
 		items[i] = new ToolItem(toolBar, 0);
 	}
-	assertThrows("No exception thrown for illegal index argument", IllegalArgumentException.class, ()->
-		toolBar.getItem(number));
+	assertThrows(IllegalArgumentException.class, ()->
+	toolBar.getItem(number));
 }
 
 @Test
@@ -121,7 +121,7 @@ public void test_getRowCount() {
 	for (int i = 0; i<number ; i++){
 		items[i] = new ToolItem(toolBar, 0);
 	}
-	assertEquals(":a:" + toolBar.getRowCount(), number, toolBar.getRowCount()); //????  because of Size(0, 0)
+	assertEquals(number, toolBar.getRowCount()); //????  because of Size(0, 0)
 
 	toolBar = new ToolBar(shell, 0);
 	number = 5;
@@ -129,7 +129,7 @@ public void test_getRowCount() {
 	for (int i = 0; i<number ; i++){
 		items[i] = new ToolItem(toolBar, 0);
 	}
-	assertEquals(":a:", 1, toolBar.getRowCount());
+	assertEquals(1, toolBar.getRowCount());
 }
 
 @Test
@@ -140,7 +140,7 @@ public void test_indexOfLorg_eclipse_swt_widgets_ToolItem() {
 		tis[i] = new ToolItem(toolBar, 0);
 	}
 	for (int i = 0; i<number ; i++){
-		assertTrue(":a:" + i, toolBar.indexOf(tis[i])==i);
+		assertTrue(toolBar.indexOf(tis[i])==i);
 	}
 
 	number = 10;
@@ -149,8 +149,7 @@ public void test_indexOfLorg_eclipse_swt_widgets_ToolItem() {
 		tis[i] = new ToolItem(toolBar, 0);
 	}
 	for (int i = 0; i<number ; i++){
-		assertThrows("No exception thrown for toolItem == null", IllegalArgumentException.class,
-				() -> toolBar.indexOf(null));
+		assertThrows(IllegalArgumentException.class, () -> toolBar.indexOf(null));
 	}
 }
 

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_ToolItem.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_ToolItem.java
@@ -14,14 +14,15 @@
 package org.eclipse.swt.tests.junit;
 
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.ToolBar;
 import org.eclipse.swt.widgets.ToolItem;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
 
 /**
  * Automated Test Suite for class org.eclipse.swt.widgets.ToolItem
@@ -31,7 +32,7 @@ import org.junit.Test;
 public class Test_org_eclipse_swt_widgets_ToolItem extends Test_org_eclipse_swt_widgets_Item {
 
 @Override
-@Before
+@BeforeEach
 public void setUp() {
 	super.setUp();
 	toolBar = new ToolBar(shell, 0);
@@ -52,9 +53,9 @@ public void test_ConstructorLorg_eclipse_swt_widgets_ToolBarI() {
 @Test
 public void test_getToolTipText() {
 	toolItem.setToolTipText("fred");
-	assertEquals(":a:", "fred", toolItem.getToolTipText());
+	assertEquals("fred", toolItem.getToolTipText());
 	toolItem.setToolTipText("fredttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttt");
-	assertEquals(":a:", "fredttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttt", toolItem.getToolTipText());
+	assertEquals("fredttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttt", toolItem.getToolTipText());
 }
 
 @Override

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Tracker.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Tracker.java
@@ -14,7 +14,7 @@
 package org.eclipse.swt.tests.junit;
 
 import org.eclipse.swt.widgets.Tracker;
-import org.junit.Before;
+import org.junit.jupiter.api.BeforeEach;
 
 /**
  * Automated Test Suite for class org.eclipse.swt.widgets.Tracker
@@ -24,7 +24,7 @@ import org.junit.Before;
 public class Test_org_eclipse_swt_widgets_Tracker extends Test_org_eclipse_swt_widgets_Widget {
 
 @Override
-@Before
+@BeforeEach
 public void setUp() {
 	super.setUp();
 	tracker = new Tracker(shell, 0);

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Tree.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Tree.java
@@ -13,13 +13,13 @@
  *******************************************************************************/
 package org.eclipse.swt.tests.junit;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -33,8 +33,9 @@ import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Tree;
 import org.eclipse.swt.widgets.TreeColumn;
 import org.eclipse.swt.widgets.TreeItem;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
 
 /**
  * Automated Test Suite for class org.eclipse.swt.widgets.Tree
@@ -46,7 +47,7 @@ public class Test_org_eclipse_swt_widgets_Tree extends Test_org_eclipse_swt_widg
 private Tree tree;
 
 @Override
-@Before
+@BeforeEach
 public void setUp() {
 	super.setUp();
 	tree = new Tree(shell, SWT.MULTI);
@@ -201,9 +202,9 @@ public void test_getHeaderHeight() {
 
 @Test
 public void test_getItemHeight() {
-	assertTrue(":a: Item height is 0", tree.getItemHeight() > 0);
+	assertTrue(tree.getItemHeight() > 0);
 	new TreeItem(tree, 0);
-	assertTrue(":b: Item height is 0", tree.getItemHeight() > 0);
+	assertTrue(tree.getItemHeight() > 0);
 }
 
 @Test
@@ -214,7 +215,7 @@ public void test_getItemI() {
 		items[i] = new TreeItem(tree, 0);
 
 	for (int i = 0; i < number; i++)
-		assertEquals("i=" + i, items[i], tree.getItem(i));
+		assertEquals(items[i], tree.getItem(i));
 	try {
 		tree.getItem(number);
 		fail("No exception thrown for illegal index argument");
@@ -958,13 +959,12 @@ public void test_Virtual() {
 	// temp code to capture screenshot
 	if (SwtTestUtil.isCocoa) {
 		// check if setData is called for root item
-		assertTrue("SetData not called for top item", top[0] != null);
+		assertTrue(top[0] != null);
 	}
 
 
 	// the "* 3" allows some surplus for platforms that pre-fetch items to improve scrolling performance:
-	assertTrue("SetData callback count not in range: " + dataCounter[0],
-			dataCounter[0] > visibleCount / 2 && dataCounter[0] <= visibleCount * 3);
+	assertTrue(dataCounter[0] > visibleCount / 2 && dataCounter[0] <= visibleCount * 3);
 }
 
 @Test

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_TreeColumn.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_TreeColumn.java
@@ -13,11 +13,11 @@
  *******************************************************************************/
 package org.eclipse.swt.tests.junit;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-import static org.junit.Assume.assumeFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -29,8 +29,8 @@ import org.eclipse.swt.events.SelectionListener;
 import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Tree;
 import org.eclipse.swt.widgets.TreeColumn;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Automated Test Suite for class org.eclipse.swt.widgets.TreeColumn
@@ -40,7 +40,7 @@ import org.junit.Test;
 public class Test_org_eclipse_swt_widgets_TreeColumn extends Test_org_eclipse_swt_widgets_Item {
 
 @Override
-@Before
+@BeforeEach
 public void setUp() {
 	super.setUp();
 	tree = new Tree(shell, SWT.SINGLE);
@@ -109,7 +109,7 @@ public void test_addSelectionListenerWidgetSelectedAdapterLorg_eclipse_swt_event
 
 @Test
 public void test_getWidth() {
-	assumeFalse("getWidth() checks below fail on macOS", SwtTestUtil.isCocoa);
+	assumeFalse(SwtTestUtil.isCocoa, "getWidth() checks below fail on macOS");
 	int testWidth = 42;
 
 //	try {
@@ -124,13 +124,13 @@ public void test_getWidth() {
 //	}
 
 	treeColumn.setWidth(0);
-	assertEquals(":a: width=" + treeColumn.getWidth() + " should be=" + 0, 0, treeColumn.getWidth());
+	assertEquals(0, treeColumn.getWidth());
 
 	treeColumn.setWidth(testWidth);
-	assertEquals(":b: width=" + treeColumn.getWidth() + " should be=" + testWidth, testWidth, treeColumn.getWidth());
+	assertEquals(testWidth, treeColumn.getWidth());
 
 	treeColumn.setWidth(testWidth);
-	assertEquals(":c: width=" + treeColumn.getWidth() + " should be=" + testWidth, testWidth, treeColumn.getWidth());
+	assertEquals(testWidth, treeColumn.getWidth());
 }
 
 @Test
@@ -154,25 +154,23 @@ public void test_removeSelectionListenerLorg_eclipse_swt_events_SelectionListene
 public void test_setAlignmentI() {
 	TreeColumn column2;
 
-	assertEquals(":a:", SWT.LEFT, treeColumn.getAlignment());
+	assertEquals(SWT.LEFT, treeColumn.getAlignment());
 
 	treeColumn.setAlignment(-1);
-	assertEquals(":b:", SWT.LEFT, treeColumn.getAlignment());
+	assertEquals(SWT.LEFT, treeColumn.getAlignment());
 
 	treeColumn.setAlignment(SWT.RIGHT);
-	assertEquals(
-			":c: Should not be allowed to set alignment of the first column",
-			SWT.LEFT, treeColumn.getAlignment());
+	assertEquals(SWT.LEFT, treeColumn.getAlignment());
 
 	column2 = new TreeColumn(tree, SWT.NULL);
 	column2.setAlignment(SWT.RIGHT);
-	assertEquals(":d:", SWT.RIGHT, column2.getAlignment());
+	assertEquals(SWT.RIGHT, column2.getAlignment());
 
 	column2.setAlignment(SWT.CENTER);
-	assertEquals(":e:", SWT.CENTER, column2.getAlignment());
+	assertEquals(SWT.CENTER, column2.getAlignment());
 
 	column2.setAlignment(SWT.LEFT);
-	assertEquals(":f:", SWT.LEFT, column2.getAlignment());
+	assertEquals(SWT.LEFT, column2.getAlignment());
 }
 
 @Override
@@ -182,25 +180,25 @@ public void test_setImageLorg_eclipse_swt_graphics_Image() {
 
 @Test
 public void test_setResizableZ() {
-	assertTrue(":a:", treeColumn.getResizable());
+	assertTrue(treeColumn.getResizable());
 
 	treeColumn.setResizable(false);
-	assertFalse(":b:", treeColumn.getResizable());
+	assertFalse(treeColumn.getResizable());
 
 	treeColumn.setResizable(false);
-	assertFalse(":c:", treeColumn.getResizable());
+	assertFalse(treeColumn.getResizable());
 
 	treeColumn.setResizable(true);
-	assertTrue(":d:", treeColumn.getResizable());
+	assertTrue(treeColumn.getResizable());
 }
 
 @Override
 @Test
 public void test_setTextLjava_lang_String() {
-	assertEquals(":a:", treeColumn.getText(), "");
+	assertEquals(treeColumn.getText(), "");
 
 	treeColumn.setText("text");
-	assertEquals(":b:", treeColumn.getText(), "text");
+	assertEquals(treeColumn.getText(), "text");
 
 	try {
 		treeColumn.setText(null);

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_TreeItem.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_TreeItem.java
@@ -13,12 +13,12 @@
  *******************************************************************************/
 package org.eclipse.swt.tests.junit;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Color;
@@ -31,8 +31,8 @@ import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Tree;
 import org.eclipse.swt.widgets.TreeColumn;
 import org.eclipse.swt.widgets.TreeItem;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Automated Test Suite for class org.eclipse.swt.widgets.TreeItem
@@ -42,7 +42,7 @@ import org.junit.Test;
 public class Test_org_eclipse_swt_widgets_TreeItem extends Test_org_eclipse_swt_widgets_Item {
 
 @Override
-@Before
+@BeforeEach
 public void setUp() {
 	super.setUp();
 	makeCleanEnvironment();
@@ -111,14 +111,14 @@ public void test_getBounds() {
 
 	// no columns
 	bounds = treeItem.getBounds();
-	assertTrue(":1a:", bounds.x > 0 && bounds.height > 0);
+	assertTrue(bounds.x > 0 && bounds.height > 0);
 
 	treeItem.setText(string);
 	GC gc = new GC(tree);
 	Point extent = gc.stringExtent(string);
 	gc.dispose();
 	bounds = treeItem.getBounds();
-	assertTrue(":1b:", bounds.x > 0 && bounds.height > extent.y && bounds.width > extent.x);
+	assertTrue(bounds.x > 0 && bounds.height > extent.y && bounds.width > extent.x);
 
 	//
 	makeCleanEnvironment();
@@ -126,29 +126,29 @@ public void test_getBounds() {
 	Rectangle rect = image.getBounds();
 	treeItem.setImage(image);
 	bounds = treeItem.getBounds();
-	assertTrue(":1c:", bounds.x > 0 && bounds.height >= rect.height);
+	assertTrue(bounds.x > 0 && bounds.height >= rect.height);
 	bounds2 = treeItem.getImageBounds(0);
-	assertTrue(":1d:", bounds.x >= bounds2.x + bounds2.width);
+	assertTrue(bounds.x >= bounds2.x + bounds2.width);
 
 	//
 	makeCleanEnvironment();
 
 	TreeItem subItem = new TreeItem(treeItem, SWT.NONE);
 	bounds = subItem.getBounds();
-	assertEquals(":1e:", new Rectangle(0, 0, 0, 0), bounds);
+	assertEquals(new Rectangle(0, 0, 0, 0), bounds);
 	treeItem.setExpanded(true);
 	bounds = subItem.getBounds();
 	bounds2 = treeItem.getBounds();
-	assertTrue(":1f:", bounds.x > bounds2.x && bounds.y >= bounds2.y + bounds2.height && bounds.height > 0);
+	assertTrue(bounds.x > bounds2.x && bounds.y >= bounds2.y + bounds2.height && bounds.height > 0);
 	treeItem.setExpanded(false);
 	bounds = subItem.getBounds();
-	assertEquals(":1g:", new Rectangle(0, 0, 0, 0), bounds);
+	assertEquals(new Rectangle(0, 0, 0, 0), bounds);
 
 	treeItem.setExpanded(true);
 	subItem.setText(string);
 	bounds = subItem.getBounds();
 	bounds2 = treeItem.getBounds();
-	assertTrue(":1h:", bounds.x > bounds2.x && bounds.y >= bounds2.y + bounds2.height && bounds.height > extent.y && bounds.width > extent.x);
+	assertTrue(bounds.x > bounds2.x && bounds.y >= bounds2.y + bounds2.height && bounds.height > extent.y && bounds.width > extent.x);
 
 	//
 	makeCleanEnvironment();
@@ -156,9 +156,9 @@ public void test_getBounds() {
 	treeItem.setExpanded(true);
 	subItem.setImage(image);
 	bounds = subItem.getBounds();
-	assertTrue(":1i:", bounds.x > 0 && bounds.height >= rect.height);
+	assertTrue(bounds.x > 0 && bounds.height >= rect.height);
 	bounds2 = subItem.getImageBounds(0);
-	assertTrue(":1j:", bounds.x >= bounds2.x + bounds2.width);
+	assertTrue(bounds.x >= bounds2.x + bounds2.width);
 
 	// TODO no columns and CHECK style
 	// TODO with columns
@@ -180,46 +180,46 @@ void getBoundsIA() {
 	makeCleanEnvironment();
 
 	bounds = treeItem.getBounds(0);
-	assertTrue(":1a:", bounds.x > 0 && bounds.height > 0);
+	assertTrue(bounds.x > 0 && bounds.height > 0);
 	bounds = treeItem.getBounds(-1);
-	assertEquals(":1b:", new Rectangle(0, 0, 0, 0), bounds);
+	assertEquals(new Rectangle(0, 0, 0, 0), bounds);
 	bounds = treeItem.getBounds(1);
-	assertEquals(":1c:", new Rectangle(0, 0, 0, 0), bounds);
+	assertEquals(new Rectangle(0, 0, 0, 0), bounds);
 	// unexpanded item
 	TreeItem subItem = new TreeItem(treeItem, SWT.NONE);
 	bounds = subItem.getBounds(0);
-	assertEquals(":1d:", new Rectangle(0, 0, 0, 0), bounds);
+	assertEquals(new Rectangle(0, 0, 0, 0), bounds);
 	treeItem.setExpanded(true);
 	bounds = subItem.getBounds(0);
-	assertTrue(":1e:", bounds.x > 0 && bounds.height > 0);
+	assertTrue(bounds.x > 0 && bounds.height > 0);
 	treeItem.setExpanded(false);
 	bounds = subItem.getBounds(0);
-	assertEquals(":1f:", new Rectangle(0, 0, 0, 0), bounds);
+	assertEquals(new Rectangle(0, 0, 0, 0), bounds);
 	treeItem.setExpanded(true);
 	subItem.setText(string);
 	bounds = subItem.getBounds(0);
 	bounds2 = treeItem.getBounds(0);
-	assertTrue(":1g:", bounds.x > bounds2.x && bounds.y >= bounds2.y + bounds2.height && bounds.height > stringExtent.y && bounds.width > stringExtent.x);
+	assertTrue(bounds.x > bounds2.x && bounds.y >= bounds2.y + bounds2.height && bounds.height > stringExtent.y && bounds.width > stringExtent.x);
 
 	treeItem.setText(string);
 	bounds = treeItem.getBounds(0);
-	assertTrue(":1h:", bounds.x > 0 && bounds.height > stringExtent.y && bounds.width > stringExtent.x);
+	assertTrue(bounds.x > 0 && bounds.height > stringExtent.y && bounds.width > stringExtent.x);
 	bounds2 = treeItem.getBounds();
 	//assertTrue(":1new:", bounds.equals(bounds2)); // TODO should bounds be equal?
 	treeItem.setText("");
 	bounds2 = treeItem.getBounds(0);
-	assertTrue(":1i:", bounds2.x > 0 && bounds2.height > 0);
-	assertTrue(":1j:", bounds2.width < bounds.width);
+	assertTrue(bounds2.x > 0 && bounds2.height > 0);
+	assertTrue(bounds2.width < bounds.width);
 
 	//
 	makeCleanEnvironment();
 
 	treeItem.setImage(image);
 	bounds = treeItem.getBounds(0);
-	assertTrue(":1k:", bounds.x > 0 && bounds.height >= imageBounds.height && bounds.width >= imageBounds.width);
+	assertTrue(bounds.x > 0 && bounds.height >= imageBounds.height && bounds.width >= imageBounds.width);
 	treeItem.setImage((Image)null);
 	bounds2 = treeItem.getBounds(0);
-	assertTrue(":1l:", bounds2.x > 0 && bounds2.height > 0);
+	assertTrue(bounds2.x > 0 && bounds2.height > 0);
 //	assertTrue(":1m:", bounds2.width > bounds.width); // once an image is added the space for it is always there
 
 	//
@@ -229,9 +229,9 @@ void getBoundsIA() {
 	bounds = treeItem.getBounds(0);
 	treeItem.setImage(image);
 	bounds2 = treeItem.getBounds(0);
-	assertTrue(":1n:", bounds2.x > 0 && bounds2.height > 0);
-	assertTrue(":1o:", bounds2.width > bounds.width);
-	assertTrue(":1p", bounds2.width >= stringExtent.x + imageBounds.width && bounds2.height >= Math.max(stringExtent.y, imageBounds.height));
+	assertTrue(bounds2.x > 0 && bounds2.height > 0);
+	assertTrue(bounds2.width > bounds.width);
+	assertTrue(bounds2.width >= stringExtent.x + imageBounds.width && bounds2.height >= Math.max(stringExtent.y, imageBounds.height));
 }
 void getBoundsIB() {
 	// no columns and CHECK style
@@ -249,36 +249,36 @@ void getBoundsIB() {
 	TreeItem treeItem2 = new TreeItem(tree2, SWT.NONE);
 
 	bounds = treeItem2.getBounds(0);
-	assertTrue(":2a:", bounds.x > 0 && bounds.height > 0);
+	assertTrue(bounds.x > 0 && bounds.height > 0);
 	bounds = treeItem2.getBounds(-1);
-	assertEquals(":2b:", new Rectangle(0, 0, 0, 0), bounds);
+	assertEquals(new Rectangle(0, 0, 0, 0), bounds);
 	bounds = treeItem2.getBounds(1);
-	assertEquals(":2c:", new Rectangle(0, 0, 0, 0), bounds);
+	assertEquals(new Rectangle(0, 0, 0, 0), bounds);
 	// unexpanded item
 	TreeItem subItem2 = new TreeItem(treeItem2, SWT.NONE);
 	bounds = subItem2.getBounds(0);
-	assertEquals(":2d:", new Rectangle(0, 0, 0, 0), bounds);
+	assertEquals(new Rectangle(0, 0, 0, 0), bounds);
 	treeItem2.setExpanded(true);
 	bounds = subItem2.getBounds(0);
-	assertTrue(":2e:", bounds.x > 0 && bounds.height > 0);
+	assertTrue(bounds.x > 0 && bounds.height > 0);
 	treeItem2.setExpanded(false);
 	bounds = subItem2.getBounds(0);
-	assertEquals(":2f", new Rectangle(0, 0, 0, 0), bounds);
+	assertEquals(new Rectangle(0, 0, 0, 0), bounds);
 	treeItem2.setExpanded(true);
 	subItem2.setText(string);
 	bounds = subItem2.getBounds(0);
 	bounds2 = treeItem2.getBounds(0);
-	assertTrue(":2g:", bounds.x > bounds2.x && bounds.y >= bounds2.y + bounds2.height && bounds.height > stringExtent.y && bounds.width > stringExtent.x);
+	assertTrue(bounds.x > bounds2.x && bounds.y >= bounds2.y + bounds2.height && bounds.height > stringExtent.y && bounds.width > stringExtent.x);
 
 	treeItem2.setText(string);
 	bounds = treeItem2.getBounds(0);
-	assertTrue(":2h:", bounds.x > 0 && bounds.height > stringExtent.y && bounds.width > stringExtent.x);
+	assertTrue(bounds.x > 0 && bounds.height > stringExtent.y && bounds.width > stringExtent.x);
 	bounds2 = treeItem2.getBounds();
 	//assertTrue(":2new:", bounds.equals(bounds2)); // TODO should bounds be equal?
 	treeItem2.setText("");
 	bounds2 = treeItem2.getBounds(0);
-	assertTrue(":2i:", bounds2.x > 0 && bounds2.height > 0);
-	assertTrue(":2j:", bounds2.width < bounds.width);
+	assertTrue(bounds2.x > 0 && bounds2.height > 0);
+	assertTrue(bounds2.width < bounds.width);
 
 	tree2.dispose();
 	tree2 = new Tree(shell, SWT.CHECK);
@@ -286,10 +286,10 @@ void getBoundsIB() {
 
 	treeItem2.setImage(image);
 	bounds = treeItem2.getBounds(0);
-	assertTrue(":2k:", bounds.x > 0 && bounds.height >= imageBounds.height && bounds.width >= imageBounds.width);
+	assertTrue(bounds.x > 0 && bounds.height >= imageBounds.height && bounds.width >= imageBounds.width);
 	treeItem2.setImage((Image)null);
 	bounds2 = treeItem2.getBounds(0);
-	assertTrue(":2l:", bounds2.x > 0 && bounds2.height > 0);
+	assertTrue(bounds2.x > 0 && bounds2.height > 0);
 	//assertTrue(":2m:", bounds2.width < bounds.width);  // once an image is added the space for it is always there
 
 	tree2.dispose();
@@ -300,9 +300,9 @@ void getBoundsIB() {
 	bounds = treeItem2.getBounds(0);
 	treeItem2.setImage(image);
 	bounds2 = treeItem2.getBounds(0);
-	assertTrue(":2n:", bounds2.x > 0 && bounds2.height > 0);
-	assertTrue(":2o:", bounds2.width > bounds.width);
-	assertTrue(":1p", bounds2.width >= stringExtent.x + imageBounds.width && bounds2.height >= Math.max(stringExtent.y, imageBounds.height));
+	assertTrue(bounds2.x > 0 && bounds2.height > 0);
+	assertTrue(bounds2.width > bounds.width);
+	assertTrue(bounds2.width >= stringExtent.x + imageBounds.width && bounds2.height >= Math.max(stringExtent.y, imageBounds.height));
 }
 void getBoundsIC() {
 	// with columns
@@ -326,54 +326,54 @@ void getBoundsIC() {
 	TreeColumn column1 = new TreeColumn(tree, SWT.CENTER);
 
 	bounds = treeItem.getBounds(0);
-	assertTrue(":3a:", bounds.x > 0 && bounds.height > 0 && bounds.width == 0);
+	assertTrue(bounds.x > 0 && bounds.height > 0 && bounds.width == 0);
 	bounds = treeItem.getBounds(1);
-	assertTrue(":3b:", /*bounds.x > 0 &&*/ bounds.height > 0 && bounds.width == 0); // TODO bounds.x == 0 Is this right?
+	assertTrue(bounds.height > 0 && bounds.width == 0); // TODO bounds.x == 0 Is this right?
 	bounds = treeItem.getBounds(-1);
-	assertEquals(":3c:", new Rectangle(0, 0, 0, 0), bounds);
+	assertEquals(new Rectangle(0, 0, 0, 0), bounds);
 	bounds = treeItem.getBounds(2);
-	assertEquals(":3d:", new Rectangle(0, 0, 0, 0), bounds);
+	assertEquals(new Rectangle(0, 0, 0, 0), bounds);
 	// unexpanded item
 	TreeItem subItem = new TreeItem(treeItem, SWT.NONE);
 	bounds = subItem.getBounds(0);
-	assertEquals(":3e:", new Rectangle(0, 0, 0, 0), bounds);
+	assertEquals(new Rectangle(0, 0, 0, 0), bounds);
 	treeItem.setExpanded(true);
 	bounds = subItem.getBounds(0);
-	assertTrue(":3f:", bounds.x > 0 && bounds.height > 0);
+	assertTrue(bounds.x > 0 && bounds.height > 0);
 	treeItem.setExpanded(false);
 	bounds = subItem.getBounds(0);
-	assertEquals(":3g:", new Rectangle(0, 0, 0, 0), bounds);
+	assertEquals(new Rectangle(0, 0, 0, 0), bounds);
 	treeItem.setExpanded(true);
 	subItem.setText(new String[] {string1, string2});
 	bounds = subItem.getBounds(0);
 	bounds2 = treeItem.getBounds(0);
-	assertTrue(":3h:", bounds.x > bounds2.x && bounds.y >= bounds2.y + bounds2.height && bounds.height > stringExtent1.y && bounds.width == 0);
+	assertTrue(bounds.x > bounds2.x && bounds.y >= bounds2.y + bounds2.height && bounds.height > stringExtent1.y && bounds.width == 0);
 
 	column0.setWidth(100);
 	bounds = treeItem.getBounds(0);
-	assertTrue(":3i:", bounds.x > 0 && bounds.height > 0 && bounds.width > 0 && bounds.width < 100);
+	assertTrue(bounds.x > 0 && bounds.height > 0 && bounds.width > 0 && bounds.width < 100);
 	bounds = treeItem.getBounds(1);
-	assertTrue(":3j:", bounds.x >= 100 && bounds.height > 0 && bounds.width == 0);
+	assertTrue(bounds.x >= 100 && bounds.height > 0 && bounds.width == 0);
 	bounds = subItem.getBounds(0);
 	bounds2 = treeItem.getBounds(0);
-	assertTrue(":3k:", bounds.x > bounds2.x && bounds.y >= bounds2.y + bounds2.height && bounds.height > stringExtent1.y && bounds.width > 0 && bounds.width < 100);
+	assertTrue(bounds.x > bounds2.x && bounds.y >= bounds2.y + bounds2.height && bounds.height > stringExtent1.y && bounds.width > 0 && bounds.width < 100);
 
 	column1.setWidth(200);
 	bounds = treeItem.getBounds(0);
-	assertTrue(":3l:", bounds.x > 0 && bounds.height > 0 && bounds.width > 0 && bounds.width < 100);
+	assertTrue(bounds.x > 0 && bounds.height > 0 && bounds.width > 0 && bounds.width < 100);
 	bounds = treeItem.getBounds(1);
-	assertTrue(":3m:", bounds.x >= 100 && bounds.height > 0 && bounds.width == 200);
+	assertTrue(bounds.x >= 100 && bounds.height > 0 && bounds.width == 200);
 
 	treeItem.setText(new String[] {string1, string2});
 	bounds = treeItem.getBounds(0);
-	assertTrue(":3n:", bounds.x > 0 && bounds.height > stringExtent1.y && bounds.width > 0 && bounds.width < 100);
+	assertTrue(bounds.x > 0 && bounds.height > stringExtent1.y && bounds.width > 0 && bounds.width < 100);
 	bounds = treeItem.getBounds(1);
-	assertTrue(":3o:", bounds.x >= 100 && bounds.height > stringExtent1.y && bounds.width  == 200);
+	assertTrue(bounds.x >= 100 && bounds.height > stringExtent1.y && bounds.width  == 200);
 	treeItem.setText(new String[] {"", ""});
 	bounds = treeItem.getBounds(0);
-	assertTrue(":3p:", bounds.x > 0 && bounds.height > stringExtent1.y && bounds.width > 0 && bounds.width < 100);
+	assertTrue(bounds.x > 0 && bounds.height > stringExtent1.y && bounds.width > 0 && bounds.width < 100);
 	bounds = treeItem.getBounds(1);
-	assertTrue(":3q:", bounds.x >= 100 && bounds.height > stringExtent1.y && bounds.width  == 200);
+	assertTrue(bounds.x >= 100 && bounds.height > stringExtent1.y && bounds.width  == 200);
 
 	//
 	makeCleanEnvironment();
@@ -384,14 +384,14 @@ void getBoundsIC() {
 
 	treeItem.setImage(new Image[] {image, image});
 	bounds = treeItem.getBounds(0);
-	assertTrue(":3r:", bounds.x > 0 && bounds.height >= imageBounds.height && bounds.width > 0 && bounds.width < 100);
+	assertTrue(bounds.x > 0 && bounds.height >= imageBounds.height && bounds.width > 0 && bounds.width < 100);
 	bounds = treeItem.getBounds(1);
-	assertTrue(":3s:", bounds.x >= 100 && bounds.height >= imageBounds.height && bounds.width  == 200);
+	assertTrue(bounds.x >= 100 && bounds.height >= imageBounds.height && bounds.width  == 200);
 	treeItem.setImage(new Image[] {null, null});
 	bounds = treeItem.getBounds(0);
-	assertTrue(":3t:", bounds.x > 0 && bounds.height > 0 && bounds.width > 0 && bounds.width < 100);
+	assertTrue(bounds.x > 0 && bounds.height > 0 && bounds.width > 0 && bounds.width < 100);
 	bounds = treeItem.getBounds(1);
-	assertTrue(":3u:", bounds.x >= 100 && bounds.height > 0 && bounds.width  == 200);
+	assertTrue(bounds.x >= 100 && bounds.height > 0 && bounds.width  == 200);
 
 	//
 	makeCleanEnvironment();
@@ -403,9 +403,9 @@ void getBoundsIC() {
 	treeItem.setText(new String[] {string1, string2});
 	treeItem.setImage(new Image[] {image, image});
 	bounds = treeItem.getBounds(0);
-	assertTrue(":3v:", bounds.x > 0 && bounds.height > stringExtent1.y && bounds.height >= imageBounds.height && bounds.width > 0 && bounds.width < 100);
+	assertTrue(bounds.x > 0 && bounds.height > stringExtent1.y && bounds.height >= imageBounds.height && bounds.width > 0 && bounds.width < 100);
 	bounds = treeItem.getBounds(1);
-	assertTrue(":3w:", bounds.x > 0 && bounds.height > stringExtent1.y && bounds.height >= imageBounds.height && bounds.width  == 200);
+	assertTrue(bounds.x > 0 && bounds.height > stringExtent1.y && bounds.height >= imageBounds.height && bounds.width  == 200);
 
 	//
 	makeCleanEnvironment();
@@ -413,7 +413,7 @@ void getBoundsIC() {
 	treeItem.setText(string1);
 	new TreeColumn(tree, SWT.RIGHT);
 	bounds = treeItem.getBounds(0);
-	assertTrue(":3x:", bounds.x > 0 && bounds.height > stringExtent1.y && bounds.width  == 0);
+	assertTrue(bounds.x > 0 && bounds.height > stringExtent1.y && bounds.width  == 0);
 }
 
 void getBoundsID() {
@@ -436,55 +436,55 @@ void getBoundsID() {
 	TreeColumn column1 = new TreeColumn(tree2, SWT.CENTER);
 
 	bounds = treeItem2.getBounds(0);
-	assertTrue(":4a:", bounds.x > 0 && bounds.height > 0 && bounds.width == 0);
+	assertTrue(bounds.x > 0 && bounds.height > 0 && bounds.width == 0);
 	bounds = treeItem2.getBounds(1);
-	assertTrue(":4b:", /*bounds.x > 0 &&*/ bounds.height > 0 && bounds.width == 0); // TODO bounds.x == 0 Is this right?
+	assertTrue(bounds.height > 0 && bounds.width == 0); // TODO bounds.x == 0 Is this right?
 	bounds = treeItem2.getBounds(-1);
-	assertEquals(":4c:", new Rectangle(0, 0, 0, 0), bounds);
+	assertEquals(new Rectangle(0, 0, 0, 0), bounds);
 	bounds = treeItem2.getBounds(2);
-	assertEquals(":4d:", new Rectangle(0, 0, 0, 0), bounds);
+	assertEquals(new Rectangle(0, 0, 0, 0), bounds);
 	// unexpanded item
 	TreeItem subItem2 = new TreeItem(treeItem2, SWT.NONE);
 	bounds = subItem2.getBounds(0);
-	assertEquals(":4e:", new Rectangle(0, 0, 0, 0), bounds);
+	assertEquals(new Rectangle(0, 0, 0, 0), bounds);
 	treeItem2.setExpanded(true);
 	bounds = subItem2.getBounds(0);
-	assertTrue(":4f:", bounds.x > 0 && bounds.height > 0);
+	assertTrue(bounds.x > 0 && bounds.height > 0);
 	treeItem2.setExpanded(false);
 	bounds = subItem2.getBounds(0);
-	assertEquals(":4g:", new Rectangle(0, 0, 0, 0), bounds);
+	assertEquals(new Rectangle(0, 0, 0, 0), bounds);
 	treeItem2.setExpanded(true);
 	subItem2.setText(new String[] {string1, string2});
 	bounds = subItem2.getBounds(0);
 	bounds2 = treeItem2.getBounds(0);
-	assertTrue(":4h:", bounds.x > bounds2.x && bounds.y >= bounds2.y + bounds2.height && bounds.height > stringExtent1.y && bounds.width == 0);
+	assertTrue(bounds.x > bounds2.x && bounds.y >= bounds2.y + bounds2.height && bounds.height > stringExtent1.y && bounds.width == 0);
 
 	column0.setWidth(100);
 	bounds = treeItem2.getBounds(0);
-	assertTrue(":4i:", bounds.x > 0 && bounds.height > 0 && bounds.width > 0 && bounds.width < 100);
+	assertTrue(bounds.x > 0 && bounds.height > 0 && bounds.width > 0 && bounds.width < 100);
 	bounds = treeItem2.getBounds(1);
-	assertTrue(":4j:", bounds.x >= 100 && bounds.height > 0 && bounds.width == 0);
+	assertTrue(bounds.x >= 100 && bounds.height > 0 && bounds.width == 0);
 	bounds = subItem2.getBounds(0);
 	bounds2 = treeItem2.getBounds(0);
-	assertTrue(":4k:", bounds.x > bounds2.x && bounds.y >= bounds2.y + bounds2.height && bounds.height > stringExtent1.y && bounds.width > 0 && bounds.width < 100);
+	assertTrue(bounds.x > bounds2.x && bounds.y >= bounds2.y + bounds2.height && bounds.height > stringExtent1.y && bounds.width > 0 && bounds.width < 100);
 
 
 	column1.setWidth(200);
 	bounds = treeItem2.getBounds(0);
-	assertTrue(":4l:", bounds.x > 0 && bounds.height > 0 && bounds.width > 0 && bounds.width < 100);
+	assertTrue(bounds.x > 0 && bounds.height > 0 && bounds.width > 0 && bounds.width < 100);
 	bounds = treeItem2.getBounds(1);
-	assertTrue(":4m:", bounds.x >= 100 && bounds.height > 0 && bounds.width == 200);
+	assertTrue(bounds.x >= 100 && bounds.height > 0 && bounds.width == 200);
 
 	treeItem2.setText(new String[] {string1, string2});
 	bounds = treeItem2.getBounds(0);
-	assertTrue(":4n:", bounds.x > 0 && bounds.height > stringExtent1.y && bounds.width > 0 && bounds.width < 100);
+	assertTrue(bounds.x > 0 && bounds.height > stringExtent1.y && bounds.width > 0 && bounds.width < 100);
 	bounds = treeItem2.getBounds(1);
-	assertTrue(":4o:", bounds.x >= 100 && bounds.height > stringExtent1.y && bounds.width  == 200);
+	assertTrue(bounds.x >= 100 && bounds.height > stringExtent1.y && bounds.width  == 200);
 	treeItem2.setText(new String[] {"", ""});
 	bounds = treeItem2.getBounds(0);
-	assertTrue(":4p:", bounds.x > 0 && bounds.height > stringExtent1.y && bounds.width > 0 && bounds.width < 100);
+	assertTrue(bounds.x > 0 && bounds.height > stringExtent1.y && bounds.width > 0 && bounds.width < 100);
 	bounds = treeItem2.getBounds(1);
-	assertTrue(":4q:", bounds.x >= 100 && bounds.height > stringExtent1.y && bounds.width  == 200);
+	assertTrue(bounds.x >= 100 && bounds.height > stringExtent1.y && bounds.width  == 200);
 
 	//
 	tree2.dispose();
@@ -497,14 +497,14 @@ void getBoundsID() {
 
 	treeItem2.setImage(new Image[] {image, image});
 	bounds = treeItem2.getBounds(0);
-	assertTrue(":4r:", bounds.x > 0 && bounds.height >= imageBounds.height && bounds.width > 0 && bounds.width < 100);
+	assertTrue(bounds.x > 0 && bounds.height >= imageBounds.height && bounds.width > 0 && bounds.width < 100);
 	bounds = treeItem2.getBounds(1);
-	assertTrue(":4s:", bounds.x >= 100 && bounds.height >= imageBounds.height && bounds.width  == 200);
+	assertTrue(bounds.x >= 100 && bounds.height >= imageBounds.height && bounds.width  == 200);
 	treeItem2.setImage(new Image[] {null, null});
 	bounds = treeItem2.getBounds(0);
-	assertTrue(":4t:", bounds.x > 0 && bounds.height > 0 && bounds.width > 0 && bounds.width < 100);
+	assertTrue(bounds.x > 0 && bounds.height > 0 && bounds.width > 0 && bounds.width < 100);
 	bounds = treeItem2.getBounds(1);
-	assertTrue(":4u:", bounds.x >= 100 && bounds.height > 0 && bounds.width  == 200);
+	assertTrue(bounds.x >= 100 && bounds.height > 0 && bounds.width  == 200);
 
 	//
 	tree2.dispose();
@@ -518,9 +518,9 @@ void getBoundsID() {
 	treeItem2.setText(new String[] {string1, string2});
 	treeItem2.setImage(new Image[] {image, image});
 	bounds = treeItem2.getBounds(0);
-	assertTrue(":4v:", bounds.x > 0 && bounds.height > stringExtent1.y && bounds.height >= imageBounds.height && bounds.width > 0 && bounds.width < 100);
+	assertTrue(bounds.x > 0 && bounds.height > stringExtent1.y && bounds.height >= imageBounds.height && bounds.width > 0 && bounds.width < 100);
 	bounds = treeItem2.getBounds(1);
-	assertTrue(":4w:", bounds.x >= 100 && bounds.height > stringExtent1.y && bounds.height >= imageBounds.height && bounds.width  == 200);
+	assertTrue(bounds.x >= 100 && bounds.height > stringExtent1.y && bounds.height >= imageBounds.height && bounds.width  == 200);
 
 	//
 	tree2.dispose();
@@ -530,7 +530,7 @@ void getBoundsID() {
 	treeItem2.setText(string1);
 	new TreeColumn(tree2, SWT.RIGHT);
 	bounds = treeItem2.getBounds(0);
-	assertTrue(":4x:", bounds.x > 0 && bounds.height > stringExtent1.y && bounds.width  == 0);
+	assertTrue(bounds.x > 0 && bounds.height > stringExtent1.y && bounds.width  == 0);
 }
 
 @Test
@@ -572,7 +572,7 @@ public void test_getImageBoundsI() {
 
 	// TODO - should this width be 0 or a value?
 	bounds = treeItem.getImageBounds(0);
-	assertEquals(":b:", 0, bounds.width);
+	assertEquals(0, bounds.width);
 
 	assertEquals(new Rectangle(0, 0, 0, 0), treeItem.getImageBounds(1));
 
@@ -642,7 +642,7 @@ public void test_getItemI() {
 		items[i] = new TreeItem(treeItem, 0);
 
 	for (int i = 0; i < number; i++)
-		assertEquals("i=" + i, items[i], treeItem.getItem(i));
+		assertEquals(items[i], treeItem.getItem(i));
 	try {
 		treeItem.getItem(number);
 		fail("No exception thrown for illegal index argument");
@@ -671,7 +671,7 @@ public void test_getItemCount() {
 		assertEquals(i, treeItem.getItemCount());
 		new TreeItem(treeItem, 0);
 	}
-	assertEquals("b: ", 10, treeItem.getItemCount());
+	assertEquals(10, treeItem.getItemCount());
 }
 
 @Test

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/performance/Test_org_eclipse_swt_widgets_Tree_Binary.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/performance/Test_org_eclipse_swt_widgets_Tree_Binary.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2015 IBM Corporation and others.
+ * Copyright (c) 2025 Kichwa Coders Canada, Inc.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -7,20 +7,12 @@
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-package org.eclipse.swt.tests.junit;
+package org.eclipse.swt.tests.junit.performance;
 
+public class Test_org_eclipse_swt_widgets_Tree_Binary extends Test_org_eclipse_swt_widgets_Tree {
 
-import org.junit.platform.suite.api.SelectClasses;
-import org.junit.platform.suite.api.Suite;
-
-@Suite
-@SelectClasses({
-	Test_org_eclipse_swt_browser_Browser.class,
-	Test_org_eclipse_swt_browser_Browser_IE.class
-})
-public class AllBrowserTests {
+	public Test_org_eclipse_swt_widgets_Tree_Binary() {
+		super(Shape.BINARY, false);
+	}
 }

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/performance/Test_org_eclipse_swt_widgets_Tree_Binary_Virtual.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/performance/Test_org_eclipse_swt_widgets_Tree_Binary_Virtual.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2015 IBM Corporation and others.
+ * Copyright (c) 2025 Kichwa Coders Canada, Inc.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -7,20 +7,12 @@
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-package org.eclipse.swt.tests.junit;
+package org.eclipse.swt.tests.junit.performance;
 
+public class Test_org_eclipse_swt_widgets_Tree_Binary_Virtual extends Test_org_eclipse_swt_widgets_Tree {
 
-import org.junit.platform.suite.api.SelectClasses;
-import org.junit.platform.suite.api.Suite;
-
-@Suite
-@SelectClasses({
-	Test_org_eclipse_swt_browser_Browser.class,
-	Test_org_eclipse_swt_browser_Browser_IE.class
-})
-public class AllBrowserTests {
+	public Test_org_eclipse_swt_widgets_Tree_Binary_Virtual() {
+		super(Shape.BINARY, true);
+	}
 }

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/performance/Test_org_eclipse_swt_widgets_Tree_Star.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/performance/Test_org_eclipse_swt_widgets_Tree_Star.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2015 IBM Corporation and others.
+ * Copyright (c) 2025 Kichwa Coders Canada, Inc.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -7,20 +7,12 @@
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-package org.eclipse.swt.tests.junit;
+package org.eclipse.swt.tests.junit.performance;
 
+public class Test_org_eclipse_swt_widgets_Tree_Star extends Test_org_eclipse_swt_widgets_Tree {
 
-import org.junit.platform.suite.api.SelectClasses;
-import org.junit.platform.suite.api.Suite;
-
-@Suite
-@SelectClasses({
-	Test_org_eclipse_swt_browser_Browser.class,
-	Test_org_eclipse_swt_browser_Browser_IE.class
-})
-public class AllBrowserTests {
+	public Test_org_eclipse_swt_widgets_Tree_Star() {
+		super(Shape.STAR, false);
+	}
 }

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/performance/Test_org_eclipse_swt_widgets_Tree_Star_Virtual.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/performance/Test_org_eclipse_swt_widgets_Tree_Star_Virtual.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2015 IBM Corporation and others.
+ * Copyright (c) 2025 Kichwa Coders Canada, Inc.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -7,20 +7,12 @@
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-package org.eclipse.swt.tests.junit;
+package org.eclipse.swt.tests.junit.performance;
 
+public class Test_org_eclipse_swt_widgets_Tree_Star_Virtual extends Test_org_eclipse_swt_widgets_Tree {
 
-import org.junit.platform.suite.api.SelectClasses;
-import org.junit.platform.suite.api.Suite;
-
-@Suite
-@SelectClasses({
-	Test_org_eclipse_swt_browser_Browser.class,
-	Test_org_eclipse_swt_browser_Browser_IE.class
-})
-public class AllBrowserTests {
+	public Test_org_eclipse_swt_widgets_Tree_Star_Virtual() {
+		super(Shape.STAR, true);
+	}
 }

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/performance/Test_situational.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/performance/Test_situational.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.swt.tests.junit.performance;
 
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
+
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.Font;
@@ -40,9 +42,8 @@ import org.eclipse.swt.widgets.Tree;
 import org.eclipse.test.performance.Dimension;
 import org.eclipse.test.performance.Performance;
 import org.eclipse.test.performance.PerformanceMeter;
-import org.junit.Assume;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Automated Performance Test Suite for class org.eclipse.swt.graphics.Color
@@ -52,7 +53,7 @@ import org.junit.Test;
 @SuppressWarnings("restriction")
 public class Test_situational extends SwtPerformanceTestCase {
 
-@Before
+@BeforeEach
 public void setUp() {
 	display = Display.getDefault();
 }
@@ -73,7 +74,7 @@ public void setUp() {
  */
 @Test
 public void test_createComposites() {
-	Assume.assumeFalse("https://github.com/eclipse-platform/eclipse.platform.swt/issues/912 Very slow on Mac OS", Platform.PLATFORM.equalsIgnoreCase("cocoa"));
+	assumeFalse(Platform.PLATFORM.equalsIgnoreCase("cocoa"), "https://github.com/eclipse-platform/eclipse.platform.swt/issues/912 Very slow on Mac OS");
 	PerformanceMeter meter = createMeter("Create composites");
 	int samples;
 

--- a/tests/org.eclipse.swt.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.swt.tests/META-INF/MANIFEST.MF
@@ -6,9 +6,7 @@ Bundle-Version: 3.107.1000.qualifier
 Bundle-Vendor: Eclipse.org
 Export-Package: org.eclipse.swt.tests.junit,
  org.eclipse.swt.tests.junit.performance
-Require-Bundle: org.junit;bundle-version="4.13.2",
- junit-vintage-engine;bundle-version="5.12.0",
- junit-jupiter-engine;bundle-version="5.12.0",
+Require-Bundle: junit-jupiter-engine;bundle-version="5.12.0",
  junit-jupiter-params;bundle-version="5.12.0",
  junit-jupiter-api;bundle-version="5.12.0",
  junit-platform-suite-api;bundle-version="1.12.0",


### PR DESCRIPTION
Because most all the tests remaining tests are in huge class hierarchy under Test_org_eclipse_swt_widgets_Widget they all need changing at once. The tests that are not under Test_org_eclipse_swt_widgets_Widget are generally pretty small, so included here to fully remove JUnit4 dependency.

This means that junit-vintage-engine and org.junit removed from Require-Bundle of the manifest.

Messages have been removed from assertions that didn't add value. The order of parameters to assertEquals and others changed, and for most of the calls I removed the message based on previous guidance. I tried to leave in messages that were more useful for documenting or diagnosing errors. But I removed messages that more or less repeated as a string what the item being tested is.

A lot of things work quite differently in JUnit5. Here are some highlights that have affected or benefited this change:

There is a better way of integrating screenshots into failed tests as tests can be intercepted between the test completion and the `@AfterEach` methods. Therefore we can take a screenshot prior to disposal, and then let the tear down message cleanup in a less convoluted way. See Test_org_eclipse_swt_widgets_Widget.afterTestExecutionCallback and tearDown methods to see this in action.

The way to get a test name is quite different. Instead of a TestName `@Rule` a `TestInfo` can be obtained. The name returned is not exactly the same format, but where the name needed a specific format, I adjusted the code appropriately. See Test_org_eclipse_swt_browser_Browser.testInfo and Test_org_eclipse_swt_widgets_Widget.testInfo for a couple of use cases.

Whole class parameterized tests don't really exist in a simple way in JUnit5. As there was very little use of this, rather than having complicated setup, I used sub-classes to provide the parameterization. See for example Test_org_eclipse_swt_widgets_DateTime and its new subclasses.