### PR TITLE
[mac] SWT: fix for #2621

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/graphics/TextLayout.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/graphics/TextLayout.java
@@ -509,7 +509,7 @@ public void draw(GC gc, int x, int y, int selectionStart, int selectionEnd, Colo
 				NSRect bounds = lineBounds[lineBounds.length - 1];
 				rect.x = pt.x + bounds.x + bounds.width;
 				rect.y = y + bounds.y;
-				rect.width = (flags & SWT.FULL_SELECTION) != 0 ? 0x7fffffff : (bounds.height + spacing) / 3;
+				rect.width = (flags & SWT.FULL_SELECTION) != 0 ? OS.MAX_TEXT_CONTAINER_SIZE : (bounds.height + spacing) / 3;
 				rect.height = Math.max(bounds.height + spacing, ascent + descent);
 				path.appendBezierPathWithRect(rect);
 			}


### PR DESCRIPTION
From MacOS 26 - > MacOs 26.1 it seems the method:
NSBezierPath.appendBezierPathWithRect(NSRect rect) can't handle huge integer values anymore. So a smaller number is defined and used. Doesn't matter for the purposes here.

See: https://github.com/eclipse-platform/eclipse.platform.swt/issues/2621
(not a mistake, PR to the swt repo master branch.)