### PR TITLE
[Win32] Improve pixel-to-point conversion precision

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/Win32DPIUtils.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/Win32DPIUtils.java
@@ -124,7 +124,7 @@ public class Win32DPIUtils {
 	}
 
 	public static Point pixelToPointAsSize(Point point, int zoom) {
-		return pixelToPoint(point, zoom, RoundingMode.DOWN);
+		return pixelToPoint(point, zoom, RoundingMode.ROUND);
 	}
 
 	public static Point pixelToPointAsLocation(Point point, int zoom) {


### PR DESCRIPTION
With recent changes to the rounding of pixel-to-point conversions the calculated sizes became too small in several use cases, leading to cut-off elements. This change adapts the rounding method to reduce the number of relevant cut-offs.

Follow-up to:
- https://github.com/eclipse-platform/eclipse.platform.swt/pull/2654

### How to test
Issues caused by pixel/point conversion roundings can best be seen at 125% or 175% monitor zoom.

Before at 125%:
<img width="566" height="250" alt="image" src="https://github.com/user-attachments/assets/555d5506-4a23-4154-a434-50bfa87c9ac6" />

After at 125%:
<img width="577" height="223" alt="image" src="https://github.com/user-attachments/assets/834abd03-d577-4642-af95-15eecf144d07" />

