### PR TITLE
Set Shell Size and the end of DPIChange

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/widgets/DPITestUtil.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/widgets/DPITestUtil.java
@@ -28,7 +28,8 @@ public final class DPITestUtil {
 
 	public static void changeDPIZoom (Shell shell, int nativeZoom) {
 		DPIUtil.setDeviceZoom(nativeZoom);
-		Event event = shell.createZoomChangedEvent(nativeZoom, true);
+		DPIChangeExecution dpiChangeExecution = new DPIChangeExecution(true, null);
+		Event event = shell.createZoomChangedEvent(nativeZoom, dpiChangeExecution);
 		shell.sendZoomChangedEvent(event, shell);
 		DPIChangeExecution data = (DPIChangeExecution) event.data;
 		waitForDPIChange(shell, TIMEOUT_MILLIS, data.taskCount);

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Shell.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Shell.java
@@ -2489,13 +2489,13 @@ private void handleMonitorSpecificDpiChange(int newNativeZoom, Rectangle newBoun
 	// Do not process DPI change for child shells asynchronous to avoid relayouting when
 	// repositioning the child shell to a different monitor upon opening
 	boolean processDpiChangeAsynchronous = getParent() == null;
-	Event zoomChangedEvent = createZoomChangedEvent(newNativeZoom, processDpiChangeAsynchronous);
+	DPIChangeExecution dpiChangeExecution = new DPIChangeExecution(processDpiChangeAsynchronous, newBoundsInPixels);
+	Event zoomChangedEvent = createZoomChangedEvent(newNativeZoom, dpiChangeExecution);
 	if (lastDpiChangeEvent != null) {
 		lastDpiChangeEvent.doit = false;
 	}
 	lastDpiChangeEvent = zoomChangedEvent;
 	notifyListeners(SWT.ZoomChanged, zoomChangedEvent);
-	this.setBoundsInPixels(newBoundsInPixels.x, newBoundsInPixels.y, newBoundsInPixels.width, newBoundsInPixels.height);
 }
 
 @Override


### PR DESCRIPTION
Currently, the shell is scaled synchronously regardless of the sync/async behaviour of scaling. With this PR the size of the shell is set at the end of a DPIChange execution to ensure the final size set to the shell consistent with the final zoom level. 

#### Why it is necessary:
In case of a DPIChange event or multiple events, the scaling of all the widgets can happen synchronously or asynchronously. In case of asynchronous execution, the shell's size might be set before all the widgets are scaled which can lead to a weird result as resizing a shell leads to the widgets to relayout. Calling a Shell:layout at the end has similar results. It is only consistent to also set the size of the shell at the end of the execution followed by a Shell::layout.