### PR TITLE
Replace File Extension based on user selection

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/FileDialog.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/FileDialog.java
@@ -144,7 +144,12 @@ private NSString appendSelectedExtension (NSString filename) {
 		NSString ext = filename.pathExtension();
 		if (ext == null || ext.length() == 0) {
 			filename = filename.stringByAppendingPathExtension(NSString.stringWith(extension));
-		}
+		}else if (!ext.getString().equalsIgnoreCase(extension)) {
+        	NSString originalName = filename.stringByDeletingPathExtension();
+        	NSString newFilename = originalName.stringByAppendingPathExtension(NSString.stringWith(extension));
+        	filename = newFilename;
+
+    }
 	}
 	return filename;
 }


### PR DESCRIPTION
Refs: https://github.com/eclipse-platform/eclipse.platform.swt/issues/2566

Fix file extension in macOS

Previously, the FileDialog would only append the selected file extension if there is no extension attached to the filename. However, if the filename already had an extension, it has to removed to accommodate the user input extension.
This PR updates the implementation to replace the existing extension with the user input file extension.
