### PR TITLE
[Win32] Only scale menu item images on monitor-specific scaling #2537

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/MenuItem.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/MenuItem.java
@@ -907,6 +907,9 @@ private long getMenuItemIconSelectedBitmapHandle() {
 }
 
 private int adaptZoomForMenuItem(int currentZoom, Image image) {
+	if (!display.isRescalingAtRuntime()) {
+		return DPIUtil.getZoomForAutoscaleProperty(currentZoom);
+	}
 	int primaryMonitorZoomAtAppStartUp = Win32DPIUtils.getPrimaryMonitorZoomAtStartup();
 	/*
 	 * Windows has inconsistent behavior when setting the size of MenuItem image and


### PR DESCRIPTION
The current mechanism to adapt the size of menu item images based on Windows system metrics, primary monitor zoom at startup and the current monitor zoom ensures that menu item images always fit to the required size for that menu. Since menus and their sizes are managed by the OS, adapting the image size as currently implemented leads to the best fitting image sizes.
However, this behavior is incompatible with the assumptions one could previously make on the sizes of those images. In particular, depending on the used auto-scale mode different kinds of scaling for those images were in place.

To achieve the best solution for all cases, this change results in the following:
- When monitor-specific scaling is enabled, menu item images are properly scaled as required for the menu. This is independent of whether any other additional legacy settings regarding auto-scaling is made, which will be overwritten by this.
- When monitor-specific scaling is disabled, the previous behavior is restored such that images are just scaled depending on the auto-scale mode but do not take into account which size is actually needed for that menu.

Fixes https://github.com/eclipse-platform/eclipse.platform.swt/issues/2537

## How to test

The issue can be reproduced and the fix tested with the snippet given in the original issue:
- https://github.com/eclipse-platform/eclipse.platform.swt/issues/2537#issue-3448031683

It also allows to test different combinations of auto-scale properties together with menus.