### PR TITLE
 [GTK] Support loading and drawing images at desired size

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/graphics/GC.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/graphics/GC.java
@@ -913,7 +913,7 @@ public void drawImage(Image image, int destX, int destY, int destWidth, int dest
 	if (image.isDisposed()) {
 		SWT.error(SWT.ERROR_INVALID_ARGUMENT);
 	}
-	drawImage(image, 0, 0, 0, 0, destX, destY, destWidth, destHeight, false);
+	image.executeOnImageAtSize(imageAtSize -> drawImage(imageAtSize, 0, 0, 0, 0, destX, destY, destWidth, destHeight, false), destWidth, destHeight);
 }
 
 void drawImage(Image srcImage, int srcX, int srcY, int srcWidth, int srcHeight, int destX, int destY, int destWidth, int destHeight, boolean simple) {

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_GC.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_GC.java
@@ -54,8 +54,6 @@ import org.eclipse.swt.widgets.Shell;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledOnOs;
-import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -442,7 +440,6 @@ public void test_drawImageLorg_eclipse_swt_graphics_ImageIIII_ImageDataProvider(
 }
 
 @Test
-@DisabledOnOs(value = OS.LINUX)
 public void test_drawImageLorg_eclipse_swt_graphics_ImageIIII_ImageDataAtSizeProvider_invalid() {
 	ImageDataAtSizeProvider provider = new ImageDataAtSizeProvider() {
 		@Override
@@ -469,11 +466,10 @@ public void test_drawImageLorg_eclipse_swt_graphics_ImageIIII_ImageDataAtSizePro
 
 @ParameterizedTest
 @ValueSource(ints = {SWT.IMAGE_COPY, SWT.IMAGE_DISABLE, SWT.IMAGE_GRAY, -1})
-@DisabledOnOs(value = OS.LINUX)
 public void test_drawImageLorg_eclipse_swt_graphics_ImageIIII_ImageDataAtSizeProvider(int styleFlag) {
 	int width = 50;
 	int height = 70;
-	Image drawToImage = new Image(display, width, height);
+	Image drawToImage = new Image(display, new ImageData(width, height, 32, new PaletteData(0xFF0000, 0xFF00, 0xFF)));
 	GC gc = new GC(drawToImage);
 	gc.setAntialias(SWT.OFF);
 	RGB drawnRgb = new RGB(255, 255, 255);


### PR DESCRIPTION
This change introduces support for loading and drawing images at custom sizes in the GTK versions of GC and Image. The GC#drawImage() method, which  only accepts the destination position and size, now attempts to load image at the destination size in case if it is provided by ImageFilenameProvider returning svgs or if the image is created with a imageDataAtSizeProvider.


Changes can be tested with snippets in #2526 for svgs and the tests with image dataAtSize provider which are enabled for linux along with this PR