### PR TITLE
Convert FileDialog#setFilterExtensions and setFilterNames to varargs

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/FileDialog.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/FileDialog.java
@@ -630,7 +630,7 @@ public void setFileName (String string) {
  * @see #setFilterNames to specify the user-friendly
  * names corresponding to the extensions
  */
-public void setFilterExtensions (String [] extensions) {
+public void setFilterExtensions (String... extensions) {
 	filterExtensions = extensions;
 }
 
@@ -668,7 +668,7 @@ public void setFilterIndex (int index) {
  *
  * @see #setFilterExtensions
  */
-public void setFilterNames (String [] names) {
+public void setFilterNames (String... names) {
 	filterNames = names;
 }
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/FileDialog.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/FileDialog.java
@@ -745,7 +745,7 @@ public void setFileName (String string) {
  * @see #setFilterNames to specify the user-friendly
  * names corresponding to the extensions
  */
-public void setFilterExtensions (String [] extensions) {
+public void setFilterExtensions (String... extensions) {
 	filterExtensions = extensions;
 }
 /**
@@ -781,7 +781,7 @@ public void setFilterIndex (int index) {
  *
  * @see #setFilterExtensions
  */
-public void setFilterNames (String [] names) {
+public void setFilterNames (String... names) {
 	filterNames = names;
 }
 /**

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/FileDialog.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/FileDialog.java
@@ -457,7 +457,7 @@ public void setFileName (String string) {
  * @see #setFilterNames to specify the user-friendly
  * names corresponding to the extensions
  */
-public void setFilterExtensions (String [] extensions) {
+public void setFilterExtensions (String... extensions) {
 	filterExtensions = extensions;
 }
 
@@ -495,7 +495,7 @@ public void setFilterIndex (int index) {
  *
  * @see #setFilterExtensions
  */
-public void setFilterNames (String [] names) {
+public void setFilterNames (String... names) {
 	filterNames = names;
 }
 

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_FileDialog.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_FileDialog.java
@@ -101,32 +101,52 @@ public void test_setFileNameLjava_lang_String() {
 
 @Test
 public void test_setFilterExtensions$Ljava_lang_String() {
+	fileDialog.setFilterExtensions("txt");
+	String[] filters = fileDialog.getFilterExtensions();
+	assertEquals(1, filters.length);
+	assertEquals("txt", filters[0]);
 	fileDialog.setFilterExtensions(new String[] {"txt","java"});
-	String filters[] = fileDialog.getFilterExtensions();
+	filters = fileDialog.getFilterExtensions();
 	assertEquals(2, filters.length);
 	assertEquals("txt", filters[0]);
 	assertEquals("java", filters[1]);
 	fileDialog.setFilterExtensions(new String[] {""});
 	filters = fileDialog.getFilterExtensions();
 	assertEquals(1, filters.length);
-	fileDialog.setFilterExtensions(null);
+	fileDialog.setFilterExtensions();
+	filters = fileDialog.getFilterExtensions();
+	assertEquals(0, filters.length);
+	fileDialog.setFilterExtensions((String[])null);
 	filters = fileDialog.getFilterExtensions();
 	assertNull(filters);
+	fileDialog.setFilterExtensions(new String[0]);
+	filters = fileDialog.getFilterExtensions();
+	assertEquals(0, filters.length);
 }
 
 @Test
 public void test_setFilterNames$Ljava_lang_String() {
+	fileDialog.setFilterNames("a.txt");
+	String[] filters = fileDialog.getFilterNames();
+	assertEquals(1, filters.length);
+	assertEquals("a.txt", filters[0]);
 	fileDialog.setFilterNames(new String[] {"a.txt","b.java"});
-	String filters[] = fileDialog.getFilterNames();
+	filters = fileDialog.getFilterNames();
 	assertEquals(2, filters.length);
 	assertEquals("a.txt", filters[0]);
 	assertEquals("b.java", filters[1]);
 	fileDialog.setFilterNames(new String[] {""});
 	filters = fileDialog.getFilterNames();
 	assertEquals(1, filters.length);
-	fileDialog.setFilterNames(null);
+	fileDialog.setFilterNames();
+	filters = fileDialog.getFilterNames();
+	assertEquals(0,filters.length);
+	fileDialog.setFilterNames((String[])null);
 	filters = fileDialog.getFilterNames();
 	assertNull(filters);
+	fileDialog.setFilterNames(new String[0]);
+	filters = fileDialog.getFilterNames();
+	assertEquals(0,filters.length);
 }
 
 @Test


### PR DESCRIPTION
Nicer to use for end user and API compliant.

If this change is
integrated we must update the usage of this method in platform to avoid compiler warnings.