### PR TITLE
[GTK] Fix compilation with gdk-pixbuf 2.44.x

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/os.c
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/os.c
@@ -1495,6 +1495,7 @@ G_GNUC_END_IGNORE_DEPRECATIONS
 #endif
 
 #ifndef NO_gdk_1pixbuf_1animation_1get_1static_1image
+G_GNUC_BEGIN_IGNORE_DEPRECATIONS
 JNIEXPORT jlong JNICALL GDK_NATIVE(gdk_1pixbuf_1animation_1get_1static_1image)
 	(JNIEnv *env, jclass that, jlong arg0)
 {
@@ -1504,9 +1505,11 @@ JNIEXPORT jlong JNICALL GDK_NATIVE(gdk_1pixbuf_1animation_1get_1static_1image)
 	GDK_NATIVE_EXIT(env, that, gdk_1pixbuf_1animation_1get_1static_1image_FUNC);
 	return rc;
 }
+G_GNUC_END_IGNORE_DEPRECATIONS
 #endif
 
 #ifndef NO_gdk_1pixbuf_1animation_1is_1static_1image
+G_GNUC_BEGIN_IGNORE_DEPRECATIONS
 JNIEXPORT jboolean JNICALL GDK_NATIVE(gdk_1pixbuf_1animation_1is_1static_1image)
 	(JNIEnv *env, jclass that, jlong arg0)
 {
@@ -1516,6 +1519,7 @@ JNIEXPORT jboolean JNICALL GDK_NATIVE(gdk_1pixbuf_1animation_1is_1static_1image)
 	GDK_NATIVE_EXIT(env, that, gdk_1pixbuf_1animation_1is_1static_1image_FUNC);
 	return rc;
 }
+G_GNUC_END_IGNORE_DEPRECATIONS
 #endif
 
 #ifndef NO_gdk_1pixbuf_1animation_1iter_1advance
@@ -1533,6 +1537,7 @@ G_GNUC_END_IGNORE_DEPRECATIONS
 #endif
 
 #ifndef NO_gdk_1pixbuf_1animation_1iter_1get_1delay_1time
+G_GNUC_BEGIN_IGNORE_DEPRECATIONS
 JNIEXPORT jint JNICALL GDK_NATIVE(gdk_1pixbuf_1animation_1iter_1get_1delay_1time)
 	(JNIEnv *env, jclass that, jlong arg0)
 {
@@ -1542,9 +1547,11 @@ JNIEXPORT jint JNICALL GDK_NATIVE(gdk_1pixbuf_1animation_1iter_1get_1delay_1time
 	GDK_NATIVE_EXIT(env, that, gdk_1pixbuf_1animation_1iter_1get_1delay_1time_FUNC);
 	return rc;
 }
+G_GNUC_END_IGNORE_DEPRECATIONS
 #endif
 
 #ifndef NO_gdk_1pixbuf_1animation_1iter_1get_1pixbuf
+G_GNUC_BEGIN_IGNORE_DEPRECATIONS
 JNIEXPORT jlong JNICALL GDK_NATIVE(gdk_1pixbuf_1animation_1iter_1get_1pixbuf)
 	(JNIEnv *env, jclass that, jlong arg0)
 {
@@ -1554,6 +1561,7 @@ JNIEXPORT jlong JNICALL GDK_NATIVE(gdk_1pixbuf_1animation_1iter_1get_1pixbuf)
 	GDK_NATIVE_EXIT(env, that, gdk_1pixbuf_1animation_1iter_1get_1pixbuf_FUNC);
 	return rc;
 }
+G_GNUC_END_IGNORE_DEPRECATIONS
 #endif
 
 #ifndef NO_gdk_1pixbuf_1copy
@@ -1751,6 +1759,7 @@ fail:
 #endif
 
 #ifndef NO_gdk_1pixbuf_1loader_1get_1animation
+G_GNUC_BEGIN_IGNORE_DEPRECATIONS
 JNIEXPORT jlong JNICALL GDK_NATIVE(gdk_1pixbuf_1loader_1get_1animation)
 	(JNIEnv *env, jclass that, jlong arg0)
 {
@@ -1760,6 +1769,7 @@ JNIEXPORT jlong JNICALL GDK_NATIVE(gdk_1pixbuf_1loader_1get_1animation)
 	GDK_NATIVE_EXIT(env, that, gdk_1pixbuf_1loader_1get_1animation_FUNC);
 	return rc;
 }
+G_GNUC_END_IGNORE_DEPRECATIONS
 #endif
 
 #ifndef NO_gdk_1pixbuf_1loader_1get_1format

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/org/eclipse/swt/internal/gtk/GDK.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/org/eclipse/swt/internal/gtk/GDK.java
@@ -625,11 +625,20 @@ public class GDK extends OS {
 	 */
 	public static final native long gdk_pango_layout_get_clip_region(long layout, int x_origin, int y_origin, int[] index_ranges, int n_ranges);
 
-	/** @param animation cast=(GdkPixbufAnimation *) */
+	/**
+	 * @param animation cast=(GdkPixbufAnimation *)
+	 * @method flags=ignore_deprecations
+	 */
 	public static final native boolean gdk_pixbuf_animation_is_static_image(long animation);
-	/** @param iter cast=(GdkPixbufAnimationIter *) */
+	/**
+	 * @param iter cast=(GdkPixbufAnimationIter *)
+	 * @method flags=ignore_deprecations
+	 */
 	public static final native int gdk_pixbuf_animation_iter_get_delay_time(long iter);
-	/** @param iter cast=(GdkPixbufAnimationIter *) */
+	/**
+	 * @param iter cast=(GdkPixbufAnimationIter *)
+	 * @method flags=ignore_deprecations
+	 */
 	public static final native long gdk_pixbuf_animation_iter_get_pixbuf(long iter);
 	/**
 	 * @method flags=ignore_deprecations
@@ -643,7 +652,10 @@ public class GDK extends OS {
 	 * @param start_time cast=(const GTimeVal *)
 	 */
 	public static final native long gdk_pixbuf_animation_get_iter(long animation, long start_time);
-	/** @param animation cast=(GdkPixbufAnimation *) */
+	/**
+	 * @param animation cast=(GdkPixbufAnimation *)
+	 * @method flags=ignore_deprecations
+	 */
 	public static final native long gdk_pixbuf_animation_get_static_image(long animation);
 	/**
 	 * @param src_pixbuf cast=(GdkPixbuf *)
@@ -670,7 +682,10 @@ public class GDK extends OS {
 	public static final native long gdk_pixbuf_loader_get_format(long loader);
 	/** @param format cast=(GdkPixbufFormat *) */
 	public static final native long gdk_pixbuf_format_get_name(long format);
-	/** @param loader cast=(GdkPixbufLoader *) */
+	/**
+	 * @param loader cast=(GdkPixbufLoader *)
+	 * @method flags=ignore_deprecations
+	 */
 	public static final native long gdk_pixbuf_loader_get_animation(long loader);
 	/**
 	 * @param data cast=(const guchar *)


### PR DESCRIPTION
Animation API is deprecated as per
https://gitlab.gnome.org/GNOME/gdk-pixbuf/-/merge_requests/250 .