### PR TITLE
[Win32] Move relayout call to end of DPI change processing

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Control.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Control.java
@@ -5948,7 +5948,7 @@ void sendZoomChangedEvent(Event event, Shell shell) {
 				}
 				if (dpiExecData.decrement()) {
 					if (event.doit) {
-						shell.WM_SIZE(0, 0);
+						shell.layout(true, true);
 					}
 				}
 			}

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Shell.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Shell.java
@@ -2787,9 +2787,4 @@ LRESULT WM_WINDOWPOSCHANGING (long wParam, long lParam) {
 	return result;
 }
 
-@Override
-void handleDPIChange(Event event, float scalingFactor) {
-	super.handleDPIChange(event, scalingFactor);
-	layout (null, SWT.DEFER | SWT.ALL | SWT.CHANGED);
-}
 }


### PR DESCRIPTION
When processing a DPI change event, a relayout of the shell is currently scheduled when the event reaches the shell. With asynchronous event processing, this can lead to the layouting being performed too early, i.e., when not all contained controls are already updated.

With this change, the layout call for the shell is moved to the end of the DPI change process, such that relayouting is only performed when all controls have been updated.

### How to test

Having two monitors with different zoom and moving around a workbench between them, at some point the layout will break. This is best visible when having a JFace Forms UI open (such as Manifest editor). Some of the visible effects are shown in the following screenshots:

#### Cut off texts
<img width="299" height="129" alt="image" src="https://github.com/user-attachments/assets/66914ba4-b630-4069-bd1e-d2409c2f293a" />
<img width="253" height="106" alt="image" src="https://github.com/user-attachments/assets/5f13f902-795c-4aff-ac10-b01ebd90d5c4" />

#### Broken layout
<img width="1226" height="878" alt="image" src="https://github.com/user-attachments/assets/f310298a-193d-49ea-8cf1-beb5582d0540" />
<img width="1491" height="945" alt="image" src="https://github.com/user-attachments/assets/66a87cf0-0c79-438a-9505-9de144efa240" />

With extensive testing, these issues were not reproducible with the proposed change anymore. At least, the current placement of the layout call does not make any sense, so moving it is reasonable anyway.