### PR TITLE
Removing Image#CreateSurface from GTK

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/cairo/org/eclipse/swt/graphics/Pattern.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cairo/org/eclipse/swt/graphics/Pattern.java
@@ -85,7 +85,6 @@ public Pattern(Device device, Image image) {
 	super(device);
 	if (image == null) SWT.error(SWT.ERROR_NULL_ARGUMENT);
 	if (image.isDisposed()) SWT.error(SWT.ERROR_INVALID_ARGUMENT);
-	image.createSurface();
 	handle = Cairo.cairo_pattern_create_for_surface(image.surface);
 	if (handle == 0) SWT.error(SWT.ERROR_NO_HANDLES);
 	Cairo.cairo_pattern_set_extend(handle, Cairo.CAIRO_EXTEND_REPEAT);

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/graphics/GC.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/graphics/GC.java
@@ -940,7 +940,6 @@ void drawImage(Image srcImage, int srcX, int srcY, int srcWidth, int srcHeight, 
 	}
 	long cairo = data.cairo;
 	if (data.alpha != 0) {
-		srcImage.createSurface();
 		Cairo.cairo_save(cairo);
 		if ((data.style & SWT.MIRRORED) != 0) {
 			Cairo.cairo_scale(cairo, -1f,  1);

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/graphics/Image.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/graphics/Image.java
@@ -909,10 +909,6 @@ void createMask() {
 	C.memmove(surfaceData, srcData, srcData.length);
 }
 
-void createSurface() {
-	if (surface != 0) return;
-}
-
 /**
  * Destroy the receiver's mask if it exists.
  */


### PR DESCRIPTION
Removing createSurface method from Image class in GTK and its callers as this method currently does not do anything. This PR is just a cleanup removing method calls which does not make any sense. 

@akurtakov could you take a look if this cleanup is acceptable or is there some reason to keep the method?