### PR TITLE
Reverting a side effect introduced in #2526

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Image.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Image.java
@@ -2028,7 +2028,7 @@ private abstract class AbstractImageProviderWrapper {
 	}
 
 	protected ImageHandle newImageHandle(ZoomContext zoomContext) {
-		ImageData resizedData = getScaledImageData (zoomContext.targetZoom());
+		ImageData resizedData = getImageData (zoomContext.targetZoom());
 		return newImageHandle(resizedData, zoomContext);
 	}
 
@@ -2070,7 +2070,7 @@ private class ExistingImageHandleProviderWrapper extends AbstractImageProviderWr
 
 	@Override
 	ImageData newImageData(ZoomContext zoomContext) {
-		return getImageData(zoomContext.targetZoom());
+		return getScaledImageData(zoomContext.targetZoom());
 	}
 
 	@Override


### PR DESCRIPTION
This commit reverts the changes introduced in #2526 where getImageData and getScaledImageData were mistakenly interchanged. The initial approach aimed to use this method in loadImageDataClosestTo when images couldn't be loaded at the exact size. However, the final implementation used loadImageData(zoom) instead, making those changes unnecessary. These leftover modifications were an unintended side effect, and this commit removes them.