### PR TITLE
Replace nativeZoom of widgets with disabled autoscaling with 100

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Control.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Control.java
@@ -78,11 +78,14 @@ public abstract class Control extends Widget implements Drawable {
 	Region region;
 	Font font;
 	int drawCount, foreground, background, backgroundAlpha = 255;
+	boolean autoScaleDisabled = false;
 
 	/** Cache for currently processed DPI change event to be able to cancel it if a new one is triggered */
 	Event currentDpiChangeEvent;
 
 	private static final String DATA_SHELL_ZOOM = "SHELL_ZOOM";
+
+	private static final String DATA_AUTOSCALE_DISABLED = "AUTOSCALE_DISABLED";
 /**
  * Prevents uninitialized instances from being created outside the package.
  */
@@ -122,6 +125,7 @@ Control () {
 public Control (Composite parent, int style) {
 	super (parent, style);
 	this.parent = parent;
+	this.autoScaleDisabled = parent.autoScaleDisabled;
 	createWidget ();
 }
 
@@ -1268,6 +1272,19 @@ public Object getData(String key) {
 		return shell == null ? null : shell.nativeZoom;
 	}
 	return super.getData(key);
+}
+
+@Override
+public void setData(String key, Object value) {
+	super.setData(key, value);
+	if (DATA_AUTOSCALE_DISABLED.equals(key)) {
+		autoScaleDisabled = Boolean.parseBoolean(value.toString());
+		if (autoScaleDisabled) {
+			this.nativeZoom = 100;
+		} else {
+			this.nativeZoom = (int) getData(DATA_SHELL_ZOOM);
+		}
+	}
 }
 
 /**
@@ -3534,7 +3551,7 @@ public void setLayoutData (Object layoutData) {
  */
 public void setLocation (int x, int y) {
 	checkWidget ();
-	int zoom = getZoom();
+	int zoom = autoScaleDisabled ? parent.getZoom() : getZoom();
 	x = DPIUtil.pointToPixel(x, zoom);
 	y = DPIUtil.pointToPixel(y, zoom);
 	setLocationInPixels(x, y);
@@ -3791,7 +3808,7 @@ public void setRegion (Region region) {
  */
 public void setSize (int width, int height) {
 	checkWidget ();
-	int zoom = getZoom();
+	int zoom = autoScaleDisabled ? parent.getZoom() : getZoom();
 	width = DPIUtil.pointToPixel(width, zoom);
 	height = DPIUtil.pointToPixel(height, zoom);
 	setSizeInPixels(width, height);
@@ -4783,6 +4800,23 @@ public boolean setParent (Composite parent) {
 	OS.SetWindowPos (topHandle, OS.HWND_BOTTOM, 0, 0, 0, 0, flags);
 	reskin (SWT.ALL);
 	return true;
+}
+
+@Override
+GC createNewGC(long hDC, GCData data) {
+	data.nativeZoom = getNativeZoom();
+	if (autoScaleDisabled && data.font != null) {
+		data.font = SWTFontProvider.getFont(display, data.font.getFontData()[0], 100);
+	}
+	return GC.win32_new(hDC, data);
+}
+
+@Override
+int getZoom() {
+	if (autoScaleDisabled) {
+		return 100;
+	}
+	return super.getZoom();
 }
 
 abstract TCHAR windowClass ();
@@ -5959,6 +5993,9 @@ void sendZoomChangedEvent(Event event, Shell shell) {
 @Override
 void handleDPIChange(Event event, float scalingFactor) {
 	super.handleDPIChange(event, scalingFactor);
+	if (this.autoScaleDisabled) {
+		this.nativeZoom = 100;
+	}
 	resizeFont(this, getNativeZoom());
 
 	Image image = backgroundImage;

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Widget.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Widget.java
@@ -65,7 +65,6 @@ public abstract class Widget {
 	 * @noreference This field is not intended to be referenced by clients.
 	 */
 	public int nativeZoom;
-	boolean autoScaleDisabled = false;
 	int style, state;
 	Display display;
 	EventTable eventTable;
@@ -133,8 +132,6 @@ public abstract class Widget {
 	/* Bidi flag and for auto text direction */
 	static final int AUTO_TEXT_DIRECTION = SWT.LEFT_TO_RIGHT | SWT.RIGHT_TO_LEFT;
 
-	private static final String DATA_AUTOSCALE_DISABLED = "AUTOSCALE_DISABLED";
-
 	/* Initialize the Common Controls DLL */
 	static {
 		INITCOMMONCONTROLSEX icce = new INITCOMMONCONTROLSEX ();
@@ -184,7 +181,6 @@ public Widget (Widget parent, int style) {
 	checkParent (parent);
 	this.style = style;
 	this.nativeZoom = parent != null ? parent.nativeZoom : DPIUtil.getNativeDeviceZoom();
-	this.autoScaleDisabled = parent.autoScaleDisabled;
 	display = parent.display;
 	reskinWidget ();
 	notifyCreationTracker();
@@ -1470,10 +1466,6 @@ public void setData (String key, Object value) {
 		}
 	}
 	if (key.equals(SWT.SKIN_CLASS) || key.equals(SWT.SKIN_ID)) this.reskin(SWT.ALL);
-
-	if (DATA_AUTOSCALE_DISABLED.equals(key)) {
-		autoScaleDisabled = Boolean.parseBoolean(value.toString());
-	}
 }
 
 boolean sendFocusEvent (int type) {
@@ -2704,23 +2696,14 @@ void notifyDisposalTracker() {
 
 GC createNewGC(long hDC, GCData data) {
 	data.nativeZoom = getNativeZoom();
-	if (autoScaleDisabled && data.font != null) {
-		data.font = SWTFontProvider.getFont(display, data.font.getFontData()[0], 100);
-	}
 	return GC.win32_new(hDC, data);
 }
 
 int getNativeZoom() {
-	if (autoScaleDisabled) {
-		return 100;
-	}
 	return nativeZoom;
 }
 
 int getZoom() {
-	if (autoScaleDisabled) {
-		return 100;
-	}
 	return DPIUtil.getZoomForAutoscaleProperty(nativeZoom);
 }
 


### PR DESCRIPTION
Few Widgets do not adhere to AUTO_SCALE_DISABLED field when set to true in Widget#setData. The proposed changes are as follow: 

- In Widget when setting DATA_AUTOSCALE_DISABLED to true we also update the nativeZoom value to 100 since it is a public field and we cannot rely on everyone calling the getter for it where we previously had a logic to return 100 in case of autoScale disablement. 
- Tracker class in some cases was using same logic as getZoom() but missing one additional detail which is present in getZoom(), that is to check if autoScale is disabled then use 100%
- In Control class when we set the bounds then we use to check for autoScale disablement but not when setting the size or location, so that's fixed too. 

### Detailed Analysis

These are the widgets or widget utils that should be affected when auto scale is disabled. 
```
org.eclipse.swt.dnd.DragSource.drag(Event)
org.eclipse.swt.dnd.DropTarget.convertPixelToPoint(int, int)
org.eclipse.swt.dnd.TableDragSourceEffect.getDragSourceImage(DragSourceEvent)
org.eclipse.swt.dnd.TableDropTargetEffect.dragOver(DropTargetEvent)
org.eclipse.swt.dnd.TreeDragSourceEffect.getDragSourceImage(DragSourceEvent)
org.eclipse.swt.dnd.TreeDropTargetEffect.dragOver(DropTargetEvent)

org.eclipse.swt.widgets.Button.Button(Composite, int)
org.eclipse.swt.widgets.Button.getCheckboxTextOffset(long)
org.eclipse.swt.widgets.Button.wmDrawChild(long, long)

org.eclipse.swt.widgets.Composite.wmNCPaint(long, long, long)

org.eclipse.swt.widgets.Control.getData(String)
org.eclipse.swt.widgets.Control.setParent(Composite)
org.eclipse.swt.widgets.Control.WM_DPICHANGED(long, long)

org.eclipse.swt.widgets.ExpandBar.computeSizeInPixels(int, int, boolean)
org.eclipse.swt.widgets.ExpandBar.drawThemeBackground(long, long, RECT)
org.eclipse.swt.widgets.ExpandBar.drawWidget(GC, RECT)

org.eclipse.swt.widgets.Menu.fixMenus(Decorations)

org.eclipse.swt.widgets.MenuItem.fixMenus(Decorations)
org.eclipse.swt.widgets.MenuItem.getMenuItemIconBitmapHandle(Image)
org.eclipse.swt.widgets.MenuItem.getMenuItemIconSelectedBitmapHandle()

org.eclipse.swt.widgets.TabFolder.drawThemeBackground(long, long, RECT)

org.eclipse.swt.widgets.Table.setCheckboxImageList(int, int, boolean)
org.eclipse.swt.widgets.Table.wmNotifyHeader(NMHDR, long, long)

org.eclipse.swt.widgets.TaskBar.createShellLink(MenuItem)

org.eclipse.swt.widgets.Text.WM_DRAWITEM(long, long)

org.eclipse.swt.widgets.Tree.calculateAndApplyIndentSize()
org.eclipse.swt.widgets.Tree.setCheckboxImageList()
org.eclipse.swt.widgets.Tree.wmNotifyHeader(NMHDR, long, long)
```

**When should auto scale disabling function?**

Whenever widget#nativeZoom or widget#getNativeZoom is called from any of the widget, the native zoom must be 100%.

### Reproduction
The drop scenario sketched above can be easily reproduced with `Snippet257`:
- Adapt the snippet as follows:
  - Start it with monitor-specific scaling enabled, e.g., add the following for line to the `main` method: `System.setProperty("swt.autoScale.updateOnRuntime", "true");`
  - Disabled autoscaling for StyledText control, i.e., call `text.setData("AUTOSCALE_DISABLED", "true");` after instantiating `text`
- Start the snippet and move the shell to a monitor with zoom != 100% (it's also sufficient if it starts on primary monitor with zoom != 100)
- Drag a text from somewhere es and try to drop it into the text widget.

Here is how it looks on 200% monitor because of the wrong coordinate conversion:
![Image](https://github.com/user-attachments/assets/65bebc36-e9cc-4467-8879-113020a06183)

### Expected Behavior
`Widget#nativeZoom` shall be adapted to always contain the actual native zoom, i.e., 100 in case `autoscaleDisabled==true`. All accesses to `Widget#nativeZoom` shall be summarized in this issue (or in the according PR) and evaluated regarding whether it is correct to use 100 when autoscaling is disabled or not. In cases where it may not be correct, `getData(DATA_NATIVE_ZOOM)` could be used to access the original native zoom.