### PR TITLE
[GTK] Mark "event-after" signal handlers as v3

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Combo.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Combo.java
@@ -1660,7 +1660,7 @@ long gtk_draw (long widget, long cairo) {
 }
 
 @Override
-long gtk_event_after (long widget, long gdkEvent)  {
+long gtk3_event_after (long widget, long gdkEvent)  {
 	/*
 	* Feature in GTK. Depending on where the user clicks, GTK prevents
 	* the left mouse button event from being propagated. The fix is to
@@ -1680,13 +1680,8 @@ long gtk_event_after (long widget, long gdkEvent)  {
 		case GDK.GDK_BUTTON_PRESS: {
 			int [] eventButton = new int [1];
 			int [] eventState = new int [1];
-			if (GTK.GTK4) {
-				eventButton[0] = GDK.gdk_button_event_get_button(gdkEvent);
-				eventState[0] = GDK.gdk_event_get_modifier_state(gdkEvent);
-			} else {
-				GDK.gdk_event_get_button(gdkEvent, eventButton);
-				GDK.gdk_event_get_state(gdkEvent, eventState);
-			}
+			GDK.gdk_event_get_button(gdkEvent, eventButton);
+			GDK.gdk_event_get_state(gdkEvent, eventState);
 
 			int eventTime = GDK.gdk_event_get_time(gdkEvent);
 
@@ -1707,13 +1702,9 @@ long gtk_event_after (long widget, long gdkEvent)  {
 		case GDK.GDK_FOCUS_CHANGE: {
 			if ((style & SWT.READ_ONLY) == 0) {
 				boolean [] focusIn = new boolean [1];
-				if (GTK.GTK4) {
-					focusIn[0] = GDK.gdk_focus_event_get_in(gdkEvent);
-				} else {
-					GdkEventFocus gdkEventFocus = new GdkEventFocus ();
-					GTK3.memmove (gdkEventFocus, gdkEvent, GdkEventFocus.sizeof);
-					focusIn[0] = gdkEventFocus.in != 0;
-				}
+				GdkEventFocus gdkEventFocus = new GdkEventFocus ();
+				GTK3.memmove (gdkEventFocus, gdkEvent, GdkEventFocus.sizeof);
+				focusIn[0] = gdkEventFocus.in != 0;
 				if (focusIn[0]) {
 					GTK.gtk_widget_set_focus_on_click(handle, false);
 				} else {
@@ -1723,7 +1714,7 @@ long gtk_event_after (long widget, long gdkEvent)  {
 			break;
 		}
 	}
-	return super.gtk_event_after(widget, gdkEvent);
+	return super.gtk3_event_after(widget, gdkEvent);
 }
 
 @Override

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Control.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Control.java
@@ -3716,7 +3716,7 @@ boolean checkSubwindow () {
 }
 
 @Override
-long gtk_event_after (long widget, long gdkEvent) {
+long gtk3_event_after (long widget, long gdkEvent) {
 	int eventType = GDK.gdk_event_get_event_type(gdkEvent);
 	eventType = fixGdkEventTypeValues(eventType);
 	switch (eventType) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Link.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Link.java
@@ -445,8 +445,8 @@ long gtk_draw (long widget, long cairo) {
 }
 
 @Override
-long gtk_event_after (long widget, long gdkEvent) {
-	long result = super.gtk_event_after (widget, gdkEvent);
+long gtk3_event_after (long widget, long gdkEvent) {
+	long result = super.gtk3_event_after (widget, gdkEvent);
 	int eventType = GDK.gdk_event_get_event_type(gdkEvent);
 	switch (eventType) {
 		case GDK.GDK_FOCUS_CHANGE:

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/ScrollBar.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/ScrollBar.java
@@ -548,17 +548,13 @@ long gtk_value_changed (long range) {
 }
 
 @Override
-long gtk_event_after (long widget, long gdkEvent) {
+long gtk3_event_after (long widget, long gdkEvent) {
 	int eventType = GDK.gdk_event_get_event_type(gdkEvent);
 	eventType = Control.fixGdkEventTypeValues(eventType);
 	switch (eventType) {
 		case GDK.GDK_BUTTON_RELEASE: {
 			int [] eventButton = new int [1];
-			if (GTK.GTK4) {
-				eventButton[0] = GDK.gdk_button_event_get_button(gdkEvent);
-			} else {
-				GDK.gdk_event_get_button(gdkEvent, eventButton);
-			}
+			GDK.gdk_event_get_button(gdkEvent, eventButton);
 
 			if (eventButton[0] == 1 && detail == GTK.GTK_SCROLL_JUMP) {
 				if (!dragSent) {
@@ -573,7 +569,7 @@ long gtk_event_after (long widget, long gdkEvent) {
 			break;
 		}
 	}
-	return super.gtk_event_after (widget, gdkEvent);
+	return super.gtk3_event_after (widget, gdkEvent);
 }
 
 @Override

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Slider.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Slider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -230,17 +230,13 @@ long gtk_value_changed(long range) {
 }
 
 @Override
-long gtk_event_after (long widget, long gdkEvent) {
+long gtk3_event_after (long widget, long gdkEvent) {
 	int eventType = GDK.gdk_event_get_event_type(gdkEvent);
 	eventType = Control.fixGdkEventTypeValues(eventType);
 	switch (eventType) {
 		case GDK.GDK_BUTTON_RELEASE: {
 			int [] eventButton = new int [1];
-			if (GTK.GTK4) {
-				eventButton[0] = GDK.gdk_button_event_get_button(gdkEvent);
-			} else {
-				GDK.gdk_event_get_button(gdkEvent, eventButton);
-			}
+			GDK.gdk_event_get_button(gdkEvent, eventButton);
 
 			if (eventButton[0] == 1 && scrollType == SWT.DRAG) {
 				if (!dragSent) {
@@ -255,7 +251,7 @@ long gtk_event_after (long widget, long gdkEvent) {
 			break;
 		}
 	}
-	return super.gtk_event_after (widget, gdkEvent);
+	return super.gtk3_event_after (widget, gdkEvent);
 }
 
 @Override

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Spinner.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Spinner.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -742,9 +742,9 @@ long gtk_delete_text (long widget, long start_pos, long end_pos) {
 }
 
 @Override
-long gtk_event_after (long widget, long gdkEvent) {
+long gtk3_event_after (long widget, long gdkEvent) {
 	if (cursor != null) setCursor (cursor.handle);
-	return super.gtk_event_after (widget, gdkEvent);
+	return super.gtk3_event_after (widget, gdkEvent);
 }
 
 @Override

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/TableColumn.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/TableColumn.java
@@ -372,17 +372,13 @@ long gtk_clicked (long widget) {
 }
 
 @Override
-long gtk_event_after (long widget, long gdkEvent) {
+long gtk3_event_after (long widget, long gdkEvent) {
 	int eventType = GDK.gdk_event_get_event_type(gdkEvent);
 	eventType = Control.fixGdkEventTypeValues(eventType);
 	switch (eventType) {
 		case GDK.GDK_BUTTON_PRESS: {
 			int [] eventButton = new int [1];
-			if (GTK.GTK4) {
-				eventButton[0] = GDK.gdk_button_event_get_button(gdkEvent);
-			} else {
-				GDK.gdk_event_get_button(gdkEvent, eventButton);
-			}
+			GDK.gdk_event_get_button(gdkEvent, eventButton);
 
 			if (eventButton[0] == 3) {
 				double [] eventRX = new double [1];

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Text.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Text.java
@@ -1718,7 +1718,7 @@ long gtk_delete_text (long widget, long start_pos, long end_pos) {
 }
 
 @Override
-long gtk_event_after (long widget, long gdkEvent) {
+long gtk3_event_after (long widget, long gdkEvent) {
 	if (cursor != null) setCursor (cursor.handle);
 	/*
 	* Feature in GTK.  The gtk-entry-select-on-focus property is a global
@@ -1732,13 +1732,9 @@ long gtk_event_after (long widget, long gdkEvent) {
 		switch (eventType) {
 			case GDK.GDK_FOCUS_CHANGE:
 				boolean [] focusIn = new boolean [1];
-				if (GTK.GTK4) {
-					focusIn[0] = GDK.gdk_focus_event_get_in(gdkEvent);
-				} else {
-					GdkEventFocus gdkEventFocus = new GdkEventFocus ();
-					GTK3.memmove (gdkEventFocus, gdkEvent, GdkEventFocus.sizeof);
-					focusIn[0] = gdkEventFocus.in != 0;
-				}
+				GdkEventFocus gdkEventFocus = new GdkEventFocus ();
+				GTK3.memmove (gdkEventFocus, gdkEvent, GdkEventFocus.sizeof);
+				focusIn[0] = gdkEventFocus.in != 0;
 				if (focusIn[0]) {
 					long settings = GTK.gtk_settings_get_default ();
 					OS.g_object_set (settings, GTK.gtk_entry_select_on_focus, true, 0);
@@ -1746,7 +1742,7 @@ long gtk_event_after (long widget, long gdkEvent) {
 				break;
 		}
 	}
-	return super.gtk_event_after (widget, gdkEvent);
+	return super.gtk3_event_after (widget, gdkEvent);
 }
 
 @Override

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/ToolItem.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/ToolItem.java
@@ -787,17 +787,13 @@ void gtk4_enter_event(long controller, double x, double y, long event) {
 }
 
 @Override
-long gtk_event_after (long widget, long gdkEvent) {
+long gtk3_event_after (long widget, long gdkEvent) {
 	int eventType = GDK.gdk_event_get_event_type(gdkEvent);
 	eventType = Control.fixGdkEventTypeValues(eventType);
 	switch (eventType) {
 		case GDK.GDK_BUTTON_PRESS: {
 			int [] eventButton = new int [1];
-			if (GTK.GTK4) {
-				eventButton[0] = GDK.gdk_button_event_get_button(gdkEvent);
-			} else {
-				GDK.gdk_event_get_button(gdkEvent, eventButton);
-			}
+			GDK.gdk_event_get_button(gdkEvent, eventButton);
 
 			if (eventButton[0] == 3) {
 				double [] eventRX = new double [1];

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/TreeColumn.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/TreeColumn.java
@@ -369,17 +369,13 @@ int gtk_gesture_press_event(long gesture, int n_press, double x, double y, long 
 }
 
 @Override
-long gtk_event_after (long widget, long gdkEvent) {
+long gtk3_event_after (long widget, long gdkEvent) {
 	int eventType = GDK.gdk_event_get_event_type(gdkEvent);
 	eventType = Control.fixGdkEventTypeValues(eventType);
 	switch (eventType) {
 		case GDK.GDK_BUTTON_PRESS: {
 			int [] eventButton = new int [1];
-			if (GTK.GTK4) {
-				eventButton[0] = GDK.gdk_button_event_get_button(gdkEvent);
-			} else {
-				GDK.gdk_event_get_button(gdkEvent, eventButton);
-			}
+			GDK.gdk_event_get_button(gdkEvent, eventButton);
 
 			double [] eventRX = new double [1];
 			double [] eventRY = new double [1];

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Widget.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Widget.java
@@ -950,7 +950,7 @@ long gtk_enter_notify_event (long widget, long event) {
 	return 0;
 }
 
-long gtk_event_after (long widget, long event) {
+long gtk3_event_after (long widget, long event) {
 	return 0;
 }
 
@@ -2626,7 +2626,7 @@ long windowProc (long handle, long arg0, long user_data) {
 		case CONFIGURE_EVENT: return gtk_configure_event (handle, arg0);
 		case DELETE_EVENT: return gtk_delete_event (handle, arg0);
 		case ENTER_NOTIFY_EVENT: return gtk_enter_notify_event (handle, arg0);
-		case EVENT_AFTER: return gtk_event_after (handle, arg0);
+		case EVENT_AFTER: return gtk3_event_after (handle, arg0);
 		case EXPOSE_EVENT: {
 			if (!GTK.GTK_IS_CONTAINER (handle)) {
 				return gtk_draw (handle, arg0);


### PR DESCRIPTION
As per https://docs.gtk.org/gtk4/migrating-3to4.html#stop-using-gtkwidget-event-signals they are no longer emitted in Gtk 4.x but SWT's codebase had a lot of code trying to handle these events in the Gtk 4 case.