### PR TITLE
[GTK4] Fix Shell.bringToTop

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/gtk4.c
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/gtk4.c
@@ -2776,6 +2776,16 @@ JNIEXPORT jlong JNICALL GTK4_NATIVE(gtk_1window_1new)
 }
 #endif
 
+#ifndef NO_gtk_1window_1present
+JNIEXPORT void JNICALL GTK4_NATIVE(gtk_1window_1present)
+	(JNIEnv *env, jclass that, jlong arg0)
+{
+	GTK4_NATIVE_ENTER(env, that, gtk_1window_1present_FUNC);
+	gtk_window_present((GtkWindow *)arg0);
+	GTK4_NATIVE_EXIT(env, that, gtk_1window_1present_FUNC);
+}
+#endif
+
 #ifndef NO_gtk_1window_1set_1child
 JNIEXPORT void JNICALL GTK4_NATIVE(gtk_1window_1set_1child)
 	(JNIEnv *env, jclass that, jlong arg0, jlong arg1)

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/gtk4_stats.h
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/gtk4_stats.h
@@ -226,6 +226,7 @@ typedef enum {
 	gtk_1window_1maximize_FUNC,
 	gtk_1window_1minimize_FUNC,
 	gtk_1window_1new_FUNC,
+	gtk_1window_1present_FUNC,
 	gtk_1window_1set_1child_FUNC,
 	gtk_1window_1set_1default_1widget_FUNC,
 	gtk_1window_1set_1icon_1name_FUNC,

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/org/eclipse/swt/internal/gtk4/GTK4.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/org/eclipse/swt/internal/gtk4/GTK4.java
@@ -453,6 +453,7 @@ public class GTK4 {
 	public static final native void gtk_window_set_child(long window, long child);
 	/** @param window cast=(GtkWindow *) */
 	public static final native void gtk_window_destroy(long window);
+
 	/** @param window cast=(GtkWindow *) */
 	public static final native long gtk_window_get_icon_name(long window);
 	/**
@@ -462,6 +463,9 @@ public class GTK4 {
 	public static final native void gtk_window_set_icon_name(long window, long name);
 	/** @param window cast=(GtkWindow *) */
 	public static final native long gtk_window_get_titlebar(long window);
+
+	/** @param window cast=(GtkWindow *) */
+	public static final native void gtk_window_present(long window) ;
 
 	/* GtkShortcutController */
 	public static final native long gtk_shortcut_controller_new();

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Shell.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Shell.java
@@ -637,7 +637,7 @@ void bringToTop (boolean force) {
 			}
 			long seat = GDK.gdk_display_get_default_seat(gdkDisplay);
 			if (GTK.GTK4) {
-				/* TODO: GTK does not provide a gdk_surface_show, probably will require use of the present api */
+				GTK4.gtk_window_present(shellHandle);
 			} else {
 				GDK.gdk_window_show(gdkResource);
 			}


### PR DESCRIPTION
As the shellHandle is always GtkWindow under Gtk 4.x, gtk_window_present can be called directly.