### PR TITLE
[Win32] Fix transparency when scaling images with transparentPixel

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/GC.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/GC.java
@@ -1527,8 +1527,8 @@ private void drawBitmap(Image srcImage, ImageHandle imageHandle, int srcX, int s
 	int depth = bm.bmPlanes * bm.bmBitsPixel;
 	if (isDib && depth == 32) {
 		drawBitmapAlpha(handle, srcX, srcY, srcWidth, srcHeight, destX, destY, destWidth, destHeight, simple);
-	} else if (srcImage.transparentPixel != -1) {
-		drawBitmapTransparent(srcImage, imageHandle, srcX, srcY, srcWidth, srcHeight, destX, destY, destWidth, destHeight, simple, bm, imgWidth, imgHeight);
+	} else if (imageHandle.transparentPixel != -1) {
+		drawBitmapTransparent(imageHandle, srcX, srcY, srcWidth, srcHeight, destX, destY, destWidth, destHeight, simple, bm, imgWidth, imgHeight);
 	} else {
 		drawBitmapColor(handle, srcX, srcY, srcWidth, srcHeight, destX, destY, destWidth, destHeight, simple);
 	}
@@ -1788,7 +1788,7 @@ private void drawBitmapMask(long srcColor, long srcMask, int srcX, int srcY, int
 	OS.DeleteDC(srcHdc);
 }
 
-private void drawBitmapTransparent(Image srcImage, ImageHandle imageHandle, int srcX, int srcY, int srcWidth, int srcHeight, int destX, int destY, int destWidth, int destHeight, boolean simple, BITMAP bm, int imgWidth, int imgHeight) {
+private void drawBitmapTransparent(ImageHandle imageHandle, int srcX, int srcY, int srcWidth, int srcHeight, int destX, int destY, int destWidth, int destHeight, boolean simple, BITMAP bm, int imgWidth, int imgHeight) {
 
 	/* Find the RGB values for the transparent pixel. */
 	boolean isDib = bm.bmBits != 0;
@@ -1796,7 +1796,7 @@ private void drawBitmapTransparent(Image srcImage, ImageHandle imageHandle, int 
 	long srcHdc = OS.CreateCompatibleDC(handle);
 	long oldSrcBitmap = OS.SelectObject(srcHdc, hBitmap);
 	byte[] originalColors = null;
-	int transparentColor = srcImage.transparentColor;
+	int transparentColor = imageHandle.transparentColor;
 	if (transparentColor == -1) {
 		int transBlue = 0, transGreen = 0, transRed = 0;
 		boolean fixPalette = false;
@@ -1805,7 +1805,7 @@ private void drawBitmapTransparent(Image srcImage, ImageHandle imageHandle, int 
 				int maxColors = 1 << bm.bmBitsPixel;
 				byte[] oldColors = new byte[maxColors * 4];
 				OS.GetDIBColorTable(srcHdc, 0, maxColors, oldColors);
-				int offset = srcImage.transparentPixel * 4;
+				int offset = imageHandle.transparentPixel * 4;
 				for (int i = 0; i < oldColors.length; i += 4) {
 					if (i != offset) {
 						if (oldColors[offset] == oldColors[i] && oldColors[offset+1] == oldColors[i+1] && oldColors[offset+2] == oldColors[i+2]) {
@@ -1838,14 +1838,14 @@ private void drawBitmapTransparent(Image srcImage, ImageHandle imageHandle, int 
 				byte[] bmi = new byte[BITMAPINFOHEADER.sizeof + numColors * 4];
 				OS.MoveMemory(bmi, bmiHeader, BITMAPINFOHEADER.sizeof);
 				OS.GetDIBits(srcHdc, imageHandle.getHandle(), 0, 0, null, bmi, OS.DIB_RGB_COLORS);
-				int offset = BITMAPINFOHEADER.sizeof + 4 * srcImage.transparentPixel;
+				int offset = BITMAPINFOHEADER.sizeof + 4 * imageHandle.transparentPixel;
 				transRed = bmi[offset + 2] & 0xFF;
 				transGreen = bmi[offset + 1] & 0xFF;
 				transBlue = bmi[offset] & 0xFF;
 			}
 		} else {
 			/* Direct color image */
-			int pixel = srcImage.transparentPixel;
+			int pixel = imageHandle.transparentPixel;
 			switch (bm.bmBitsPixel) {
 				case 16:
 					transBlue = (pixel & 0x1F) << 3;
@@ -1865,7 +1865,7 @@ private void drawBitmapTransparent(Image srcImage, ImageHandle imageHandle, int 
 			}
 		}
 		transparentColor = transBlue << 16 | transGreen << 8 | transRed;
-		if (!fixPalette) srcImage.transparentColor = transparentColor;
+		if (!fixPalette) imageHandle.transparentColor = transparentColor;
 	}
 
 	if (originalColors == null) {


### PR DESCRIPTION
### Description

**Move Transparent Pixel Handling from Image to ImageHandle**

Previously, the transparency pixel was managed at the Image level, which caused issues when an Image had multiple handles at different zoom levels or color models (e.g., indexed vs. direct/ARGB). For example, a GIF image at 100% zoom may use a transparency pixel, but when scaled, SWT converts it to a direct image with alpha data, making the transparency pixel concept invalid for the scaled handle.

This change moves the transparency pixel field from the Image class to the ImageHandle class. Now, each handle manages its own transparency information, allowing a single Image to have multiple handles, each with the correct transparency type (pixel or alpha) according to its color model. This ensures correct transparency handling for all handles, regardless of how they were created or scaled.

### How to test
1. Run the following snippet on 100% zoom monitor
```
import org.eclipse.swt.*;
import org.eclipse.swt.graphics.*;
import org.eclipse.swt.widgets.*;


public class ButtonWithGifImage {
    public static void main(String[] args) {
    	System.setProperty("swt.autoScale.updateOnRuntime", "true");
    	System.setProperty("swt.autoScale", "quarter");
        Display display = new Display();
        Shell shell = new Shell(display);
        shell.setText("SWT Button with GIF Image");
        shell.setSize(300, 200);

        Button button = new Button(shell, SWT.PUSH);
        button.setBounds(80, 60, 140, 60);
        button.setText("Click Me");

        Image image = new Image(display,
            ButtonWithGifImage.class.getResourceAsStream("sample.gif"));
        button.setImage(image);

        shell.open();
        while (!shell.isDisposed()) {
            if (!display.readAndDispatch())
                display.sleep();
        }

        image.dispose();
        display.dispose();
    }
}

```
2. Move the window to a 150% DPI monitor (causing scaling) — verify the image still renders correctly (no jagged/incorrect background).
3. Move back to 100% — verify the image still renders correctly and no gray background appears.

GIF Image: 
![sample](https://github.com/user-attachments/assets/77ec93b8-7146-4453-9ac5-177a38a35d58)


### Result 
 
Here's the preview how it looked before and after this PR change. 100 -> 150 -> 100

**Before:**
<img width="418" height="318" alt="image" src="https://github.com/user-attachments/assets/e1496561-f81f-456b-a714-f3fcd781d154" />

**After**
<img width="450" height="284" alt="image" src="https://github.com/user-attachments/assets/352dec80-c64d-474b-89d3-9314757e8163" />

- [x] Requires: https://github.com/eclipse-platform/eclipse.platform.swt/pull/2651/files 

Fixes: https://github.com/eclipse-platform/eclipse.platform.swt/issues/2494