### PR TITLE
Document macOS URLTransfer uses out of date transfer type name

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/cocoa/org/eclipse/swt/dnd/URLTransfer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/cocoa/org/eclipse/swt/dnd/URLTransfer.java
@@ -33,6 +33,8 @@ import org.eclipse.swt.internal.cocoa.*;
 public class URLTransfer extends ByteArrayTransfer {
 
 	static URLTransfer _instance = new URLTransfer();
+	// XXX: SWT uses the deprecated format name here,
+	// the new name is "public.url" aka NSPasteboardTypeURL
 	static final String URL = OS.NSURLPboardType.getString();
 	static final String URL1 = OS.kUTTypeURL.getString();
 	static final int URL_ID = registerType(URL);


### PR DESCRIPTION
Part of #2126

Perhaps if a macOS maintainer wants to test this they can update to the new transfer type. I don't know if there is a negative effect of leaving this or moving it.

The full DND transfer tests that I am writing will make it easier to test and maintain that the transfer is implemented. Have a look at Test_org_eclipse_swt_dnd_URLTransfer (once that PR is merged)