### PR TITLE
[Win32] Add PrtScr hotkey check for KeyEvent tests #2516

### DIFF
--- a/tests/org.eclipse.swt.tests.win32/JUnit Tests/org/eclipse/swt/tests/win32/Test_org_eclipse_swt_events_KeyEvent.java
+++ b/tests/org.eclipse.swt.tests.win32/JUnit Tests/org/eclipse/swt/tests/win32/Test_org_eclipse_swt_events_KeyEvent.java
@@ -18,7 +18,6 @@ import org.eclipse.swt.internal.win32.OS;
 import org.eclipse.swt.widgets.Event;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
 
 /**
  * Automated Test Suite for class org.eclipse.swt.events.KeyEvent
@@ -26,7 +25,6 @@ import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
  * @see org.eclipse.swt.events.KeyEvent
  */
 @SuppressWarnings("restriction")
-@DisabledIfEnvironmentVariable(named = "GITHUB_ACTIONS", matches = "true", disabledReason = "Windows Server 2025 incompatibility: https://github.com/eclipse-platform/eclipse.platform.swt/issues/2516")
 public class Test_org_eclipse_swt_events_KeyEvent extends KeyboardLayoutTest {
 	// Windows layouts suitable for 'LoadKeyboardLayout()', obtained from 'GetKeyboardLayoutName()'
 	static char[] LAYOUT_BENGALI        = "00020445\0".toCharArray();
@@ -111,6 +109,11 @@ public class Test_org_eclipse_swt_events_KeyEvent extends KeyboardLayoutTest {
 						return true;
 				}
 				break;
+			case PrtScr:
+				switch (state) {
+					case ____: // Opens snipping tool
+						return true;
+				}
 			case F4:
 				switch (state) {
 					case A___:  // Closes current Shell

--- a/tests/org.eclipse.swt.tests.win32/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.swt.tests.win32/META-INF/MANIFEST.MF
@@ -9,7 +9,6 @@ Eclipse-BundleShape: dir
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Automatic-Module-Name: org.eclipse.swt.tests.win32
 Import-Package: org.junit.jupiter.api;version="[5.13.0,6.0.0)",
- org.junit.jupiter.api.condition;version="[5.13.0,6.0.0)",
  org.junit.jupiter.params;version="[5.13.0,6.0.0)",
  org.junit.jupiter.params.provider;version="[5.13.0,6.0.0)",
  org.junit.platform.suite.api;version="[1.13.0,2.0.0)"


### PR DESCRIPTION
The Win32 KeyEvent tests started to fail on GitHub Actions when the environment was updated to Windows Server 2025. Using the print screen button opens the Windows snipping tools which, for yet unknown reason, now receives the focus and does not close automatically when processing further key events, like it did before and does on Windows 11 systems.

To keep the tests working properly, this change excludes the PtrScr key as a system hotkey when not combined with any modifier key. It reverts the complete disablement of the tests performed in https://github.com/eclipse-platform/eclipse.platform.swt/pull/2559.

Fixes https://github.com/eclipse-platform/eclipse.platform.swt/issues/2516

@jonahgraham this is an extended version of your experiment https://github.com/jonahgraham/eclipse.platform.swt/pull/2
It limits the exclusion of the PtrScr key to the case where no state modifier is used, as this seems to be sufficient and ensures that we preserve testing of the other key combinations. I've successfully run this configuration three time in https://github.com/HeikoKlare/eclipse.platform.swt/pull/2.