### PR TITLE
[Win32] Fix shell zoom when disabling autoscaling on shell

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Control.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Control.java
@@ -1282,7 +1282,7 @@ public Cursor getCursor () {
 public Object getData(String key) {
 	if (DATA_SHELL_ZOOM.equals(key)) {
 		Shell shell = getShell();
-		return shell == null ? null : shell.nativeZoom;
+		return shell == null ? null : DPIUtil.mapDPIToZoom(OS.GetDpiForWindow(shell.handle));
 	}
 	return super.getData(key);
 }


### PR DESCRIPTION
Recent simplifications to how autoscaling can be disabled for controls (https://github.com/eclipse-platform/eclipse.platform.swt/pull/2599) leads to a wrong native zoom being reported via getData("SHELL_ZOOM") when autoscaling is disabled at the shell itself. Instead of the actual zoom it always reports 100 because the shell's nativeZoom is overwritten when autoscaling is disabled for the shell.

This change adapts the way in which the shell zoom is retrieved when calling getData("SHELL_ZOOM") to be independent of the stored nativeZoom value.