### PR TITLE
[MacOS] Support loading and drawing images at desired size

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/graphics/GC.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/graphics/GC.java
@@ -1238,7 +1238,9 @@ public void drawImage(Image image, int destX, int destY, int destWidth, int dest
 	if (image.isDisposed()) {
 		SWT.error(SWT.ERROR_INVALID_ARGUMENT);
 	}
-	drawImage(image, 0, 0, 0, 0, destX, destY, destWidth, destHeight, false);
+	image.executeOnImageAtSizeBestFittingSize(imageAtSize -> {
+		drawImage(imageAtSize, 0, 0, imageAtSize.width, imageAtSize.height, destX, destY, destWidth, destHeight, false);
+	}, destWidth, destHeight);
 }
 
 void drawImage(Image srcImage, int srcX, int srcY, int srcWidth, int srcHeight, int destX, int destY, int destWidth, int destHeight, boolean simple) {

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_GC.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_GC.java
@@ -54,7 +54,7 @@ import org.eclipse.swt.widgets.Shell;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -442,7 +442,7 @@ public void test_drawImageLorg_eclipse_swt_graphics_ImageIIII_ImageDataProvider(
 }
 
 @Test
-@EnabledOnOs(value = OS.WINDOWS)
+@DisabledOnOs(value = OS.LINUX)
 public void test_drawImageLorg_eclipse_swt_graphics_ImageIIII_ImageDataAtSizeProvider_invalid() {
 	ImageDataAtSizeProvider provider = new ImageDataAtSizeProvider() {
 		@Override
@@ -469,7 +469,7 @@ public void test_drawImageLorg_eclipse_swt_graphics_ImageIIII_ImageDataAtSizePro
 
 @ParameterizedTest
 @ValueSource(ints = {SWT.IMAGE_COPY, SWT.IMAGE_DISABLE, SWT.IMAGE_GRAY, -1})
-@EnabledOnOs(value = OS.WINDOWS)
+@DisabledOnOs(value = OS.LINUX)
 public void test_drawImageLorg_eclipse_swt_graphics_ImageIIII_ImageDataAtSizeProvider(int styleFlag) {
 	int width = 50;
 	int height = 70;


### PR DESCRIPTION
With the support of SVGs and the addition of the ImageDataAtSizeProvider, it is possible for many Image instances to provide a handle that represents the image at sharply rendered specific size in addition to the existing support of providing an image at different zooms of a base size.

This change adds according support to the MacOS implementations of GC and Image. The GC#drawImage() method accepting only destination position and size now makes use of enhanced Image capabilities to load the image at the desired size if possible instead of just using the best fitting zoomed handle.

Can be tested with the snippets provided for the Windows implementation PR:
- https://github.com/eclipse-platform/eclipse.platform.swt/pull/2526