### PR TITLE
[GTK4] Fix Control.update on Wayland

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Control.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Control.java
@@ -6813,8 +6813,10 @@ void update (boolean all, boolean flush) {
 	if(GTK.GTK4) GTK.gtk_widget_queue_draw(handle);
 	if (!GTK.gtk_widget_get_visible (topHandle ())) return;
 	if (!GTK.gtk_widget_get_realized (handle)) return;
-	long window = paintWindow ();
-	if (flush) display.flushExposes (window, all);
+	if (flush && OS.isX11()) {
+		long window = paintWindow ();
+		display.flushExposes (window, all);
+	}
 }
 
 void updateBackgroundMode () {


### PR DESCRIPTION
Display.flushExposes is strictly X11 specific so it makes not sense to fail Table.paintWindow() due to usage of
GTK3.gtk_tree_view_get_bin_window when in the end that would not be used at all on Wayland.
Gtk4/X11 case will remain broken but considering that distros stop shipping Gnome on X11 it is not worth supporting smth that users will not get easily available
(https://fedoraproject.org/wiki/Changes/WaylandOnlyGNOME ). Fixes Ctrl+3 in Eclipse.