### PR TITLE
[Windows] Place new windows near top-left corner of their parents #2608

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Control.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Control.java
@@ -668,12 +668,25 @@ Widget [] computeTabList () {
 
 void createHandle () {
 	long hwndParent = widgetParent ();
+
+	int x=OS.CW_USEDEFAULT;
+	int y=0;
+
+	// Set it to be near the top-left corner of the parent shell by default
+	if (hwndParent != 0) {
+		RECT rect = new RECT();
+		OS.GetWindowRect(hwndParent, rect);
+
+		x = rect.left + 100;
+		y = rect.top + 100;
+	}
+
 	handle = OS.CreateWindowEx (
 		widgetExtStyle (),
 		windowClass (),
 		null,
 		widgetStyle (),
-		OS.CW_USEDEFAULT, 0, OS.CW_USEDEFAULT, 0,
+		x, y, OS.CW_USEDEFAULT, 0,
 		hwndParent,
 		0,
 		OS.GetModuleHandle (null),


### PR DESCRIPTION
## What it does
If there is a parent present at the moment when the window is created then set the initial position of the new window to be near the top-left corner of its parent. This avoids unnecessary DPI change events in case that the new window stays in the same monitor were its parent is.

Fixes https://github.com/eclipse-platform/eclipse.platform.swt/issues/2608

## How to test

You need an SDK / IDE to be able to reproduce the error _i.e._ you will either have to test this in tonight's I-BUILD or you have to manually drop the newly compiled `Control.class` file inside the proper SWT Jar of your Eclipse IDE/SDK.

For instructions on how to reproduce the error, see: https://github.com/eclipse-platform/eclipse.platform.swt/issues/2608#issuecomment-3400418489