### PR TITLE
[Win32] Autoscale cursor even on widgets that have autoscaling disabled

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Control.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Control.java
@@ -1283,7 +1283,7 @@ public void setData(String key, Object value) {
 		if (autoScaleDisabled) {
 			this.nativeZoom = 100;
 		} else {
-			this.nativeZoom = (int) getData(DATA_SHELL_ZOOM);
+			this.nativeZoom = getShellZoom();
 		}
 	}
 }
@@ -4817,6 +4817,13 @@ int getZoom() {
 	return super.getZoom();
 }
 
+int getShellZoom() {
+	if (getData(DATA_SHELL_ZOOM) instanceof Integer shellZoom) {
+		return shellZoom;
+	}
+	return nativeZoom;
+}
+
 abstract TCHAR windowClass ();
 
 abstract long windowProc ();
@@ -5503,7 +5510,7 @@ LRESULT WM_SETCURSOR (long wParam, long lParam) {
 		if (control == null) return null;
 		Cursor cursor = control.findCursor ();
 		if (cursor != null) {
-			OS.SetCursor (Cursor.win32_getHandle(cursor, DPIUtil.getZoomForAutoscaleProperty(getNativeZoom())));
+			OS.SetCursor (Cursor.win32_getHandle(cursor, DPIUtil.getZoomForAutoscaleProperty(getShellZoom())));
 			return LRESULT.ONE;
 		}
 	}

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Shell.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Shell.java
@@ -2719,7 +2719,7 @@ LRESULT WM_SETCURSOR (long wParam, long lParam) {
 				RECT rect = new RECT ();
 				OS.GetClientRect (handle, rect);
 				if (OS.PtInRect (rect, pt)) {
-					OS.SetCursor (Cursor.win32_getHandle(cursor, DPIUtil.getZoomForAutoscaleProperty(getNativeZoom())));
+					OS.SetCursor (Cursor.win32_getHandle(cursor, DPIUtil.getZoomForAutoscaleProperty(getShellZoom())));
 					switch (msg) {
 						case OS.WM_LBUTTONDOWN:
 						case OS.WM_RBUTTONDOWN:

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Tracker.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Tracker.java
@@ -823,7 +823,7 @@ public void setCursor(Cursor newCursor) {
 	checkWidget();
 	clientCursor = newCursor;
 	if (newCursor != null) {
-		if (inEvent) OS.SetCursor (Cursor.win32_getHandle(clientCursor, DPIUtil.getZoomForAutoscaleProperty(getNativeZoom())));
+		if (inEvent) OS.SetCursor (Cursor.win32_getHandle(clientCursor, DPIUtil.getZoomForAutoscaleProperty(parent != null ? parent.getShellZoom() : getNativeZoom())));
 	}
 }
 
@@ -892,7 +892,7 @@ long transparentProc (long hwnd, long msg, long wParam, long lParam) {
 			break;
 		case OS.WM_SETCURSOR:
 			if (clientCursor != null) {
-				OS.SetCursor (Cursor.win32_getHandle(clientCursor, DPIUtil.getZoomForAutoscaleProperty(getNativeZoom())));
+				OS.SetCursor (Cursor.win32_getHandle(clientCursor, DPIUtil.getZoomForAutoscaleProperty(parent != null ? parent.getShellZoom() : getNativeZoom())));
 				return 1;
 			}
 			if (resizeCursor != 0) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Tree.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Tree.java
@@ -4665,7 +4665,7 @@ void setCursor () {
 	* is IDC_ARROW.
 	*/
 	Cursor cursor = findCursor ();
-	long hCursor = cursor == null ? OS.LoadCursor (0, OS.IDC_ARROW) : Cursor.win32_getHandle(cursor, DPIUtil.getZoomForAutoscaleProperty(getNativeZoom()));
+	long hCursor = cursor == null ? OS.LoadCursor (0, OS.IDC_ARROW) : Cursor.win32_getHandle(cursor, DPIUtil.getZoomForAutoscaleProperty(getShellZoom()));
 	OS.SetCursor (hCursor);
 }
 


### PR DESCRIPTION
Cursors are initialized with the zoom of the control on which they are set. However, cursors are usually expected to scale according to the autoscaled UI around those controls for which autoscaling was disabled.

This change adapts the cursor initializations to use the autoscale zoom of the containing shell instead of the zoom of the control itself. In consequence, cursors will have the same size in the whole shell, no matter on which control they are set.

Contributes to https://github.com/eclipse-gef/gef-classic/pull/821

### How to test
Best possibility to productively test is with Draw2d/GEF and according examples.

For simple testing, the following snippet can be used (adapted from https://github.com/eclipse-platform/eclipse.platform.swt/issues/2308). The lines for different properties `AUTOSCALE_DISABLED`, `swt.autoScale` and `swt.autoScale.updateOnRuntime` can be changed to test different combinations. The combination that is activated by default shows the bug in the existing implementation. The others allow to test that we do not have possible regressions regarding previous issue reports, such as https://github.com/eclipse-platform/eclipse.platform.swt/issues/2308.

In any case, a primary monitor with zoom != 100% should be used.

```java
public class Snippet1 {

	public static void main(String[] args) {
//		System.setProperty("swt.autoScale", "200");
//		System.setProperty("swt.autoScale", "false");
		System.setProperty("swt.autoScale.updateOnRuntime", "true");
		Cursor cursor = new Cursor(null, getImageData(100), 0, 0);

		Shell shell = new Shell(SWT.NO_TRIM);
		shell.setSize(100, 100);
		shell.setLayout(new FillLayout());
		Composite c = new Composite(shell, SWT.NONE);
		c.setBackground(new Color(0, 255, 0));
		c.setData("AUTOSCALE_DISABLED", true);
		c.setCursor(cursor);
		shell.open();

		Display display = shell.getDisplay();
		while (!display.isDisposed()) {
			display.readAndDispatch();
		}
		cursor.dispose();
	}

	private static ImageData getImageData(int zoom) {
		Image image = new Image(null, 50, 50);
		try {
			GC gc = new GC(image);
			gc.setBackground(new Color(255, 0, 0));
			gc.fillRectangle(0, 0, 50, 50);
			return image.getImageData(zoom);
		} finally {
			image.dispose();
		}
	}
}
```

The red cursor is expected to always have half the width and height of the green shell.

With the default configuration is looks like this without the change:
<img width="80" height="79" alt="cursor_old" src="https://github.com/user-attachments/assets/66d5219e-7d3a-4c5c-ad7f-eefed1db3c48" />

And this is how it looks with the change:
<img width="80" height="79" alt="cursor_new" src="https://github.com/user-attachments/assets/1a094018-e117-4e6e-953c-75c5e7eb6558" />