### PR TITLE
[GTK] Fix HTMLTransfer loses last byte if copied data is odd length

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/gtk/org/eclipse/swt/dnd/HTMLTransfer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/gtk/org/eclipse/swt/dnd/HTMLTransfer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -90,14 +90,26 @@ public void javaToNative (Object object, TransferData transferData){
 @Override
 public Object nativeToJava(TransferData transferData){
 	if ( !isSupportedType(transferData) ||  transferData.pValue == 0 ) return null;
-	/* Ensure byteCount is a multiple of 2 bytes */
-	int size = (transferData.format * transferData.length / 8) / 2 * 2;
+
+	int size = (transferData.format * transferData.length / 8);
 	if (size <= 0) return null;
 	char[] bom = new char[1]; // look for a Byte Order Mark
 	if (size > 1) C.memmove (bom, transferData.pValue, 2);
 	String string;
 	if (bom[0] == '\ufeff' || bom[0] == '\ufffe') {
-		// utf16
+		// XXX Follow up to Bugs 376589 384381 this is almost
+		// certainly wrong as it leaves the BOM as the first
+		// character in the string. This probably should be
+		//
+		// byte[] bytes = new byte [size];
+		// C.memmove (bytes, transferData.pValue, size);
+		// string = new String(bytes, StandardCharset.UTF16);
+		//
+		// However I cannot find any current Linux program that
+		// copies text/html to the clipboard in UTF16 anymore
+		// so it is probably not a big issue
+		/* Ensure byteCount is a multiple of 2 bytes */
+		size = size / 2 * 2;
 		char[] chars = new char [size/2];
 		C.memmove (chars, transferData.pValue, size);
 		string = new String (chars);

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_dnd_HTMLTransfer.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_dnd_HTMLTransfer.java
@@ -126,7 +126,17 @@ public class Test_org_eclipse_swt_dnd_HTMLTransfer extends ClipboardBase {
 
 	static Stream<Arguments> testData() {
 		return Stream.of(//
-				Arguments.of("hello_world", "<b>Hello, World!</b>") //
+				Arguments.of("hello_world", "<b>Hello, World!</b>"), //
+				/*
+				 * single_char and odd_chars are a regression test specifically for a bug that
+				 * if there was only 1 byte in the clipboard the return value of getContents was
+				 * null instead of the single character and if there was odd > 1 the last byte
+				 * would be dropped. See
+				 * https://github.com/eclipse-platform/eclipse.platform.swt/issues/2666
+				 */
+				Arguments.of("single_char", " "), //
+				Arguments.of("odd_chars", "12345"), //
+				Arguments.of("even_chars", "123456") //
 		);
 	}
 


### PR DESCRIPTION
As a follow up to Bugs 376589 & 384381 which changed the serialization deserializtion from UTF16 to UTF8, there was some remnant code that ensured input was handled in pairs of bytes that should have been moved into the UTF16 part of the new if statement.

Fixes https://github.com/eclipse-platform/eclipse.platform.swt/issues/2666

This is a GTK only fix that affects GTK3 and GTK4