### PR TITLE
[gtk] Destroy cached image at size handle

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/graphics/Image.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/graphics/Image.java
@@ -928,6 +928,7 @@ void destroy() {
 	if (surface != 0) Cairo.cairo_surface_destroy(surface);
 	surface = mask = 0;
 	memGC = null;
+	cachedImageAtSize.destroy();
 }
 
 private CachedImageAtSize cachedImageAtSize = new CachedImageAtSize();


### PR DESCRIPTION
This PR ensures the cleanup of the image handle cached by size on destruction of the Image.