### PR TITLE
[GTK] Fix memory leak, GUri was not freed.

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/os.c
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/os.c
@@ -12907,6 +12907,24 @@ fail:
 }
 #endif
 
+#ifndef NO_g_1uri_1unref
+JNIEXPORT void JNICALL OS_NATIVE(g_1uri_1unref)
+	(JNIEnv *env, jclass that, jlong arg0)
+{
+	OS_NATIVE_ENTER(env, that, g_1uri_1unref_FUNC);
+/*
+	g_uri_unref(arg0);
+*/
+	{
+		OS_LOAD_FUNCTION(fp, g_uri_unref)
+		if (fp) {
+			((void (CALLING_CONVENTION*)(jlong))fp)(arg0);
+		}
+	}
+	OS_NATIVE_EXIT(env, that, g_1uri_1unref_FUNC);
+}
+#endif
+
 #ifndef NO_g_1utf16_1offset_1to_1pointer
 JNIEXPORT jlong JNICALL OS_NATIVE(g_1utf16_1offset_1to_1pointer)
 	(JNIEnv *env, jclass that, jlong arg0, jlong arg1)

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/os_custom.h
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/os_custom.h
@@ -60,6 +60,7 @@
 #define FcConfigAppFontAddFile_LIB LIB_FONTCONFIG
 #define pango_attr_insert_hyphens_new_LIB LIB_PANGO
 #define g_uri_parse_LIB LIB_GLIB
+#define g_uri_unref_LIB LIB_GLIB
 
 /* Field accessors */
 #define G_OBJECT_CLASS_CONSTRUCTOR(arg0) (arg0)->constructor

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/os_stats.h
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/os_stats.h
@@ -1038,6 +1038,7 @@ typedef enum {
 	g_1type_1register_1static_FUNC,
 	g_1unsetenv_FUNC,
 	g_1uri_1parse_FUNC,
+	g_1uri_1unref_FUNC,
 	g_1utf16_1offset_1to_1pointer_FUNC,
 	g_1utf16_1offset_1to_1utf8_1offset_FUNC,
 	g_1utf16_1pointer_1to_1offset_FUNC,

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/org/eclipse/swt/internal/gtk/OS.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/org/eclipse/swt/internal/gtk/OS.java
@@ -1552,6 +1552,10 @@ public static final native void g_unsetenv(byte [] variable);
  * @param error cast=(GError **)
  */
 public static final native long g_uri_parse (byte[] uri_string,  long flags, long[] error);
+/**
+ * @method flags=dynamic
+ */
+public static final native void g_uri_unref (long uri);
 /** @method flags=const */
 public static final native int glib_major_version();
 /** @method flags=const */

--- a/bundles/org.eclipse.swt/Eclipse SWT WebKit/gtk/org/eclipse/swt/browser/WebKit.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT WebKit/gtk/org/eclipse/swt/browser/WebKit.java
@@ -1196,7 +1196,11 @@ private static class Webkit2AsyncToSync {
 				setCookie_callback.getAddress(), callbackID);
 		Webkit2AsyncReturnObj retObj = execAsyncAndWaitForReturn(cookieBrowser, asyncFunc, " setCookie() was called");
 
-		WebKitGTK.soup_uri_free (uri);
+		if (WebKitGTK.soup_get_major_version()==2) {
+			WebKitGTK.soup_uri_free (uri);
+		} else {
+			OS.g_uri_unref(uri);
+		}
 
 		if (retObj.swtAsyncTimeout) {
 			return false;


### PR DESCRIPTION
Don't call soup_uri_free on libsoup3, use g_uri_unref instead. soup_uri_free was removed in libsoup3.
