### PR TITLE
Make ImageDataProvider in test adhere to linear scaling requirement

### DIFF
--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_GC.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_GC.java
@@ -444,7 +444,7 @@ public void test_drawImageLorg_eclipse_swt_graphics_ImageIIII_ImageDataAtSizePro
 	ImageDataAtSizeProvider provider = new ImageDataAtSizeProvider() {
 		@Override
 		public ImageData getImageData(int zoom) {
-			return new ImageData(1, 1, 32, new PaletteData(0xFF0000, 0xFF00, 0xFF));
+			return new ImageData(1 * zoom / 100, 1 * zoom / 100, 32, new PaletteData(0xFF0000, 0xFF00, 0xFF));
 		}
 
 		@Override
@@ -492,7 +492,7 @@ public void test_drawImageLorg_eclipse_swt_graphics_ImageIIII_ImageDataAtSizePro
 		}
 		@Override
 		public ImageData getImageData(int zoom) {
-			return new ImageData(1, 1, 32, new PaletteData(0xFF0000, 0xFF00, 0xFF));
+			return new ImageData(1 * zoom / 100, 1 * zoom / 100, 32, new PaletteData(0xFF0000, 0xFF00, 0xFF));
 		}
 	};
 	Image image = styleImage(new Image(display, imageDataAtSizeProvider), styleFlag);


### PR DESCRIPTION
Fixes these logged warnings in test execution, e.g., in https://github.com/eclipse-platform/eclipse.platform.swt/actions/runs/18940122934/job/54076562163?pr=2711:
```
***WARNING: ImageData should be linearly scaled across zooms but size is (1, 1) at 100% and (1, 1) at 200%.
java.lang.Error
	at org.eclipse.swt.internal.DPIUtil.validateLinearScaling(DPIUtil.java:247)
	at org.eclipse.swt.graphics.Image.lambda$0(Image.java:679)
	at org.eclipse.swt.internal.StrictChecks.runIfStrictChecksEnabled(StrictChecks.java:28)
	at org.eclipse.swt.graphics.Image.<init>(Image.java:678)
	at org.eclipse.swt.tests.junit.Test_org_eclipse_swt_graphics_GC.test_drawImageLorg_eclipse_swt_graphics_ImageIIII_ImageDataAtSizeProvider(Test_org_eclipse_swt_graphics_GC.java:498)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
```