### PR TITLE
[Win32] Pass point values to size computation methods

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Button.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Button.java
@@ -322,8 +322,11 @@ int computeLeftMargin () {
 	return margin;
 }
 
-@Override Point computeSizeInPixels (int wHint, int hHint, boolean changed) {
+@Override
+Point computeSizeInPixels (Point hintInPoints, boolean changed) {
 	checkWidget ();
+	int zoom = getZoom();
+	Point hintInPixels = Win32DPIUtils.pointToPixelAsSize(hintInPoints, zoom);
 	int width = 0, height = 0, border = getBorderWidthInPixels ();
 	if ((style & SWT.ARROW) != 0) {
 		if ((style & (SWT.UP | SWT.DOWN)) != 0) {
@@ -336,8 +339,8 @@ int computeLeftMargin () {
 	} else {
 		if ((style & SWT.COMMAND) != 0) {
 			SIZE size = new SIZE ();
-			if (wHint != SWT.DEFAULT) {
-				size.cx = wHint;
+			if (hintInPoints.x != SWT.DEFAULT) {
+				size.cx = hintInPixels.x;
 				OS.SendMessage (handle, OS.BCM_GETIDEALSIZE, 0, size);
 				width = size.cx;
 				height = size.cy;
@@ -381,9 +384,9 @@ int computeLeftMargin () {
 					char [] buffer = text.toCharArray ();
 					RECT rect = new RECT ();
 					int flags = OS.DT_CALCRECT | OS.DT_SINGLELINE;
-					if ((style & SWT.WRAP) != 0 && wHint != SWT.DEFAULT) {
+					if ((style & SWT.WRAP) != 0 && hintInPoints.x != SWT.DEFAULT) {
 						flags = OS.DT_CALCRECT | OS.DT_WORDBREAK;
-						rect.right = wHint - width - 2 * border;
+						rect.right = hintInPixels.x - width - 2 * border;
 						if (isRadioOrCheck()) {
 							rect.right -= checkWidth + 3;
 						} else {
@@ -412,8 +415,8 @@ int computeLeftMargin () {
 			}
 		}
 	}
-	if (wHint != SWT.DEFAULT) width = wHint;
-	if (hHint != SWT.DEFAULT) height = hHint;
+	if (hintInPoints.x != SWT.DEFAULT) width = hintInPixels.x;
+	if (hintInPoints.y != SWT.DEFAULT) height = hintInPixels.y;
 	width += border * 2;
 	height += border * 2;
 	return new Point (width, height);

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Combo.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Combo.java
@@ -592,10 +592,13 @@ public void clearSelection () {
 	OS.SendMessage (handle, OS.CB_SETEDITSEL, 0, -1);
 }
 
-@Override Point computeSizeInPixels (int wHint, int hHint, boolean changed) {
+@Override
+Point computeSizeInPixels (Point hintInPoints, boolean changed) {
 	checkWidget ();
+	int zoom = getZoom();
+	Point hintInPixels = Win32DPIUtils.pointToPixelAsSize(hintInPoints, zoom);
 	int width = 0, height = 0;
-	if (wHint == SWT.DEFAULT) {
+	if (hintInPoints.x == SWT.DEFAULT) {
 		long newFont, oldFont = 0;
 		long hDC = OS.GetDC (handle);
 		newFont = OS.SendMessage (handle, OS.WM_GETFONT, 0, 0);
@@ -627,7 +630,7 @@ public void clearSelection () {
 		if (newFont != 0) OS.SelectObject (hDC, oldFont);
 		OS.ReleaseDC (handle, hDC);
 	}
-	if (hHint == SWT.DEFAULT) {
+	if (hintInPoints.y == SWT.DEFAULT) {
 		if ((style & SWT.SIMPLE) != 0) {
 			int count = (int)OS.SendMessage (handle, OS.CB_GETCOUNT, 0, 0);
 			int itemHeight = (int)OS.SendMessage (handle, OS.CB_GETITEMHEIGHT, 0, 0);
@@ -636,8 +639,8 @@ public void clearSelection () {
 	}
 	if (width == 0) width = DEFAULT_WIDTH;
 	if (height == 0) height = DEFAULT_HEIGHT;
-	if (wHint != SWT.DEFAULT) width = wHint;
-	if (hHint != SWT.DEFAULT) height = hHint;
+	if (hintInPoints.x != SWT.DEFAULT) width = hintInPixels.x;
+	if (hintInPoints.y != SWT.DEFAULT) height = hintInPixels.y;
 	if ((style & SWT.READ_ONLY) != 0) {
 		width += 8;
 	} else {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Composite.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Composite.java
@@ -207,31 +207,29 @@ Widget [] computeTabList () {
 }
 
 @Override
-Point computeSizeInPixels (int wHint, int hHint, boolean changed) {
+Point computeSizeInPixels (Point hintInPoints, boolean changed) {
 	display.runSkin ();
-	Point size;
+	Point sizeInPoints;
 	if (layout != null) {
-		if (wHint == SWT.DEFAULT || hHint == SWT.DEFAULT) {
+		if (hintInPoints.x == SWT.DEFAULT || hintInPoints.y == SWT.DEFAULT) {
 			changed |= (state & LAYOUT_CHANGED) != 0;
 			state &= ~LAYOUT_CHANGED;
-			int zoom = getZoom();
-			size = Win32DPIUtils.pointToPixelAsSize(layout.computeSize (this, DPIUtil.pixelToPoint(wHint, zoom), DPIUtil.pixelToPoint(hHint, zoom), changed), zoom);
+			sizeInPoints = layout.computeSize (this, hintInPoints.x, hintInPoints.y, changed);
 		} else {
-			size = new Point (wHint, hHint);
+			sizeInPoints = hintInPoints;
 		}
 	} else {
-		size = minimumSize (wHint, hHint, changed);
-		if (size.x == 0) size.x = DEFAULT_WIDTH;
-		if (size.y == 0) size.y = DEFAULT_HEIGHT;
+		sizeInPoints = minimumSize (hintInPoints, changed);
+		if (sizeInPoints.x == 0) sizeInPoints.x = DEFAULT_WIDTH;
+		if (sizeInPoints.y == 0) sizeInPoints.y = DEFAULT_HEIGHT;
 	}
-	if (wHint != SWT.DEFAULT) size.x = wHint;
-	if (hHint != SWT.DEFAULT) size.y = hHint;
+	if (hintInPoints.x != SWT.DEFAULT) sizeInPoints.x = hintInPoints.x;
+	if (hintInPoints.y != SWT.DEFAULT) sizeInPoints.y = hintInPoints.y;
 	/*
 	 * Since computeTrim can be overridden by subclasses, we cannot
 	 * call computeTrimInPixels directly.
 	 */
-	int zoom = getZoom();
-	Rectangle trim = Win32DPIUtils.pointToPixel(computeTrim (0, 0, DPIUtil.pixelToPoint(size.x, zoom), DPIUtil.pixelToPoint(size.y, zoom)), zoom);
+	Rectangle trim = Win32DPIUtils.pointToPixel(computeTrim (0, 0, sizeInPoints.x, sizeInPoints.y), getZoom());
 	return new Point (trim.width, trim.height);
 }
 
@@ -869,16 +867,15 @@ void markLayout (boolean changed, boolean all) {
 	}
 }
 
-Point minimumSize (int wHint, int hHint, boolean changed) {
+Point minimumSize (Point hintInPoints, boolean changed) {
 	/*
 	 * Since getClientArea can be overridden by subclasses, we cannot
 	 * call getClientAreaInPixels directly.
 	 */
-	int zoom = getZoom();
-	Rectangle clientArea = Win32DPIUtils.pointToPixel(getClientArea (), zoom);
+	Rectangle clientArea = getClientArea ();
 	int width = 0, height = 0;
 	for (Control element : _getChildren ()) {
-		Rectangle rect = Win32DPIUtils.pointToPixel(element.getBounds (), zoom);
+		Rectangle rect = element.getBounds ();
 		width = Math.max (width, rect.x - clientArea.x + rect.width);
 		height = Math.max (height, rect.y - clientArea.y + rect.height);
 	}

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Control.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Control.java
@@ -619,18 +619,18 @@ public Point computeSize (int wHint, int hHint) {
 public Point computeSize (int wHint, int hHint, boolean changed){
 	checkWidget ();
 	int zoom = getZoom();
-	wHint = (wHint != SWT.DEFAULT ? DPIUtil.pointToPixel(wHint, zoom) : wHint);
-	hHint = (hHint != SWT.DEFAULT ? DPIUtil.pointToPixel(hHint, zoom) : hHint);
 	//We should never return a size that is to small, RoundingMode.UP ensures we at worst case report
 	//a size that is a bit too large by half a point
-	return Win32DPIUtils.pixelToPointAsConservativeSize(computeSizeInPixels(wHint, hHint, changed), zoom);
+	return Win32DPIUtils.pixelToPointAsConservativeSize(computeSizeInPixels(new Point.OfFloat(wHint, hHint, RoundingMode.UP), changed), zoom);
 }
 
-Point computeSizeInPixels (int wHint, int hHint, boolean changed) {
+Point computeSizeInPixels (Point hintInPoints, boolean changed) {
 	int width = DEFAULT_WIDTH;
 	int height = DEFAULT_HEIGHT;
-	if (wHint != SWT.DEFAULT) width = wHint;
-	if (hHint != SWT.DEFAULT) height = hHint;
+	int zoom = getZoom();
+	Point hintInPixels = Win32DPIUtils.pointToPixelAsSize(hintInPoints, zoom);
+	if (hintInPoints.x != SWT.DEFAULT) width = hintInPixels.x;
+	if (hintInPoints.y != SWT.DEFAULT) height = hintInPixels.y;
 	int border = getBorderWidthInPixels ();
 	width += border * 2;
 	height += border * 2;

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/CoolBar.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/CoolBar.java
@@ -140,11 +140,14 @@ protected void checkSubclass () {
 	if (!isValidSubclass ()) error (SWT.ERROR_INVALID_SUBCLASS);
 }
 
-@Override Point computeSizeInPixels (int wHint, int hHint, boolean changed) {
+@Override
+Point computeSizeInPixels (Point hintInPoints, boolean changed) {
+	int zoom = getZoom();
+	Point hintInPixels = Win32DPIUtils.pointToPixelAsSize(hintInPoints, zoom);
 	int width = 0, height = 0;
 	int border = getBorderWidthInPixels ();
-	int newWidth = wHint == SWT.DEFAULT ? 0x3FFF : wHint + (border * 2);
-	int newHeight = hHint == SWT.DEFAULT ? 0x3FFF : hHint + (border * 2);
+	int newWidth = hintInPoints.x == SWT.DEFAULT ? 0x3FFF : hintInPixels.x + (border * 2);
+	int newHeight = hintInPoints.y == SWT.DEFAULT ? 0x3FFF : hintInPixels.y + (border * 2);
 	int count = (int)OS.SendMessage (handle, OS.RB_GETBANDCOUNT, 0, 0);
 	if (count != 0) {
 		ignoreResize = true;
@@ -189,8 +192,8 @@ protected void checkSubclass () {
 		width = height;
 		height = tmp;
 	}
-	if (wHint != SWT.DEFAULT) width = wHint;
-	if (hHint != SWT.DEFAULT) height = hHint;
+	if (hintInPoints.x != SWT.DEFAULT) width = hintInPixels.x;
+	if (hintInPoints.y != SWT.DEFAULT) height = hintInPixels.y;
 	height += border * 2;
 	width += border * 2;
 	return new Point (width, height);
@@ -1225,7 +1228,7 @@ void handleDPIChange(Event event, float scalingFactor) {
 			item.setControl(control);
 		}
 
-		Point preferredControlSize =  item.getControl().computeSizeInPixels(SWT.DEFAULT, SWT.DEFAULT, true);
+		Point preferredControlSize =  item.getControl().computeSizeInPixels(new Point(SWT.DEFAULT, SWT.DEFAULT), true);
 		int controlWidth = preferredControlSize.x;
 		int controlHeight = preferredControlSize.y;
 		if (((style & SWT.VERTICAL) != 0)) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/DateTime.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/DateTime.java
@@ -16,6 +16,7 @@ package org.eclipse.swt.widgets;
 import org.eclipse.swt.*;
 import org.eclipse.swt.events.*;
 import org.eclipse.swt.graphics.*;
+import org.eclipse.swt.internal.*;
 import org.eclipse.swt.internal.win32.*;
 
 /**
@@ -217,10 +218,13 @@ protected void checkSubclass () {
 	if (!isValidSubclass ()) error (SWT.ERROR_INVALID_SUBCLASS);
 }
 
-@Override Point computeSizeInPixels (int wHint, int hHint, boolean changed) {
+@Override
+Point computeSizeInPixels (Point hintInPoints, boolean changed) {
 	checkWidget ();
+	int zoom = getZoom();
+	Point hintInPixels = Win32DPIUtils.pointToPixelAsSize(hintInPoints, zoom);
 	int width = 0, height = 0;
-	if (wHint == SWT.DEFAULT || hHint == SWT.DEFAULT) {
+	if (hintInPoints.x == SWT.DEFAULT || hintInPoints.y == SWT.DEFAULT) {
 		if ((style & SWT.CALENDAR) != 0) {
 			RECT rect = new RECT ();
 			OS.SendMessage(handle, OS.MCM_GETMINREQRECT, 0, rect);
@@ -244,8 +248,8 @@ protected void checkSubclass () {
 	}
 	if (width == 0) width = DEFAULT_WIDTH;
 	if (height == 0) height = DEFAULT_HEIGHT;
-	if (wHint != SWT.DEFAULT) width = wHint;
-	if (hHint != SWT.DEFAULT) height = hHint;
+	if (hintInPoints.x != SWT.DEFAULT) width = hintInPixels.x;
+	if (hintInPoints.y != SWT.DEFAULT) height = hintInPixels.y;
 	int border = getBorderWidthInPixels ();
 	width += border * 2;
 	height += border * 2;

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ExpandBar.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ExpandBar.java
@@ -126,9 +126,12 @@ static int checkStyle (int style) {
 	return style | SWT.NO_BACKGROUND;
 }
 
-@Override Point computeSizeInPixels (int wHint, int hHint, boolean changed) {
+@Override
+Point computeSizeInPixels (Point hintInPoints, boolean changed) {
+	int zoom = getZoom();
+	Point hintInPixels = Win32DPIUtils.pointToPixelAsSize(hintInPoints, zoom);
 	int height = 0, width = 0;
-	if (wHint == SWT.DEFAULT || hHint == SWT.DEFAULT) {
+	if (hintInPoints.x == SWT.DEFAULT || hintInPoints.y == SWT.DEFAULT) {
 		if (itemCount > 0) {
 			long hDC = OS.GetDC (handle);
 			long hTheme = 0;
@@ -168,8 +171,8 @@ static int checkStyle (int style) {
 	}
 	if (width == 0) width = DEFAULT_WIDTH;
 	if (height == 0) height = DEFAULT_HEIGHT;
-	if (wHint != SWT.DEFAULT) width = wHint;
-	if (hHint != SWT.DEFAULT) height = hHint;
+	if (hintInPoints.x != SWT.DEFAULT) width = hintInPixels.x;
+	if (hintInPoints.y != SWT.DEFAULT) height = hintInPixels.y;
 	Rectangle trim = computeTrimInPixels (0, 0, width, height);
 	return new Point (trim.width, trim.height);
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Group.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Group.java
@@ -138,9 +138,10 @@ protected void checkSubclass () {
 	if (!isValidSubclass ()) error (SWT.ERROR_INVALID_SUBCLASS);
 }
 
-@Override Point computeSizeInPixels (int wHint, int hHint, boolean changed) {
+@Override
+Point computeSizeInPixels (Point hintInPoints, boolean changed) {
 	checkWidget ();
-	Point size = super.computeSizeInPixels (wHint, hHint, changed);
+	Point size = super.computeSizeInPixels (hintInPoints, changed);
 	int length = text.length ();
 	if (length != 0) {
 		String string = fixText (false);

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Label.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Label.java
@@ -130,8 +130,11 @@ static int checkStyle (int style) {
 	return checkBits (style, SWT.LEFT, SWT.CENTER, SWT.RIGHT, 0, 0, 0);
 }
 
-@Override Point computeSizeInPixels (int wHint, int hHint, boolean changed) {
+@Override
+Point computeSizeInPixels (Point hintInPoints, boolean changed) {
 	checkWidget ();
+	int zoom = getZoom();
+	Point hintInPixels = Win32DPIUtils.pointToPixelAsSize(hintInPoints, zoom);
 	int width = 0, height = 0, border = getBorderWidthInPixels ();
 	if ((style & SWT.SEPARATOR) != 0) {
 		int lineWidth = getSystemMetrics (OS.SM_CXBORDER);
@@ -140,8 +143,8 @@ static int checkStyle (int style) {
 		} else {
 			width = lineWidth * 2; height = DEFAULT_HEIGHT;
 		}
-		if (wHint != SWT.DEFAULT) width = wHint;
-		if (hHint != SWT.DEFAULT) height = hHint;
+		if (hintInPoints.x != SWT.DEFAULT) width = hintInPixels.x;
+		if (hintInPoints.y != SWT.DEFAULT) height = hintInPixels.y;
 		width += border * 2; height += border * 2;
 		return new Point (width, height);
 	}
@@ -161,9 +164,9 @@ static int checkStyle (int style) {
 		} else {
 			RECT rect = new RECT ();
 			int flags = OS.DT_CALCRECT | OS.DT_EDITCONTROL | OS.DT_EXPANDTABS;
-			if ((style & SWT.WRAP) != 0 && wHint != SWT.DEFAULT) {
+			if ((style & SWT.WRAP) != 0 && hintInPoints.x != SWT.DEFAULT) {
 				flags |= OS.DT_WORDBREAK;
-				rect.right = Math.max (0, wHint - width);
+				rect.right = Math.max (0, hintInPixels.x - width);
 			}
 			char [] buffer = new char [length + 1];
 			OS.GetWindowText (handle, buffer, length + 1);
@@ -174,8 +177,8 @@ static int checkStyle (int style) {
 		if (newFont != 0) OS.SelectObject (hDC, oldFont);
 		OS.ReleaseDC (handle, hDC);
 	}
-	if (wHint != SWT.DEFAULT) width = wHint;
-	if (hHint != SWT.DEFAULT) height = hHint;
+	if (hintInPoints.x != SWT.DEFAULT) width = hintInPixels.x;
+	if (hintInPoints.y != SWT.DEFAULT) height = hintInPixels.y;
 	width += border * 2;
 	height += border * 2;
 	return new Point (width, height);

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Link.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Link.java
@@ -159,8 +159,10 @@ long callWindowProc (long hwnd, int msg, long wParam, long lParam) {
 }
 
 @Override
-Point computeSizeInPixels (int wHint, int hHint, boolean changed) {
+Point computeSizeInPixels (Point hintInPoints, boolean changed) {
 	checkWidget ();
+	int zoom = getZoom();
+	Point hintInPixels = Win32DPIUtils.pointToPixelAsSize(hintInPoints, zoom);
 	int width, height;
 	/*
 	 * When the text is empty, LM_GETIDEALSIZE returns zero width and height,
@@ -178,13 +180,13 @@ Point computeSizeInPixels (int wHint, int hHint, boolean changed) {
 		OS.ReleaseDC (handle, hDC);
 	} else {
 		SIZE size = new SIZE ();
-		int maxWidth = (wHint == SWT.DEFAULT) ? 0x7fffffff : wHint;
+		int maxWidth = (hintInPoints.x == SWT.DEFAULT) ? 0x7fffffff : hintInPixels.x;
 		OS.SendMessage (handle, OS.LM_GETIDEALSIZE, maxWidth, size);
 		width = size.cx;
 		height = size.cy;
 	}
-	if (wHint != SWT.DEFAULT) width = wHint;
-	if (hHint != SWT.DEFAULT) height = hHint;
+	if (hintInPoints.x != SWT.DEFAULT) width = hintInPixels.x;
+	if (hintInPoints.y != SWT.DEFAULT) height = hintInPixels.y;
 	int border = getBorderWidthInPixels ();
 	width += border * 2;
 	height += border * 2;

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/List.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/List.java
@@ -213,10 +213,13 @@ static int checkStyle (int style) {
 	return checkBits (style, SWT.SINGLE, SWT.MULTI, 0, 0, 0, 0);
 }
 
-@Override Point computeSizeInPixels (int wHint, int hHint, boolean changed) {
+@Override
+Point computeSizeInPixels (Point hintInPoints, boolean changed) {
 	checkWidget ();
+	int zoom = getZoom();
+	Point hintInPixels = Win32DPIUtils.pointToPixelAsSize(hintInPoints, zoom);
 	int width = 0, height = 0;
-	if (wHint == SWT.DEFAULT) {
+	if (hintInPoints.x == SWT.DEFAULT) {
 		if ((style & SWT.H_SCROLL) != 0) {
 			width = (int)OS.SendMessage (handle, OS.LB_GETHORIZONTALEXTENT, 0, 0);
 			width -= INSET;
@@ -246,15 +249,15 @@ static int checkStyle (int style) {
 			OS.ReleaseDC (handle, hDC);
 		}
 	}
-	if (hHint == SWT.DEFAULT) {
+	if (hintInPoints.y == SWT.DEFAULT) {
 		int count = (int)OS.SendMessage (handle, OS.LB_GETCOUNT, 0, 0);
 		int itemHeight = (int)OS.SendMessage (handle, OS.LB_GETITEMHEIGHT, 0, 0);
 		height = count * itemHeight;
 	}
 	if (width == 0) width = DEFAULT_WIDTH;
 	if (height == 0) height = DEFAULT_HEIGHT;
-	if (wHint != SWT.DEFAULT) width = wHint;
-	if (hHint != SWT.DEFAULT) height = hHint;
+	if (hintInPoints.x != SWT.DEFAULT) width = hintInPixels.x;
+	if (hintInPoints.y != SWT.DEFAULT) height = hintInPixels.y;
 	int border = getBorderWidthInPixels ();
 	width += border * 2 + INSET;
 	height += border * 2;

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ProgressBar.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ProgressBar.java
@@ -14,9 +14,10 @@
 package org.eclipse.swt.widgets;
 
 
-import org.eclipse.swt.internal.win32.*;
 import org.eclipse.swt.*;
 import org.eclipse.swt.graphics.*;
+import org.eclipse.swt.internal.*;
+import org.eclipse.swt.internal.win32.*;
 
 /**
  * Instances of the receiver represent an unselectable
@@ -118,8 +119,11 @@ static int checkStyle (int style) {
 	return checkBits (style, SWT.HORIZONTAL, SWT.VERTICAL, 0, 0, 0, 0);
 }
 
-@Override Point computeSizeInPixels (int wHint, int hHint, boolean changed) {
+@Override
+Point computeSizeInPixels (Point hintInPoints, boolean changed) {
 	checkWidget ();
+	int zoom = getZoom();
+	Point hintInPixels = Win32DPIUtils.pointToPixelAsSize(hintInPoints, zoom);
 	int border = getBorderWidthInPixels ();
 	int width = border * 2, height = border * 2;
 	if ((style & SWT.HORIZONTAL) != 0) {
@@ -129,8 +133,8 @@ static int checkStyle (int style) {
 		width += getSystemMetrics (OS.SM_CXVSCROLL);
 		height += getSystemMetrics (OS.SM_CYVSCROLL) * 10;
 	}
-	if (wHint != SWT.DEFAULT) width = wHint + (border * 2);
-	if (hHint != SWT.DEFAULT) height = hHint + (border * 2);
+	if (hintInPoints.x != SWT.DEFAULT) width = hintInPixels.x + (border * 2);
+	if (hintInPoints.y != SWT.DEFAULT) height = hintInPixels.y + (border * 2);
 	return new Point (width, height);
 }
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Sash.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Sash.java
@@ -126,8 +126,11 @@ static int checkStyle (int style) {
 	return checkBits (style, SWT.HORIZONTAL, SWT.VERTICAL, 0, 0, 0, 0);
 }
 
-@Override Point computeSizeInPixels (int wHint, int hHint, boolean changed) {
+@Override
+Point computeSizeInPixels (Point hintInPoints, boolean changed) {
 	checkWidget ();
+	int zoom = getZoom();
+	Point hintInPixels = Win32DPIUtils.pointToPixelAsSize(hintInPoints, zoom);
 	int border = getBorderWidthInPixels ();
 	int width = border * 2, height = border * 2;
 	if ((style & SWT.HORIZONTAL) != 0) {
@@ -135,8 +138,8 @@ static int checkStyle (int style) {
 	} else {
 		width += 3; height += DEFAULT_HEIGHT;
 	}
-	if (wHint != SWT.DEFAULT) width = wHint + (border * 2);
-	if (hHint != SWT.DEFAULT) height = hHint + (border * 2);
+	if (hintInPoints.x != SWT.DEFAULT) width = hintInPixels.x + (border * 2);
+	if (hintInPoints.y != SWT.DEFAULT) height = hintInPixels.y + (border * 2);
 	return new Point (width, height);
 }
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Scale.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Scale.java
@@ -17,6 +17,7 @@ package org.eclipse.swt.widgets;
 import org.eclipse.swt.*;
 import org.eclipse.swt.events.*;
 import org.eclipse.swt.graphics.*;
+import org.eclipse.swt.internal.*;
 import org.eclipse.swt.internal.win32.*;
 
 /**
@@ -143,8 +144,11 @@ static int checkStyle (int style) {
 	return checkBits (style, SWT.HORIZONTAL, SWT.VERTICAL, 0, 0, 0, 0);
 }
 
-@Override Point computeSizeInPixels (int wHint, int hHint, boolean changed) {
+@Override
+Point computeSizeInPixels (Point hintInPoints, boolean changed) {
 	checkWidget ();
+	int zoom = getZoom();
+	Point hintInPixels = Win32DPIUtils.pointToPixelAsSize(hintInPoints, zoom);
 	int border = getBorderWidthInPixels ();
 	int width = border * 2, height = border * 2;
 	RECT rect = new RECT ();
@@ -158,8 +162,8 @@ static int checkStyle (int style) {
 		width += (rect.left * 2) + scrollX + (scrollX / 3);
 		height += getSystemMetrics (OS.SM_CYVSCROLL) * 10;
 	}
-	if (wHint != SWT.DEFAULT) width = wHint + (border * 2);
-	if (hHint != SWT.DEFAULT) height = hHint + (border * 2);
+	if (hintInPoints.x != SWT.DEFAULT) width = hintInPixels.x + (border * 2);
+	if (hintInPoints.y != SWT.DEFAULT) height = hintInPixels.y + (border * 2);
 	return new Point (width, height);
 }
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Slider.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Slider.java
@@ -17,6 +17,7 @@ package org.eclipse.swt.widgets;
 import org.eclipse.swt.*;
 import org.eclipse.swt.events.*;
 import org.eclipse.swt.graphics.*;
+import org.eclipse.swt.internal.*;
 import org.eclipse.swt.internal.win32.*;
 
 /**
@@ -176,8 +177,11 @@ static int checkStyle (int style) {
 	return checkBits (style, SWT.HORIZONTAL, SWT.VERTICAL, 0, 0, 0, 0);
 }
 
-@Override Point computeSizeInPixels (int wHint, int hHint, boolean changed) {
+@Override
+Point computeSizeInPixels (Point hintInPoints, boolean changed) {
 	checkWidget ();
+	int zoom = getZoom();
+	Point hintInPixels = Win32DPIUtils.pointToPixelAsSize(hintInPoints, zoom);
 	int border = getBorderWidthInPixels ();
 	int width = border * 2, height = border * 2;
 	if ((style & SWT.HORIZONTAL) != 0) {
@@ -187,8 +191,8 @@ static int checkStyle (int style) {
 		width += getSystemMetrics (OS.SM_CXVSCROLL);
 		height += getSystemMetrics (OS.SM_CYVSCROLL) * 10;
 	}
-	if (wHint != SWT.DEFAULT) width = wHint + (border * 2);
-	if (hHint != SWT.DEFAULT) height = hHint + (border * 2);
+	if (hintInPoints.x != SWT.DEFAULT) width = hintInPixels.x + (border * 2);
+	if (hintInPoints.y != SWT.DEFAULT) height = hintInPixels.y + (border * 2);
 	return new Point (width, height);
 }
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Spinner.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Spinner.java
@@ -17,6 +17,7 @@ package org.eclipse.swt.widgets;
 import org.eclipse.swt.*;
 import org.eclipse.swt.events.*;
 import org.eclipse.swt.graphics.*;
+import org.eclipse.swt.internal.*;
 import org.eclipse.swt.internal.win32.*;
 
 /**
@@ -256,10 +257,13 @@ void addVerifyListener (VerifyListener listener) {
 	addTypedListener(listener, SWT.Verify);
 }
 
-@Override Point computeSizeInPixels (int wHint, int hHint, boolean changed) {
+@Override
+Point computeSizeInPixels (Point hintInPoints, boolean changed) {
 	checkWidget ();
+	int zoom = getZoom();
+	Point hintInPixels = Win32DPIUtils.pointToPixelAsSize(hintInPoints, zoom);
 	int width = 0, height = 0;
-	if (wHint == SWT.DEFAULT || hHint == SWT.DEFAULT) {
+	if (hintInPoints.x == SWT.DEFAULT || hintInPoints.y == SWT.DEFAULT) {
 		long newFont, oldFont = 0;
 		long hDC = OS.GetDC (hwndText);
 		newFont = OS.SendMessage (hwndText, OS.WM_GETFONT, 0, 0);
@@ -291,10 +295,10 @@ void addVerifyListener (VerifyListener listener) {
 	}
 	if (width == 0) width = DEFAULT_WIDTH;
 	if (height == 0) height = DEFAULT_HEIGHT;
-	if (wHint != SWT.DEFAULT) width = wHint;
-	if (hHint != SWT.DEFAULT)
-		height = hHint;
-	else {
+	if (hintInPoints.x != SWT.DEFAULT) width = hintInPixels.x;
+	if (hintInPoints.y != SWT.DEFAULT) {
+		height = hintInPixels.y;
+	} else {
 		int borderAdjustment = (style & SWT.BORDER) != 0 ? -1 : 3;
 		int upDownHeight = getSystemMetrics (OS.SM_CYVSCROLL);
 		height = Math.max(height, upDownHeight + borderAdjustment);

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TabFolder.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TabFolder.java
@@ -178,9 +178,10 @@ protected void checkSubclass () {
 	if (!isValidSubclass ()) error (SWT.ERROR_INVALID_SUBCLASS);
 }
 
-@Override Point computeSizeInPixels (int wHint, int hHint, boolean changed) {
+@Override
+Point computeSizeInPixels (Point hintInPoints, boolean changed) {
 	checkWidget ();
-	Point size = super.computeSizeInPixels (wHint, hHint, changed);
+	Point size = super.computeSizeInPixels (hintInPoints, changed);
 	RECT insetRect = new RECT (), itemRect = new RECT ();
 	OS.SendMessage (handle, OS.TCM_ADJUSTRECT, 0, insetRect);
 	int width = insetRect.left - insetRect.right;
@@ -498,7 +499,7 @@ public int indexOf (TabItem item) {
 }
 
 @Override
-Point minimumSize (int wHint, int hHint, boolean flushCache) {
+Point minimumSize (Point hintInPoints, boolean flushCache) {
 	int width = 0, height = 0;
 	for (Control child : _getChildren ()) {
 		int index = 0;
@@ -507,9 +508,8 @@ Point minimumSize (int wHint, int hHint, boolean flushCache) {
 			if (items [index].control == child) break;
 			index++;
 		}
-		int zoom = getZoom();
 		if (index == count) {
-			Rectangle rect = Win32DPIUtils.pointToPixel(child.getBounds (), zoom);
+			Rectangle rect = child.getBounds ();
 			width = Math.max (width, rect.x + rect.width);
 			height = Math.max (height, rect.y + rect.height);
 		} else {
@@ -517,7 +517,7 @@ Point minimumSize (int wHint, int hHint, boolean flushCache) {
 			 * Since computeSize can be overridden by subclasses, we cannot
 			 * call computeSizeInPixels directly.
 			 */
-			Point size = Win32DPIUtils.pointToPixelAsSize(child.computeSize (DPIUtil.pixelToPoint(wHint, zoom), DPIUtil.pixelToPoint(hHint, zoom), flushCache), zoom);
+			Point size = child.computeSize (hintInPoints.x, hintInPoints.y, flushCache);
 			width = Math.max (width, size.x);
 			height = Math.max (height, size.y);
 		}

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Table.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Table.java
@@ -1426,7 +1426,10 @@ public void clearAll () {
 	}
 }
 
-@Override Point computeSizeInPixels (int wHint, int hHint, boolean changed) {
+@Override
+Point computeSizeInPixels (Point hintInPoints, boolean changed) {
+	int zoom = getZoom();
+	Point hintInPixels = Win32DPIUtils.pointToPixelAsSize(hintInPoints, zoom);
 	if (fixScrollWidth) setScrollWidth (null, true);
 	//This code is intentionally commented
 //	if (itemHeight == -1 && hooks (SWT.MeasureItem)) {
@@ -1454,8 +1457,8 @@ public void clearAll () {
 	OS.GetWindowRect (hwndHeader, rect);
 	int height = rect.bottom - rect.top;
 	int bits = 0;
-	if (wHint != SWT.DEFAULT) {
-		bits |= wHint & 0xFFFF;
+	if (hintInPoints.x != SWT.DEFAULT) {
+		bits |= hintInPixels.x & 0xFFFF;
 	} else {
 		int width = 0;
 		int count = (int)OS.SendMessage (hwndHeader, OS.HDM_GETITEMCOUNT, 0, 0);
@@ -1472,8 +1475,8 @@ public void clearAll () {
 	height += (int)OS.SendMessage (handle, OS.LVM_GETITEMCOUNT, 0, 0) * itemHeight;
 	if (width == 0) width = DEFAULT_WIDTH;
 	if (height == 0) height = DEFAULT_HEIGHT;
-	if (wHint != SWT.DEFAULT) width = wHint;
-	if (hHint != SWT.DEFAULT) height = hHint;
+	if (hintInPoints.x != SWT.DEFAULT) width = hintInPixels.x;
+	if (hintInPoints.y != SWT.DEFAULT) height = hintInPixels.y;
 	int border = getBorderWidthInPixels ();
 	width += border * 2;  height += border * 2;
 	if ((style & SWT.V_SCROLL) != 0) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Text.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Text.java
@@ -702,10 +702,13 @@ public void clearSelection () {
 	OS.SendMessage (handle, OS.EM_SETSEL, -1, 0);
 }
 
-@Override Point computeSizeInPixels (int wHint, int hHint, boolean changed) {
+@Override
+Point computeSizeInPixels (Point hintInPoints, boolean changed) {
 	checkWidget ();
+	int zoom = getZoom();
+	Point hintInPixels = Win32DPIUtils.pointToPixelAsSize(hintInPoints, zoom);
 	int height = 0, width = 0;
-	if (wHint == SWT.DEFAULT || hHint == SWT.DEFAULT) {
+	if (hintInPoints.x == SWT.DEFAULT || hintInPoints.y == SWT.DEFAULT) {
 		long newFont, oldFont = 0;
 		long hDC = OS.GetDC (handle);
 		newFont = OS.SendMessage (handle, OS.WM_GETFONT, 0, 0);
@@ -717,9 +720,9 @@ public void clearSelection () {
 		RECT rect = new RECT ();
 		int flags = OS.DT_CALCRECT | OS.DT_EDITCONTROL | OS.DT_NOPREFIX;
 		boolean wrap = (style & SWT.MULTI) != 0 && (style & SWT.WRAP) != 0;
-		if (wrap && wHint != SWT.DEFAULT) {
+		if (wrap && hintInPoints.x != SWT.DEFAULT) {
 			flags |= OS.DT_WORDBREAK;
-			rect.right = wHint;
+			rect.right = hintInPixels.x;
 		}
 		int length = OS.GetWindowTextLength (handle);
 		if (length != 0) {
@@ -729,7 +732,7 @@ public void clearSelection () {
 			Arrays.fill (buffer, '\0'); // erase sensitive data
 			width = rect.right - rect.left;
 		}
-		if (wrap && hHint == SWT.DEFAULT) {
+		if (wrap && hintInPoints.y == SWT.DEFAULT) {
 			int newHeight = rect.bottom - rect.top;
 			if (newHeight != 0) height = newHeight;
 		}
@@ -744,8 +747,8 @@ public void clearSelection () {
 	}
 	if (width == 0) width = DEFAULT_WIDTH;
 	if (height == 0) height = DEFAULT_HEIGHT;
-	if (wHint != SWT.DEFAULT) width = wHint;
-	if (hHint != SWT.DEFAULT) height = hHint;
+	if (hintInPoints.x != SWT.DEFAULT) width = hintInPixels.x;
+	if (hintInPoints.y != SWT.DEFAULT) height = hintInPixels.y;
 	Rectangle trim = computeTrimInPixels (0, 0, width, height);
 	return new Point (trim.width, trim.height);
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ToolBar.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ToolBar.java
@@ -208,15 +208,18 @@ void clearSizeCache(boolean changed) {
 	}
 }
 
-@Override Point computeSizeInPixels (int wHint, int hHint, boolean changed) {
+@Override
+Point computeSizeInPixels (Point hintInPoints, boolean changed) {
+	int zoom = getZoom();
+	Point hintInPixels = Win32DPIUtils.pointToPixelAsSize(hintInPoints, zoom);
 	int count = (int)OS.SendMessage (handle, OS.TB_BUTTONCOUNT, 0, 0);
-	if (count == this._count && wHint == this._wHint && hHint == this._hHint) {
+	if (count == this._count && hintInPixels.x == this._wHint && hintInPixels.y == this._hHint) {
 		// Return already cached values calculated previously
 		return new Point (_width, _height);
 	}
 	this._count = count;
-	this._wHint = wHint;
-	this._hHint = hHint;
+	this._wHint = hintInPixels.x;
+	this._hHint = hintInPixels.y;
 	int width = 0, height = 0;
 	if ((style & SWT.VERTICAL) != 0) {
 		RECT rect = new RECT ();
@@ -241,8 +244,8 @@ void clearSizeCache(boolean changed) {
 		int oldWidth = oldRect.right - oldRect.left;
 		int oldHeight = oldRect.bottom - oldRect.top;
 		int border = getBorderWidthInPixels ();
-		int newWidth = wHint == SWT.DEFAULT ? 0x3FFF : wHint + border * 2;
-		int newHeight = hHint == SWT.DEFAULT ? 0x3FFF : hHint + border * 2;
+		int newWidth = hintInPoints.x == SWT.DEFAULT ? 0x3FFF : hintInPixels.x + border * 2;
+		int newHeight = hintInPoints.y == SWT.DEFAULT ? 0x3FFF : hintInPixels.y + border * 2;
 		boolean redraw = getDrawing () && OS.IsWindowVisible (handle);
 		ignoreResize = true;
 		if (redraw) OS.UpdateWindow (handle);
@@ -268,8 +271,8 @@ void clearSizeCache(boolean changed) {
 	*/
 	if (width == 0) width = DEFAULT_WIDTH;
 	if (height == 0) height = DEFAULT_HEIGHT;
-	if (wHint != SWT.DEFAULT) width = wHint;
-	if (hHint != SWT.DEFAULT) height = hHint;
+	if (hintInPoints.x != SWT.DEFAULT) width = hintInPixels.x;
+	if (hintInPoints.y != SWT.DEFAULT) height = hintInPixels.y;
 	Rectangle trim = computeTrimInPixels (0, 0, width, height);
 	width = trim.width;  height = trim.height;
 	/*

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Tree.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Tree.java
@@ -1823,7 +1823,10 @@ long CompareFunc (long lParam1, long lParam2, long lParamSort) {
 	return sortDirection == SWT.UP ? text1.compareTo (text2) : text2.compareTo (text1);
 }
 
-@Override Point computeSizeInPixels (int wHint, int hHint, boolean changed) {
+@Override
+Point computeSizeInPixels (Point hintInPoints, boolean changed) {
+	int zoom = getZoom();
+	Point hintInPixels = Win32DPIUtils.pointToPixelAsSize(hintInPoints, zoom);
 	int width = 0, height = 0;
 	if (hwndHeader != 0) {
 		HDITEM hdItem = new HDITEM ();
@@ -1856,8 +1859,8 @@ long CompareFunc (long lParam1, long lParam2, long lParamSort) {
 	}
 	if (width == 0) width = DEFAULT_WIDTH;
 	if (height == 0) height = DEFAULT_HEIGHT;
-	if (wHint != SWT.DEFAULT) width = wHint;
-	if (hHint != SWT.DEFAULT) height = hHint;
+	if (hintInPoints.x != SWT.DEFAULT) width = hintInPixels.x;
+	if (hintInPoints.y != SWT.DEFAULT) height = hintInPixels.y;
 	int border = getBorderWidthInPixels ();
 	width += border * 2;
 	height += border * 2;


### PR DESCRIPTION
This increase precision of size computation by reducing the number of pixel/point conversions. In particular, the minimumSize() method unnecessarily calculated in pixels even though all relevant values are in points. Inside the computeSizeInPixels() methods, several conversions were done as most other called methods operate on point values.

I was not able to demonstrate benefits of the higher precision yet, but it anyway cleans up the code by removing unnecessary conversions.