### PR TITLE
[GTK3] Defer disposing Callbacks while GTK still has pointer to them

### DIFF
--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/SwtTestUtil.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/SwtTestUtil.java
@@ -150,6 +150,28 @@ public class SwtTestUtil {
 	}
 
 	/**
+	 * Return whether running on GTK3. This is dynamically set at runtime and cannot
+	 * be accessed before the corresponding property is initialized in OS.
+	 *
+	 * <strong>Note:</strong> this method still must be called after the static
+	 * block of OS is run.
+	 */
+	public final static boolean isGTK3() {
+		if (!isGTK) {
+			return false;
+		}
+
+		String version = System.getProperty("org.eclipse.swt.internal.gtk.version", "");
+		if (version.startsWith("3")) {
+			return true;
+		} else if (!version.isBlank()) {
+			return false;
+		}
+		fail("org.eclipse.swt.internal.gtk.version System property is not set yet. Create a new Display (or otherwise access OS) before calling isGTK4");
+		throw new IllegalStateException("unreachable");
+	}
+
+	/**
 	 * Return whether running on GTK4. This is dynamically set at runtime and cannot
 	 * be accessed before the corresponding property is initialized in OS.
 	 *


### PR DESCRIPTION
The calls to gtk_clipboard_set_with_owner (in ClipboardProxy.setData) means the GtkClipboard (in C side) has function pointers saved to the getFunc + clearFunc callbacks.

Therefore, when we dispose ClipboardProxy we cannot dispose the callbacks until we know that GtkClipboard doesn't have a pointer to these callbacks. GtkClipboard clears these pointers in [clipboard_unset ](https://gitlab.gnome.org/GNOME/gtk/-/blob/716458e86a222f43e64f7a4feda37749f3469ee4/gtk/gtkclipboard.c#L755) and notifies us that the pointers are no longer stored by calling [clearFunc ](https://gitlab.gnome.org/GNOME/gtk/-/blob/716458e86a222f43e64f7a4feda37749f3469ee4/gtk/gtkclipboard.c#L782)

Therefore, after disposing ClipboardProxy we need to defer disposing the callbacks until clearFunc has been called.

We know if we have been called sufficiently (for both clipboards that could have a handle stored) when both clipboards no longer have data stored.

If we don't defer the disposal it causes SIGSEGV or other undefined behavior.

Fixes https://github.com/eclipse-platform/eclipse.platform.swt/issues/2675