### PR TITLE
[win32] Always reset cached current DPIChangeEvent

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Control.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Control.java
@@ -5940,13 +5940,13 @@ void sendZoomChangedEvent(Event event, Shell shell) {
 					notifyListeners(SWT.ZoomChanged, event);
 				}
 			} finally {
+				if (event == currentDpiChangeEvent) {
+					currentDpiChangeEvent = null;
+				}
 				if (shell.isDisposed()) {
 					return;
 				}
 				if (dpiExecData.decrement()) {
-					if (event == currentDpiChangeEvent) {
-						currentDpiChangeEvent = null;
-					}
 					if (event.doit) {
 						shell.WM_SIZE(0, 0);
 					}


### PR DESCRIPTION
This PR ensures to always reset the currently cached DPIChangeEvent of a Control in any case. Otherwise spawning dpi change events for multiple Controls that are related via parent->child hierarchy could lead to a currentDpiChangeEvent of the parent being canceled by the creation of the event of the child.

So, as as example: there is Composite A and B and A is the parent of B. Now an asynchronous DPI change event for A is created because A is added to a new parent, now the same is done for B while the first event is already propagated the cached event for B could be already there and will be canceled when adding the second event which will cancel further processing. Therefor it is important wo always nullify `Control#currentDpiChangeEvent` after the event for a Control is processed and not only when it is the final `Control`

This fixes the effect in https://github.com/eclipse-platform/eclipse.platform.swt/issues/2608#issuecomment-3400547868.
It can be reproduced in the runtime for me, by moving it to the secondary monitor - primary and secondary must have different zooms of course.