### PR TITLE
Add clipboard tag to all SWT tests

### DIFF
--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/AllBrowserTests.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/AllBrowserTests.java
@@ -17,7 +17,7 @@ package org.eclipse.swt.tests.junit;
 import org.junit.platform.suite.api.SelectClasses;
 import org.junit.platform.suite.api.Suite;
 
-@Suite
+@Suite(failIfNoTests = false)
 @SelectClasses({
 	Test_org_eclipse_swt_browser_Browser.class,
 	Test_org_eclipse_swt_browser_Browser_IE.class

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/AllGraphicsTests.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/AllGraphicsTests.java
@@ -19,7 +19,7 @@ import org.junit.platform.suite.api.Suite;
 /**
  * Suite for testing all of the graphics test cases.
  */
-@Suite
+@Suite(failIfNoTests = false)
 @SelectClasses({ //
 		// Sorted list of tests
 		Test_org_eclipse_swt_graphics_Color.class, //

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/AllNonBrowserTests.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/AllNonBrowserTests.java
@@ -26,7 +26,7 @@ import org.junit.platform.suite.api.Suite;
 /**
  * Suite for running most SWT test cases (all except for browser tests).
  */
-@Suite
+@Suite(failIfNoTests = false)
 @SelectClasses({ //
 		// Basic tests
 		Test_org_eclipse_swt_SWT.class, //

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/AllTests.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/AllTests.java
@@ -20,7 +20,7 @@ import org.junit.platform.suite.api.Suite;
 /**
  * Suite for running all SWT test cases.
  */
-@Suite
+@Suite(failIfNoTests = false)
 @SelectClasses({
 	AllNonBrowserTests.class,
 	AllBrowserTests.class

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_custom_CCombo.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_custom_CCombo.java
@@ -33,6 +33,7 @@ import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Text;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -75,6 +76,7 @@ public void test_ConstructorLorg_eclipse_swt_widgets_CompositeI() {
 		assertNotNull(ccombo.getAccessible());
 }
 
+@Tag("clipboard")
 @Test
 public void test_copy() {
 	if (SwtTestUtil.isCocoa) {
@@ -93,6 +95,7 @@ public void test_copy() {
 	assertEquals("23123456", ccombo.getText());
 }
 
+@Tag("clipboard")
 @Test
 public void test_cut() {
 	if (SwtTestUtil.isCocoa) {
@@ -130,6 +133,7 @@ public void test_isFocusControl() {
 	}
 }
 
+@Tag("clipboard")
 @Test
 public void test_paste() {
 	if (SwtTestUtil.isCocoa) {

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_custom_LineBackgroundListener.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_custom_LineBackgroundListener.java
@@ -22,6 +22,7 @@ import org.eclipse.swt.custom.LineBackgroundListener;
 import org.eclipse.swt.custom.StyledText;
 import org.eclipse.swt.widgets.Shell;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -40,6 +41,7 @@ public void setUp() {
 	shell.open();
 }
 
+@Tag("clipboard")
 @Test
 public void test_lineGetBackgroundLorg_eclipse_swt_custom_LineBackgroundEvent() {
 	LineBackgroundListener listener = event -> {

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_custom_StyledText.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_custom_StyledText.java
@@ -78,6 +78,7 @@ import org.eclipse.swt.widgets.ScrollBar;
 import org.eclipse.swt.widgets.Text;
 import org.eclipse.swt.widgets.Widget;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -323,6 +324,7 @@ public void test_removeCaretListener_CaretListenerNotCalled() {
 	assertFalse(listenerCalled);
 }
 
+@Tag("clipboard")
 @Test
 public void test_addLineBackgroundListenerLorg_eclipse_swt_custom_LineBackgroundListener() {
 	String line = "Line1";
@@ -348,6 +350,7 @@ public void test_addLineBackgroundListenerLorg_eclipse_swt_custom_LineBackground
 	assertFalse(listenerCalled);
 }
 
+@Tag("clipboard")
 @Test
 public void test_addLineStyleListenerLorg_eclipse_swt_custom_LineStyleListener() {
 	String line = "Line1";
@@ -687,6 +690,8 @@ public void test_marginsCorrect(){
 	assertEquals(leftMargin, singleText.getLeftMargin());
 	singleText.dispose();
 }
+
+@Tag("clipboard")
 @Test
 public void test_copy() {
 	if (SwtTestUtil.isCocoa) {
@@ -763,6 +768,7 @@ private static StyleRange getRangeForText(String str, String subStr) {
 	return null;
 }
 
+@Tag("clipboard")
 @Test
 public void test_clipboardWithHtml() {
 	String content = "This is red, background yellow, bold, italic, underscore, big, small, super, sub.";
@@ -814,6 +820,7 @@ public void test_clipboardWithHtml() {
 	fontArial8.dispose();
 }
 
+@Tag("clipboard")
 @Test
 public void test_cut() {
 	if (SwtTestUtil.isCocoa) {
@@ -2239,6 +2246,7 @@ public void test_invokeActionI() {
 	text.invokeAction(ST.TOGGLE_OVERWRITE);
 }
 
+@Tag("clipboard")
 @Test
 public void test_paste(){
 	if (SwtTestUtil.isCocoa) {
@@ -5265,6 +5273,7 @@ public void test_selectAllInBlockSelectionMode() {
 	assertEquals("Test" + System.lineSeparator(), text.getSelectionText());
 }
 
+@Tag("clipboard")
 @Test
 public void test_cutTextInBlockSelection() {
 	text.setText(blockSelectionTestText());
@@ -5281,6 +5290,7 @@ public void test_cutTextInBlockSelection() {
 			+ "Sample Test Selection" + System.lineSeparator()));
 }
 
+@Tag("clipboard")
 @Test
 public void test_pasteInsertsTextInBlockSelectionAsBlock() {
 	text.setText(blockSelectionTestText());
@@ -5300,6 +5310,7 @@ public void test_pasteInsertsTextInBlockSelectionAsBlock() {
 			+ blockSelectionTestTextOneLine()));
 }
 
+@Tag("clipboard")
 @Test
 public void test_cutAndPasteInBlockSelection() {
 	text.setText(blockSelectionTestText());
@@ -5811,6 +5822,7 @@ public void test_bug551335_lostStyles() throws InterruptedException {
  * from clipboard. It should be still possible to paste text which was copied
  * from a now disposed/unavailable StyledText.
  */
+@Tag("clipboard")
 @Test
 public void test_clipboardCarryover() {
 	assumeFalse(SwtTestUtil.isCocoa, "Disabled on Mac because similar clipboard tests are also disabled.");

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_custom_StyledText_multiCaretsSelections.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_custom_StyledText_multiCaretsSelections.java
@@ -28,6 +28,7 @@ import org.eclipse.swt.widgets.Shell;
 import org.eclipse.test.Screenshots;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.AfterTestExecutionCallback;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -220,6 +221,7 @@ public class Test_org_eclipse_swt_custom_StyledText_multiCaretsSelections {
 		assertArrayEquals(new int[] { 2, 0, 7, 0 }, text.getSelectionRanges());
 	}
 
+	@Tag("clipboard")
 	@Test
 	public void test_MultiCarets_CopyPaste() {
 		text.setText("1\n2");

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Combo.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Combo.java
@@ -36,6 +36,7 @@ import org.eclipse.swt.graphics.Rectangle;
 import org.eclipse.swt.widgets.Combo;
 import org.eclipse.swt.widgets.Display;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -222,6 +223,7 @@ public void test_computeSizeIIZ() {
 	// super class test is sufficient
 }
 
+@Tag("clipboard")
 @Test
 public void test_copy() {
 	if (SwtTestUtil.isCocoa) {
@@ -245,6 +247,7 @@ public void test_copy() {
 	assertEquals("23123456", combo.getText());
 }
 
+@Tag("clipboard")
 @Test
 public void test_cut() {
 	if (SwtTestUtil.isCocoa) {
@@ -492,6 +495,7 @@ public void test_indexOfLjava_lang_StringI() {
 		assertEquals(i, combo.indexOf("fred" + i, i));
 }
 
+@Tag("clipboard")
 @Test
 public void test_paste() {
 	if (SwtTestUtil.isCocoa) {
@@ -1036,6 +1040,7 @@ public void test_consistency_DragDetect () {
 	consistencyEvent(10, 5, 20, 10, ConsistencyUtility.MOUSE_DRAG);
 }
 
+@Tag("clipboard")
 @Test
 public void test_consistency_Segments () {
 	if (!SwtTestUtil.isWindows) {

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Text.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Text.java
@@ -35,6 +35,7 @@ import org.eclipse.swt.widgets.Group;
 import org.eclipse.swt.widgets.Text;
 import org.eclipse.swt.widgets.Widget;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -263,6 +264,7 @@ public void test_computeSizeIIZ() {
 	// super class test is sufficient
 }
 
+@Tag("clipboard")
 @Test
 public void test_copy() {
 	if (SwtTestUtil.isCocoa) {
@@ -928,6 +930,7 @@ public void test_isVisible() {
 	assertFalse(control.isVisible());
 }
 
+@Tag("clipboard")
 @Test
 public void test_paste() {
 	if (SwtTestUtil.isCocoa) {
@@ -1429,6 +1432,7 @@ public void test_consistency_DragDetect () {
 	consistencyEvent(30, 10, 50, 0, ConsistencyUtility.MOUSE_DRAG);
 }
 
+@Tag("clipboard")
 @Test
 public void test_consistency_Segments () {
 	if (SwtTestUtil.isCocoa) {


### PR DESCRIPTION
Add 'clipboard' Tag to all tests that use it, and mark all suites as `failIfNoTests` = `false` so that tags are useful

This makes it easy to run all tests that affect the clipboard even though they are spread across many different tests.

Part of #2126

Note Test_org_eclipse_swt_dnd_Clipboard already has this tag as it was accidentally included when I split out #2649 out of #2588