### PR TITLE
Add restricted version-ranges for junit-jupiter dependencies

### DIFF
--- a/tests/org.eclipse.swt.tests.gtk/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.swt.tests.gtk/META-INF/MANIFEST.MF
@@ -4,9 +4,9 @@ Bundle-Name: Eclipse SWT Tests Linux/gtk
 Bundle-SymbolicName: org.eclipse.swt.tests.gtk
 Bundle-Version: 3.109.100.qualifier
 Bundle-Vendor: Eclipse.org
-Require-Bundle: junit-jupiter-api,
+Require-Bundle: junit-jupiter-api;bundle-version="[5.14.0,6.0.0)",
  org.eclipse.swt,
- junit-platform-suite-api
+ junit-platform-suite-api;bundle-version="[1.14.0,2.0.0)"
 Eclipse-BundleShape: dir
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Automatic-Module-Name: org.eclipse.swt.tests.gtk

--- a/tests/org.eclipse.swt.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.swt.tests/META-INF/MANIFEST.MF
@@ -6,13 +6,13 @@ Bundle-Version: 3.107.1000.qualifier
 Bundle-Vendor: Eclipse.org
 Export-Package: org.eclipse.swt.tests.junit,
  org.eclipse.swt.tests.junit.performance
-Require-Bundle: junit-jupiter-engine;bundle-version="5.12.0",
- junit-jupiter-params;bundle-version="5.12.0",
- junit-jupiter-api;bundle-version="5.12.0",
- junit-platform-suite-api;bundle-version="1.12.0",
- junit-platform-suite-commons;bundle-version="1.12.0",
- junit-platform-suite-engine;bundle-version="1.12.0",
- org.opentest4j;bundle-version="1.3.0",
+Require-Bundle: junit-jupiter-engine;bundle-version="[5.12.0,6.0.0)",
+ junit-jupiter-params;bundle-version="[5.12.0,6.0.0)",
+ junit-jupiter-api;bundle-version="[5.12.0,6.0.0)",
+ junit-platform-suite-api;bundle-version="[1.12.0,2.0.0)",
+ junit-platform-suite-commons;bundle-version="[1.12.0,2.0.0)",
+ junit-platform-suite-engine;bundle-version="[1.12.0,2.0.0)",
+ org.opentest4j;bundle-version="[1.3.0,2.0.0)",
  org.eclipse.swt;bundle-version="3.120.0",
  org.eclipse.test;bundle-version="3.6.200",
  org.eclipse.test.performance;bundle-version="3.13.0"


### PR DESCRIPTION
Part of
- https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/3430