### PR TITLE
[GTK4] Clone instead of reusing objects on local clipbpard operations

### DIFF
--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_dnd_ByteArrayTransfer.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_dnd_ByteArrayTransfer.java
@@ -13,6 +13,7 @@ package org.eclipse.swt.tests.junit;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -180,6 +181,7 @@ public class Test_org_eclipse_swt_dnd_ByteArrayTransfer extends ClipboardBase {
 		setContents(test);
 		MyType contents = getContents();
 		assertMyTypeEquals(test, contents);
+		assertNotSame(test, contents);
 	}
 
 	@Test

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_dnd_FileTransfer.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_dnd_FileTransfer.java
@@ -13,6 +13,7 @@ package org.eclipse.swt.tests.junit;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -152,10 +153,10 @@ public class Test_org_eclipse_swt_dnd_FileTransfer extends ClipboardBase {
 		String[] fileList = getFileList();
 
 		openAndFocusShell(false);
-		// Put a type on the clipboard and ensure we don't match it
 		setContents(fileList);
 		String[] contents = getContents();
 		assertArrayEquals(fileList, contents);
+		assertNotSame(fileList, contents);
 	}
 
 	@Test

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_dnd_HTMLTransfer.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_dnd_HTMLTransfer.java
@@ -13,6 +13,7 @@ package org.eclipse.swt.tests.junit;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -122,6 +123,7 @@ public class Test_org_eclipse_swt_dnd_HTMLTransfer extends ClipboardBase {
 		setContents(test);
 		String contents = getContents();
 		assertEquals(test, contents);
+		assertNotSame(test, contents);
 	}
 
 	static Stream<Arguments> testData() {

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_dnd_ImageTransfer.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_dnd_ImageTransfer.java
@@ -14,6 +14,7 @@ import static org.eclipse.swt.tests.graphics.ImageDataTestHelper.imageDataCompar
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -128,10 +129,10 @@ public class Test_org_eclipse_swt_dnd_ImageTransfer extends ClipboardBase {
 		ImageData imageData = getImageData();
 
 		openAndFocusShell(false);
-		// Put a type on the clipboard and ensure we don't match it
 		setContents(imageData);
 		ImageData contents = getContents();
 		assertEquals(0, imageDataComparator().compare(imageData, contents));
+		assertNotSame(imageData, contents);
 	}
 
 	@Test

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_dnd_RTFTransfer.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_dnd_RTFTransfer.java
@@ -13,6 +13,7 @@ package org.eclipse.swt.tests.junit;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -118,6 +119,7 @@ public class Test_org_eclipse_swt_dnd_RTFTransfer extends ClipboardBase {
 		setContents(test);
 		String contents = getContents();
 		assertEquals(test, contents);
+		assertNotSame(test, contents);
 	}
 
 	@Test

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_dnd_TextTransfer.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_dnd_TextTransfer.java
@@ -13,6 +13,7 @@ package org.eclipse.swt.tests.junit;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -126,6 +127,7 @@ public class Test_org_eclipse_swt_dnd_TextTransfer extends ClipboardBase {
 		setContents(test);
 		String contents = getContents();
 		assertEquals(test, contents);
+		assertNotSame(test, contents);
 	}
 
 	@ParameterizedTest(name = "{0}")

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_dnd_URLTransfer.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_dnd_URLTransfer.java
@@ -13,6 +13,7 @@ package org.eclipse.swt.tests.junit;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -128,6 +129,7 @@ public class Test_org_eclipse_swt_dnd_URLTransfer extends ClipboardBase {
 		setContents(test);
 		String contents = getContents();
 		assertEquals(test, contents);
+		assertNotSame(test, contents);
 	}
 
 	@Test


### PR DESCRIPTION
When calling gdk_clipboard_read_value_async and related functions, if the clipboard is owned locally it returns the instance that was placed on the clipboard and avoid the serialization and deserialization.

This presents a problem for SWT because SWT has always returned a copy (javaToNative/nativeToJava) of the object between the setContents and the getContents.
For some objects, like String it may be ok to return the same instance since String is immutable, but for others, such as ImageData or custom types a copy definitely needs to be made to preserve the pre-existing behavior. However, to maintain compatibility with the pre-existing implementations for even String type Transfers that have returned a copy, we copy String types too in this implementation.

Part of https://github.com/eclipse-platform/eclipse.platform.swt/issues/2126