### PR TITLE
Mark long-deprecated and unused SWT constants for removal

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Accessibility/common/org/eclipse/swt/accessibility/ACC.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Accessibility/common/org/eclipse/swt/accessibility/ACC.java
@@ -79,7 +79,7 @@ public class ACC {
 	public static final int ROLE_TABLECELL = 0x1d;
 	public static final int ROLE_TABLECOLUMNHEADER = 0x19;
 	/** @deprecated use ROLE_TABLECOLUMNHEADER */
-	@Deprecated
+	@Deprecated(forRemoval = true, since = "2025-12")
 	public static final int ROLE_TABLECOLUMN = ROLE_TABLECOLUMNHEADER;
 	public static final int ROLE_TABLEROWHEADER = 0x1a;
 	public static final int ROLE_TREE = 0x23;

--- a/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CTabFolder.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CTabFolder.java
@@ -79,7 +79,7 @@ public class CTabFolder extends Composite {
 	 *
 	 * @deprecated This field is no longer used.  See setMinimumCharacters(int)
 	 */
-	@Deprecated
+	@Deprecated(forRemoval = true, since = "2025-12")
 	public int MIN_TAB_WIDTH = 4;
 
 	/**

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/SWT.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/SWT.java
@@ -978,14 +978,14 @@ public class SWT {
 	 * @deprecated The same as PreExternalEventDispatch (value is 52).
 	 * @since 3.103
 	 */
-	@Deprecated
+	@Deprecated(forRemoval = true, since = "2025-12")
 	public static final int Sleep = PreExternalEventDispatch;
 
 	/**
 	 * @deprecated The same as PostExternalEventDispatch (value is 53).
 	 * @since 3.103
 	 */
-	@Deprecated
+	@Deprecated(forRemoval = true, since = "2025-12")
 	public static final int Wakeup = PostExternalEventDispatch;
 
 	/**
@@ -2549,7 +2549,7 @@ public class SWT {
 	 *             XULRunner as a browser renderer is no longer supported. Use
 	 *             <code>SWT.WEBKIT</code> or <code>SWT.NONE</code> instead.
 	 */
-	@Deprecated
+	@Deprecated(forRemoval = true, since = "2025-12")
 	public static final int MOZILLA = 1 << 15;
 
 	/**


### PR DESCRIPTION
There are few constants in SWT that have been deprecated for a long time and are no longer referenced within the codebase.
This change adds `Deprecated` tags for those to indicate their planned removal in a future release.