### PR TITLE
Verify that the leak detection reports properly 

### DIFF
--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/AllNonBrowserTests.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/AllNonBrowserTests.java
@@ -32,49 +32,49 @@ import org.junit.platform.suite.api.Suite;
 		Test_org_eclipse_swt_SWT.class, //
 		Test_org_eclipse_swt_SWTException.class, //
 		Test_org_eclipse_swt_SWTError.class, //
-		Test_org_eclipse_swt_widgets_Display.class, //
-		// Groups of tests
-		AllGraphicsTests.class, //
-		AllWidgetTests.class, //
-		// Rest of tests alphabetically
-		DPIUtilTests.class, //
-		JSVGRasterizerTest.class, //
-		Test_org_eclipse_swt_accessibility_Accessible.class, //
-		Test_org_eclipse_swt_accessibility_AccessibleControlEvent.class, //
-		Test_org_eclipse_swt_accessibility_AccessibleEvent.class, //
-		Test_org_eclipse_swt_accessibility_AccessibleTextEvent.class, //
-		Test_org_eclipse_swt_dnd_ByteArrayTransfer.class, //
-		Test_org_eclipse_swt_dnd_Clipboard.class, //
-		Test_org_eclipse_swt_dnd_FileTransfer.class, //
-		Test_org_eclipse_swt_dnd_HTMLTransfer.class, //
-		Test_org_eclipse_swt_dnd_ImageTransfer.class, //
-		Test_org_eclipse_swt_dnd_RTFTransfer.class, //
-		Test_org_eclipse_swt_dnd_TextTransfer.class, //
-		Test_org_eclipse_swt_dnd_URLTransfer.class, //
-		Test_org_eclipse_swt_events_ArmEvent.class, //
-		Test_org_eclipse_swt_events_ControlEvent.class, //
-		Test_org_eclipse_swt_events_DisposeEvent.class, //
-		Test_org_eclipse_swt_events_FocusEvent.class, //
-		Test_org_eclipse_swt_events_HelpEvent.class, //
-		Test_org_eclipse_swt_events_KeyEvent.class, //
-		Test_org_eclipse_swt_events_MenuEvent.class, //
-		Test_org_eclipse_swt_events_ModifyEvent.class, //
-		Test_org_eclipse_swt_events_MouseEvent.class, //
-		Test_org_eclipse_swt_events_PaintEvent.class, //
-		Test_org_eclipse_swt_events_SelectionEvent.class, //
-		Test_org_eclipse_swt_events_ShellEvent.class, //
-		Test_org_eclipse_swt_events_TraverseEvent.class, //
-		Test_org_eclipse_swt_events_TreeEvent.class, //
-		Test_org_eclipse_swt_events_TypedEvent.class, //
-		Test_org_eclipse_swt_events_VerifyEvent.class, //
-		Test_org_eclipse_swt_internal_SVGRasterizer.class, //
-		Test_org_eclipse_swt_layout_BorderLayout.class, //
-		Test_org_eclipse_swt_layout_FormAttachment.class, //
-		Test_org_eclipse_swt_layout_GridData.class, //
-		Test_org_eclipse_swt_printing_PrintDialog.class, //
-		Test_org_eclipse_swt_printing_Printer.class, //
-		Test_org_eclipse_swt_printing_PrinterData.class, //
-		Test_org_eclipse_swt_program_Program.class, //
+//		Test_org_eclipse_swt_widgets_Display.class, //
+//		// Groups of tests
+//		AllGraphicsTests.class, //
+//		AllWidgetTests.class, //
+//		// Rest of tests alphabetically
+//		DPIUtilTests.class, //
+//		JSVGRasterizerTest.class, //
+//		Test_org_eclipse_swt_accessibility_Accessible.class, //
+//		Test_org_eclipse_swt_accessibility_AccessibleControlEvent.class, //
+//		Test_org_eclipse_swt_accessibility_AccessibleEvent.class, //
+//		Test_org_eclipse_swt_accessibility_AccessibleTextEvent.class, //
+//		Test_org_eclipse_swt_dnd_ByteArrayTransfer.class, //
+//		Test_org_eclipse_swt_dnd_Clipboard.class, //
+//		Test_org_eclipse_swt_dnd_FileTransfer.class, //
+//		Test_org_eclipse_swt_dnd_HTMLTransfer.class, //
+//		Test_org_eclipse_swt_dnd_ImageTransfer.class, //
+//		Test_org_eclipse_swt_dnd_RTFTransfer.class, //
+//		Test_org_eclipse_swt_dnd_TextTransfer.class, //
+//		Test_org_eclipse_swt_dnd_URLTransfer.class, //
+//		Test_org_eclipse_swt_events_ArmEvent.class, //
+//		Test_org_eclipse_swt_events_ControlEvent.class, //
+//		Test_org_eclipse_swt_events_DisposeEvent.class, //
+//		Test_org_eclipse_swt_events_FocusEvent.class, //
+//		Test_org_eclipse_swt_events_HelpEvent.class, //
+//		Test_org_eclipse_swt_events_KeyEvent.class, //
+//		Test_org_eclipse_swt_events_MenuEvent.class, //
+//		Test_org_eclipse_swt_events_ModifyEvent.class, //
+//		Test_org_eclipse_swt_events_MouseEvent.class, //
+//		Test_org_eclipse_swt_events_PaintEvent.class, //
+//		Test_org_eclipse_swt_events_SelectionEvent.class, //
+//		Test_org_eclipse_swt_events_ShellEvent.class, //
+//		Test_org_eclipse_swt_events_TraverseEvent.class, //
+//		Test_org_eclipse_swt_events_TreeEvent.class, //
+//		Test_org_eclipse_swt_events_TypedEvent.class, //
+//		Test_org_eclipse_swt_events_VerifyEvent.class, //
+//		Test_org_eclipse_swt_internal_SVGRasterizer.class, //
+//		Test_org_eclipse_swt_layout_BorderLayout.class, //
+//		Test_org_eclipse_swt_layout_FormAttachment.class, //
+//		Test_org_eclipse_swt_layout_GridData.class, //
+//		Test_org_eclipse_swt_printing_PrintDialog.class, //
+//		Test_org_eclipse_swt_printing_Printer.class, //
+//		Test_org_eclipse_swt_printing_PrinterData.class, //
+//		Test_org_eclipse_swt_program_Program.class, //
 })
 public class AllNonBrowserTests {
 	private static List<Error> leakedResources;

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_SWT.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_SWT.java
@@ -30,6 +30,8 @@ import java.util.List;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.SWTError;
 import org.eclipse.swt.SWTException;
+import org.eclipse.swt.graphics.Image;
+import org.eclipse.swt.widgets.Display;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
@@ -49,6 +51,9 @@ public class Test_org_eclipse_swt_SWT {
 				"did not correctly throw exception for ERROR_NO_HANDLES");
 		assertThrows(SWTError.class, () -> SWT.error(-1),
 				"did not correctly throw exception for error(-1)");
+
+
+		new Image(Display.getDefault(), 100, 100);
 	}
 
 	@Test


### PR DESCRIPTION
In https://github.com/eclipse-platform/eclipse.platform.swt/pull/2686 I fixed/reenabled the leak detection reporting. This PR introduces a leaked image (and disables most tests) to verify that https://github.com/eclipse-platform/eclipse.platform.swt/pull/2686 really is working.

This is not for merging (obviously?) but it set as non-draft so it runs on Jenkins as well as GHA.