### PR TITLE
Modernize ByteArrayTransfer javadoc

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/cocoa/org/eclipse/swt/dnd/ByteArrayTransfer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/cocoa/org/eclipse/swt/dnd/ByteArrayTransfer.java
@@ -47,74 +47,76 @@ import org.eclipse.swt.internal.cocoa.*;
  *	private static final int MYTYPEID = registerType(MYTYPENAME);
  *	private static MyTypeTransfer _instance = new MyTypeTransfer();
  *
- * private MyTypeTransfer() {}
+ * private MyTypeTransfer() {
+ * }
  *
- * public static MyTypeTransfer getInstance () {
+ * public static MyTypeTransfer getInstance() {
  * 	return _instance;
  * }
- * public void javaToNative (Object object, TransferData transferData) {
- * 	if (object == null || !(object instanceof MyType[])) return;
  *
- * 	if (isSupportedType(transferData)) {
- * 		MyType[] myTypes = (MyType[]) object;
- * 		try {
- * 			// write data to a byte array and then ask super to convert to pMedium
- * 			ByteArrayOutputStream out = new ByteArrayOutputStream();
- * 			DataOutputStream writeOut = new DataOutputStream(out);
- * 			for (int i = 0, length = myTypes.length; i &lt; length;  i++){
- * 				byte[] buffer = myTypes[i].fileName.getBytes();
- * 				writeOut.writeInt(buffer.length);
- * 				writeOut.write(buffer);
- * 				writeOut.writeLong(myTypes[i].fileLength);
- * 				writeOut.writeLong(myTypes[i].lastModified);
- * 			}
- * 			byte[] buffer = out.toByteArray();
- * 			writeOut.close();
+ * &#64;Override
+ * public void javaToNative(Object object, TransferData transferData) {
+ * 	if (!checkMyType(object) || !isSupportedType(transferData)) {
+ * 		DND.error(DND.ERROR_INVALID_DATA);
+ * 	}
  *
- * 			super.javaToNative(buffer, transferData);
- *
- * 		} catch (IOException e) {
- * 		}
+ * 	MyType myType = (MyType) object;
+ * 	// write data to a byte array and then ask super to convert to native
+ * 	ByteArrayOutputStream out = new ByteArrayOutputStream();
+ * 	try (DataOutputStream writeOut = new DataOutputStream(out)) {
+ * 		byte[] fileNameBytes = myType.fileName.getBytes(StandardCharsets.UTF_8);
+ * 		writeOut.writeInt(fileNameBytes.length);
+ * 		writeOut.write(fileNameBytes);
+ * 		writeOut.writeLong(myType.fileLength);
+ * 		writeOut.writeLong(myType.lastModified);
+ * 		super.javaToNative(out.toByteArray(), transferData);
+ * 	} catch (IOException e) {
  * 	}
  * }
- * public Object nativeToJava(TransferData transferData){
  *
- * 	if (isSupportedType(transferData)) {
- *
- * 		byte[] buffer = (byte[])super.nativeToJava(transferData);
- * 		if (buffer == null) return null;
- *
- * 		MyType[] myData = new MyType[0];
- * 		try {
- * 			ByteArrayInputStream in = new ByteArrayInputStream(buffer);
- * 			DataInputStream readIn = new DataInputStream(in);
- * 			while(readIn.available() &gt; 20) {
- * 				MyType datum = new MyType();
- * 				int size = readIn.readInt();
- * 				byte[] name = new byte[size];
- * 				readIn.read(name);
- * 				datum.fileName = new String(name);
- * 				datum.fileLength = readIn.readLong();
- * 				datum.lastModified = readIn.readLong();
- * 				MyType[] newMyData = new MyType[myData.length + 1];
- * 				System.arraycopy(myData, 0, newMyData, 0, myData.length);
- * 				newMyData[myData.length] = datum;
- * 				myData = newMyData;
- * 			}
- * 			readIn.close();
- * 		} catch (IOException ex) {
- * 			return null;
- * 		}
- * 		return myData;
+ * &#64;Override
+ * public Object nativeToJava(TransferData transferData) {
+ * 	if (!isSupportedType(transferData)) {
+ * 		return null;
  * 	}
  *
+ * 	byte[] buffer = (byte[]) super.nativeToJava(transferData);
+ * 	if (buffer == null) {
+ * 		return null;
+ * 	}
+ *
+ * 	ByteArrayInputStream in = new ByteArrayInputStream(buffer);
+ * 	try (DataInputStream readIn = new DataInputStream(in)) {
+ * 		MyType myType = new MyType();
+ * 		int size = readIn.readInt();
+ * 		byte[] name = new byte[size];
+ * 		readIn.read(name);
+ * 		myType.fileName = new String(name);
+ * 		myType.fileLength = readIn.readLong();
+ * 		myType.lastModified = readIn.readLong();
+ * 		return myType;
+ * 	} catch (IOException ex) {
+ * 	}
  * 	return null;
  * }
- * protected String[] getTypeNames(){
- * 	return new String[]{MYTYPENAME};
+ *
+ * &#64;Override
+ * protected String[] getTypeNames() {
+ * 	return new String[] { MYTYPENAME };
  * }
- * protected int[] getTypeIds(){
- * 	return new int[] {MYTYPEID};
+ *
+ * &#64;Override
+ * protected int[] getTypeIds() {
+ * 	return new int[] { MYTYPEID };
+ * }
+ *
+ * private boolean checkMyType(Object object) {
+ * 	return (object instanceof MyType);
+ * }
+ *
+ * &#64;Override
+ * protected boolean validate(Object object) {
+ * 	return checkMyType(object);
  * }
  * }
  * </code></pre>

--- a/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/gtk/org/eclipse/swt/dnd/ByteArrayTransfer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/gtk/org/eclipse/swt/dnd/ByteArrayTransfer.java
@@ -47,74 +47,76 @@ import org.eclipse.swt.internal.gtk.*;
  *	private static final int MYTYPEID = registerType(MYTYPENAME);
  *	private static MyTypeTransfer _instance = new MyTypeTransfer();
  *
- * private MyTypeTransfer() {}
+ * private MyTypeTransfer() {
+ * }
  *
- * public static MyTypeTransfer getInstance () {
+ * public static MyTypeTransfer getInstance() {
  * 	return _instance;
  * }
- * public void javaToNative (Object object, TransferData transferData) {
- * 	if (object == null || !(object instanceof MyType[])) return;
  *
- * 	if (isSupportedType(transferData)) {
- * 		MyType[] myTypes = (MyType[]) object;
- * 		try {
- * 			// write data to a byte array and then ask super to convert to pMedium
- * 			ByteArrayOutputStream out = new ByteArrayOutputStream();
- * 			DataOutputStream writeOut = new DataOutputStream(out);
- * 			for (int i = 0, length = myTypes.length; i &lt; length;  i++){
- * 				byte[] buffer = myTypes[i].fileName.getBytes();
- * 				writeOut.writeInt(buffer.length);
- * 				writeOut.write(buffer);
- * 				writeOut.writeLong(myTypes[i].fileLength);
- * 				writeOut.writeLong(myTypes[i].lastModified);
- * 			}
- * 			byte[] buffer = out.toByteArray();
- * 			writeOut.close();
+ * &#64;Override
+ * public void javaToNative(Object object, TransferData transferData) {
+ * 	if (!checkMyType(object) || !isSupportedType(transferData)) {
+ * 		DND.error(DND.ERROR_INVALID_DATA);
+ * 	}
  *
- * 			super.javaToNative(buffer, transferData);
- *
- * 		} catch (IOException e) {
- * 		}
+ * 	MyType myType = (MyType) object;
+ * 	// write data to a byte array and then ask super to convert to native
+ * 	ByteArrayOutputStream out = new ByteArrayOutputStream();
+ * 	try (DataOutputStream writeOut = new DataOutputStream(out)) {
+ * 		byte[] fileNameBytes = myType.fileName.getBytes(StandardCharsets.UTF_8);
+ * 		writeOut.writeInt(fileNameBytes.length);
+ * 		writeOut.write(fileNameBytes);
+ * 		writeOut.writeLong(myType.fileLength);
+ * 		writeOut.writeLong(myType.lastModified);
+ * 		super.javaToNative(out.toByteArray(), transferData);
+ * 	} catch (IOException e) {
  * 	}
  * }
- * public Object nativeToJava(TransferData transferData){
  *
- * 	if (isSupportedType(transferData)) {
- *
- * 		byte[] buffer = (byte[])super.nativeToJava(transferData);
- * 		if (buffer == null) return null;
- *
- * 		MyType[] myData = new MyType[0];
- * 		try {
- * 			ByteArrayInputStream in = new ByteArrayInputStream(buffer);
- * 			DataInputStream readIn = new DataInputStream(in);
- * 			while(readIn.available() &gt; 20) {
- * 				MyType datum = new MyType();
- * 				int size = readIn.readInt();
- * 				byte[] name = new byte[size];
- * 				readIn.read(name);
- * 				datum.fileName = new String(name);
- * 				datum.fileLength = readIn.readLong();
- * 				datum.lastModified = readIn.readLong();
- * 				MyType[] newMyData = new MyType[myData.length + 1];
- * 				System.arraycopy(myData, 0, newMyData, 0, myData.length);
- * 				newMyData[myData.length] = datum;
- * 				myData = newMyData;
- * 			}
- * 			readIn.close();
- * 		} catch (IOException ex) {
- * 			return null;
- * 		}
- * 		return myData;
+ * &#64;Override
+ * public Object nativeToJava(TransferData transferData) {
+ * 	if (!isSupportedType(transferData)) {
+ * 		return null;
  * 	}
  *
+ * 	byte[] buffer = (byte[]) super.nativeToJava(transferData);
+ * 	if (buffer == null) {
+ * 		return null;
+ * 	}
+ *
+ * 	ByteArrayInputStream in = new ByteArrayInputStream(buffer);
+ * 	try (DataInputStream readIn = new DataInputStream(in)) {
+ * 		MyType myType = new MyType();
+ * 		int size = readIn.readInt();
+ * 		byte[] name = new byte[size];
+ * 		readIn.read(name);
+ * 		myType.fileName = new String(name);
+ * 		myType.fileLength = readIn.readLong();
+ * 		myType.lastModified = readIn.readLong();
+ * 		return myType;
+ * 	} catch (IOException ex) {
+ * 	}
  * 	return null;
  * }
- * protected String[] getTypeNames(){
- * 	return new String[]{MYTYPENAME};
+ *
+ * &#64;Override
+ * protected String[] getTypeNames() {
+ * 	return new String[] { MYTYPENAME };
  * }
- * protected int[] getTypeIds(){
- * 	return new int[] {MYTYPEID};
+ *
+ * &#64;Override
+ * protected int[] getTypeIds() {
+ * 	return new int[] { MYTYPEID };
+ * }
+ *
+ * private boolean checkMyType(Object object) {
+ * 	return (object instanceof MyType);
+ * }
+ *
+ * &#64;Override
+ * protected boolean validate(Object object) {
+ * 	return checkMyType(object);
  * }
  * }
  * </code></pre>

--- a/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/win32/org/eclipse/swt/dnd/ByteArrayTransfer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/win32/org/eclipse/swt/dnd/ByteArrayTransfer.java
@@ -47,74 +47,76 @@ import org.eclipse.swt.internal.win32.*;
  *	private static final int MYTYPEID = registerType(MYTYPENAME);
  *	private static MyTypeTransfer _instance = new MyTypeTransfer();
  *
- * private MyTypeTransfer() {}
+ * private MyTypeTransfer() {
+ * }
  *
- * public static MyTypeTransfer getInstance () {
+ * public static MyTypeTransfer getInstance() {
  * 	return _instance;
  * }
- * public void javaToNative (Object object, TransferData transferData) {
- * 	if (object == null || !(object instanceof MyType[])) return;
  *
- * 	if (isSupportedType(transferData)) {
- * 		MyType[] myTypes = (MyType[]) object;
- * 		try {
- * 			// write data to a byte array and then ask super to convert to pMedium
- * 			ByteArrayOutputStream out = new ByteArrayOutputStream();
- * 			DataOutputStream writeOut = new DataOutputStream(out);
- * 			for (int i = 0, length = myTypes.length; i &lt; length;  i++){
- * 				byte[] buffer = myTypes[i].fileName.getBytes();
- * 				writeOut.writeInt(buffer.length);
- * 				writeOut.write(buffer);
- * 				writeOut.writeLong(myTypes[i].fileLength);
- * 				writeOut.writeLong(myTypes[i].lastModified);
- * 			}
- * 			byte[] buffer = out.toByteArray();
- * 			writeOut.close();
+ * &#64;Override
+ * public void javaToNative(Object object, TransferData transferData) {
+ * 	if (!checkMyType(object) || !isSupportedType(transferData)) {
+ * 		DND.error(DND.ERROR_INVALID_DATA);
+ * 	}
  *
- * 			super.javaToNative(buffer, transferData);
- *
- * 		} catch (IOException e) {
- * 		}
+ * 	MyType myType = (MyType) object;
+ * 	// write data to a byte array and then ask super to convert to native
+ * 	ByteArrayOutputStream out = new ByteArrayOutputStream();
+ * 	try (DataOutputStream writeOut = new DataOutputStream(out)) {
+ * 		byte[] fileNameBytes = myType.fileName.getBytes(StandardCharsets.UTF_8);
+ * 		writeOut.writeInt(fileNameBytes.length);
+ * 		writeOut.write(fileNameBytes);
+ * 		writeOut.writeLong(myType.fileLength);
+ * 		writeOut.writeLong(myType.lastModified);
+ * 		super.javaToNative(out.toByteArray(), transferData);
+ * 	} catch (IOException e) {
  * 	}
  * }
- * public Object nativeToJava(TransferData transferData){
  *
- * 	if (isSupportedType(transferData)) {
- *
- * 		byte[] buffer = (byte[])super.nativeToJava(transferData);
- * 		if (buffer == null) return null;
- *
- * 		MyType[] myData = new MyType[0];
- * 		try {
- * 			ByteArrayInputStream in = new ByteArrayInputStream(buffer);
- * 			DataInputStream readIn = new DataInputStream(in);
- * 			while(readIn.available() &gt; 20) {
- * 				MyType datum = new MyType();
- * 				int size = readIn.readInt();
- * 				byte[] name = new byte[size];
- * 				readIn.read(name);
- * 				datum.fileName = new String(name);
- * 				datum.fileLength = readIn.readLong();
- * 				datum.lastModified = readIn.readLong();
- * 				MyType[] newMyData = new MyType[myData.length + 1];
- * 				System.arraycopy(myData, 0, newMyData, 0, myData.length);
- * 				newMyData[myData.length] = datum;
- * 				myData = newMyData;
- * 			}
- * 			readIn.close();
- * 		} catch (IOException ex) {
- * 			return null;
- * 		}
- * 		return myData;
+ * &#64;Override
+ * public Object nativeToJava(TransferData transferData) {
+ * 	if (!isSupportedType(transferData)) {
+ * 		return null;
  * 	}
  *
+ * 	byte[] buffer = (byte[]) super.nativeToJava(transferData);
+ * 	if (buffer == null) {
+ * 		return null;
+ * 	}
+ *
+ * 	ByteArrayInputStream in = new ByteArrayInputStream(buffer);
+ * 	try (DataInputStream readIn = new DataInputStream(in)) {
+ * 		MyType myType = new MyType();
+ * 		int size = readIn.readInt();
+ * 		byte[] name = new byte[size];
+ * 		readIn.read(name);
+ * 		myType.fileName = new String(name);
+ * 		myType.fileLength = readIn.readLong();
+ * 		myType.lastModified = readIn.readLong();
+ * 		return myType;
+ * 	} catch (IOException ex) {
+ * 	}
  * 	return null;
  * }
- * protected String[] getTypeNames(){
- * 	return new String[]{MYTYPENAME};
+ *
+ * &#64;Override
+ * protected String[] getTypeNames() {
+ * 	return new String[] { MYTYPENAME };
  * }
- * protected int[] getTypeIds(){
- * 	return new int[] {MYTYPEID};
+ *
+ * &#64;Override
+ * protected int[] getTypeIds() {
+ * 	return new int[] { MYTYPEID };
+ * }
+ *
+ * private boolean checkMyType(Object object) {
+ * 	return (object instanceof MyType);
+ * }
+ *
+ * &#64;Override
+ * protected boolean validate(Object object) {
+ * 	return checkMyType(object);
  * }
  * }
  * </code></pre>

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_dnd_ByteArrayTransfer.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_dnd_ByteArrayTransfer.java
@@ -209,12 +209,16 @@ public class Test_org_eclipse_swt_dnd_ByteArrayTransfer extends ClipboardBase {
 		assertMyTypeEquals(test, result);
 	}
 
+	// apart from the static, this should be a straight copy/paste of
+	// the code in the ByteArrayTransfer javadoc
 	public static class MyType {
 		public String fileName;
 		public long fileLength;
 		public long lastModified;
 	}
 
+	// apart from the static, this should be a straight copy/paste of
+	// the code in the ByteArrayTransfer javadoc
 	public static class MyTypeTransfer extends ByteArrayTransfer {
 
 		private static final String MYTYPENAME = "my_type_name";


### PR DESCRIPTION
Now that ByteArrayTransfer has a unit test, the unit test verifies that the code in this Javadoc operates correctly. This commit synchronizes the javadoc back to the contents of the test classes.

This includes

- Simplifying the code a little
- Changing the transfer to support a single MyType instead of an array of them (which simplifies the example quite a bit)
- Add `@Override` to the appropriate methods
- Format the code to Eclipse default settings
- Validating the objects

Part of https://github.com/eclipse-platform/eclipse.platform.swt/issues/2126