### PR TITLE
[Win32] Fix initial control location #2643

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Control.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Control.java
@@ -672,25 +672,13 @@ Widget [] computeTabList () {
 
 void createHandle () {
 	long hwndParent = widgetParent ();
-
-	int x=OS.CW_USEDEFAULT;
-	int y=0;
-
-	// Set it to be near the top-left corner of the parent shell by default
-	if (hwndParent != 0) {
-		RECT rect = new RECT();
-		OS.GetWindowRect(hwndParent, rect);
-
-		x = rect.left + 100;
-		y = rect.top + 100;
-	}
-
+	Point initialLocation = getInitialLocation();
 	handle = OS.CreateWindowEx (
 		widgetExtStyle (),
 		windowClass (),
 		null,
 		widgetStyle (),
-		x, y, OS.CW_USEDEFAULT, 0,
+		initialLocation.x, initialLocation.y, OS.CW_USEDEFAULT, 0,
 		hwndParent,
 		0,
 		OS.GetModuleHandle (null),
@@ -700,6 +688,10 @@ void createHandle () {
 	if ((bits & OS.WS_CHILD) != 0) {
 		OS.SetWindowLongPtr (handle, OS.GWLP_ID, handle);
 	}
+}
+
+Point getInitialLocation() {
+	return new Point(OS.CW_USEDEFAULT, 0);
 }
 
 void checkGesture () {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Shell.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Shell.java
@@ -645,6 +645,18 @@ void createHandle () {
 	}
 }
 
+@Override
+Point getInitialLocation() {
+	long hwndParent = widgetParent ();
+	// Set it to be near the top-left corner of the parent shell by default
+	if (hwndParent != 0) {
+		RECT rect = new RECT();
+		OS.GetWindowRect(hwndParent, rect);
+		return new Point(rect.left + 100, rect.top + 100);
+	}
+	return super.getInitialLocation();
+}
+
 void createMenuItemToolTipHandle() {
 	menuItemToolTipHandle = createToolTipHandle (0);
 }


### PR DESCRIPTION
With a recent change to the initial location of newly created controls, the locations of some controls inside shells are broken. The intent of that previous change was to improve the initial location of shells.

This change adapts the previous modification to only apply an improved pattern for initial shell placement when the control is actually shell and to keep the previous behavior for all other controls.

Fixes https://github.com/eclipse-platform/eclipse.platform.swt/issues/2643