### PR TITLE
Automatic refactoring: move Win32DPIUtils.pointToPixel(size,zoom) to DPIUtil

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Browser/win32/org/eclipse/swt/browser/Edge.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Browser/win32/org/eclipse/swt/browser/Edge.java
@@ -1323,8 +1323,8 @@ int handleContextMenuRequested(long pView, long pArgs) {
 	//   to PIXEL coordinates with the real native zoom value
 	//   independent from the swt.autoScale property:
 	Point pt = new Point( //
-			Win32DPIUtils.pointToPixel(win32Point.x, DPIUtil.getNativeDeviceZoom()), //
-			Win32DPIUtils.pointToPixel(win32Point.y, DPIUtil.getNativeDeviceZoom()));
+			DPIUtil.pointToPixel(win32Point.x, DPIUtil.getNativeDeviceZoom()), //
+			DPIUtil.pointToPixel(win32Point.y, DPIUtil.getNativeDeviceZoom()));
 	// - then, scale back down from PIXEL to DISPLAY coordinates, taking
 	//   swt.autoScale property into account
 	//   which is also later considered in Menu#setLocation()

--- a/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/win32/org/eclipse/swt/dnd/DragSource.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/win32/org/eclipse/swt/dnd/DragSource.java
@@ -538,8 +538,8 @@ private void drag(Event dragEvent) {
 		int flags = OS.RDW_UPDATENOW | OS.RDW_ALLCHILDREN;
 		OS.RedrawWindow (topControl.handle, null, 0, flags);
 		POINT pt = new POINT ();
-		pt.x = Win32DPIUtils.pointToPixel(dragEvent.x, zoom);// To Pixels
-		pt.y = Win32DPIUtils.pointToPixel(dragEvent.y, zoom);// To Pixels
+		pt.x = DPIUtil.pointToPixel(dragEvent.x, zoom);// To Pixels
+		pt.y = DPIUtil.pointToPixel(dragEvent.y, zoom);// To Pixels
 		OS.MapWindowPoints (control.handle, 0, pt, 1);
 		RECT rect = new RECT ();
 		OS.GetWindowRect (hwndDrag, rect);

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/DPIUtil.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/DPIUtil.java
@@ -24,15 +24,6 @@ import org.eclipse.swt.graphics.*;
 /**
  * This class hold common constants and utility functions w.r.t. to SWT high DPI
  * functionality.
- * <p>
- * The {@code autoScaleUp(..)} methods convert from API coordinates (in
- * SWT points) to internal high DPI coordinates (in pixels) that interface with
- * native widgets.
- * </p>
- * <p>
- * The {@code autoScaleDown(..)} convert from high DPI pixels to API coordinates
- * (in SWT points).
- * </p>
  *
  * @since 3.105
  */
@@ -255,6 +246,12 @@ public static void validateLinearScaling(ImageDataProvider provider) {
 				baseImageData.width, baseImageData.height, scaledImageData.width, scaledImageData.height));
 		new Error().printStackTrace(System.err);
 	}
+}
+
+public static int pointToPixel(int size, int zoom) {
+	if (zoom == 100 || size == SWT.DEFAULT) return size;
+	float scaleFactor = getScalingFactor(zoom);
+	return Math.round (size * scaleFactor);
 }
 
 /**

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Cursor.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Cursor.java
@@ -598,11 +598,11 @@ private static abstract class HotspotAwareCursorHandleProvider implements Cursor
 	}
 
 	protected final int getHotpotXInPixels(int zoom) {
-		return Win32DPIUtils.pointToPixel(hotspotX, zoom);
+		return DPIUtil.pointToPixel(hotspotX, zoom);
 	}
 
 	protected final int getHotpotYInPixels(int zoom) {
-		return Win32DPIUtils.pointToPixel(hotspotY, zoom);
+		return DPIUtil.pointToPixel(hotspotY, zoom);
 	}
 
 	protected static final void validateHotspotInsideImage(ImageData source, int hotspotX, int hotspotY) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Image.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Image.java
@@ -2320,8 +2320,8 @@ private class PlainImageProviderWrapper extends AbstractImageProviderWrapper {
 
 	private long initHandle(int zoom) {
 		if (isDisposed()) SWT.error(SWT.ERROR_GRAPHIC_DISPOSED);
-		int scaledWidth = Win32DPIUtils.pointToPixel (width, zoom);
-		int scaledHeight = Win32DPIUtils.pointToPixel (height, zoom);
+		int scaledWidth = DPIUtil.pointToPixel (width, zoom);
+		int scaledHeight = DPIUtil.pointToPixel (height, zoom);
 		long hDC = device.internal_new_GC(null);
 		long newHandle = OS.CreateCompatibleBitmap(hDC, scaledWidth, scaledHeight);
 		/*
@@ -2752,8 +2752,8 @@ private class ImageGcDrawerWrapper extends DynamicImageProviderWrapper {
 		int gcStyle = drawer.getGcStyle();
 		Image image;
 		if ((gcStyle & SWT.TRANSPARENT) != 0) {
-			int scaledHeight = Win32DPIUtils.pointToPixel(height, targetZoom);
-			int scaledWidth = Win32DPIUtils.pointToPixel(width, targetZoom);
+			int scaledHeight = DPIUtil.pointToPixel(height, targetZoom);
+			int scaledWidth = DPIUtil.pointToPixel(width, targetZoom);
 			/* Create a 24 bit image data with alpha channel */
 			final ImageData resultData = new ImageData (scaledWidth, scaledHeight, 24, new PaletteData (0xFF, 0xFF00, 0xFF0000));
 			resultData.alphaData = new byte [scaledWidth * scaledHeight];

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Region.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Region.java
@@ -202,8 +202,8 @@ public boolean contains (int x, int y) {
 	if (isDisposed()) SWT.error(SWT.ERROR_GRAPHIC_DISPOSED);
 	return applyUsingAnyHandle(regionHandle -> {
 		int zoom = regionHandle.zoom();
-		int xInPixels = Win32DPIUtils.pointToPixel(x, zoom);
-		int yInPixels = Win32DPIUtils.pointToPixel(y, zoom);
+		int xInPixels = DPIUtil.pointToPixel(x, zoom);
+		int yInPixels = DPIUtil.pointToPixel(y, zoom);
 		return containsInPixels(regionHandle.handle(), xInPixels, yInPixels);
 	});
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/TextLayout.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/TextLayout.java
@@ -379,9 +379,9 @@ void computeRuns (GC gc) {
 	}
 	SCRIPT_LOGATTR logAttr = new SCRIPT_LOGATTR();
 	SCRIPT_PROPERTIES properties = new SCRIPT_PROPERTIES();
-	int wrapIndentInPixels = Win32DPIUtils.pointToPixel(wrapIndent, getZoom(gc));
-	int indentInPixels = Win32DPIUtils.pointToPixel(indent, getZoom(gc));
-	int wrapWidthInPixels = Win32DPIUtils.pointToPixel(wrapWidth, getZoom(gc));
+	int wrapIndentInPixels = DPIUtil.pointToPixel(wrapIndent, getZoom(gc));
+	int indentInPixels = DPIUtil.pointToPixel(indent, getZoom(gc));
+	int wrapWidthInPixels = DPIUtil.pointToPixel(wrapWidth, getZoom(gc));
 	int[] tabsInPixels = Win32DPIUtils.pointToPixel(tabs, getZoom(gc));
 	int lineWidth = indentInPixels, lineStart = 0, lineCount = 1;
 	for (int i=0; i<allRuns.length - 1; i++) {
@@ -1896,8 +1896,8 @@ Rectangle getBoundsInPixels (int start, int end) {
 		}
 		left = Math.min(left, runLead);
 		right = Math.max(right, runTrail);
-		top = Math.min(top, Win32DPIUtils.pointToPixel(lineY[lineIndex], getZoom(null)));
-		bottom = Math.max(bottom, Win32DPIUtils.pointToPixel(lineY[lineIndex + 1] - lineSpacingInPoints, getZoom(null)));
+		top = Math.min(top, DPIUtil.pointToPixel(lineY[lineIndex], getZoom(null)));
+		bottom = Math.max(bottom, DPIUtil.pointToPixel(lineY[lineIndex + 1] - lineSpacingInPoints, getZoom(null)));
 	}
 	return new Rectangle(left, top, right - left, bottom - top + getScaledVerticalIndent());
 }
