### PR TITLE
[GTK] Remove unused and deprecated bindings

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/os.c
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/os.c
@@ -2399,26 +2399,6 @@ JNIEXPORT void JNICALL GDK_NATIVE(gdk_1surface_1set_1cursor)
 }
 #endif
 
-#ifndef NO_gdk_1surface_1set_1input_1region
-JNIEXPORT void JNICALL GDK_NATIVE(gdk_1surface_1set_1input_1region)
-	(JNIEnv *env, jclass that, jlong arg0, jlong arg1)
-{
-	GDK_NATIVE_ENTER(env, that, gdk_1surface_1set_1input_1region_FUNC);
-	gdk_surface_set_input_region((GdkSurface *)arg0, (cairo_region_t *)arg1);
-	GDK_NATIVE_EXIT(env, that, gdk_1surface_1set_1input_1region_FUNC);
-}
-#endif
-
-#ifndef NO_gdk_1surface_1set_1opaque_1region
-JNIEXPORT void JNICALL GDK_NATIVE(gdk_1surface_1set_1opaque_1region)
-	(JNIEnv *env, jclass that, jlong arg0, jlong arg1)
-{
-	GDK_NATIVE_ENTER(env, that, gdk_1surface_1set_1opaque_1region_FUNC);
-	gdk_surface_set_opaque_region((GdkSurface *)arg0, (cairo_region_t *)arg1);
-	GDK_NATIVE_EXIT(env, that, gdk_1surface_1set_1opaque_1region_FUNC);
-}
-#endif
-
 #ifndef NO_gdk_1text_1property_1to_1utf8_1list_1for_1display
 JNIEXPORT jint JNICALL GDK_NATIVE(gdk_1text_1property_1to_1utf8_1list_1for_1display)
 	(JNIEnv *env, jclass that, jlong arg0, jlong arg1, jint arg2, jlong arg3, jint arg4, jlongArray arg5)
@@ -3138,18 +3118,6 @@ JNIEXPORT jlong JNICALL GDK_NATIVE(gdk_1x11_1surface_1get_1xid)
 	GDK_NATIVE_ENTER(env, that, gdk_1x11_1surface_1get_1xid_FUNC);
 	rc = (jlong)gdk_x11_surface_get_xid((GdkSurface *)arg0);
 	GDK_NATIVE_EXIT(env, that, gdk_1x11_1surface_1get_1xid_FUNC);
-	return rc;
-}
-#endif
-
-#ifndef NO_gdk_1x11_1surface_1lookup_1for_1display
-JNIEXPORT jlong JNICALL GDK_NATIVE(gdk_1x11_1surface_1lookup_1for_1display)
-	(JNIEnv *env, jclass that, jlong arg0, jlong arg1)
-{
-	jlong rc = 0;
-	GDK_NATIVE_ENTER(env, that, gdk_1x11_1surface_1lookup_1for_1display_FUNC);
-	rc = (jlong)gdk_x11_surface_lookup_for_display((GdkDisplay *)arg0, (Window)arg1);
-	GDK_NATIVE_EXIT(env, that, gdk_1x11_1surface_1lookup_1for_1display_FUNC);
 	return rc;
 }
 #endif

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/os.h
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/os.h
@@ -59,7 +59,6 @@
 #if !GTK_CHECK_VERSION(4,0,0)
 #include <gtk/gtkx.h>
 #define NO_gdk_1x11_1surface_1get_1xid
-#define NO_gdk_1x11_1surface_1lookup_1for_1display
 #else
 #define NO_gdk_1x11_1get_1default_1xdisplay
 #define NO_gdk_1x11_1window_1get_1xid
@@ -286,8 +285,6 @@
 #define NO_gdk_1surface_1get_1root_1origin
 #define NO_gdk_1surface_1invalidate_1region
 #define NO_gdk_1event_1get_1surface
-#define NO_gdk_1surface_1set_1input_1region
-#define NO_gdk_1surface_1set_1opaque_1region
 
 // No GdkToplevel on GTK3
 #define NO_gdk_1toplevel_1present

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/os_stats.h
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/os_stats.h
@@ -179,8 +179,6 @@ typedef enum {
 	gdk_1surface_1new_1popup_FUNC,
 	gdk_1surface_1new_1toplevel_FUNC,
 	gdk_1surface_1set_1cursor_FUNC,
-	gdk_1surface_1set_1input_1region_FUNC,
-	gdk_1surface_1set_1opaque_1region_FUNC,
 	gdk_1text_1property_1to_1utf8_1list_1for_1display_FUNC,
 	gdk_1texture_1new_1for_1pixbuf_FUNC,
 	gdk_1texture_1new_1from_1file_FUNC,
@@ -236,7 +234,6 @@ typedef enum {
 	gdk_1x11_1screen_1get_1window_1manager_1name_FUNC,
 	gdk_1x11_1screen_1lookup_1visual_FUNC,
 	gdk_1x11_1surface_1get_1xid_FUNC,
-	gdk_1x11_1surface_1lookup_1for_1display_FUNC,
 	gdk_1x11_1window_1get_1xid_FUNC,
 	gdk_1x11_1window_1lookup_1for_1display_FUNC,
 } GDK_FUNCS;

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/org/eclipse/swt/internal/gtk/GDK.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/org/eclipse/swt/internal/gtk/GDK.java
@@ -286,12 +286,6 @@ public class GDK extends OS {
 	/* [GTK3 only, if-def'd in os.h] */
 	public static final native long gdk_x11_window_lookup_for_display(long gdkdisplay, long xid);
 	/**
-	 * @param gdkdisplay cast=(GdkDisplay *)
-	 * @param xid cast=(Window)
-	 */
-	/* [GTK4 only, if-def'd in os.h] */
-	public static final native long gdk_x11_surface_lookup_for_display(long gdkdisplay, long xid);
-	/**
 	 * @method flags=dynamic
 	 * @param atom_name cast=(const gchar *),flags=no_out critical
 	 */
@@ -352,18 +346,6 @@ public class GDK extends OS {
 	 */
 	/* [GTK4 only, if-def'd in os.h] */
 	public static final native int gdk_surface_get_height(long surface);
-	/**
-	 * @param surface cast=(GdkSurface *)
-	 * @param region cast=(cairo_region_t *)
-	 */
-	/* [GTK4 only, if-def'd in os.h] */
-	public static final native void gdk_surface_set_input_region(long surface, long region);
-	/**
-	 * @param surface cast=(GdkSurface *)
-	 * @param region cast=(cairo_region_t *)
-	 */
-	/* [GTK4 only, if-def'd in os.h] */
-	public static final native void gdk_surface_set_opaque_region(long surface, long region);
 	/**
 	 * @param cairo cast=(cairo_t *)
 	 * @param pixbuf cast=(const GdkPixbuf *)


### PR DESCRIPTION
Reduces build warnings for gtk4 port.