### PR TITLE
[GTK] Events "key-press"/"key-release" are Gtk 3 only

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Button.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Button.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2023 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -674,8 +674,8 @@ boolean gtk4_key_press_event(long controller, int keyval, int keycode, int state
 }
 
 @Override
-long gtk_key_press_event (long widget, long event) {
-	long result = super.gtk_key_press_event (widget, event);
+long gtk3_key_press_event (long widget, long event) {
+	long result = super.gtk3_key_press_event (widget, event);
 	if (result != 0) return result;
 	if ((style & SWT.RADIO) != 0) {
 		selected  = getSelection ();

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Combo.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Combo.java
@@ -1773,8 +1773,8 @@ long gtk_insert_text (long widget, long new_text, long new_text_length, long pos
 }
 
 @Override
-long gtk_key_press_event (long widget, long event) {
-	long result = super.gtk_key_press_event (widget, event);
+long gtk3_key_press_event (long widget, long event) {
+	long result = super.gtk3_key_press_event (widget, event);
 	if (result != 0) {
 		gdkEventKey = 0;
 		fixIM ();
@@ -1786,11 +1786,7 @@ long gtk_key_press_event (long widget, long event) {
 		int oldIndex = GTK.gtk_combo_box_get_active (handle);
 		int newIndex = oldIndex;
 		int [] eventKeyval = new int [1];
-		if (GTK.GTK4) {
-			eventKeyval[0] = GDK.gdk_key_event_get_keyval(event);
-		} else {
-			GDK.gdk_event_get_keyval(event, eventKeyval);
-		}
+		GDK.gdk_event_get_keyval(event, eventKeyval);
 
 		switch (eventKeyval[0]) {
 			case GDK.GDK_Down:

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Composite.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Composite.java
@@ -915,8 +915,8 @@ boolean gtk4_key_press_event(long controller, int keyval, int keycode, int state
 }
 
 @Override
-long gtk_key_press_event (long widget, long event) {
-	long result = super.gtk_key_press_event (widget, event);
+long gtk3_key_press_event (long widget, long event) {
+	long result = super.gtk3_key_press_event (widget, event);
 	if (result != 0) return result;
 	/*
 	* Feature in GTK.  The default behavior when the return key

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Control.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Control.java
@@ -3994,7 +3994,7 @@ boolean gtk4_key_press_event(long controller, int keyval, int keycode, int state
 }
 
 @Override
-long gtk_key_press_event (long widget, long event) {
+long gtk3_key_press_event (long widget, long event) {
 	int [] eventKeyval = new int [1];
 	GDK.gdk_event_get_keyval(event, eventKeyval);
 
@@ -4021,7 +4021,7 @@ long gtk_key_press_event (long widget, long event) {
 	if (translateTraversal (event)) return 1;
 	// widget could be disposed at this point
 	if (isDisposed ()) return 0;
-	return super.gtk_key_press_event (widget, event);
+	return super.gtk3_key_press_event (widget, event);
 }
 
 @Override
@@ -4037,13 +4037,13 @@ void gtk4_key_release_event(long controller, int keyval, int keycode, int state,
 }
 
 @Override
-long gtk_key_release_event (long widget, long event) {
+long gtk3_key_release_event (long widget, long event) {
 	if (!hasFocus ()) return 0;
 	long imHandle = imHandle ();
 	if (imHandle != 0) {
 		if (GTK3.gtk_im_context_filter_keypress(imHandle, event)) return 1;
 	}
-	return super.gtk_key_release_event (widget, event);
+	return super.gtk3_key_release_event (widget, event);
 }
 
 @Override

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/DateTime.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/DateTime.java
@@ -2025,7 +2025,7 @@ boolean gtk4_key_press_event(long controller, int keyval, int keycode, int state
 }
 
 @Override
-long gtk_key_press_event (long widget, long event) {
+long gtk3_key_press_event (long widget, long event) {
 	if (!isReadOnly () && (isTime () || isDate ())) {
 		int [] key = new int[1];
 		GDK.gdk_event_get_keyval(event, key);

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/ExpandBar.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/ExpandBar.java
@@ -312,9 +312,9 @@ public int getSpacing () {
 }
 
 @Override
-long gtk_key_press_event (long widget, long event) {
+long gtk3_key_press_event (long widget, long event) {
 	if (!hasFocus ()) return 0;
-	long result = super.gtk_key_press_event (widget, event);
+	long result = super.gtk3_key_press_event (widget, event);
 	if (result != 0) return result;
 	int index = 0;
 	while (index < itemCount) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Link.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Link.java
@@ -487,8 +487,8 @@ boolean gtk4_key_press_event(long controller, int keyval, int keycode, int state
 }
 
 @Override
-long gtk_key_press_event (long widget, long eventPtr) {
-	long result = super.gtk_key_press_event (widget, eventPtr);
+long gtk3_key_press_event (long widget, long eventPtr) {
+	long result = super.gtk3_key_press_event (widget, eventPtr);
 	if (result != 0) return result;
 	if (focusIndex == -1) return result;
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/List.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/List.java
@@ -920,16 +920,12 @@ long gtk_row_activated (long tree, long path, long column) {
 
 
 @Override
-long gtk_key_press_event (long widget, long event) {
+long gtk3_key_press_event (long widget, long event) {
 	int [] key = new int [1];
-	if (GTK.GTK4) {
-		key[0] = GDK.gdk_key_event_get_keyval(event);
-	} else {
-		GDK.gdk_event_get_keyval(event, key);
-	}
+	GDK.gdk_event_get_keyval(event, key);
 
 	keyPressDefaultSelectionHandler (event, key[0]);
-	return super.gtk_key_press_event (widget, event);
+	return super.gtk3_key_press_event (widget, event);
 }
 
 @Override

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Sash.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Sash.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -449,8 +449,8 @@ long gtk_focus_in_event(long widget, long event) {
 }
 
 @Override
-long gtk_key_press_event(long widget, long eventPtr) {
-	long result = super.gtk_key_press_event(widget, eventPtr);
+long gtk3_key_press_event(long widget, long eventPtr) {
+	long result = super.gtk3_key_press_event(widget, eventPtr);
 	if (result != 0) return result;
 
 	int[] key = new int[1], state = new int[1];

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Shell.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Shell.java
@@ -1783,7 +1783,7 @@ long gtk_motion_notify_event (long widget, long event) {
 }
 
 @Override
-long gtk_key_press_event (long widget, long event) {
+long gtk3_key_press_event (long widget, long event) {
 	if (widget == shellHandle) {
 		/* Stop menu mnemonics when the shell is disabled */
 		if ((state & DISABLED) != 0) return 1;
@@ -1812,7 +1812,7 @@ long gtk_key_press_event (long widget, long event) {
 
 						int mask = GTK.gtk_accelerator_get_default_mod_mask ();
 						if (key[0] == keyval [0] && (state[0] & mask) == (mods [0] & mask)) {
-							return focusControl.gtk_key_press_event (focusControl.focusHandle (), event);
+							return focusControl.gtk3_key_press_event (focusControl.focusHandle (), event);
 						}
 					}
 				}
@@ -1820,7 +1820,7 @@ long gtk_key_press_event (long widget, long event) {
 		}
 		return 0;
 	}
-	return super.gtk_key_press_event (widget, event);
+	return super.gtk3_key_press_event (widget, event);
 }
 
 @Override

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Spinner.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Spinner.java
@@ -795,8 +795,8 @@ long gtk_insert_text (long widget, long new_text, long new_text_length, long pos
 }
 
 @Override
-long gtk_key_press_event (long widget, long event) {
-	long result = super.gtk_key_press_event (widget, event);
+long gtk3_key_press_event (long widget, long event) {
+	long result = super.gtk3_key_press_event (widget, event);
 	if (result != 0) fixIM ();
 	if (gdkEventKey == -1) result = 1;
 	gdkEventKey = 0;

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Table.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Table.java
@@ -2139,13 +2139,9 @@ long gtk_row_activated (long tree, long path, long column) {
 
 
 @Override
-long gtk_key_press_event (long widget, long event) {
+long gtk3_key_press_event (long widget, long event) {
 	int [] key = new int[1];
-	if (GTK.GTK4) {
-		key[0] = GDK.gdk_key_event_get_keyval(event);
-	} else {
-		GDK.gdk_event_get_keyval(event, key);
-	}
+	GDK.gdk_event_get_keyval(event, key);
 
 	switch (key[0]) {
 		case GDK.GDK_Return:
@@ -2171,7 +2167,7 @@ long gtk_key_press_event (long widget, long event) {
 			break;
 	}
 
-	return super.gtk_key_press_event (widget, event);
+	return super.gtk3_key_press_event (widget, event);
 }
 
 private void toggleItemAndSendEvent(TableItem item) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Text.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Text.java
@@ -1843,22 +1843,17 @@ long gtk_insert_text (long widget, long new_text, long new_text_length, long pos
 }
 
 @Override
-long gtk_key_press_event (long widget, long event) {
+long gtk3_key_press_event (long widget, long event) {
 	boolean handleSegments = false, segmentsCleared = false;
 	if (hooks (SWT.Segments) || filters (SWT.Segments)) {
 		int length = 0;
 		int [] state = new int[1];
 
-		if (GTK.GTK4) {
-			/* TODO: GTK4 no access to key event string */
-			state[0] = GDK.gdk_event_get_modifier_state(event);
-		} else {
-			GDK.gdk_event_get_state(event, state);
+		GDK.gdk_event_get_state(event, state);
 
-			GdkEventKey gdkEvent = new GdkEventKey ();
-			GTK3.memmove(gdkEvent, event, GdkEventKey.sizeof);
-			length = gdkEvent.length;
-		}
+		GdkEventKey gdkEvent = new GdkEventKey ();
+		GTK3.memmove(gdkEvent, event, GdkEventKey.sizeof);
+		length = gdkEvent.length;
 
 		if (length > 0 && (state[0] & (GDK.GDK_MOD1_MASK | GDK.GDK_CONTROL_MASK)) == 0) {
 			handleSegments = true;
@@ -1868,7 +1863,7 @@ long gtk_key_press_event (long widget, long event) {
 			}
 		}
 	}
-	long result = super.gtk_key_press_event (widget, event);
+	long result = super.gtk3_key_press_event (widget, event);
 	if (result != 0) fixIM ();
 	if (gdkEventKey == -1) result = 1;
 	gdkEventKey = 0;

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/ToolBar.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/ToolBar.java
@@ -431,9 +431,9 @@ ToolItem [] _getTabItemList () {
 }
 
 @Override
-long gtk_key_press_event (long widget, long eventPtr) {
+long gtk3_key_press_event (long widget, long eventPtr) {
 	if (!hasFocus ()) return 0;
-	long result = super.gtk_key_press_event (widget, eventPtr);
+	long result = super.gtk3_key_press_event (widget, eventPtr);
 	return result;
 }
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Tracker.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Tracker.java
@@ -474,19 +474,14 @@ long gtk_button_release_event (long widget, long event) {
 }
 
 @Override
-long gtk_key_press_event (long widget, long eventPtr) {
-	long result = super.gtk_key_press_event (widget, eventPtr);
+long gtk3_key_press_event (long widget, long eventPtr) {
+	long result = super.gtk3_key_press_event (widget, eventPtr);
 	if (result != 0) return result;
 
 	int [] state = new int [1];
 	int [] keyval = new int [1];
-	if (GTK.GTK4) {
-		state[0] = GDK.gdk_event_get_modifier_state(eventPtr);
-		keyval[0] = GDK.gdk_key_event_get_keyval(eventPtr);
-	} else {
-		GDK.gdk_event_get_state(eventPtr, state);
-		GDK.gdk_event_get_keyval(eventPtr, keyval);
-	}
+	GDK.gdk_event_get_state(eventPtr, state);
+	GDK.gdk_event_get_keyval(eventPtr, keyval);
 
 	int stepSize = ((state[0] & GDK.GDK_CONTROL_MASK) != 0) ? STEPSIZE_SMALL : STEPSIZE_LARGE;
 	int xChange = 0, yChange = 0;
@@ -923,8 +918,8 @@ boolean processEvent (long eventPtr) {
 	switch (eventType) {
 		case GDK.GDK_MOTION_NOTIFY: gtk_motion_notify_event (widget, eventPtr); break;
 		case GDK.GDK_BUTTON_RELEASE: gtk_button_release_event (widget, eventPtr); break;
-		case GDK.GDK_KEY_PRESS: gtk_key_press_event (widget, eventPtr); break;
-		case GDK.GDK_KEY_RELEASE: gtk_key_release_event (widget, eventPtr); break;
+		case GDK.GDK_KEY_PRESS: gtk3_key_press_event (widget, eventPtr); break;
+		case GDK.GDK_KEY_RELEASE: gtk3_key_release_event (widget, eventPtr); break;
 		case GDK.GDK_BUTTON_PRESS:
 		case GDK.GDK_2BUTTON_PRESS:
 		case GDK.GDK_3BUTTON_PRESS:

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Tree.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Tree.java
@@ -2319,14 +2319,9 @@ long gtk_row_activated (long tree, long path, long column) {
 }
 
 @Override
-long gtk_key_press_event (long widget, long event) {
+long gtk3_key_press_event (long widget, long event) {
 	int [] key = new int[1];
-
-	if (GTK.GTK4) {
-		key[0] = GDK.gdk_key_event_get_keyval(event);
-	} else {
-		GDK.gdk_event_get_keyval(event, key);
-	}
+	GDK.gdk_event_get_keyval(event, key);
 
 	switch (key[0]) {
 		case GDK.GDK_Return:
@@ -2341,7 +2336,7 @@ long gtk_key_press_event (long widget, long event) {
 			break;
 	}
 
-	return super.gtk_key_press_event (widget, event);
+	return super.gtk3_key_press_event (widget, event);
 }
 
 /**

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Widget.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Widget.java
@@ -996,11 +996,11 @@ long gtk_insert_text (long widget, long new_text, long new_text_length, long pos
 	return 0;
 }
 
-long gtk_key_press_event (long widget, long event) {
+long gtk3_key_press_event (long widget, long event) {
 	return sendKeyEvent (SWT.KeyDown, event) ? 0 : 1;
 }
 
-long gtk_key_release_event (long widget, long event) {
+long gtk3_key_release_event (long widget, long event) {
 	return sendKeyEvent (SWT.KeyUp, event) ? 0 : 1;
 }
 
@@ -2636,8 +2636,8 @@ long windowProc (long handle, long arg0, long user_data) {
 		case FOCUS: return gtk_focus (handle, arg0);
 		case FOCUS_IN_EVENT: return gtk_focus_in_event (handle, arg0);
 		case FOCUS_OUT_EVENT: return gtk_focus_out_event (handle, arg0);
-		case KEY_PRESS_EVENT: return gtk_key_press_event (handle, arg0);
-		case KEY_RELEASE_EVENT: return gtk_key_release_event (handle, arg0);
+		case KEY_PRESS_EVENT: return gtk3_key_press_event (handle, arg0);
+		case KEY_RELEASE_EVENT: return gtk3_key_release_event (handle, arg0);
 		case INPUT: return gtk_input (handle, arg0);
 		case LEAVE_NOTIFY_EVENT: return gtk_leave_notify_event (handle, arg0);
 		case MAP_EVENT: return gtk_map_event (handle, arg0);


### PR DESCRIPTION
On Gtk 4 that is handled via Widget.keyPressReleaseProc method. Simplifies Gtk3 implementation to not needlessly try to be Gtk 4 safe and also makes it clear that these handlers are for Gtk 3 only by just reading the name.