### PR TITLE
Dont put the handles created at fixed size to zoomLevelToImageHandle

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Image.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Image.java
@@ -1636,8 +1636,8 @@ private static HandleForImageDataContainer init(Device device, ImageData i) {
 	}
 }
 
-private void setImageMetadataForHandle(ImageHandle imageMetadata, Integer zoom) {
-	if (zoom == null)
+private void setImageMetadataForHandle(ImageHandle imageMetadata, int zoom) {
+	if (zoom == -1)
 		return;
 	if (zoomLevelToImageHandle.containsKey(zoom)) {
 		SWT.error(SWT.ERROR_ITEM_NOT_ADDED);


### PR DESCRIPTION
The image handles created for a given target height and width is created by passing a zoom of -1. It does not make sense to put this handle in zoomLevelToImageHandle map. Putting the handle in the map would result in the image handle to be destroyed when switching monitors.

This currently solves a regression that can be seen in GEF introduced after 
- https://github.com/eclipse-platform/eclipse.platform.swt/pull/2601

Steps to reproduce

1)Open a eclipse GEF diagram 
2)Move across 2 monitors which would cause the below stack trace in console 

```
java.lang.IllegalArgumentException: Argument not valid
	at org.eclipse.swt.SWT.error(SWT.java:4931)
	at org.eclipse.swt.SWT.error(SWT.java:4865)
	at org.eclipse.swt.SWT.error(SWT.java:4836)
	at org.eclipse.swt.graphics.GC.drawImage(GC.java:1302)
	at org.eclipse.swt.graphics.GC.lambda$1(GC.java:1237)
	at org.eclipse.swt.graphics.Image.executeOnImageHandleAtSize(Image.java:864)
	at org.eclipse.swt.graphics.GC.drawImage(GC.java:1236)
	at org.eclipse.swt.graphics.GC$DrawScaledImageOperation.apply(GC.java:1230)
	at org.eclipse.swt.graphics.GC.storeAndApplyOperationForExistingHandle(GC.java:6043)
	at org.eclipse.swt.graphics.GC.drawImage(GC.java:1161)
	at org.eclipse.swt.custom.CTabFolderRenderer.drawUnselected(CTabFolderRenderer.java:1648)
	at org.eclipse.swt.custom.CTabFolderRenderer.draw(CTabFolderRenderer.java:647)
	at org.eclipse.e4.ui.workbench.renderers.swt.CTabRendering.draw(CTabRendering.java:309)
	at org.eclipse.swt.custom.CTabFolder.onPaint(CTabFolder.java:2101)
	at org.eclipse.swt.custom.CTabFolder.lambda$0(CTabFolder.java:338)
	at org.eclipse.swt.widgets.EventTable.sendEvent(EventTable.java:91)
	at org.eclipse.swt.widgets.Display.sendEvent(Display.java:4357)
	at org.eclipse.swt.widgets.Widget.sendEvent(Widget.java:1221)
	at org.eclipse.swt.widgets.Widget.sendEvent(Widget.java:1245)
	at org.eclipse.swt.widgets.Widget.sendEvent(Widget.java:1230)
	at org.eclipse.swt.widgets.Composite.WM_PAINT(Composite.java:1539)
	at org.eclipse.swt.widgets.Control.windowProc(Control.java:4856)
	at org.eclipse.swt.widgets.Display.windowProc(Display.java:5125)
	at org.eclipse.swt.internal.win32.OS.DefWindowProc(Native Method)
	at org.eclipse.swt.widgets.Shell.callWindowProc(Shell.java:504)
	at org.eclipse.swt.widgets.Control.windowProc(Control.java:4901)
	at org.eclipse.swt.widgets.Canvas.windowProc(Canvas.java:336)
	at org.eclipse.swt.widgets.Decorations.windowProc(Decorations.java:1499)
	at org.eclipse.swt.widgets.Shell.windowProc(Shell.java:2378)
	at org.eclipse.swt.widgets.Display.windowProc(Display.java:5125)
	at org.eclipse.swt.internal.win32.OS.DefWindowProc(Native Method)
	at org.eclipse.swt.widgets.Shell.callWindowProc(Shell.java:504)
	at org.eclipse.swt.widgets.Control.windowProc(Control.java:4901)
	at org.eclipse.swt.widgets.Canvas.windowProc(Canvas.java:336)
	at org.eclipse.swt.widgets.Decorations.windowProc(Decorations.java:1499)
	at org.eclipse.swt.widgets.Shell.windowProc(Shell.java:2378)
	at org.eclipse.swt.widgets.Display.windowProc(Display.java:5125)
	at org.eclipse.swt.internal.win32.OS.DispatchMessage(Native Method)
	at org.eclipse.swt.widgets.Display.readAndDispatch(Display.java:3741)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine$5.run(PartRenderingEngine.java:1147)
	at org.eclipse.core.databinding.observable.Realm.runWithDefault(Realm.java:339)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine.run(PartRenderingEngine.java:1038)
	at org.eclipse.e4.ui.internal.workbench.E4Workbench.createAndRunUI(E4Workbench.java:153)
	at org.eclipse.ui.internal.Workbench.lambda$3(Workbench.java:677)
	at org.eclipse.core.databinding.observable.Realm.runWithDefault(Realm.java:339)
	at org.eclipse.ui.internal.Workbench.createAndRunWorkbench(Workbench.java:583)
	at org.eclipse.ui.PlatformUI.createAndRunWorkbench(PlatformUI.java:173)
	at org.eclipse.ui.internal.ide.application.IDEApplication.start(IDEApplication.java:185)
	at org.eclipse.equinox.internal.app.EclipseAppHandle.run(EclipseAppHandle.java:219)
	at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.runApplication(EclipseAppLauncher.java:149)
	at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.start(EclipseAppLauncher.java:115)
	at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:467)
	at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:298)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at org.eclipse.equinox.launcher.Main.invokeFramework(Main.java:627)
	at org.eclipse.equinox.launcher.Main.basicRun(Main.java:575)
	at org.eclipse.equinox.launcher.Main.run(Main.java:1431)
	at org.eclipse.equinox.launcher.Main.main(Main.java:1403)
```

`Root cause:`
During a DPI change, all image handles stored in zoomLevelToImageHandle are destroyed. When drawing a new image of the same size, the destroyed handle is reused, resulting in the IllegalArgumentException. Now we dont put handles to the map for drawing at target size solving the problem