### PR TITLE
[Win32] Remove obsolete HandleAtSizeConsumer

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/GC.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/GC.java
@@ -1233,10 +1233,11 @@ private class DrawScaledImageOperation extends ImageOperation {
 }
 
 private void drawImage(Image image, int destX, int destY, int destWidth, int destHeight, int imageZoom) {
-	Rectangle destPixels = Win32DPIUtils.pointToPixel(drawable, new Rectangle(destX, destY, destWidth, destHeight), imageZoom);
-	image.executeOnImageHandleAtSize((tempHandle, handleSize) -> {
-		drawImage(image, 0, 0, handleSize.x, handleSize.y, destPixels.x, destPixels.y, destPixels.width,
-				destPixels.height, false, tempHandle);
+	Rectangle destPixels = Win32DPIUtils.pointToPixel(drawable, new Rectangle(destX, destY, destWidth, destHeight),
+			imageZoom);
+	image.executeOnImageHandleAtBestFittingSize(tempHandle -> {
+		drawImage(image, 0, 0, tempHandle.getWidth(), tempHandle.getHeight(), destPixels.x, destPixels.y,
+				destPixels.width, destPixels.height, false, tempHandle);
 	}, destPixels.width, destPixels.height);
 }
 


### PR DESCRIPTION
With latest refactorings, the HandleAtSizeConsumer inside Image became obsolete as the ImageHandle passed to it already contains the other information encapsulated in that consumer. Thus, this follow-up refactoring replaces the HandleAtSizeConsumer with a simple ImageHandle consumer. To do so, it properly encapsulates and exposes the width/height information in an ImageHandle. It also aligns the name of the method processing such a consumer to fit the actual behavior and the according MacOS implementation.