### PR TITLE
Add a SWTTest Junit extension to allow tests executed in the UI thread

### DIFF
--- a/binaries/.classpath_cocoa
+++ b/binaries/.classpath_cocoa
@@ -30,4 +30,5 @@
     <classpathentry kind="src" path="Eclipse SWT OpenGL/cocoa"/>
     <classpathentry kind="src" path="Eclipse SWT OpenGL/common"/>
     <classpathentry kind="output" path="bin"/>
+    <classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 </classpath>

--- a/binaries/.classpath_gtk
+++ b/binaries/.classpath_gtk
@@ -32,4 +32,5 @@
 	<classpathentry kind="src" path="Eclipse SWT OpenGL/common"/>
 	<classpathentry kind="src" path="Eclipse SWT WebKit/gtk"/>
 	<classpathentry kind="output" path="bin"/>
+	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 </classpath>

--- a/binaries/.classpath_win32
+++ b/binaries/.classpath_win32
@@ -32,4 +32,5 @@
 	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/5"/>
 	<classpathentry kind="output" path="bin"/>
+	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 </classpath>

--- a/binaries/org.eclipse.swt.gtk.linux.x86_64/build.properties
+++ b/binaries/org.eclipse.swt.gtk.linux.x86_64/build.properties
@@ -43,6 +43,8 @@ source.. = \
 	../../bundles/org.eclipse.swt/Eclipse SWT WebKit/gtk
 output.. = bin/
 
+jars.extra.classpath = platform:/plugin/junit-jupiter-api
+
 pom.model.property.os=linux
 pom.model.property.ws=gtk
 pom.model.property.arch=x86_64

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/test/SWTTest.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/test/SWTTest.java
@@ -1,0 +1,64 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Christoph Läubrich and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.swt.test;
+
+import java.lang.reflect.*;
+
+import org.eclipse.pde.api.tools.annotations.*;
+import org.eclipse.swt.widgets.*;
+import org.junit.jupiter.api.extension.*;
+
+/**
+ * The {@link SWTTest} is an extension that can be using in JUnit Platform
+ * Runners as an extension to execute the test code in the default display
+ * thread.
+ * <p>
+ * <b>Usage: </b>You would never use this in any client code but when writing a
+ * test for the JUnit Platform like in this example:
+ * </p>
+ * <p>
+ * <pre>
+ * &#64;ExtendWith(SWTTest.class)
+ * public class MyTestThaRequireUI {
+ *
+ * }
+ * </pre>
+ * </p>
+ */
+@NoInstantiate
+public final class SWTTest implements InvocationInterceptor {
+
+	@Override
+	public void interceptTestMethod(Invocation<Void> invocation, ReflectiveInvocationContext<Method> invocationContext,
+			ExtensionContext extensionContext) throws Throwable {
+
+		if (Display.getCurrent() == null) {
+			invocation.proceed();
+		} else {
+			Throwable[] throwable = new Throwable[1];
+			Display.getDefault().syncExec(() -> {
+				try {
+					invocation.proceed();
+				} catch (Throwable t) {
+					throwable[0] = t;
+				}
+
+			});
+			Throwable t = throwable[0];
+			if (t != null) {
+				throw t;
+			}
+		}
+	}
+}

--- a/bundles/org.eclipse.swt/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.swt/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-SymbolicName: org.eclipse.swt; singleton:=true
 Bundle-Version: 3.132.0.qualifier
 Bundle-ManifestVersion: 2
 Bundle-Localization: plugin
-DynamicImport-Package: org.eclipse.swt.accessibility2
+DynamicImport-Package: org.eclipse.swt.accessibility2,org.junit.jupiter.api.extension.*
 Export-Package: 
  org.eclipse.swt,
  org.eclipse.swt.accessibility,


### PR DESCRIPTION
Currently we require SWT-UI based tests to be executed by special runners known as the 'UIHarness' to be run in the UI thread, what has several problems:

1) is requires usually to fire up a whole workbench (and a workspace) 2) the whole testsuite has to run in the UI thread 3) no way to customize this further
4) actually this is nothing that belongs into the test framework

This now adds a new SWTTest JUnit extension that allows to mark a test class with an extension and get your methods executed in the UI thread.