### PR TITLE
Streamline rounding for rectangles and add rounding mode to them

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/Point.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/Point.java
@@ -177,7 +177,7 @@ public static sealed class OfFloat extends Point permits Point.WithMonitor {
 
 	@Override
 	public Point.OfFloat clone() {
-		return new Point.OfFloat(getX(), getY());
+		return new Point.OfFloat(getX(), getY(), roundingMode);
 	}
 
 	/**

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/Rectangle.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/Rectangle.java
@@ -86,6 +86,9 @@ public Rectangle (int x, int y, int width, int height) {
 	this.height = height;
 }
 
+private Rectangle() {
+}
+
 /**
  * Destructively replaces the x, y, width and height values
  * in the receiver with ones which represent the union of the
@@ -411,16 +414,25 @@ public static sealed class OfFloat extends Rectangle permits Rectangle.WithMonit
 
 	private float residualX, residualY, residualWidth, residualHeight;
 
+	private RoundingMode locationRounding = RoundingMode.ROUND;
+
+	private RoundingMode sizeRounding = RoundingMode.ROUND;
+
 	public OfFloat(int x, int y, int width, int height) {
 		super(x, y, width, height);
 	}
 
 	public OfFloat(float x, float y, float width, float height) {
-		super(Math.round(x), Math.round(y), Math.round(width), Math.round(height));
-		this.residualX = x - this.x;
-		this.residualY = y - this.y;
-		this.residualWidth = width - this.width;
-		this.residualHeight = height - this.height;
+		this(x, y, width, height, RoundingMode.ROUND, RoundingMode.ROUND);
+	}
+
+	private OfFloat(float x, float y, float width, float height, RoundingMode locationRounding, RoundingMode sizeRounding) {
+		this.locationRounding = locationRounding;
+		this.sizeRounding = sizeRounding;
+		setX(x);
+		setY(y);
+		setWidth(width);
+		setHeight(height);
 	}
 
 	public float getX() {
@@ -440,28 +452,38 @@ public static sealed class OfFloat extends Rectangle permits Rectangle.WithMonit
 	}
 
 	public void setX(float x) {
-		this.x = Math.round(x);
+		this.x = locationRounding.round(x);
 		this.residualX = x - this.x;
+		setWidth(getWidth());
 	}
 
 	public void setY(float y) {
-		this.y = Math.round(y);
+		this.y = locationRounding.round(y);
 		this.residualY = y - this.y;
+		setHeight(getHeight());
 	}
 
 	public void setWidth(float width) {
-		this.width = Math.round(width);
+		this.width = sizeRounding.round(width + getX()) - x;
 		this.residualWidth = width - this.width;
 	}
 
 	public void setHeight(float height) {
-		this.height = Math.round(height);
+		this.height = sizeRounding.round(height + getY()) - y;
 		this.residualHeight = height - this.height;
+	}
+
+	public Point.OfFloat getTopLeft() {
+		return new Point.OfFloat(getX(), getY(), locationRounding);
+	}
+
+	public Point.OfFloat getBottomRight() {
+		return new Point.OfFloat(getX() + getWidth(), getY() + getHeight(), sizeRounding);
 	}
 
 	@Override
 	public Rectangle.OfFloat clone() {
-		return new Rectangle.OfFloat(getX(), getY(), getWidth(), getHeight());
+		return new Rectangle.OfFloat(getX(), getY(), getWidth(), getHeight(), locationRounding, sizeRounding);
 	}
 
 	/**

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/Win32DPIUtils.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/Win32DPIUtils.java
@@ -137,29 +137,29 @@ public class Win32DPIUtils {
 
 	private static Point pixelToPoint(Point point, int zoom, RoundingMode mode) {
 		if (zoom == 100 || point == null) return point;
-		Point.OfFloat fPoint = Point.OfFloat.from(point);
+		Point.OfFloat floatPoint = Point.OfFloat.from(point);
+		return pixelToPoint(new Point.OfFloat(floatPoint.getX(), floatPoint.getY(), mode), zoom);
+	}
+
+	private static Point.OfFloat pixelToPoint(Point.OfFloat point, int zoom) {
+		Point.OfFloat scaledPoint = point.clone();
 		float scaleFactor = DPIUtil.getScalingFactor(zoom);
-		float scaledX = fPoint.getX() / scaleFactor;
-		float scaledY = fPoint.getY() / scaleFactor;
-		return new Point.OfFloat(scaledX, scaledY, mode);
+		scaledPoint.setX(point.getX() / scaleFactor);
+		scaledPoint.setY(point.getY() / scaleFactor);
+		return scaledPoint;
 	}
 
 	public static Rectangle pixelToPoint(Rectangle rect, int zoom) {
 		if (zoom == 100 || rect == null) return rect;
-		if (rect instanceof Rectangle.OfFloat rectOfFloat) return pixelToPoint(rectOfFloat, zoom);
-		Rectangle scaledRect = new Rectangle.OfFloat (0,0,0,0);
-		Point scaledTopLeft = pixelToPointAsLocation(new Point (rect.x, rect.y), zoom);
-		Point scaledBottomRight = pixelToPointAsSize(new Point (rect.x + rect.width, rect.y + rect.height), zoom);
-
-		scaledRect.x = scaledTopLeft.x;
-		scaledRect.y = scaledTopLeft.y;
-		scaledRect.width = scaledBottomRight.x - scaledTopLeft.x;
-		scaledRect.height = scaledBottomRight.y - scaledTopLeft.y;
+		Rectangle.OfFloat floatRect = Rectangle.OfFloat.from(rect);
+		Point.OfFloat scaledTopLeft = pixelToPoint(floatRect.getTopLeft(), zoom);
+		Point.OfFloat scaledBottomRight = pixelToPoint(floatRect.getBottomRight(), zoom);
+		Rectangle.OfFloat scaledRect = floatRect.clone();
+		scaledRect.setX(scaledTopLeft.getX());
+		scaledRect.setY(scaledTopLeft.getY());
+		scaledRect.setWidth(scaledBottomRight.getX() - scaledTopLeft.getX());
+		scaledRect.setHeight(scaledBottomRight.getY() - scaledTopLeft.getY());
 		return scaledRect;
-	}
-
-	private static Rectangle pixelToPoint(Rectangle.OfFloat rect, int zoom) {
-		return scaleBounds(rect, 100, zoom);
 	}
 
 	public static Rectangle pixelToPoint(Drawable drawable, Rectangle rect, int zoom) {
@@ -229,11 +229,16 @@ public class Win32DPIUtils {
 
 	private static Point pointToPixel(Point point, int zoom, RoundingMode mode) {
 		if (zoom == 100 || point == null) return point;
-		Point.OfFloat fPoint = Point.OfFloat.from(point);
+		Point.OfFloat floatPoint = Point.OfFloat.from(point);
+		return pointToPixel(new Point.OfFloat(floatPoint.getX(), floatPoint.getY(), mode), zoom);
+	}
+
+	private static Point.OfFloat pointToPixel(Point.OfFloat point, int zoom) {
+		Point.OfFloat scaledPoint = point.clone();
 		float scaleFactor = DPIUtil.getScalingFactor(zoom);
-		float scaledX = fPoint.getX() * scaleFactor;
-		float scaledY = fPoint.getY() * scaleFactor;
-		return new Point.OfFloat(scaledX, scaledY, mode);
+		scaledPoint.setX(point.getX() * scaleFactor);
+		scaledPoint.setY(point.getY() * scaleFactor);
+		return scaledPoint;
 	}
 
 	public static Point pointToPixelAsSize(Drawable drawable, Point point, int zoom) {
@@ -256,20 +261,15 @@ public class Win32DPIUtils {
 
 	public static Rectangle pointToPixel(Rectangle rect, int zoom) {
 		if (zoom == 100 || rect == null) return rect;
-		if (rect instanceof Rectangle.OfFloat rectOfFloat) return pointToPixel(rectOfFloat, zoom);
-		Rectangle scaledRect = new Rectangle.OfFloat(0,0,0,0);
-		Point scaledTopLeft = pointToPixelAsLocation (new Point(rect.x, rect.y), zoom);
-		Point scaledBottomRight = pointToPixelAsLocation (new Point(rect.x + rect.width, rect.y + rect.height), zoom);
-
-		scaledRect.x = scaledTopLeft.x;
-		scaledRect.y = scaledTopLeft.y;
-		scaledRect.width = scaledBottomRight.x - scaledTopLeft.x;
-		scaledRect.height = scaledBottomRight.y - scaledTopLeft.y;
+		Rectangle.OfFloat floatRect = Rectangle.OfFloat.from(rect);
+		Point.OfFloat scaledTopLeft = pointToPixel(floatRect.getTopLeft(), zoom);
+		Point.OfFloat scaledBottomRight = pointToPixel(floatRect.getBottomRight(), zoom);
+		Rectangle.OfFloat scaledRect = floatRect.clone();
+		scaledRect.setX(scaledTopLeft.getX());
+		scaledRect.setY(scaledTopLeft.getY());
+		scaledRect.setWidth(scaledBottomRight.getX() - scaledTopLeft.getX());
+		scaledRect.setHeight(scaledBottomRight.getY() - scaledTopLeft.getY());
 		return scaledRect;
-	}
-
-	private static Rectangle pointToPixel(Rectangle.OfFloat rect, int zoom) {
-		return scaleBounds(rect, zoom, 100);
 	}
 
 	public static Rectangle pointToPixel(Drawable drawable, Rectangle rect, int zoom) {


### PR DESCRIPTION
For the float-aware Point class, a rounding mode has been introduced to store in which way the Point needs to be rounded when necessary. For rectangles, this has not been implemented yet and is added by this change. It also correct the way in which rectangle values are rounded by considering the top-left and bottom-right corner instead of top-left corner and width/height, also done in the Win32DPIUtils. So it streamlines the rounding behavior in Win32DPIUtils and the Rectangle class to uniformly scale the upper left and bottom right corner of a rectangle.

The changes also makes proper use of the floating-precision coordinates in the point/pixel conversions for rectangles in the Win32DPIUtils.