### PR TITLE
Spin event loop in widget tests that access Clipboard

### DIFF
--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_custom_CCombo.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_custom_CCombo.java
@@ -76,7 +76,7 @@ public void test_ConstructorLorg_eclipse_swt_widgets_CompositeI() {
 }
 
 @Test
-public void test_copy() {
+public void test_copy() throws InterruptedException {
 	if (SwtTestUtil.isCocoa) {
 		// TODO Fix Cocoa failure.
 		if (SwtTestUtil.verbose) {
@@ -90,6 +90,7 @@ public void test_copy() {
 	ccombo.copy();
 	ccombo.setSelection(new Point(0,0));
 	ccombo.paste();
+	SwtTestUtil.processEvents(1000, () -> "23123456".equals(ccombo.getText()));
 	assertEquals("23123456", ccombo.getText());
 }
 
@@ -131,7 +132,7 @@ public void test_isFocusControl() {
 }
 
 @Test
-public void test_paste() {
+public void test_paste() throws InterruptedException {
 	if (SwtTestUtil.isCocoa) {
 		// TODO Fix Cocoa failure.
 		if (SwtTestUtil.verbose) {
@@ -143,8 +144,10 @@ public void test_paste() {
 	ccombo.setText("123456");
 	ccombo.setSelection(new Point(1,3));
 	ccombo.cut();
+	SwtTestUtil.processEvents(1000, () -> "1456".equals(ccombo.getText()));
 	assertEquals("1456", ccombo.getText());
 	ccombo.paste();
+	SwtTestUtil.processEvents(1000, () -> "123456".equals(ccombo.getText()));
 	assertEquals("123456", ccombo.getText());
 }
 

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Text.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Text.java
@@ -49,7 +49,7 @@ public class Test_org_eclipse_swt_widgets_Text extends Test_org_eclipse_swt_widg
 public void setUp() {
 	super.setUp();
 	shell.pack();
-	shell.open();
+	SwtTestUtil.openShell(shell);
 	makeCleanEnvironment(false); // use multi-line by default
 }
 
@@ -929,7 +929,7 @@ public void test_isVisible() {
 }
 
 @Test
-public void test_paste() {
+public void test_paste() throws InterruptedException {
 	if (SwtTestUtil.isCocoa) {
 		// TODO Fix Cocoa failure.
 		if (SwtTestUtil.verbose) {
@@ -942,12 +942,16 @@ public void test_paste() {
 	text.setSelection(2, 4);
 	assertEquals("01234567890", text.getText());
 	text.copy();
+	SwtTestUtil.processEvents(100, null);
 	text.setSelection(0);
 	text.paste();
+	SwtTestUtil.processEvents(1000, () -> "2301234567890".equals(text.getText()));
 	assertEquals("2301234567890", text.getText());
 	text.copy();
+	SwtTestUtil.processEvents(100, null);
 	text.setSelection(3);
 	text.paste();
+	SwtTestUtil.processEvents(1000, () -> "230231234567890".equals(text.getText()));
 	assertEquals("230231234567890", text.getText());
 
 	text.setText("0" + delimiterString + "1");
@@ -955,7 +959,9 @@ public void test_paste() {
 	text.copy();
 	text.setSelection(0);
 	text.paste();
-	assertEquals("0" + delimiterString + "1" + "0" + delimiterString + "1", text.getText());
+	String expected = "0" + delimiterString + "1" + "0" + delimiterString + "1";
+	SwtTestUtil.processEvents(1000, () -> expected.equals(text.getText()));
+	assertEquals(expected, text.getText());
 
 	// tests a SINGLE line text editor
 	makeCleanEnvironment(true);
@@ -966,10 +972,12 @@ public void test_paste() {
 	text.copy();
 	text.setSelection(0);
 	text.paste();
+	SwtTestUtil.processEvents(1000, () -> "2301234567890".equals(text.getText()));
 	assertEquals("2301234567890", text.getText());
 	text.copy();
 	text.setSelection(3);
 	text.paste();
+	SwtTestUtil.processEvents(1000, () -> "230231234567890".equals(text.getText()));
 	assertEquals("230231234567890", text.getText());
 
 	// tests a SINGLE line text editor
@@ -981,8 +989,11 @@ public void test_paste() {
 	text.setSelection(0);
 	text.paste();
 
-	if (SwtTestUtil.fCheckSWTPolicy)
+	if (SwtTestUtil.fCheckSWTPolicy) {
+		String expected2 = "0" + delimiterString + "1" + "0" + delimiterString + "1";
+		SwtTestUtil.processEvents(1000, () -> expected2.equals(text.getText()));
 		assertEquals("0" + delimiterString + "1" + "0" + delimiterString + "1", text.getText());
+	}
 }
 
 @Test


### PR DESCRIPTION
This carries on earlier work, such as PR #2489

Part of #2598