### PR TITLE
[GTK] send a g_critical if SWT calls a function that failed to load

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT WebKit/gtk/library/webkitgtk.h
+++ b/bundles/org.eclipse.swt/Eclipse SWT WebKit/gtk/library/webkitgtk.h
@@ -52,6 +52,7 @@
 		} \
 		if (handle) { \
 			var = dlsym(handle,	#name); \
+			if (!var) {	g_critical("SWT webkitgtk: Failed to load webkit function %s", #name); } \
 		} \
 		CHECK_DLERROR \
 		initialized = 1; \


### PR DESCRIPTION
When a library function fails to load, the JNI wrapper returns 0 (or similar) for that function. There is no way to tell from the Java side that the function failed to work.

This change prints a g_critical error so that it is somewhat detectable, at least by SWT devs, that something has gone wrong in the implementation.

Ideally I would throw an unsatisfied link exception or something similar, but that would change a potentially minor error into a show stopper. For example, if we threw an exception the simple memory leak fixed in https://github.com/eclipse-platform/eclipse.platform.swt/pull/2704 would have been throwing an exception all this time instead of silently not freeing the memory.

This change is especially useful as we work on GTK4 which includes lots of breaking API changes in webkit.