### PR TITLE
Stop swallowing System.err in JUnit tests

### DIFF
--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/AllNonBrowserTests.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/AllNonBrowserTests.java
@@ -111,8 +111,7 @@ public class AllNonBrowserTests {
 		}
 
 		for (Error leak : leakedResources) {
-			// For some reason, printing to System.err in JUnit test has no effect
-			leak.printStackTrace (System.out);
+			leak.printStackTrace ();
 		}
 
 		if (0 != leakedResources.size ()) {

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/SwtTestUtil.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/SwtTestUtil.java
@@ -19,9 +19,11 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashMap;
@@ -763,5 +765,27 @@ static <T> T runOperationInThread(int timeoutMs, ExceptionalSupplier<T> supplier
 	@SuppressWarnings("unchecked")
 	T result = (T) supplierValue[0];
 	return result;
+}
+
+/**
+ * Capture any output on System.err
+ *
+ * This method does not capture output on stderr from C level, such as
+ * Gdk-CRITICAL messages.
+ *
+ * @param runnable to run while capturing output
+ * @return output on System.err
+ */
+public static String runWithCapturedStderr(Runnable runnable) {
+	PrintStream originalErr = System.err;
+	ByteArrayOutputStream errContent = new ByteArrayOutputStream();
+	System.setErr(new PrintStream(errContent, true, StandardCharsets.UTF_8));
+	try {
+		runnable.run();
+		return errContent.toString(StandardCharsets.UTF_8);
+
+	} finally {
+		System.setErr(originalErr);
+	}
 }
 }

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_SWTError.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_SWTError.java
@@ -17,9 +17,6 @@ package org.eclipse.swt.tests.junit;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.io.ByteArrayOutputStream;
-import java.io.PrintStream;
-
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.SWTError;
 import org.junit.jupiter.api.Test;
@@ -63,21 +60,17 @@ public void test_getMessage() {
 public void test_printStackTrace() {
 
 	// test default SWTError
-
-	ByteArrayOutputStream out = new ByteArrayOutputStream();
-	System.setErr(new PrintStream(out));
-	SWTError error = new SWTError();
-	error.printStackTrace();
-	assertTrue(out.size() > 0);
-	assertTrue(new String(out.toByteArray()).contains("test_printStackTrace"));
+	SWTError error1 = new SWTError();
+	String stderr = SwtTestUtil.runWithCapturedStderr(() -> {
+		error1.printStackTrace();
+	});
+	assertTrue(stderr.contains("test_printStackTrace"));
 
 	// test SWTError with code
-
-	out = new ByteArrayOutputStream();
-	System.setErr(new PrintStream(out));
-	error = new SWTError(SWT.ERROR_INVALID_ARGUMENT);
-	error.printStackTrace();
-	assertTrue(out.size() > 0);
-	assertTrue(new String(out.toByteArray()).contains("test_printStackTrace"));
+	SWTError error2 = new SWTError(SWT.ERROR_INVALID_ARGUMENT);
+	stderr = SwtTestUtil.runWithCapturedStderr(() -> {
+		error2.printStackTrace();
+	});
+	assertTrue(stderr.contains("test_printStackTrace"));
 }
 }

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_SWTException.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_SWTException.java
@@ -17,9 +17,6 @@ package org.eclipse.swt.tests.junit;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.io.ByteArrayOutputStream;
-import java.io.PrintStream;
-
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.SWTException;
 import org.junit.jupiter.api.Test;
@@ -64,21 +61,17 @@ public void test_getMessage() {
 public void test_printStackTrace() {
 
 	// test default SWTException
-
-	ByteArrayOutputStream out = new ByteArrayOutputStream();
-	System.setErr(new PrintStream(out));
-	SWTException error = new SWTException();
-	error.printStackTrace();
-	assertTrue(out.size() > 0);
-	assertTrue(new String(out.toByteArray()).contains("test_printStackTrace"));
+	SWTException error1 = new SWTException();
+	String stderr = SwtTestUtil.runWithCapturedStderr(() -> {
+		error1.printStackTrace();
+	});
+	assertTrue(stderr.contains("test_printStackTrace"));
 
 	// test SWTException with code
-
-	out = new ByteArrayOutputStream();
-	System.setErr(new PrintStream(out));
-	error = new SWTException(SWT.ERROR_INVALID_ARGUMENT);
-	error.printStackTrace();
-	assertTrue(out.size() > 0);
-	assertTrue(new String(out.toByteArray()).contains("test_printStackTrace"));
+	SWTException error2 = new SWTException(SWT.ERROR_INVALID_ARGUMENT);
+	stderr = SwtTestUtil.runWithCapturedStderr(() -> {
+		error2.printStackTrace();
+	});
+	assertTrue(stderr.contains("test_printStackTrace"));
 }
 }


### PR DESCRIPTION
test_printStackTrace overrides System.err with its own print stream to check functionality. But these tests did not restore System.err, so all System.err output for the rest of the test suite was lost into the last of these ByteArrayOutputStreams that was created.

The tests themselves have little intrinsic value as they really test nothing of SWT itself, but it does help achieve code coverage.

This was discovered when working on https://github.com/eclipse-platform/eclipse.platform.swt/pull/2684 as I could not see the output when running all the tests.