### PR TITLE
Add support loading images with a size hint

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/image/FileFormat.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/image/FileFormat.java
@@ -116,6 +116,9 @@ public abstract class FileFormat {
  * device independent image array represented by the stream.
  */
 public List<ElementAtZoom<ImageData>> loadFromStream(LEDataInputStream stream, int fileZoom, int targetZoom) {
+	return loadFromStream(stream, fileZoom, targetZoom, null);
+}
+public List<ElementAtZoom<ImageData>> loadFromStream(LEDataInputStream stream, int fileZoom, int targetZoom, Supplier<Point> sizeHintSupplier) {
 	try {
 		inputStream = stream;
 		return loadFromByteStream(fileZoom, targetZoom);
@@ -148,13 +151,16 @@ public ImageData loadFromStreamBySize(LEDataInputStream stream, int width, int h
  * return the device independent image array represented by the stream.
  */
 public static List<ElementAtZoom<ImageData>> load(ElementAtZoom<InputStream> is, ImageLoader loader, int targetZoom) {
+	return load(is, loader, targetZoom, null);
+}
+public static List<ElementAtZoom<ImageData>> load(ElementAtZoom<InputStream> is, ImageLoader loader, int targetZoom, Supplier<Point> sizeHintSupplier) {
 	LEDataInputStream stream = new LEDataInputStream(is.element());
 	FileFormat fileFormat = determineFileFormat(stream).orElseGet(() -> {
 		SWT.error(SWT.ERROR_UNSUPPORTED_FORMAT);
 		return null;
 	});
 	fileFormat.loader = loader;
-	return fileFormat.loadFromStream(stream, is.zoom(), targetZoom);
+	return fileFormat.loadFromStream(stream, is.zoom(), targetZoom, sizeHintSupplier);
 }
 
 public static ImageData load(InputStream is, ImageLoader loader, int width, int height) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/image/SVGFileFormat.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/image/SVGFileFormat.java
@@ -15,6 +15,7 @@ package org.eclipse.swt.internal.image;
 import java.io.*;
 import java.nio.charset.*;
 import java.util.*;
+import java.util.function.*;
 
 import org.eclipse.swt.*;
 import org.eclipse.swt.graphics.*;
@@ -50,6 +51,29 @@ public class SVGFileFormat extends FileFormat {
 		}
 		if (targetZoom <= 0) {
 			SWT.error(SWT.ERROR_INVALID_ARGUMENT, null, " [Cannot rasterize SVG for zoom <= 0]");
+		}
+		ImageData rasterizedImageData = RASTERIZER.rasterizeSVG(inputStream, 100 * targetZoom / fileZoom);
+		return List.of(new ElementAtZoom<>(rasterizedImageData, targetZoom));
+	}
+
+	@Override
+	public List<ElementAtZoom<ImageData>> loadFromStream(LEDataInputStream stream, int fileZoom, int targetZoom,
+			Supplier<Point> sizeHintSupplier) {
+		if (RASTERIZER == null) {
+			SWT.error(SWT.ERROR_UNSUPPORTED_FORMAT, null, " [No SVG rasterizer found]");
+		}
+		if (targetZoom <= 0) {
+			SWT.error(SWT.ERROR_INVALID_ARGUMENT, null, " [Cannot rasterize SVG for zoom <= 0]");
+		}
+		if (sizeHintSupplier != null) {
+			Point point = sizeHintSupplier.get();
+			if (point != null) {
+				double factor = targetZoom / 100d;
+				int w = (int) (factor * point.x);
+				int h = (int) (factor * point.y);
+				ImageData imageData = RASTERIZER.rasterizeSVG(inputStream, w, h);
+				return List.of(new ElementAtZoom<>(imageData, targetZoom));
+			}
 		}
 		ImageData rasterizedImageData = RASTERIZER.rasterizeSVG(inputStream, 100 * targetZoom / fileZoom);
 		return List.of(new ElementAtZoom<>(rasterizedImageData, targetZoom));

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/internal/NativeImageLoader.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/internal/NativeImageLoader.java
@@ -18,6 +18,7 @@ package org.eclipse.swt.internal;
 import java.io.*;
 import java.util.*;
 import java.util.List;
+import java.util.function.*;
 
 import org.eclipse.swt.*;
 import org.eclipse.swt.graphics.*;
@@ -34,6 +35,10 @@ public class NativeImageLoader {
 	// --- loading ---
 
 	public static List<ElementAtZoom<ImageData>> load(ElementAtZoom<InputStream> streamAtZoom, ImageLoader imageLoader, int targetZoom) {
+		return load(streamAtZoom, imageLoader, targetZoom, null);
+	}
+
+	public static List<ElementAtZoom<ImageData>> load(ElementAtZoom<InputStream> streamAtZoom, ImageLoader imageLoader, int targetZoom, Supplier<Point> sizeHintSupplier) {
 		// 1) Load InputStream into byte array
 		byte[] data_buffer;
 		InputStream stream = streamAtZoom.element();
@@ -53,7 +58,7 @@ public class NativeImageLoader {
 			} catch (IOException e) {
 				SWT.error(SWT.ERROR_IO);
 			}
-			return FileFormat.load(new ElementAtZoom<>(stream2, streamAtZoom.zoom()), imageLoader, targetZoom);
+			return FileFormat.load(new ElementAtZoom<>(stream2, streamAtZoom.zoom()), imageLoader, targetZoom, sizeHintSupplier);
 		}
 		List<ImageData> imgDataList = new ArrayList<>();
 		long loader = GDK.gdk_pixbuf_loader_new();


### PR DESCRIPTION
Currently when loading a SVG image it always uses the size declared in the document but storing an SVG at the size to load the image is not really sufficient as it for example require to store the same SVG multiple times if one wants to load it at different sizes.

This now adds a new parameter to the NativeImageLoader that allows to pass a sizeHintSupplier that when we get a dynamic image will load it at the supplied size. This can then later be used in JFace to retrive the target size from the URL.

@HeikoKlare can you take a look if it makes sense to you? I'm not completely sure about `fileZoom` and `targetZoom` here...