@@ -2057,14 +2057,14 @@ int getLineIndent(int lineIndex) {
 }
 
 int getLineIndentInPixel (int lineIndex) {
-	int lineIndent = Win32DPIUtils.pointToPixel(wrapIndent, getZoom());
+	int lineIndent = DPIUtil.pointToPixel(wrapIndent, getZoom());
 	if (lineIndex == 0) {
-		lineIndent = Win32DPIUtils.pointToPixel(indent, getZoom());
+		lineIndent = DPIUtil.pointToPixel(indent, getZoom());
 	} else {
 		StyleItem[] previousLine = runs[lineIndex - 1];
 		StyleItem previousRun = previousLine[previousLine.length - 1];
 		if (previousRun.lineBreak && !previousRun.softBreak) {
-			lineIndent = Win32DPIUtils.pointToPixel(indent, getZoom());
+			lineIndent = DPIUtil.pointToPixel(indent, getZoom());
 		}
 	}
 	if (wrapWidth != -1) {
@@ -2078,8 +2078,8 @@ int getLineIndentInPixel (int lineIndex) {
 		if (partialLine) {
 			int lineWidth = this.lineWidthInPixels[lineIndex] + lineIndent;
 			switch (alignment) {
-				case SWT.CENTER: lineIndent += (Win32DPIUtils.pointToPixel(wrapWidth, getZoom()) - lineWidth) / 2; break;
-				case SWT.RIGHT: lineIndent += Win32DPIUtils.pointToPixel(wrapWidth, getZoom()) - lineWidth; break;
+				case SWT.CENTER: lineIndent += (DPIUtil.pointToPixel(wrapWidth, getZoom()) - lineWidth) / 2; break;
+				case SWT.RIGHT: lineIndent += DPIUtil.pointToPixel(wrapWidth, getZoom()) - lineWidth; break;
 			}
 		}
 	}

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/ImageList.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/ImageList.java
@@ -337,8 +337,8 @@ public int getStyle () {
 
 public long getHandle(int targetZoom) {
 	if (!zoomToHandle.containsKey(targetZoom)) {
-		int scaledWidth = Win32DPIUtils.pointToPixel(DPIUtil.pixelToPoint(width, this.zoom), targetZoom);
-		int scaledHeight = Win32DPIUtils.pointToPixel(DPIUtil.pixelToPoint(height, this.zoom), targetZoom);
+		int scaledWidth = DPIUtil.pointToPixel(DPIUtil.pixelToPoint(width, this.zoom), targetZoom);
+		int scaledHeight = DPIUtil.pointToPixel(DPIUtil.pixelToPoint(height, this.zoom), targetZoom);
 		long newImageListHandle = OS.ImageList_Create(scaledWidth, scaledHeight, flags, 16, 16);
 		int count = OS.ImageList_GetImageCount (handle);
 		for (int i = 0; i < count; i++) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/Win32DPIUtils.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/Win32DPIUtils.java
@@ -207,18 +207,9 @@ public class Win32DPIUtils {
 		return pointToPixel (pointArray, zoom);
 	}
 
-	/**
-	 * Auto-scale up int dimensions to match the given zoom level
-	 */
-	public static int pointToPixel(int size, int zoom) {
-		if (zoom == 100 || size == SWT.DEFAULT) return size;
-		float scaleFactor = DPIUtil.getScalingFactor(zoom);
-		return Math.round (size * scaleFactor);
-	}
-
 	public static int pointToPixel(Drawable drawable, int size, int zoom) {
 		if (drawable != null && !drawable.isAutoScalable()) return size;
-		return pointToPixel (size, zoom);
+		return DPIUtil.pointToPixel (size, zoom);
 	}
 
 	public static float pointToPixel(float size, int zoom) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Button.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Button.java
@@ -360,10 +360,10 @@ int computeLeftMargin () {
 					Rectangle rect = Win32DPIUtils.scaleBounds(image.getBounds(), this.getZoom(), 100);
 					width = rect.width;
 					if (hasText && text.length () != 0) {
-						width += Win32DPIUtils.pointToPixel(MARGIN * 2, getZoom());;
+						width += DPIUtil.pointToPixel(MARGIN * 2, getZoom());;
 					}
 					height = rect.height;
-					extra = Win32DPIUtils.pointToPixel(MARGIN * 2, getZoom());;
+					extra = DPIUtil.pointToPixel(MARGIN * 2, getZoom());;
 				}
 			}
 			if (hasText) {
@@ -377,7 +377,7 @@ int computeLeftMargin () {
 				if (length == 0) {
 					height = Math.max (height, lptm.tmHeight);
 				} else {
-					extra = Math.max (Win32DPIUtils.pointToPixel(MARGIN * 2, getZoom()), lptm.tmAveCharWidth);
+					extra = Math.max (DPIUtil.pointToPixel(MARGIN * 2, getZoom()), lptm.tmAveCharWidth);
 					char [] buffer = text.toCharArray ();
 					RECT rect = new RECT ();
 					int flags = OS.DT_CALCRECT | OS.DT_SINGLELINE;
@@ -1313,7 +1313,7 @@ private int getCheckboxTextOffset(long hdc) {
 		OS.GetThemePartSize(display.hButtonTheme(nativeZoom), hdc, OS.BP_CHECKBOX, OS.CBS_UNCHECKEDNORMAL, null, OS.TS_TRUE, size);
 		result += size.cx;
 	} else {
-		result += Win32DPIUtils.pointToPixel(13, nativeZoom);
+		result += DPIUtil.pointToPixel(13, nativeZoom);
 	}
 
 	// Windows uses half width of '0' as checkbox-to-text distance.

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Canvas.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Canvas.java
@@ -198,8 +198,8 @@ void reskinChildren (int flags) {
 public void scroll (int destX, int destY, int x, int y, int width, int height, boolean all) {
 	checkWidget ();
 	int zoom = getZoom();
-	destX = Win32DPIUtils.pointToPixel(destX, zoom);
-	destY = Win32DPIUtils.pointToPixel(destY, zoom);
+	destX = DPIUtil.pointToPixel(destX, zoom);
+	destY = DPIUtil.pointToPixel(destY, zoom);
 	Rectangle rectangle = Win32DPIUtils.pointToPixel(new Rectangle(x, y, width, height), zoom);
 	scrollInPixels(destX, destY, rectangle.x, rectangle.y, rectangle.width, rectangle.height, all);
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Caret.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Caret.java
@@ -140,7 +140,7 @@ private OptionalInt getSystemCaretWidthInPixelsForCurrentMonitor() {
 	int [] buffer = new int [1];
 	if (OS.SystemParametersInfo (OS.SPI_GETCARETWIDTH, 0, buffer, 0)) {
 		int width = DPIUtil.pixelToPoint(buffer [0], Win32DPIUtils.getPrimaryMonitorZoomAtStartup());
-		int widthInPixels = Win32DPIUtils.pointToPixel(width, getNativeZoom());
+		int widthInPixels = DPIUtil.pointToPixel(width, getNativeZoom());
 		return OptionalInt.of(widthInPixels);
 	}
 	return OptionalInt.empty();
@@ -241,19 +241,19 @@ Point getSizeInPixels () {
 }
 
 private int getWidthInPixels() {
-	return Win32DPIUtils.pointToPixel(width, getZoom());
+	return DPIUtil.pointToPixel(width, getZoom());
 }
 
 private int getHeightInPixels() {
-	return Win32DPIUtils.pointToPixel(height, getZoom());
+	return DPIUtil.pointToPixel(height, getZoom());
 }
 
 private int getXInPixels() {
-	return Win32DPIUtils.pointToPixel(x, getZoom());
+	return DPIUtil.pointToPixel(x, getZoom());
 }
 
 private int getYInPixels() {
-	return Win32DPIUtils.pointToPixel(y, getZoom());
+	return DPIUtil.pointToPixel(y, getZoom());
 }
 
 /**

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Composite.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Composite.java
@@ -353,8 +353,8 @@ public void drawBackground (GC gc, int x, int y, int width, int height, int offs
 	checkWidget ();
 	int zoom = getZoom();
 	Rectangle rectangle = Win32DPIUtils.pointToPixel(new Rectangle(x, y, width, height), zoom);
-	offsetX = Win32DPIUtils.pointToPixel(offsetX, zoom);
-	offsetY = Win32DPIUtils.pointToPixel(offsetY, zoom);
+	offsetX = DPIUtil.pointToPixel(offsetX, zoom);
+	offsetY = DPIUtil.pointToPixel(offsetY, zoom);
 	drawBackgroundInPixels(gc, rectangle.x, rectangle.y, rectangle.width, rectangle.height, offsetX, offsetY);
 }
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Control.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Control.java
@@ -619,8 +619,8 @@ public Point computeSize (int wHint, int hHint) {
 public Point computeSize (int wHint, int hHint, boolean changed){
 	checkWidget ();
 	int zoom = getZoom();
-	wHint = (wHint != SWT.DEFAULT ? Win32DPIUtils.pointToPixel(wHint, zoom) : wHint);
-	hHint = (hHint != SWT.DEFAULT ? Win32DPIUtils.pointToPixel(hHint, zoom) : hHint);
+	wHint = (wHint != SWT.DEFAULT ? DPIUtil.pointToPixel(wHint, zoom) : wHint);
+	hHint = (hHint != SWT.DEFAULT ? DPIUtil.pointToPixel(hHint, zoom) : hHint);
 	//We should never return a size that is to small, RoundingMode.UP ensures we at worst case report
 	//a size that is a bit too large by half a point
 	return Win32DPIUtils.pixelToPointAsSize(computeSizeInPixels(wHint, hHint, changed), zoom);
@@ -785,7 +785,7 @@ public boolean dragDetect (Event event) {
 	if (event == null) error (SWT.ERROR_NULL_ARGUMENT);
 	Point loc = event.getLocation();
 	int zoom = getZoom();
-	return dragDetect (event.button, event.count, event.stateMask, Win32DPIUtils.pointToPixel(loc.x, zoom), Win32DPIUtils.pointToPixel(loc.y, zoom));
+	return dragDetect (event.button, event.count, event.stateMask, DPIUtil.pointToPixel(loc.x, zoom), DPIUtil.pointToPixel(loc.y, zoom));
 }
 
 /**
@@ -828,7 +828,7 @@ public boolean dragDetect (MouseEvent event) {
 	checkWidget ();
 	if (event == null) error (SWT.ERROR_NULL_ARGUMENT);
 	int zoom = getZoom();
-	return dragDetect (event.button, event.count, event.stateMask, Win32DPIUtils.pointToPixel(event.x, zoom), Win32DPIUtils.pointToPixel(event.y, zoom)); // To Pixels
+	return dragDetect (event.button, event.count, event.stateMask, DPIUtil.pointToPixel(event.x, zoom), DPIUtil.pointToPixel(event.y, zoom)); // To Pixels
 }
 
 boolean dragDetect (int button, int count, int stateMask, int x, int y) {
@@ -2000,8 +2000,8 @@ void mapEvent (long hwnd, Event event) {
 		POINT point = new POINT ();
 		Point loc = event.getLocation();
 		int zoom = getZoom();
-		point.x = Win32DPIUtils.pointToPixel(loc.x, zoom);
-		point.y = Win32DPIUtils.pointToPixel(loc.y, zoom);
+		point.x = DPIUtil.pointToPixel(loc.x, zoom);
+		point.y = DPIUtil.pointToPixel(loc.y, zoom);
 		OS.MapWindowPoints (hwnd, handle, point, 1);
 		event.setLocation(DPIUtil.pixelToPoint(point.x, zoom), DPIUtil.pixelToPoint(point.y, zoom));
 	}
@@ -3535,8 +3535,8 @@ public void setLayoutData (Object layoutData) {
 public void setLocation (int x, int y) {
 	checkWidget ();
 	int zoom = getZoom();
-	x = Win32DPIUtils.pointToPixel(x, zoom);
-	y = Win32DPIUtils.pointToPixel(y, zoom);
+	x = DPIUtil.pointToPixel(x, zoom);
+	y = DPIUtil.pointToPixel(y, zoom);
 	setLocationInPixels(x, y);
 }
 
@@ -3792,8 +3792,8 @@ public void setRegion (Region region) {
 public void setSize (int width, int height) {
 	checkWidget ();
 	int zoom = getZoom();
-	width = Win32DPIUtils.pointToPixel(width, zoom);
-	height = Win32DPIUtils.pointToPixel(height, zoom);
+	width = DPIUtil.pointToPixel(width, zoom);
+	height = DPIUtil.pointToPixel(height, zoom);
 	setSizeInPixels(width, height);
 }
 
@@ -4102,7 +4102,7 @@ public Point toControl (Point point) {
 public Point toDisplay (int x, int y) {
 	checkWidget ();
 	int zoom = getZoom();
-	Point displayPointInPixels = toDisplayInPixels(Win32DPIUtils.pointToPixel(x, zoom), Win32DPIUtils.pointToPixel(y, zoom));
+	Point displayPointInPixels = toDisplayInPixels(DPIUtil.pointToPixel(x, zoom), DPIUtil.pointToPixel(y, zoom));
 	return getDisplay().translateFromDisplayCoordinates(displayPointInPixels);
 }
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/CoolBar.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/CoolBar.java
@@ -411,7 +411,7 @@ int getMargin (int index) {
 	}
 	if ((style & SWT.FLAT) == 0) {
 		if (!isLastItemOfRow (index)) {
-			margin += Win32DPIUtils.pointToPixel(SEPARATOR_WIDTH, getZoom());
+			margin += DPIUtil.pointToPixel(SEPARATOR_WIDTH, getZoom());
 		}
 	}
 	return margin;

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/CoolItem.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/CoolItem.java
@@ -186,8 +186,8 @@ protected void checkSubclass () {
 public Point computeSize (int wHint, int hHint) {
 	checkWidget ();
 	int zoom = getZoom();
-	wHint = (wHint != SWT.DEFAULT ? Win32DPIUtils.pointToPixel(wHint, zoom) : wHint);
-	hHint = (hHint != SWT.DEFAULT ? Win32DPIUtils.pointToPixel(hHint, zoom) : hHint);
+	wHint = (wHint != SWT.DEFAULT ? DPIUtil.pointToPixel(wHint, zoom) : wHint);
+	hHint = (hHint != SWT.DEFAULT ? DPIUtil.pointToPixel(hHint, zoom) : hHint);
 	return Win32DPIUtils.pixelToPointAsSize(computeSizeInPixels(wHint, hHint), zoom);
 }
 Point computeSizeInPixels (int wHint, int hHint) {
@@ -415,7 +415,7 @@ Point getPreferredSizeInPixels () {
 public void setPreferredSize (int width, int height) {
 	checkWidget ();
 	int zoom = getZoom();
-	setPreferredSizeInPixels(Win32DPIUtils.pointToPixel(width, zoom), Win32DPIUtils.pointToPixel(height, zoom));
+	setPreferredSizeInPixels(DPIUtil.pointToPixel(width, zoom), DPIUtil.pointToPixel(height, zoom));
 }
 
 void setPreferredSizeInPixels (int width, int height) {
@@ -526,7 +526,7 @@ Point getSizeInPixels() {
 public void setSize (int width, int height) {
 	checkWidget ();
 	int zoom = getZoom();
-	setSizeInPixels(Win32DPIUtils.pointToPixel(width, zoom), Win32DPIUtils.pointToPixel(height, zoom));
+	setSizeInPixels(DPIUtil.pointToPixel(width, zoom), DPIUtil.pointToPixel(height, zoom));
 }
 
 void setSizeInPixels (int width, int height) {
@@ -645,7 +645,7 @@ Point getMinimumSizeInPixels () {
 public void setMinimumSize (int width, int height) {
 	checkWidget ();
 	int zoom = getZoom();
-	setMinimumSizeInPixels(Win32DPIUtils.pointToPixel(width, zoom), Win32DPIUtils.pointToPixel(height, zoom));
+	setMinimumSizeInPixels(DPIUtil.pointToPixel(width, zoom), DPIUtil.pointToPixel(height, zoom));
 }
 
 void setMinimumSizeInPixels (int width, int height) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Display.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Display.java
@@ -2057,7 +2057,7 @@ ImageList getImageList (int style, int width, int height, int zoom) {
 		imageList = newList;
 	}
 
-	ImageList list = new ImageList (style, Win32DPIUtils.pointToPixel(width, zoom), Win32DPIUtils.pointToPixel(height, zoom), zoom);
+	ImageList list = new ImageList (style, DPIUtil.pointToPixel(width, zoom), DPIUtil.pointToPixel(height, zoom), zoom);
 	imageList [i] = list;
 	list.addRef();
 	return list;
@@ -2087,7 +2087,7 @@ ImageList getImageListToolBar (int style, int width, int height, int zoom) {
 		toolImageList = newList;
 	}
 
-	ImageList list = new ImageList (style, Win32DPIUtils.pointToPixel(width, zoom), Win32DPIUtils.pointToPixel(height, zoom), zoom);
+	ImageList list = new ImageList (style, DPIUtil.pointToPixel(width, zoom), DPIUtil.pointToPixel(height, zoom), zoom);
 	toolImageList [i] = list;
 	list.addRef();
 	return list;
@@ -2117,7 +2117,7 @@ ImageList getImageListToolBarDisabled (int style, int width, int height, int zoo
 		toolDisabledImageList = newList;
 	}
 
-	ImageList list = new ImageList (style, Win32DPIUtils.pointToPixel(width, zoom), Win32DPIUtils.pointToPixel(height, zoom), zoom);
+	ImageList list = new ImageList (style, DPIUtil.pointToPixel(width, zoom), DPIUtil.pointToPixel(height, zoom), zoom);
 	toolDisabledImageList [i] = list;
 	list.addRef();
 	return list;
@@ -2147,7 +2147,7 @@ ImageList getImageListToolBarHot (int style, int width, int height, int zoom) {
 		toolHotImageList = newList;
 	}
 
-	ImageList list = new ImageList (style, Win32DPIUtils.pointToPixel(width, zoom), Win32DPIUtils.pointToPixel(height, zoom), zoom);
+	ImageList list = new ImageList (style, DPIUtil.pointToPixel(width, zoom), DPIUtil.pointToPixel(height, zoom), zoom);
 	toolHotImageList [i] = list;
 	list.addRef();
 	return list;
@@ -2604,7 +2604,7 @@ public Image getSystemImage (int id) {
 
 private ImageDataProvider getImageDataProviderForIcon(int iconName) {
 	return zoom -> {
-		int scaledIconSize = Win32DPIUtils.pointToPixel(ICON_SIZE_AT_100, zoom);
+		int scaledIconSize = DPIUtil.pointToPixel(ICON_SIZE_AT_100, zoom);
 		long [] hIcon = new long [1];
 		OS.LoadIconWithScaleDown(0, iconName, scaledIconSize, scaledIconSize, hIcon);
 		Image image = Image.win32_new (this, SWT.ICON, hIcon[0], zoom);

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ExpandBar.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ExpandBar.java
@@ -557,7 +557,7 @@ void setScrollbar () {
  */
 public void setSpacing (int spacing) {
 	checkWidget ();
-	setSpacingInPixels(Win32DPIUtils.pointToPixel(spacing, getZoom()));
+	setSpacingInPixels(DPIUtil.pointToPixel(spacing, getZoom()));
 }
 
 void setSpacingInPixels (int spacing) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ExpandItem.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ExpandItem.java
@@ -182,8 +182,8 @@ void drawItem (GC gc, long hTheme, RECT clipRect, boolean drawFocus) {
 	long hDC = gc.handle;
 	int headerHeightinPixels = getHeaderHeightInPixels();
 	int zoom = getZoom();
-	int imageHeightInPixels = Win32DPIUtils.pointToPixel(imageHeight, zoom);
-	int imageWidthInPixels = Win32DPIUtils.pointToPixel(imageWidth, zoom);
+	int imageHeightInPixels = DPIUtil.pointToPixel(imageHeight, zoom);
+	int imageWidthInPixels = DPIUtil.pointToPixel(imageWidth, zoom);
 
 	RECT rect = new RECT ();
 	OS.SetRect (rect, x, y, x + width, y + headerHeightinPixels);
@@ -307,7 +307,7 @@ public int getHeaderHeight () {
 
 int getHeaderHeightInPixels () {
 	int headerHeightInPixels = parent.getBandHeight();
-	int imageHeightInPixels = Win32DPIUtils.pointToPixel(imageHeight, getZoom());
+	int imageHeightInPixels = DPIUtil.pointToPixel(imageHeight, getZoom());
 	int imageHeaderDiff = headerHeightInPixels - imageHeightInPixels;
 	if (imageHeaderDiff < IMAGE_MARGIN) {
 		headerHeightInPixels = imageHeightInPixels + IMAGE_MARGIN;
@@ -376,8 +376,8 @@ void redraw (boolean all) {
 	long parentHandle = parent.handle;
 	int headerHeightInPixels = getHeaderHeightInPixels();
 	int zoom = getZoom();
-	int imageHeightInPixels = Win32DPIUtils.pointToPixel(imageHeight, zoom);
-	int imageWidthInPixels = Win32DPIUtils.pointToPixel(imageWidth, zoom);
+	int imageHeightInPixels = DPIUtil.pointToPixel(imageHeight, zoom);
+	int imageWidthInPixels = DPIUtil.pointToPixel(imageWidth, zoom);
 	RECT rect = new RECT ();
 	int left = all ? x : x + width - headerHeightInPixels;
 	OS.SetRect (rect, left, y, x + width, y + headerHeightInPixels);
@@ -492,7 +492,7 @@ public void setExpanded (boolean expanded) {
  */
 public void setHeight (int height) {
 	checkWidget ();
-	setHeightInPixels(Win32DPIUtils.pointToPixel(height, getZoom()));
+	setHeightInPixels(DPIUtil.pointToPixel(height, getZoom()));
 }
 
 void setHeightInPixels (int height) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/MenuItem.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/MenuItem.java
@@ -1359,7 +1359,7 @@ LRESULT wmMeasureChild (long wParam, long lParam) {
 		if (parent.needsMenuCallback()) {
 			Point point = calculateRenderedTextSize();
 			int menuZoom = getDisplay().isRescalingAtRuntime() ? super.getZoom() : getMonitorZoom();
-			struct.itemHeight = Win32DPIUtils.pointToPixel(point.y, menuZoom);
+			struct.itemHeight = DPIUtil.pointToPixel(point.y, menuZoom);
 			/*
 			 * Weirdness in Windows. Setting `HBMMENU_CALLBACK` causes
 			 * item sizes to mean something else. It seems that it is
@@ -1369,7 +1369,7 @@ LRESULT wmMeasureChild (long wParam, long lParam) {
 			 * that value of 5 works well in matching text to mnemonic.
 			 */
 			int horizontalSpaceImage = this.image != null ? this.image.getBounds().width + IMAGE_TEXT_GAP: 0;
-			struct.itemWidth = Win32DPIUtils.pointToPixel(LEFT_TEXT_MARGIN + point.x - WINDOWS_OVERHEAD + horizontalSpaceImage, menuZoom);
+			struct.itemWidth = DPIUtil.pointToPixel(LEFT_TEXT_MARGIN + point.x - WINDOWS_OVERHEAD + horizontalSpaceImage, menuZoom);
 			OS.MoveMemory (lParam, struct, MEASUREITEMSTRUCT.sizeof);
 			return null;
 		}

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/MultiZoomCoordinateSystemMapper.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/MultiZoomCoordinateSystemMapper.java
@@ -143,8 +143,8 @@ class MultiZoomCoordinateSystemMapper implements CoordinateSystemMapper {
 		monitor = getValidMonitorIfApplicable(x, y, width, height, monitor);
 		Point topLeft = getPixelsFromPoint(monitor, x, y);
 		int zoom = getApplicableMonitorZoom(monitor);
-		int widthInPixels = Win32DPIUtils.pointToPixel(width, zoom);
-		int heightInPixels = Win32DPIUtils.pointToPixel(height, zoom);
+		int widthInPixels = DPIUtil.pointToPixel(width, zoom);
+		int heightInPixels = DPIUtil.pointToPixel(height, zoom);
 		return new Rectangle(topLeft.x, topLeft.y, widthInPixels, heightInPixels);
 	}
 
@@ -204,8 +204,8 @@ class MultiZoomCoordinateSystemMapper implements CoordinateSystemMapper {
 		for (Monitor currentMonitor : monitors) {
 			// Obtain the rectangle in pixels per monitor for absolute comparison
 			Point topLeftOfRectangle = getPixelsFromPoint(currentMonitor, x, y);
-			int widthInPixels = Win32DPIUtils.pointToPixel(width, getApplicableMonitorZoom(currentMonitor));
-			int heightInPixels = Win32DPIUtils.pointToPixel(height, getApplicableMonitorZoom(currentMonitor));
+			int widthInPixels = DPIUtil.pointToPixel(width, getApplicableMonitorZoom(currentMonitor));
+			int heightInPixels = DPIUtil.pointToPixel(height, getApplicableMonitorZoom(currentMonitor));
 			Rectangle boundsInPixel = new Rectangle(topLeftOfRectangle.x, topLeftOfRectangle.y, widthInPixels, heightInPixels);
 			Rectangle clientArea = getMonitorClientAreaInPixels(currentMonitor);
 			Rectangle intersection = clientArea.intersection(boundsInPixel);
@@ -251,15 +251,15 @@ class MultiZoomCoordinateSystemMapper implements CoordinateSystemMapper {
 
 	private Rectangle getMonitorClientAreaInPixels(Monitor monitor) {
 		int zoom = getApplicableMonitorZoom(monitor);
-		int widthInPixels = Win32DPIUtils.pointToPixel(monitor.clientWidth, zoom);
-		int heightInPixels = Win32DPIUtils.pointToPixel(monitor.clientHeight, zoom);
+		int widthInPixels = DPIUtil.pointToPixel(monitor.clientWidth, zoom);
+		int heightInPixels = DPIUtil.pointToPixel(monitor.clientHeight, zoom);
 		return new Rectangle(monitor.clientX, monitor.clientY, widthInPixels, heightInPixels);
 	}
 
 	private Point getPixelsFromPoint(Monitor monitor, int x, int y) {
 		int zoom = getApplicableMonitorZoom(monitor);
-		int mappedX = Win32DPIUtils.pointToPixel(x - monitor.clientX, zoom) + monitor.clientX;
-		int mappedY = Win32DPIUtils.pointToPixel(y - monitor.clientY, zoom) + monitor.clientY;
+		int mappedX = DPIUtil.pointToPixel(x - monitor.clientX, zoom) + monitor.clientX;
+		int mappedY = DPIUtil.pointToPixel(y - monitor.clientY, zoom) + monitor.clientY;
 		return new Point(mappedX, mappedY);
 	}
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Sash.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Sash.java
@@ -332,8 +332,8 @@ LRESULT WM_LBUTTONUP (long wParam, long lParam) {
 	Rectangle bounds = event.getBounds();
 	if (event.doit) {
 		if ((style & SWT.SMOOTH) != 0) {
-			int xInPixels = Win32DPIUtils.pointToPixel(bounds.x, getZoom());
-			int yInPixels = Win32DPIUtils.pointToPixel(bounds.y, getZoom());
+			int xInPixels = DPIUtil.pointToPixel(bounds.x, getZoom());
+			int yInPixels = DPIUtil.pointToPixel(bounds.y, getZoom());
 			setBoundsInPixels (xInPixels, yInPixels, widthInPixels, heightInPixels);
 			// widget could be disposed at this point
 		}
@@ -379,8 +379,8 @@ LRESULT WM_MOUSEMOVE (long wParam, long lParam) {
 	if (isDisposed ()) return LRESULT.ZERO;
 	if (event.doit) {
 		Rectangle bounds = event.getBounds();
-		lastX = Win32DPIUtils.pointToPixel(bounds.x, zoom);
-		lastY = Win32DPIUtils.pointToPixel(bounds.y, zoom);
+		lastX = DPIUtil.pointToPixel(bounds.x, zoom);
+		lastY = DPIUtil.pointToPixel(bounds.y, zoom);
 	}
 	int flags = OS.RDW_UPDATENOW | OS.RDW_ALLCHILDREN;
 	OS.RedrawWindow (hwndTrack, null, 0, flags);

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Shell.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Shell.java
@@ -1592,8 +1592,8 @@ public void setBounds(Rectangle rect) {
 	// the WM_DPICHANGED event processing. So to avoid duplicate scaling, we always
 	// have to scale width and height with the zoom of the original monitor (still
 	// returned by getZoom()) here.
-	setBoundsInPixels(boundsInPixels.x, boundsInPixels.y, Win32DPIUtils.pointToPixel(rect.width, getZoom()),
-			Win32DPIUtils.pointToPixel(rect.height, getZoom()));
+	setBoundsInPixels(boundsInPixels.x, boundsInPixels.y, DPIUtil.pointToPixel(rect.width, getZoom()),
+			DPIUtil.pointToPixel(rect.height, getZoom()));
 }
 
 @Override
@@ -1769,7 +1769,7 @@ public void setImeInputMode (int mode) {
 public void setMaximumSize (int width, int height) {
 	checkWidget ();
 	int zoom = getZoom();
-	setMaximumSizeInPixels(Win32DPIUtils.pointToPixel(width, zoom), Win32DPIUtils.pointToPixel(height, zoom));
+	setMaximumSizeInPixels(DPIUtil.pointToPixel(width, zoom), DPIUtil.pointToPixel(height, zoom));
 }
 
 /**
@@ -1844,7 +1844,7 @@ void setMaximumSizeInPixels (int width, int height) {
 public void setMinimumSize (int width, int height) {
 	checkWidget ();
 	int zoom = getZoom();
-	setMinimumSizeInPixels(Win32DPIUtils.pointToPixel(width, zoom), Win32DPIUtils.pointToPixel(height, zoom));
+	setMinimumSizeInPixels(DPIUtil.pointToPixel(width, zoom), DPIUtil.pointToPixel(height, zoom));
 }
 
 void setMinimumSizeInPixels (int width, int height) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/SingleZoomCoordinateSystemMapper.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/SingleZoomCoordinateSystemMapper.java
@@ -55,18 +55,18 @@ class SingleZoomCoordinateSystemMapper implements CoordinateSystemMapper {
 	@Override
 	public Point map(Control from, Control to, int x, int y) {
 		int zoom = getZoomLevelForMapping(from, to);
-		x = Win32DPIUtils.pointToPixel(x, zoom);
-		y = Win32DPIUtils.pointToPixel(y, zoom);
+		x = DPIUtil.pointToPixel(x, zoom);
+		y = DPIUtil.pointToPixel(y, zoom);
 		return Win32DPIUtils.pixelToPointAsLocation(display.mapInPixels(from, to, x, y), zoom);
 	}
 
 	@Override
 	public Rectangle map(Control from, Control to, int x, int y, int width, int height) {
 		int zoom = getZoomLevelForMapping(from, to);
-		x = Win32DPIUtils.pointToPixel(x, zoom);
-		y = Win32DPIUtils.pointToPixel(y, zoom);
-		width = Win32DPIUtils.pointToPixel(width, zoom);
-		height = Win32DPIUtils.pointToPixel(height, zoom);
+		x = DPIUtil.pointToPixel(x, zoom);
+		y = DPIUtil.pointToPixel(y, zoom);
+		width = DPIUtil.pointToPixel(width, zoom);
+		height = DPIUtil.pointToPixel(height, zoom);
 		return Win32DPIUtils.pixelToPoint(display.mapInPixels(from, to, x, y, width, height), zoom);
 	}
 
@@ -105,7 +105,7 @@ class SingleZoomCoordinateSystemMapper implements CoordinateSystemMapper {
 	@Override
 	public void setCursorLocation(int x, int y) {
 		int zoom = DPIUtil.getDeviceZoom();
-		display.setCursorLocationInPixels(Win32DPIUtils.pointToPixel(x, zoom), Win32DPIUtils.pointToPixel(y, zoom));
+		display.setCursorLocationInPixels(DPIUtil.pointToPixel(x, zoom), DPIUtil.pointToPixel(y, zoom));
 	}
 
 	@Override

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Table.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Table.java
@@ -2336,7 +2336,7 @@ public int getGridLineWidth () {
 }
 
 int getGridLineWidthInPixels () {
-	return Win32DPIUtils.pointToPixel(GRID_WIDTH, getZoom());
+	return DPIUtil.pointToPixel(GRID_WIDTH, getZoom());
 }
 
 /**
@@ -3543,7 +3543,7 @@ void sendEraseItemEvent (TableItem item, NMLVCUSTOMDRAW nmcd, long lParam, Event
 			boolean backgroundWanted = !ignoreDrawHot || drawDrophilited || (!ignoreDrawSelection && clrSelectionBk != -1);
 
 			if (backgroundWanted) {
-				int explorerExtraInPixels = Win32DPIUtils.pointToPixel(EXPLORER_EXTRA, getZoom());
+				int explorerExtraInPixels = DPIUtil.pointToPixel(EXPLORER_EXTRA, getZoom());
 				RECT pClipRect = new RECT ();
 				OS.SetRect (pClipRect, nmcd.left, nmcd.top, nmcd.right, nmcd.bottom);
 				RECT rect = new RECT ();
@@ -4859,7 +4859,7 @@ boolean setScrollWidth (TableItem item, boolean force) {
 		if (hStateList != 0) {
 			int [] cx = new int [1], cy = new int [1];
 			OS.ImageList_GetIconSize (hStateList, cx, cy);
-			newWidth += cx [0] + Win32DPIUtils.pointToPixel(INSET, getZoom());
+			newWidth += cx [0] + DPIUtil.pointToPixel(INSET, getZoom());
 		}
 		long hImageList = OS.SendMessage (handle, OS.LVM_GETIMAGELIST, OS.LVSIL_SMALL, 0);
 		if (hImageList != 0) {
@@ -4879,7 +4879,7 @@ boolean setScrollWidth (TableItem item, boolean force) {
 			*/
 			newWidth++;
 		}
-		newWidth += Win32DPIUtils.pointToPixel(INSET * 2, getZoom()) + Win32DPIUtils.pointToPixel(VISTA_EXTRA, getZoom());
+		newWidth += DPIUtil.pointToPixel(INSET * 2, getZoom()) + DPIUtil.pointToPixel(VISTA_EXTRA, getZoom());
 		int oldWidth = (int)OS.SendMessage (handle, OS.LVM_GETCOLUMNWIDTH, 0, 0);
 		if (newWidth > oldWidth) {
 			setScrollWidth (newWidth);
@@ -5744,7 +5744,7 @@ long windowProc (long hwnd, int msg, long wParam, long lParam) {
 		OS.GetClientRect (handle, clientRect);
 		TableItem item = _getItem (selection);
 		RECT rect = item.getBounds (selection, 0, true, true, true);
-		int dragImageSizeInPixel = Win32DPIUtils.pointToPixel(DRAG_IMAGE_SIZE, getZoom());
+		int dragImageSizeInPixel = DPIUtil.pointToPixel(DRAG_IMAGE_SIZE, getZoom());
 		if ((style & SWT.FULL_SELECTION) != 0) {
 			int width = dragImageSizeInPixel;
 			rect.left = Math.max (clientRect.left, mousePos.x - width / 2);
@@ -6915,7 +6915,7 @@ LRESULT wmNotifyHeader (NMHDR hdr, long wParam, long lParam) {
 							 * Sort indicator size needs to scale as per the Native Windows OS DPI level
 							 * when header is custom drawn. For more details refer bug 537097.
 							 */
-							int leg = Win32DPIUtils.pointToPixel(3, nativeZoom);
+							int leg = DPIUtil.pointToPixel(3, nativeZoom);
 							if (sortDirection == SWT.UP) {
 								OS.Polyline(nmcd.hdc, new int[] {center-leg, 1+leg, center+1, 0}, 2);
 								OS.Polyline(nmcd.hdc, new int[] {center+leg, 1+leg, center-1, 0}, 2);
@@ -6961,7 +6961,7 @@ LRESULT wmNotifyHeader (NMHDR hdr, long wParam, long lParam) {
 							}
 						}
 
-						int x = rects[i].left + Win32DPIUtils.pointToPixel(INSET + 2, getZoom());
+						int x = rects[i].left + DPIUtil.pointToPixel(INSET + 2, getZoom());
 						if (columns[i].image != null) {
 							GCData data = new GCData();
 							data.device = display;
@@ -7302,9 +7302,9 @@ LRESULT wmNotifyToolTip (NMTTCUSTOMDRAW nmcd, long lParam) {
 						int zoom = getZoom();
 						rect = Win32DPIUtils.pixelToPoint(rect, zoom);
 						gc.drawImage (image, rect.x, rect.y, rect.width, rect.height, DPIUtil.pixelToPoint(x, zoom), DPIUtil.pixelToPoint(y, zoom), DPIUtil.pixelToPoint(size.x, zoom), DPIUtil.pixelToPoint(size.y, zoom));
-						x += size.x + Win32DPIUtils.pointToPixel(INSET + (pinfo.iSubItem == 0 ? -2 : 4), zoom);
+						x += size.x + DPIUtil.pointToPixel(INSET + (pinfo.iSubItem == 0 ? -2 : 4), zoom);
 					} else {
-						x += Win32DPIUtils.pointToPixel(INSET + 2, getZoom());
+						x += DPIUtil.pointToPixel(INSET + 2, getZoom());
 					}
 					String string = item.getText (pinfo.iSubItem);
 					if (string != null) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TableColumn.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TableColumn.java
@@ -432,7 +432,7 @@ public void pack () {
 				if (hFont != -1) hFont = OS.SelectObject (hDC, hFont);
 				if (isDisposed () || parent.isDisposed ()) break;
 				Rectangle bounds = event.getBounds();
-				columnWidth = Math.max (columnWidth, Win32DPIUtils.pointToPixel(bounds.x + bounds.width, getZoom()) - headerRect.left);
+				columnWidth = Math.max (columnWidth, DPIUtil.pointToPixel(bounds.x + bounds.width, getZoom()) - headerRect.left);
 			}
 		}
 		if (newFont != 0) OS.SelectObject (hDC, oldFont);
@@ -846,7 +846,7 @@ public void setToolTipText (String string) {
  */
 public void setWidth (int width) {
 	checkWidget ();
-	setWidthInPixels(Win32DPIUtils.pointToPixel(width, getZoom()));
+	setWidthInPixels(DPIUtil.pointToPixel(width, getZoom()));
 }
 
 void setWidthInPixels (int width) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TableItem.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TableItem.java
@@ -296,7 +296,7 @@ RECT getBounds (int row, int column, boolean getText, boolean getImage, boolean 
 					}
 				}
 				if (!getImage) rect.left = rect.right;
-				rect.right += width + Win32DPIUtils.pointToPixel(Table.INSET * 2, getZoom());
+				rect.right += width + DPIUtil.pointToPixel(Table.INSET * 2, getZoom());
 			}
 		} else {
 			if (getText) {
@@ -373,7 +373,7 @@ RECT getBounds (int row, int column, boolean getText, boolean getImage, boolean 
 					iconRect.top = column;
 					iconRect.left = OS.LVIR_ICON;
 					if (OS.SendMessage (hwnd, OS. LVM_GETSUBITEMRECT, row, iconRect) != 0) {
-						rect.left = iconRect.right + Win32DPIUtils.pointToPixel(Table.INSET / 2, getZoom());
+						rect.left = iconRect.right + DPIUtil.pointToPixel(Table.INSET / 2, getZoom());
 					}
 				}
 			} else {
@@ -400,7 +400,7 @@ RECT getBounds (int row, int column, boolean getText, boolean getImage, boolean 
 					char [] buffer = string.toCharArray ();
 					int flags = OS.DT_NOPREFIX | OS.DT_SINGLELINE | OS.DT_CALCRECT;
 					OS.DrawText (hDC, buffer, buffer.length, textRect, flags);
-					rect.right += textRect.right - textRect.left + Win32DPIUtils.pointToPixel(Table.INSET * 3 + 2, getZoom());
+					rect.right += textRect.right - textRect.left + DPIUtil.pointToPixel(Table.INSET * 3 + 2, getZoom());
 				}
 			}
 		}
@@ -696,9 +696,9 @@ Rectangle getTextBoundsInPixels (int index) {
 	if (itemIndex == -1) return new Rectangle (0, 0, 0, 0);
 	RECT rect = getBounds (itemIndex, index, true, false, true);
 	rect.left += 2;
-	if (index != 0) rect.left += Win32DPIUtils.pointToPixel(Table.INSET, getZoom());
+	if (index != 0) rect.left += DPIUtil.pointToPixel(Table.INSET, getZoom());
 	rect.left = Math.min (rect.left, rect.right);
-	rect.right = rect.right - Win32DPIUtils.pointToPixel(Table.INSET, getZoom());
+	rect.right = rect.right - DPIUtil.pointToPixel(Table.INSET, getZoom());
 	int width = Math.max (0, rect.right - rect.left);
 	int height = Math.max (0, rect.bottom - rect.top);
 	return new Rectangle (rect.left, rect.top, width, height);

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ToolItem.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ToolItem.java
@@ -1076,7 +1076,7 @@ public void setToolTipText (String string) {
  */
 public void setWidth (int width) {
 	checkWidget();
-	setWidthInPixels(Win32DPIUtils.pointToPixel(width, getZoom()));
+	setWidthInPixels(DPIUtil.pointToPixel(width, getZoom()));
 }
 
 void setWidthInPixels (int width) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ToolTip.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ToolTip.java
@@ -358,7 +358,7 @@ public void setAutoHide (boolean autoHide) {
 public void setLocation (int x, int y) {
 	checkWidget ();
 	int zoom = getZoom();
-	setLocationInPixels(Win32DPIUtils.pointToPixel(x, zoom), Win32DPIUtils.pointToPixel(y, zoom));
+	setLocationInPixels(DPIUtil.pointToPixel(x, zoom), DPIUtil.pointToPixel(y, zoom));
 }
 
 void setLocationInPixels (int x, int y) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Tree.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Tree.java
@@ -465,7 +465,7 @@ LRESULT CDDS_ITEMPOSTPAINT (NMTVCUSTOMDRAW nmcd, long wParam, long lParam) {
 					if (explorerTheme) {
 						if (hooks (SWT.EraseItem)) {
 							RECT itemRect = item.getBounds (index, true, true, false, false, true, hDC);
-							int explorerExtraInPixels = Win32DPIUtils.pointToPixel(EXPLORER_EXTRA, zoom);
+							int explorerExtraInPixels = DPIUtil.pointToPixel(EXPLORER_EXTRA, zoom);
 							itemRect.left -= explorerExtraInPixels;
 							itemRect.right += explorerExtraInPixels + 1;
 							pClipRect.left = itemRect.left;
@@ -748,7 +748,7 @@ LRESULT CDDS_ITEMPOSTPAINT (NMTVCUSTOMDRAW nmcd, long wParam, long lParam) {
 						}
 					}
 				}
-				rect.left += Win32DPIUtils.pointToPixel(INSET - 1, zoom) ;
+				rect.left += DPIUtil.pointToPixel(INSET - 1, zoom) ;
 				if (drawImage) {
 					Image image = null;
 					if (index == 0) {
@@ -757,14 +757,14 @@ LRESULT CDDS_ITEMPOSTPAINT (NMTVCUSTOMDRAW nmcd, long wParam, long lParam) {
 						Image [] images  = item.images;
 						if (images != null) image = images [index];
 					}
-					int inset = i != 0 ? Win32DPIUtils.pointToPixel(INSET, zoom) : 0;
-					int offset = i != 0 ? Win32DPIUtils.pointToPixel(INSET, zoom) : Win32DPIUtils.pointToPixel(INSET + 2, zoom);
+					int inset = i != 0 ? DPIUtil.pointToPixel(INSET, zoom) : 0;
+					int offset = i != 0 ? DPIUtil.pointToPixel(INSET, zoom) : DPIUtil.pointToPixel(INSET + 2, zoom);
 					if (image != null) {
 						Rectangle bounds = image.getBounds (); // Points
 						if (size == null) size = Win32DPIUtils.pixelToPointAsSize (getImageSize (), zoom); // To Points
 						if (!ignoreDrawForeground) {
 							//int y1 = rect.top + (index == 0 ? (getItemHeight () - size.y) / 2 : 0);
-							int y1 = rect.top + Win32DPIUtils.pointToPixel((getItemHeight () - size.y) / 2, zoom);
+							int y1 = rect.top + DPIUtil.pointToPixel((getItemHeight () - size.y) / 2, zoom);
 							int x1 = Math.max (rect.left, rect.left - inset + 1);
 							GCData data = new GCData();
 							data.device = display;
@@ -774,7 +774,7 @@ LRESULT CDDS_ITEMPOSTPAINT (NMTVCUSTOMDRAW nmcd, long wParam, long lParam) {
 							OS.SelectClipRgn (hDC, 0);
 							gc.dispose ();
 						}
-						OS.SetRect (rect, rect.left + Win32DPIUtils.pointToPixel(size.x, zoom) + offset, rect.top, rect.right - inset, rect.bottom);
+						OS.SetRect (rect, rect.left + DPIUtil.pointToPixel(size.x, zoom) + offset, rect.top, rect.right - inset, rect.bottom);
 					} else {
 						if (i == 0) {
 							if (OS.SendMessage (handle, OS.TVM_GETIMAGELIST, OS.TVSIL_NORMAL, 0) != 0) {
@@ -1132,7 +1132,7 @@ LRESULT CDDS_ITEMPREPAINT (NMTVCUSTOMDRAW nmcd, long wParam, long lParam) {
 					if ((style & SWT.FULL_SELECTION) == 0) {
 						RECT pRect = item.getBounds (index, true, true, false, false, false, hDC);
 						RECT pClipRect = item.getBounds (index, true, true, true, false, true, hDC);
-						int explorerExtraInPixels = Win32DPIUtils.pointToPixel(EXPLORER_EXTRA, zoom);
+						int explorerExtraInPixels = DPIUtil.pointToPixel(EXPLORER_EXTRA, zoom);
 						if (measureEvent != null) {
 							pRect.right = Math.min (pClipRect.right, boundsInPixels.x + boundsInPixels.width);
 						} else {
@@ -1209,7 +1209,7 @@ LRESULT CDDS_ITEMPREPAINT (NMTVCUSTOMDRAW nmcd, long wParam, long lParam) {
 			OS.SaveDC (hDC);
 			OS.SelectClipRgn (hDC, 0);
 			if (explorerTheme) {
-				int explorerExtraInPixels = Win32DPIUtils.pointToPixel(EXPLORER_EXTRA, getZoom());
+				int explorerExtraInPixels = DPIUtil.pointToPixel(EXPLORER_EXTRA, getZoom());
 				itemRect.left -= explorerExtraInPixels;
 				itemRect.right += explorerExtraInPixels;
 			}
@@ -2966,7 +2966,7 @@ public int getGridLineWidth () {
 }
 
 int getGridLineWidthInPixels () {
-	return Win32DPIUtils.pointToPixel(GRID_WIDTH, getZoom());
+	return DPIUtil.pointToPixel(GRID_WIDTH, getZoom());
 }
 
 /**
@@ -5037,7 +5037,7 @@ void setScrollWidth (int width) {
 		}
 	}
 	if (horizontalBar != null) {
-		horizontalBar.setIncrement (Win32DPIUtils.pointToPixel(INCREMENT, getZoom()));
+		horizontalBar.setIncrement (DPIUtil.pointToPixel(INCREMENT, getZoom()));
 		horizontalBar.setPageIncrement (info.nPage);
 	}
 	OS.GetClientRect (hwndParent, rect);
@@ -5373,7 +5373,7 @@ public void setTopItem (TreeItem item) {
  * In a Tree without imageList, the indent also controls the chevron (glyph) size.
  */
 private void calculateAndApplyIndentSize() {
-	int indent = Win32DPIUtils.pointToPixel(DEFAULT_INDENT, nativeZoom);
+	int indent = DPIUtil.pointToPixel(DEFAULT_INDENT, nativeZoom);
 	OS.SendMessage(handle, OS.TVM_SETINDENT, indent, 0);
 }
 
@@ -5486,7 +5486,7 @@ public void showColumn (TreeColumn column) {
 			SCROLLINFO info = new SCROLLINFO();
 			info.cbSize = SCROLLINFO.sizeof;
 			info.fMask = OS.SIF_POS;
-			info.nPos = Math.max(0, headerRect.left - Win32DPIUtils.pointToPixel(INSET / 2, getZoom()));
+			info.nPos = Math.max(0, headerRect.left - DPIUtil.pointToPixel(INSET / 2, getZoom()));
 			OS.SetScrollInfo(hwndParent, OS.SB_HORZ, info, true);
 			setScrollWidth();
 		} else if (scrollBecauseRight) {
@@ -5500,8 +5500,8 @@ public void showColumn (TreeColumn column) {
 			// info.nPos + wideRect = headerRect.left + wideHeader
 			// info.nPos = headerRect.left + wideHeader - wideRect
 			info.nPos = Math.max(0, wideHeader + headerRect.left - wideRect
-					- Win32DPIUtils.pointToPixel(INSET / 2, getZoom()) );
-			info.nPos = Math.min(rect.right - Win32DPIUtils.pointToPixel(INSET / 2, getZoom()), info.nPos);
+					- DPIUtil.pointToPixel(INSET / 2, getZoom()) );
+			info.nPos = Math.min(rect.right - DPIUtil.pointToPixel(INSET / 2, getZoom()), info.nPos);
 
 			OS.SetScrollInfo(hwndParent, OS.SB_HORZ, info, true);
 			setScrollWidth();
@@ -6073,7 +6073,7 @@ long windowProc (long hwnd, int msg, long wParam, long lParam) {
 			RECT clientRect = new RECT ();
 			OS.GetClientRect(handle, clientRect);
 			RECT rect = items [0].getBounds (0, true, true, false);
-			int dragImageSizeInPixels = Win32DPIUtils.pointToPixel(DRAG_IMAGE_SIZE, getZoom());
+			int dragImageSizeInPixels = DPIUtil.pointToPixel(DRAG_IMAGE_SIZE, getZoom());
 			if ((style & SWT.FULL_SELECTION) != 0) {
 				int width = dragImageSizeInPixels;
 				rect.left = Math.max (clientRect.left, mousePos.x - width / 2);
@@ -7889,7 +7889,7 @@ LRESULT wmNotifyHeader (NMHDR hdr, long wParam, long lParam) {
 							 * Sort indicator size needs to scale as per the Native Windows OS DPI level
 							 * when header is custom drawn. For more details refer bug 537097.
 							 */
-							int leg = Win32DPIUtils.pointToPixel(3, nativeZoom);
+							int leg = DPIUtil.pointToPixel(3, nativeZoom);
 							if (sortDirection == SWT.UP) {
 								OS.Polyline(nmcd.hdc, new int[] {center-leg, 1+leg, center+1, 0}, 2);
 								OS.Polyline(nmcd.hdc, new int[] {center+leg, 1+leg, center-1, 0}, 2);
@@ -7928,7 +7928,7 @@ LRESULT wmNotifyHeader (NMHDR hdr, long wParam, long lParam) {
 							}
 						}
 
-						int x = rects[i].left + Win32DPIUtils.pointToPixel(INSET + 2, getZoom());
+						int x = rects[i].left + DPIUtil.pointToPixel(INSET + 2, getZoom());
 						if (columns[i].image != null) {
 							GCData data = new GCData();
 							data.device = display;
@@ -8246,7 +8246,7 @@ LRESULT wmNotifyToolTip (NMTTCUSTOMDRAW nmcd, long lParam) {
 							data.background = OS.GetBkColor (nmcd.hdc);
 							data.font = Font.win32_new (display, hFont);
 							GC gc = createNewGC(nmcd.hdc, data);
-							int x = cellRect [0].left + Win32DPIUtils.pointToPixel(INSET, getZoom());
+							int x = cellRect [0].left + DPIUtil.pointToPixel(INSET, getZoom());
 							if (index [0] != 0) x -= gridWidth;
 							Image image = item [0].getImage (index [0]);
 							if (image != null || index [0] == 0) {
@@ -8257,11 +8257,11 @@ LRESULT wmNotifyToolTip (NMTTCUSTOMDRAW nmcd, long lParam) {
 									Rectangle rect = image.getBounds (); // Points
 									int zoom = getZoom();
 									gc.drawImage (image, rect.x, rect.y, rect.width, rect.height, DPIUtil.pixelToPoint(x, zoom), DPIUtil.pixelToPoint(imageRect.top, zoom), DPIUtil.pixelToPoint(size.x, zoom), DPIUtil.pixelToPoint(size.y, zoom));
-									x += Win32DPIUtils.pointToPixel(INSET, getZoom()) + (index [0] == 0 ? 1 : 0);
+									x += DPIUtil.pointToPixel(INSET, getZoom()) + (index [0] == 0 ? 1 : 0);
 								}
 								x += size.x;
 							} else {
-								x += Win32DPIUtils.pointToPixel(INSET, getZoom());
+								x += DPIUtil.pointToPixel(INSET, getZoom());
 							}
 							String string = item [0].getText (index [0]);
 							if (string != null) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TreeColumn.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TreeColumn.java
@@ -355,7 +355,7 @@ public void pack () {
 				Event event = parent.sendMeasureItemEvent (item, index, hDC, detail);
 				if (isDisposed () || parent.isDisposed ()) break;
 				Rectangle bounds = event.getBounds();
-				itemRight = Win32DPIUtils.pointToPixel(bounds.x + bounds.width, getZoom());
+				itemRight = DPIUtil.pointToPixel(bounds.x + bounds.width, getZoom());
 			} else {
 				long hFont = item.fontHandle (index);
 				if (hFont != -1) hFont = OS.SelectObject (hDC, hFont);
@@ -371,8 +371,8 @@ public void pack () {
 	int flags = OS.DT_CALCRECT | OS.DT_NOPREFIX;
 	char [] buffer = text.toCharArray ();
 	OS.DrawText (hDC, buffer, buffer.length, rect, flags);
-	int headerWidth = rect.right - rect.left + Win32DPIUtils.pointToPixel(Tree.HEADER_MARGIN, getZoom());
-	if (OS.IsAppThemed ()) headerWidth += Win32DPIUtils.pointToPixel(Tree.HEADER_EXTRA, getZoom());
+	int headerWidth = rect.right - rect.left + DPIUtil.pointToPixel(Tree.HEADER_MARGIN, getZoom());
+	if (OS.IsAppThemed ()) headerWidth += DPIUtil.pointToPixel(Tree.HEADER_EXTRA, getZoom());
 	if (image != null) {
 		Rectangle bounds = Win32DPIUtils.pointToPixel(image.getBounds(), getZoom());
 		headerWidth += bounds.width;
@@ -705,7 +705,7 @@ public void setToolTipText (String string) {
  */
 public void setWidth (int width) {
 	checkWidget ();
-	setWidthInPixels(Win32DPIUtils.pointToPixel(width, getZoom()));
+	setWidthInPixels(DPIUtil.pointToPixel(width, getZoom()));
 }
 
 void setWidthInPixels (int width) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TreeItem.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TreeItem.java
@@ -440,7 +440,7 @@ RECT getBounds (int index, boolean getText, boolean getImage, boolean fullText, 
 		if (getImage && !fullImage) {
 			if (OS.SendMessage (hwnd, OS.TVM_GETIMAGELIST, OS.TVSIL_NORMAL, 0) != 0) {
 				Point size = parent.getImageSize ();
-				rect.left -= size.x + Win32DPIUtils.pointToPixel(Tree.INSET, getZoom());
+				rect.left -= size.x + DPIUtil.pointToPixel(Tree.INSET, getZoom());
 				if (!getText) rect.right = rect.left + size.x;
 			} else {
 				if (!getText) rect.right = rect.left;
@@ -492,7 +492,7 @@ RECT getBounds (int index, boolean getText, boolean getImage, boolean fullText, 
 			}
 			if (getText) {
 				if (fullText && clip) {
-					rect.left = rect.right + Win32DPIUtils.pointToPixel(Tree.INSET, getZoom());
+					rect.left = rect.right + DPIUtil.pointToPixel(Tree.INSET, getZoom());
 					rect.right = headerRect.right;
 				} else {
 					String string = index == 0 ? text : strings != null ? strings [index] : null;
@@ -513,10 +513,10 @@ RECT getBounds (int index, boolean getText, boolean getImage, boolean fullText, 
 							OS.ReleaseDC (hwnd, hNewDC);
 						}
 						if (getImage) {
-							rect.right += textRect.right - textRect.left + Win32DPIUtils.pointToPixel(Tree.INSET * 3, getZoom());
+							rect.right += textRect.right - textRect.left + DPIUtil.pointToPixel(Tree.INSET * 3, getZoom());
 						} else {
-							rect.left = rect.right + Win32DPIUtils.pointToPixel(Tree.INSET, getZoom());
-							rect.right = rect.left + (textRect.right - textRect.left) + Win32DPIUtils.pointToPixel(Tree.INSET, getZoom());
+							rect.left = rect.right + DPIUtil.pointToPixel(Tree.INSET, getZoom());
+							rect.right = rect.left + (textRect.right - textRect.left) + DPIUtil.pointToPixel(Tree.INSET, getZoom());
 						}
 					}
 				}
@@ -915,7 +915,7 @@ Rectangle getTextBoundsInPixels (int index) {
 	if (!parent.checkData (this, true)) error (SWT.ERROR_WIDGET_DISPOSED);
 	RECT rect = getBounds (index, true, false, true);
 	rect.left = Math.min (rect.left, rect.right);
-	rect.right = rect.right + Win32DPIUtils.pointToPixel(Tree.INSET, getZoom()); // Add INSET margin to avoid truncation of text seen with "Segoe UI" font
+	rect.right = rect.right + DPIUtil.pointToPixel(Tree.INSET, getZoom()); // Add INSET margin to avoid truncation of text seen with "Segoe UI" font
 	int width = Math.max (0, rect.right - rect.left);
 	int height = Math.max (0, rect.bottom - rect.top);
 	return new Rectangle (rect.left, rect.top, width, height);

--- a/tests/org.eclipse.swt.tests.win32/JUnit Tests/org/eclipse/swt/tests/win32/Win32DPIUtilTests.java
+++ b/tests/org.eclipse.swt.tests.win32/JUnit Tests/org/eclipse/swt/tests/win32/Win32DPIUtilTests.java
@@ -146,16 +146,10 @@ public class Win32DPIUtilTests {
 		int valueAt150 = 8;
 		int valueAt100 = 5;
 
-		int scaledValue = Win32DPIUtils.pointToPixel(valueAt100, 200);
-		assertEquals(valueAt200, scaledValue, "Scaling up integer to 200 failed");
-		scaledValue = Win32DPIUtils.pointToPixel((Device) null, valueAt100, 200);
+		int scaledValue = Win32DPIUtils.pointToPixel((Device) null, valueAt100, 200);
 		assertEquals(valueAt200, scaledValue, "Scaling up integer to 200 with device failed");
-		scaledValue = Win32DPIUtils.pointToPixel(valueAt100, 150);
-		assertEquals(valueAt150, scaledValue, "Scaling up integer to 150 failed");
 		scaledValue = Win32DPIUtils.pointToPixel((Device) null, valueAt100, 150);
 		assertEquals(valueAt150, scaledValue, "Scaling up integer to 150 with device failed");
-		scaledValue = Win32DPIUtils.pointToPixel(valueAt100, 100);
-		assertSame(valueAt100, scaledValue, "Scaling up integer without zoom change failed");
 		scaledValue = Win32DPIUtils.pointToPixel((Device) null, valueAt100, 100);
 		assertSame(valueAt100, scaledValue,"Scaling up integer without zoom change with device failed");
 	}

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/DPIUtilTests.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/DPIUtilTests.java
@@ -55,4 +55,17 @@ public class DPIUtilTests {
 		assertEquals(valueAt100, scaledValue, .001f, "Scaling down float without zoom change failed");
 	}
 
+	@Test
+	public void scaleUpInteger() {
+		int valueAt200 = 10;
+		int valueAt150 = 8;
+		int valueAt100 = 5;
+		int scaledValue = DPIUtil.pointToPixel(valueAt100, 200);
+		assertEquals(valueAt200, scaledValue, "Scaling up integer to 200 failed");
+		scaledValue = DPIUtil.pointToPixel(valueAt100, 150);
+		assertEquals(valueAt150, scaledValue, "Scaling up integer to 150 failed");
+		scaledValue = DPIUtil.pointToPixel(valueAt100, 100);
+		assertSame(valueAt100, scaledValue, "Scaling up integer without zoom change failed");
+	}
+
 }


### PR DESCRIPTION

The change is required for  the below PRs as they would need to do point to pixel conversions

- https://github.com/eclipse-platform/eclipse.platform.swt/pull/2284
- #2622
- https://github.com/eclipse-platform/eclipse.platform.swt/pull/2619