### PR TITLE
Add explicit activation (by tester) to Clipboard tests on Wayland

### DIFF
--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/RemoteClipboard.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/RemoteClipboard.java
@@ -205,4 +205,9 @@ public class RemoteClipboard implements ClipboardCommands {
 	public void waitUntilReady() throws RemoteException {
 		remote.waitUntilReady();
 	}
+
+	@Override
+	public void waitForButtonPress()  throws RemoteException {
+		remote.waitForButtonPress();
+	}
 }

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/SwtTestUtil.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/SwtTestUtil.java
@@ -126,6 +126,28 @@ public class SwtTestUtil {
 	}
 
 	/**
+	 * Return whether running on Wayland. This is dynamically set at runtime and cannot
+	 * be accessed before the corresponding property is initialized in Display.
+	 *
+	 * <strong>Note:</strong> this method still must be called after the first
+	 * Display is created to be valid
+	 */
+	public final static boolean isWayland() {
+		if (!isGTK) {
+			return false;
+		}
+		String backend = System.getProperty("org.eclipse.swt.internal.gdk.backend");
+
+		if ("wayland".equals(backend)) {
+			return true;
+		} else if ("x11".equals(backend)) {
+			return false;
+		}
+		fail("org.eclipse.swt.internal.gdk.backend System property is not set yet. Create a new Display before calling isWayland");
+		throw new IllegalStateException("unreachable");
+	}
+
+	/**
 	 * Return whether running on GTK4. This is dynamically set at runtime and cannot
 	 * be accessed before the corresponding property is initialized in OS.
 	 *

--- a/tests/org.eclipse.swt.tests/data/clipboard/ClipboardCommands.java
+++ b/tests/org.eclipse.swt.tests/data/clipboard/ClipboardCommands.java
@@ -43,4 +43,6 @@ public interface ClipboardCommands extends Remote {
 	String getStringContents(int clipboardId) throws RemoteException;
 
 	void waitUntilReady() throws RemoteException;
+
+	void waitForButtonPress() throws RemoteException;
 }

--- a/tests/org.eclipse.swt.tests/data/clipboard/ClipboardTest.java
+++ b/tests/org.eclipse.swt.tests/data/clipboard/ClipboardTest.java
@@ -56,7 +56,7 @@ public class ClipboardTest extends JFrame {
 
 	private static Registry rmiRegistry;
 	private JTextArea textArea;
-	private ClipboardCommands commands;
+	private ClipboardCommandsImpl commands;
 
 	public ClipboardTest() throws RemoteException {
 		super("ClipboardTest");
@@ -68,6 +68,7 @@ public class ClipboardTest extends JFrame {
 
 		JButton copyButton = new JButton("Copy");
 		JButton pasteButton = new JButton("Paste");
+		JButton pressToContinue = new JButton("Press To Continue Test");
 
 		copyButton.addActionListener(e -> {
 			String text = textArea.getSelectedText();
@@ -88,9 +89,14 @@ public class ClipboardTest extends JFrame {
 			}
 		});
 
+		pressToContinue.addActionListener(e -> {
+			commands.buttonPressed.countDown();
+		});
+
 		JPanel buttonPanel = new JPanel();
 		buttonPanel.add(copyButton);
 		buttonPanel.add(pasteButton);
+		buttonPanel.add(pressToContinue);
 
 		add(scrollPane, BorderLayout.CENTER);
 		add(buttonPanel, BorderLayout.SOUTH);


### PR DESCRIPTION
On Wayland apps are not allowed to take ownership of the system clipboard unless the Wayland compositer (e.g KWin, mutter or others) believes that the user has initiated the request for ownership.

This means that activating and focusing the Shell may not be sufficient.

Therefore we require the person running the tests to press a button in the shell so the compositer believes that the clipboard access is legitimate.

This commit adds such a button, and a short timeout to press it. If not pressed in time the tests requiring SWT to take ownership of the clipboard will be skipped.

The button must be pressed multiple times throughout the test, therefore we group the affected tests to run first with TestMethodOrder annotation.

On GitHub actions + Jenkins these tests are skipped by default.

Note: At the moment activating + focusing the shell is sufficient to read from the system clipboard. In addition, X11 (and therefore the Swing remote clipboard test app) run under Xwayland do not require such explicit activation, so the key presses are only on the couple of tests that require ownership of system clipboard to operate properly.

Part of #2126
