### PR TITLE
Replacement of Image(device, int, int) constructor for Snippets

### DIFF
--- a/examples/org.eclipse.swt.examples/src/org/eclipse/swt/examples/controlexample/Tab.java
+++ b/examples/org.eclipse.swt.examples/src/org/eclipse/swt/examples/controlexample/Tab.java
@@ -43,8 +43,8 @@ import org.eclipse.swt.events.VerifyEvent;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.Font;
 import org.eclipse.swt.graphics.FontData;
-import org.eclipse.swt.graphics.GC;
 import org.eclipse.swt.graphics.Image;
+import org.eclipse.swt.graphics.ImageGcDrawer;
 import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.graphics.RGB;
 import org.eclipse.swt.graphics.Rectangle;
@@ -1294,60 +1294,58 @@ abstract class Tab {
 	}
 
 	Image colorImage (Color color) {
-		Image image = new Image (display, IMAGE_SIZE, IMAGE_SIZE);
-		GC gc = new GC(image);
-		gc.setBackground(color);
-		Rectangle bounds = image.getBounds();
-		gc.fillRectangle(0, 0, bounds.width, bounds.height);
-		gc.setBackground(display.getSystemColor(SWT.COLOR_BLACK));
-		gc.drawRectangle(0, 0, bounds.width - 1, bounds.height - 1);
-		gc.dispose();
+		ImageGcDrawer imageGcDrawer = (gc, iwidth, iheight) -> {
+			gc.setBackground(color);
+			gc.fillRectangle(0, 0, iwidth, iheight);
+			gc.setBackground(display.getSystemColor(SWT.COLOR_BLACK));
+			gc.drawRectangle(0, 0, iwidth - 1, iheight - 1);
+		};
+		Image image = new Image (display, imageGcDrawer, IMAGE_SIZE, IMAGE_SIZE);
 		return image;
 	}
 
 	Image fontImage (Font font) {
-		Image image = new Image (display, IMAGE_SIZE, IMAGE_SIZE);
-		GC gc = new GC(image);
-		Rectangle bounds = image.getBounds();
-		gc.setBackground(display.getSystemColor(SWT.COLOR_WHITE));
-		gc.fillRectangle(0, 0, bounds.width, bounds.height);
-		gc.setBackground(display.getSystemColor(SWT.COLOR_BLACK));
-		gc.drawRectangle(0, 0, bounds.width - 1, bounds.height - 1);
-		FontData data[] = font.getFontData();
-		int style = data[0].getStyle();
-		switch (style) {
-		case SWT.NORMAL:
-			gc.drawLine(3, 3, 3, 8);
-			gc.drawLine(4, 3, 7, 8);
-			gc.drawLine(8, 3, 8, 8);
-			break;
-		case SWT.BOLD:
-			gc.drawLine(3, 2, 3, 9);
-			gc.drawLine(4, 2, 4, 9);
-			gc.drawLine(5, 2, 7, 2);
-			gc.drawLine(5, 3, 8, 3);
-			gc.drawLine(5, 5, 7, 5);
-			gc.drawLine(5, 6, 7, 6);
-			gc.drawLine(5, 8, 8, 8);
-			gc.drawLine(5, 9, 7, 9);
-			gc.drawLine(7, 4, 8, 4);
-			gc.drawLine(7, 7, 8, 7);
-			break;
-		case SWT.ITALIC:
-			gc.drawLine(6, 2, 8, 2);
-			gc.drawLine(7, 3, 4, 8);
-			gc.drawLine(3, 9, 5, 9);
-			break;
-		case SWT.BOLD | SWT.ITALIC:
-			gc.drawLine(5, 2, 8, 2);
-			gc.drawLine(5, 3, 8, 3);
-			gc.drawLine(6, 4, 4, 7);
-			gc.drawLine(7, 4, 5, 7);
-			gc.drawLine(3, 8, 6, 8);
-			gc.drawLine(3, 9, 6, 9);
-			break;
-		}
-		gc.dispose();
+		ImageGcDrawer igc = (gc, iwidth, iheight) -> {
+			gc.setBackground(display.getSystemColor(SWT.COLOR_WHITE));
+			gc.fillRectangle(0, 0, iwidth, iheight);
+			gc.setBackground(display.getSystemColor(SWT.COLOR_BLACK));
+			gc.drawRectangle(0, 0, iwidth - 1, iheight - 1);
+			FontData data[] = font.getFontData();
+			int style = data[0].getStyle();
+			switch (style) {
+			case SWT.NORMAL:
+				gc.drawLine(3, 3, 3, 8);
+				gc.drawLine(4, 3, 7, 8);
+				gc.drawLine(8, 3, 8, 8);
+				break;
+			case SWT.BOLD:
+				gc.drawLine(3, 2, 3, 9);
+				gc.drawLine(4, 2, 4, 9);
+				gc.drawLine(5, 2, 7, 2);
+				gc.drawLine(5, 3, 8, 3);
+				gc.drawLine(5, 5, 7, 5);
+				gc.drawLine(5, 6, 7, 6);
+				gc.drawLine(5, 8, 8, 8);
+				gc.drawLine(5, 9, 7, 9);
+				gc.drawLine(7, 4, 8, 4);
+				gc.drawLine(7, 7, 8, 7);
+				break;
+			case SWT.ITALIC:
+				gc.drawLine(6, 2, 8, 2);
+				gc.drawLine(7, 3, 4, 8);
+				gc.drawLine(3, 9, 5, 9);
+				break;
+			case SWT.BOLD | SWT.ITALIC:
+				gc.drawLine(5, 2, 8, 2);
+				gc.drawLine(5, 3, 8, 3);
+				gc.drawLine(6, 4, 4, 7);
+				gc.drawLine(7, 4, 5, 7);
+				gc.drawLine(3, 8, 6, 8);
+				gc.drawLine(3, 9, 6, 9);
+				break;
+			}
+		};
+		Image image = new Image (display, igc, IMAGE_SIZE, IMAGE_SIZE);
 		return image;
 	}
 

--- a/examples/org.eclipse.swt.examples/src/org/eclipse/swt/examples/graphics/GradientTab.java
+++ b/examples/org.eclipse.swt.examples/src/org/eclipse/swt/examples/graphics/GradientTab.java
@@ -19,6 +19,7 @@ import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.Device;
 import org.eclipse.swt.graphics.GC;
 import org.eclipse.swt.graphics.Image;
+import org.eclipse.swt.graphics.ImageGcDrawer;
 import org.eclipse.swt.graphics.Path;
 import org.eclipse.swt.graphics.Pattern;
 import org.eclipse.swt.graphics.Point;
@@ -177,29 +178,26 @@ public void paint(GC gc, int width, int height) {
  *            Height of the drawing surface
  */
 Image createImage(Device device, Color color1, Color color2, int width, int height) {
-	Image image = new Image(device, width/2, height/2);
-	GC gc = new GC(image);
-	Rectangle rect = image.getBounds();
+	ImageGcDrawer igc = (gc, iwidth, iheight) -> {
+		Pattern pattern1 = new Pattern(device, 0, 0, iwidth/2f, iheight/2f, color1, color2);
+		gc.setBackgroundPattern(pattern1);
+		Path path = new Path(device);
+		path.addRectangle(0, 0, width/4f, height/4f);
+		path.addRectangle(width/4f, height/4f, width/4f, height/4f);
+		gc.fillPath(path);
+		path.dispose();
 
-	Pattern pattern1 = new Pattern(device, rect.x, rect.y, rect.width/2f, rect.height/2f, color1, color2);
-	gc.setBackgroundPattern(pattern1);
-	Path path = new Path(device);
-	path.addRectangle(0, 0, width/4f, height/4f);
-	path.addRectangle(width/4f, height/4f, width/4f, height/4f);
-	gc.fillPath(path);
-	path.dispose();
-
-	Pattern pattern2 = new Pattern(device, rect.width, 0, rect.width/2f, rect.height/2f, color1, color2);
-	gc.setBackgroundPattern(pattern2);
-	path = new Path(device);
-	path.addRectangle(width/4f, 0, width/4f, height/4f);
-	path.addRectangle(0, height/4f, width/4f, height/4f);
-	gc.fillPath(path);
-	path.dispose();
-
-	gc.dispose();
-	pattern1.dispose();
-	pattern2.dispose();
+		Pattern pattern2 = new Pattern(device, iwidth, 0, iwidth/2f, iheight/2f, color1, color2);
+		gc.setBackgroundPattern(pattern2);
+		path = new Path(device);
+		path.addRectangle(width/4f, 0, width/4f, height/4f);
+		path.addRectangle(0, height/4f, width/4f, height/4f);
+		gc.fillPath(path);
+		path.dispose();
+		pattern1.dispose();
+		pattern2.dispose();
+	};
+	Image image = new Image(device, igc,  width/2, height/2);
 	return image;
 }
 

--- a/examples/org.eclipse.swt.examples/src/org/eclipse/swt/examples/graphics/GraphicsExample.java
+++ b/examples/org.eclipse.swt.examples/src/org/eclipse/swt/examples/graphics/GraphicsExample.java
@@ -28,6 +28,7 @@ import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.Device;
 import org.eclipse.swt.graphics.GC;
 import org.eclipse.swt.graphics.Image;
+import org.eclipse.swt.graphics.ImageGcDrawer;
 import org.eclipse.swt.graphics.Path;
 import org.eclipse.swt.graphics.Pattern;
 import org.eclipse.swt.graphics.Point;
@@ -325,11 +326,10 @@ static Image createThumbnail(Device device, String name) {
 	Rectangle src = image.getBounds();
 	Image result = null;
 	if (src.width != 16 || src.height != 16) {
-		result = new Image(device, 16, 16);
-		GC gc = new GC(result);
-		Rectangle dest = result.getBounds();
-		gc.drawImage(image, src.x, src.y, src.width, src.height, dest.x, dest.y, dest.width, dest.height);
-		gc.dispose();
+		ImageGcDrawer igc = (gc, iwidth, iheight) -> {
+			gc.drawImage(image, src.x, src.y, src.width, src.height, 0, 0, iwidth, iheight);
+		};
+		result = new Image(device, igc, 16, 16);
 	}
 	if (result != null) {
 		image.dispose();
@@ -347,16 +347,15 @@ static Image createThumbnail(Device device, String name) {
  *
  * */
 static Image createImage(Device device, Color color1, Color color2, int width, int height) {
-	Image image = new Image(device, width, height);
-	GC gc = new GC(image);
-	Rectangle rect = image.getBounds();
-	Pattern pattern = new Pattern(device, rect.x, rect.y, rect.width - 1,
-				rect.height - 1, color1, color2);
-	gc.setBackgroundPattern(pattern);
-	gc.fillRectangle(rect);
-	gc.drawRectangle(rect.x, rect.y, rect.width - 1, rect.height - 1);
-	gc.dispose();
-	pattern.dispose();
+	ImageGcDrawer igc = (gc, iwidth, iheight) ->  {
+		Pattern pattern = new Pattern(device, 0, 0, iwidth - 1,
+				iheight - 1, color1, color2);
+		gc.setBackgroundPattern(pattern);
+		gc.fillRectangle(0,0,iwidth,iheight);
+		gc.drawRectangle(0, 0, iwidth - 1, iheight - 1);
+		pattern.dispose();
+	};
+	Image image = new Image(device, igc, width, height);
 	return image;
 }
 
@@ -368,16 +367,15 @@ static Image createImage(Device device, Color color1, Color color2, int width, i
  *
  * */
 static Image createImage(Device device, Color color) {
-	Image image = new Image(device, 16, 16);
-	GC gc = new GC(image);
-	gc.setBackground(color);
-	Rectangle rect = image.getBounds();
-	gc.fillRectangle(rect);
-	if (color.equals(device.getSystemColor(SWT.COLOR_BLACK))) {
-		gc.setForeground(device.getSystemColor(SWT.COLOR_WHITE));
-	}
-	gc.drawRectangle(rect.x, rect.y, rect.width - 1, rect.height - 1);
-	gc.dispose();
+	ImageGcDrawer igc = (gc, iwidth, iheight) ->  {
+		gc.setBackground(color);
+		gc.fillRectangle(0,0,iwidth,iheight);
+		if (color.equals(device.getSystemColor(SWT.COLOR_BLACK))) {
+			gc.setForeground(device.getSystemColor(SWT.COLOR_WHITE));
+		}
+		gc.drawRectangle(0, 0, iwidth - 1, iheight - 1);
+	};
+	Image image = new Image(device, igc, 16, 16);
 	return image;
 }
 

--- a/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet10.java
+++ b/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet10.java
@@ -32,12 +32,13 @@ public class Snippet10 {
 		shell.setText("Advanced Graphics");
 		FontData fd = shell.getFont().getFontData()[0];
 		final Font font = new Font(display, fd.getName(), 60, SWT.BOLD | SWT.ITALIC);
-		final Image image = new Image(display, 640, 480);
+		final ImageGcDrawer imageGcDrawer = (gc, imageWidth, imageHeight) -> {
+			gc.setBackground(display.getSystemColor(SWT.COLOR_RED));
+			gc.fillOval(0, 0, imageWidth, imageHeight);
+		};
+		final Image image = new Image(display,imageGcDrawer, 640, 480);
 		final Rectangle rect = image.getBounds();
-		GC gc = new GC(image);
-		gc.setBackground(display.getSystemColor(SWT.COLOR_RED));
-		gc.fillOval(rect.x, rect.y, rect.width, rect.height);
-		gc.dispose();
+
 		shell.addListener(SWT.Paint, event -> {
 			GC gc1 = event.gc;
 			Transform tr = new Transform(display);
@@ -61,6 +62,7 @@ public class Snippet10 {
 			if (!display.readAndDispatch())
 				display.sleep();
 		}
+
 		image.dispose();
 		font.dispose();
 		display.dispose();

--- a/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet104.java
+++ b/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet104.java
@@ -26,58 +26,63 @@ import org.eclipse.swt.widgets.*;
 
 public class Snippet104 {
 
-public static void main(String[] args) {
-	final Display display = new Display();
-	final int [] count = new int [] {4};
-	final Image image = new Image(display, 300, 300);
-	GC gc = new GC(image);
-	gc.setBackground(display.getSystemColor(SWT.COLOR_CYAN));
-	gc.fillRectangle(image.getBounds());
-	gc.drawText("Splash Screen", 10, 10);
-	gc.dispose();
-	final Shell splash = new Shell(SWT.ON_TOP);
-	final ProgressBar bar = new ProgressBar(splash, SWT.NONE);
-	bar.setMaximum(count[0]);
-	Label label = new Label(splash, SWT.NONE);
-	label.setImage(image);
-	FormLayout layout = new FormLayout();
-	splash.setLayout(layout);
-	FormData labelData = new FormData ();
-	labelData.right = new FormAttachment (100, 0);
-	labelData.bottom = new FormAttachment (100, 0);
-	label.setLayoutData(labelData);
-	FormData progressData = new FormData ();
-	progressData.left = new FormAttachment (0, 5);
-	progressData.right = new FormAttachment (100, -5);
-	progressData.bottom = new FormAttachment (100, -5);
-	bar.setLayoutData(progressData);
-	splash.pack();
-	Rectangle splashRect = splash.getBounds();
-	Rectangle displayRect = display.getBounds();
-	int x = (displayRect.width - splashRect.width) / 2;
-	int y = (displayRect.height - splashRect.height) / 2;
-	splash.setLocation(x, y);
-	splash.open();
-	display.asyncExec(() -> {
-		Shell [] shells = new Shell[count[0]];
-		for (int i1=0; i1<count[0]; i1++) {
-			shells [i1] = new Shell(display);
-			shells [i1].setSize (300, 300);
-			shells [i1].addListener(SWT.Close, e -> --count[0]);
-			bar.setSelection(i1+1);
-			try {Thread.sleep(1000);} catch (Throwable e) {}
+	public static void main(String[] args) {
+		final Display display = new Display();
+		final int[] count = new int[] { 4 };
+
+		ImageGcDrawer imageGcDrawer = (gc, imageWidth, imageHeight) -> {
+			gc.setBackground(display.getSystemColor(SWT.COLOR_CYAN));
+			gc.fillRectangle(0, 0, imageWidth, imageHeight);
+			gc.drawText("Splash Screen", 10, 10);
+		};
+		final Image image = new Image(display, imageGcDrawer, 300, 300);
+		final Shell splash = new Shell(SWT.ON_TOP);
+		final ProgressBar bar = new ProgressBar(splash, SWT.NONE);
+		bar.setMaximum(count[0]);
+		Label label = new Label(splash, SWT.NONE);
+		label.setImage(image);
+		FormLayout layout = new FormLayout();
+		splash.setLayout(layout);
+		FormData labelData = new FormData();
+		labelData.right = new FormAttachment(100, 0);
+		labelData.bottom = new FormAttachment(100, 0);
+		label.setLayoutData(labelData);
+		FormData progressData = new FormData();
+		progressData.left = new FormAttachment(0, 5);
+		progressData.right = new FormAttachment(100, -5);
+		progressData.bottom = new FormAttachment(100, -5);
+		bar.setLayoutData(progressData);
+		splash.pack();
+		Rectangle splashRect = splash.getBounds();
+		Rectangle displayRect = display.getBounds();
+		int x = (displayRect.width - splashRect.width) / 2;
+		int y = (displayRect.height - splashRect.height) / 2;
+		splash.setLocation(x, y);
+		splash.open();
+		display.asyncExec(() -> {
+			Shell[] shells = new Shell[count[0]];
+			for (int i1 = 0; i1 < count[0]; i1++) {
+				shells[i1] = new Shell(display);
+				shells[i1].setSize(300, 300);
+				shells[i1].addListener(SWT.Close, e -> --count[0]);
+				bar.setSelection(i1 + 1);
+				try {
+					Thread.sleep(1000);
+				} catch (Throwable e) {
+				}
+			}
+			splash.close();
+			image.dispose();
+			for (int i2 = 0; i2 < count[0]; i2++) {
+				shells[i2].setText("SWT Snippet 104 - " + (i2 + 1));
+				shells[i2].open();
+			}
+		});
+		while (count[0] != 0) {
+			if (!display.readAndDispatch())
+				display.sleep();
 		}
-		splash.close();
-		image.dispose();
-		for (int i2=0; i2<count[0]; i2++) {
-			shells [i2].setText("SWT Snippet 104 - " + (i2+1));
-			shells [i2].open();
-		}
-	});
-	while (count [0] != 0) {
-		if (!display.readAndDispatch ()) display.sleep ();
+		display.dispose();
 	}
-	display.dispose();
-}
 
 }

--- a/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet112.java
+++ b/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet112.java
@@ -28,12 +28,14 @@ public class Snippet112 {
 
 public static void main (String [] args) {
 	Display display = new Display ();
-	final Image image = new Image (display, 20, 20);
 	Color color = display.getSystemColor (SWT.COLOR_RED);
-	GC gc = new GC (image);
-	gc.setBackground (color);
-	gc.fillRectangle (image.getBounds ());
-	gc.dispose ();
+
+	final ImageGcDrawer imageGcDrawer = (gc, imageWidth, imageHeight) -> {
+		gc.setBackground(color);
+		gc.fillRectangle(0, 0, imageWidth, imageHeight);
+	};
+
+	final Image image = new Image (display, imageGcDrawer, 20, 20);
 
 	Shell shell = new Shell (display);
 	shell.setText("Snippet 112");

--- a/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet138.java
+++ b/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet138.java
@@ -28,7 +28,7 @@ import org.eclipse.swt.widgets.*;
 public class Snippet138 {
 	public static void main(String[] args) {
 		Display display = new Display();
-
+/*
 		Image small = new Image(display, 16, 16);
 		GC gc = new GC(small);
 		gc.setBackground(display.getSystemColor(SWT.COLOR_RED));
@@ -40,6 +40,21 @@ public class Snippet138 {
 		gc.setBackground(display.getSystemColor(SWT.COLOR_RED));
 		gc.fillArc(0, 0, 32, 32, 45, 270);
 		gc.dispose();
+*/
+
+		 final ImageGcDrawer imageGcDrawer = (gc, imageWidth, imageHeight) -> {
+			gc.setBackground(display.getSystemColor(SWT.COLOR_RED));
+			gc.fillArc(0, 0, imageWidth, imageHeight, 45, 270);
+		};
+		Image small = new Image(display, imageGcDrawer, 16, 16);
+
+		final ImageGcDrawer imageGcDrawer1 = (gc, imageWidth, imageHeight) -> {
+			gc.setBackground(display.getSystemColor(SWT.COLOR_RED));
+			gc.fillArc(0, 0, imageWidth, imageHeight, 45, 270);
+		};
+		Image large = new Image(display, imageGcDrawer1, 32, 32);
+
+
 
 		/* Provide different resolutions for icons to get
 		 * high quality rendering wherever the OS needs

--- a/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet139.java
+++ b/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet139.java
@@ -91,7 +91,6 @@ static ImageData flip(ImageData srcData, boolean vertical) {
 public static void main(String[] args) {
 	Display display = new Display();
 
-	// create an image with the word "hello" on it
 	final Image image0 = new Image(display, 50, 30);
 	GC gc = new GC(image0);
 	gc.setBackground(display.getSystemColor(SWT.COLOR_RED));
@@ -100,8 +99,9 @@ public static void main(String[] args) {
 	gc.dispose();
 
 	ImageData data = image0.getImageData();
+
 	// rotate and flip this image
-	final Image image1 = new Image(display, rotate(data, SWT.LEFT));
+ 	final Image image1 = new Image(display, rotate(data, SWT.LEFT));
 	final Image image2 = new Image(display, rotate(data, SWT.RIGHT));
 	final Image image3 = new Image(display, rotate(data, SWT.DOWN));
 	final Image image4 = new Image(display, flip(data, true));

--- a/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet143.java
+++ b/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet143.java
@@ -27,44 +27,47 @@ import org.eclipse.swt.widgets.*;
 
 public class Snippet143 {
 
-public static void main(String[] args) {
-	Display display = new Display ();
-	Shell shell = new Shell (display);
-	shell.setText("Snippet 143");
-	Image image = new Image (display, 16, 16);
-	Image image2 = new Image (display, 16, 16);
-	GC gc = new GC(image2);
-	gc.setBackground(display.getSystemColor(SWT.COLOR_BLACK));
-	gc.fillRectangle(image2.getBounds());
-	gc.dispose();
-	final Tray tray = display.getSystemTray ();
-	if (tray == null) {
-		System.out.println ("The system tray is not available");
-	} else {
-		final TrayItem item = new TrayItem (tray, SWT.NONE);
-		item.setToolTipText("SWT TrayItem");
-		item.addListener (SWT.Show, event -> System.out.println("show"));
-		item.addListener (SWT.Hide, event -> System.out.println("hide"));
-		item.addListener (SWT.Selection, event -> System.out.println("selection"));
-		item.addListener (SWT.DefaultSelection, event -> System.out.println("default selection"));
-		final Menu menu = new Menu (shell, SWT.POP_UP);
-		for (int i = 0; i < 8; i++) {
-			MenuItem mi = new MenuItem (menu, SWT.PUSH);
-			mi.setText ("Item" + i);
-			mi.addListener (SWT.Selection, event -> System.out.println("selection " + event.widget));
-			if (i == 0) menu.setDefaultItem(mi);
+	public static void main(String[] args) {
+		Display display = new Display();
+		Shell shell = new Shell(display);
+		shell.setText("Snippet 143");
+		ImageGcDrawer imgc1 = (gc, iwidth, iheight) -> {};
+		Image image = new Image(display, imgc1, 16, 16);
+		ImageGcDrawer imgc = (gc, iwidth, iheight) -> {
+			gc.setBackground(display.getSystemColor(SWT.COLOR_BLACK));
+			gc.fillRectangle(0, 0, iwidth, iheight);
+		};
+		Image image2 = new Image(display, imgc, 16, 16);
+		final Tray tray = display.getSystemTray();
+		if (tray == null) {
+			System.out.println("The system tray is not available");
+		} else {
+			final TrayItem item = new TrayItem(tray, SWT.NONE);
+			item.setToolTipText("SWT TrayItem");
+			item.addListener(SWT.Show, event -> System.out.println("show"));
+			item.addListener(SWT.Hide, event -> System.out.println("hide"));
+			item.addListener(SWT.Selection, event -> System.out.println("selection"));
+			item.addListener(SWT.DefaultSelection, event -> System.out.println("default selection"));
+			final Menu menu = new Menu(shell, SWT.POP_UP);
+			for (int i = 0; i < 8; i++) {
+				MenuItem mi = new MenuItem(menu, SWT.PUSH);
+				mi.setText("Item" + i);
+				mi.addListener(SWT.Selection, event -> System.out.println("selection " + event.widget));
+				if (i == 0)
+					menu.setDefaultItem(mi);
+			}
+			item.addListener(SWT.MenuDetect, event -> menu.setVisible(true));
+			item.setImage(image2);
+			//item.setHighlightImage(image);
 		}
-		item.addListener (SWT.MenuDetect, event -> menu.setVisible (true));
-		item.setImage (image2);
-		item.setHighlightImage (image);
+		shell.setBounds(50, 50, 300, 200);
+		shell.open();
+		while (!shell.isDisposed()) {
+			if (!display.readAndDispatch())
+				display.sleep();
+		}
+		image.dispose();
+		image2.dispose();
+		display.dispose();
 	}
-	shell.setBounds(50, 50, 300, 200);
-	shell.open ();
-	while (!shell.isDisposed ()) {
-		if (!display.readAndDispatch ()) display.sleep ();
-	}
-	image.dispose ();
-	image2.dispose ();
-	display.dispose ();
-}
 }

--- a/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet156.java
+++ b/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet156.java
@@ -31,168 +31,177 @@ import org.eclipse.swt.widgets.*;
 
 public class Snippet156 {
 
-static BufferedImage convertToAWT(ImageData data) {
-	ColorModel colorModel = null;
-	PaletteData palette = data.palette;
-	if (palette.isDirect) {
-		colorModel = new DirectColorModel(data.depth, palette.redMask, palette.greenMask, palette.blueMask);
-		BufferedImage bufferedImage = new BufferedImage(colorModel, colorModel.createCompatibleWritableRaster(data.width, data.height), false, null);
-		for (int y = 0; y < data.height; y++) {
-			for (int x = 0; x < data.width; x++) {
-				int pixel = data.getPixel(x, y);
-				RGB rgb = palette.getRGB(pixel);
-				bufferedImage.setRGB(x, y,  rgb.red << 16 | rgb.green << 8 | rgb.blue);
-			}
-		}
-		return bufferedImage;
-	} else {
-		RGB[] rgbs = palette.getRGBs();
-		byte[] red = new byte[rgbs.length];
-		byte[] green = new byte[rgbs.length];
-		byte[] blue = new byte[rgbs.length];
-		for (int i = 0; i < rgbs.length; i++) {
-			RGB rgb = rgbs[i];
-			red[i] = (byte)rgb.red;
-			green[i] = (byte)rgb.green;
-			blue[i] = (byte)rgb.blue;
-		}
-		if (data.transparentPixel != -1) {
-			colorModel = new IndexColorModel(data.depth, rgbs.length, red, green, blue, data.transparentPixel);
-		} else {
-			colorModel = new IndexColorModel(data.depth, rgbs.length, red, green, blue);
-		}
-		BufferedImage bufferedImage = new BufferedImage(colorModel, colorModel.createCompatibleWritableRaster(data.width, data.height), false, null);
-		WritableRaster raster = bufferedImage.getRaster();
-		int[] pixelArray = new int[1];
-		for (int y = 0; y < data.height; y++) {
-			for (int x = 0; x < data.width; x++) {
-				int pixel = data.getPixel(x, y);
-				pixelArray[0] = pixel;
-				raster.setPixel(x, y, pixelArray);
-			}
-		}
-		return bufferedImage;
-	}
-}
-
-static ImageData convertToSWT(BufferedImage bufferedImage) {
-	if (bufferedImage.getColorModel() instanceof DirectColorModel) {
-		DirectColorModel colorModel = (DirectColorModel)bufferedImage.getColorModel();
-		PaletteData palette = new PaletteData(colorModel.getRedMask(), colorModel.getGreenMask(), colorModel.getBlueMask());
-		ImageData data = new ImageData(bufferedImage.getWidth(), bufferedImage.getHeight(), colorModel.getPixelSize(), palette);
-		for (int y = 0; y < data.height; y++) {
-			for (int x = 0; x < data.width; x++) {
-				int rgb = bufferedImage.getRGB(x, y);
-				int pixel = palette.getPixel(new RGB((rgb >> 16) & 0xFF, (rgb >> 8) & 0xFF, rgb & 0xFF));
-				data.setPixel(x, y, pixel);
-				if (colorModel.hasAlpha()) {
-					data.setAlpha(x, y, (rgb >> 24) & 0xFF);
+	static BufferedImage convertToAWT(ImageData data) {
+		ColorModel colorModel = null;
+		PaletteData palette = data.palette;
+		if (palette.isDirect) {
+			colorModel = new DirectColorModel(data.depth, palette.redMask, palette.greenMask, palette.blueMask);
+			BufferedImage bufferedImage = new BufferedImage(colorModel,
+					colorModel.createCompatibleWritableRaster(data.width, data.height), false, null);
+			for (int y = 0; y < data.height; y++) {
+				for (int x = 0; x < data.width; x++) {
+					int pixel = data.getPixel(x, y);
+					RGB rgb = palette.getRGB(pixel);
+					bufferedImage.setRGB(x, y, rgb.red << 16 | rgb.green << 8 | rgb.blue);
 				}
 			}
-		}
-		return data;
-	} else if (bufferedImage.getColorModel() instanceof IndexColorModel) {
-		IndexColorModel colorModel = (IndexColorModel)bufferedImage.getColorModel();
-		int size = colorModel.getMapSize();
-		byte[] reds = new byte[size];
-		byte[] greens = new byte[size];
-		byte[] blues = new byte[size];
-		colorModel.getReds(reds);
-		colorModel.getGreens(greens);
-		colorModel.getBlues(blues);
-		RGB[] rgbs = new RGB[size];
-		for (int i = 0; i < rgbs.length; i++) {
-			rgbs[i] = new RGB(reds[i] & 0xFF, greens[i] & 0xFF, blues[i] & 0xFF);
-		}
-		PaletteData palette = new PaletteData(rgbs);
-		ImageData data = new ImageData(bufferedImage.getWidth(), bufferedImage.getHeight(), colorModel.getPixelSize(), palette);
-		data.transparentPixel = colorModel.getTransparentPixel();
-		WritableRaster raster = bufferedImage.getRaster();
-		int[] pixelArray = new int[1];
-		for (int y = 0; y < data.height; y++) {
-			for (int x = 0; x < data.width; x++) {
-				raster.getPixel(x, y, pixelArray);
-				data.setPixel(x, y, pixelArray[0]);
+			return bufferedImage;
+		} else {
+			RGB[] rgbs = palette.getRGBs();
+			byte[] red = new byte[rgbs.length];
+			byte[] green = new byte[rgbs.length];
+			byte[] blue = new byte[rgbs.length];
+			for (int i = 0; i < rgbs.length; i++) {
+				RGB rgb = rgbs[i];
+				red[i] = (byte) rgb.red;
+				green[i] = (byte) rgb.green;
+				blue[i] = (byte) rgb.blue;
 			}
+			if (data.transparentPixel != -1) {
+				colorModel = new IndexColorModel(data.depth, rgbs.length, red, green, blue, data.transparentPixel);
+			} else {
+				colorModel = new IndexColorModel(data.depth, rgbs.length, red, green, blue);
+			}
+			BufferedImage bufferedImage = new BufferedImage(colorModel,
+					colorModel.createCompatibleWritableRaster(data.width, data.height), false, null);
+			WritableRaster raster = bufferedImage.getRaster();
+			int[] pixelArray = new int[1];
+			for (int y = 0; y < data.height; y++) {
+				for (int x = 0; x < data.width; x++) {
+					int pixel = data.getPixel(x, y);
+					pixelArray[0] = pixel;
+					raster.setPixel(x, y, pixelArray);
+				}
+			}
+			return bufferedImage;
 		}
+	}
+
+	static ImageData convertToSWT(BufferedImage bufferedImage) {
+		if (bufferedImage.getColorModel() instanceof DirectColorModel) {
+			DirectColorModel colorModel = (DirectColorModel) bufferedImage.getColorModel();
+			PaletteData palette = new PaletteData(colorModel.getRedMask(), colorModel.getGreenMask(),
+					colorModel.getBlueMask());
+			ImageData data = new ImageData(bufferedImage.getWidth(), bufferedImage.getHeight(),
+					colorModel.getPixelSize(), palette);
+			for (int y = 0; y < data.height; y++) {
+				for (int x = 0; x < data.width; x++) {
+					int rgb = bufferedImage.getRGB(x, y);
+					int pixel = palette.getPixel(new RGB((rgb >> 16) & 0xFF, (rgb >> 8) & 0xFF, rgb & 0xFF));
+					data.setPixel(x, y, pixel);
+					if (colorModel.hasAlpha()) {
+						data.setAlpha(x, y, (rgb >> 24) & 0xFF);
+					}
+				}
+			}
+			return data;
+		} else if (bufferedImage.getColorModel() instanceof IndexColorModel) {
+			IndexColorModel colorModel = (IndexColorModel) bufferedImage.getColorModel();
+			int size = colorModel.getMapSize();
+			byte[] reds = new byte[size];
+			byte[] greens = new byte[size];
+			byte[] blues = new byte[size];
+			colorModel.getReds(reds);
+			colorModel.getGreens(greens);
+			colorModel.getBlues(blues);
+			RGB[] rgbs = new RGB[size];
+			for (int i = 0; i < rgbs.length; i++) {
+				rgbs[i] = new RGB(reds[i] & 0xFF, greens[i] & 0xFF, blues[i] & 0xFF);
+			}
+			PaletteData palette = new PaletteData(rgbs);
+			ImageData data = new ImageData(bufferedImage.getWidth(), bufferedImage.getHeight(),
+					colorModel.getPixelSize(), palette);
+			data.transparentPixel = colorModel.getTransparentPixel();
+			WritableRaster raster = bufferedImage.getRaster();
+			int[] pixelArray = new int[1];
+			for (int y = 0; y < data.height; y++) {
+				for (int x = 0; x < data.width; x++) {
+					raster.getPixel(x, y, pixelArray);
+					data.setPixel(x, y, pixelArray[0]);
+				}
+			}
+			return data;
+		}
+		return null;
+	}
+
+	static ImageData createSampleImage(Display display) {
+
+		ImageGcDrawer imageGcDrawer = (gc, imageWidth, imageHeight) -> {
+			gc.setBackground(display.getSystemColor(SWT.COLOR_BLUE));
+			gc.fillRectangle(0, 0, imageWidth, imageHeight);
+			gc.setBackground(display.getSystemColor(SWT.COLOR_GREEN));
+			gc.fillOval(0, 0, imageWidth, imageHeight);
+			gc.setForeground(display.getSystemColor(SWT.COLOR_RED));
+			gc.drawLine(0, 0, imageWidth, imageHeight);
+			gc.drawLine(imageWidth, 0, 0, imageHeight);
+		};
+		Image image = new Image(display, imageGcDrawer, 100, 100);
+		ImageData data = image.getImageData();
 		return data;
 	}
-	return null;
-}
 
-static ImageData createSampleImage(Display display) {
-	Image image = new Image(display, 100, 100);
-	Rectangle bounds = image.getBounds();
-	GC gc = new GC(image);
-	gc.setBackground(display.getSystemColor(SWT.COLOR_BLUE));
-	gc.fillRectangle(bounds);
-	gc.setBackground(display.getSystemColor(SWT.COLOR_GREEN));
-	gc.fillOval(0, 0, bounds.width, bounds.height);
-	gc.setForeground(display.getSystemColor(SWT.COLOR_RED));
-	gc.drawLine(0, 0, bounds.width, bounds.height);
-	gc.drawLine(bounds.width, 0, 0, bounds.height);
-	gc.dispose();
-	ImageData data = image.getImageData();
-	image.dispose();
-	return data;
-}
-
-public static void main(String[] args) {
-	Display display = new Display();
-	Shell shell = new Shell(display);
-	shell.setText("SWT Image");
-	ImageData data;
-	if (args.length > 0) {
-		String fileName = args[0];
-		data = new ImageData(fileName);
-	} else {
-		data = createSampleImage(display);
-	}
-	final Image swtImage = new Image(display, data);
-	final BufferedImage awtImage = convertToAWT(data);
-	final Image swtImage2 = new Image(display, convertToSWT(awtImage));
-	shell.addListener(SWT.Paint, e -> {
-		int y = 10;
-		if (swtImage != null) {
-			e.gc.drawImage(swtImage, 10, y);
-			y += swtImage.getBounds().height + 10;
+	public static void main(String[] args) {
+		Display display = new Display();
+		Shell shell = new Shell(display);
+		shell.setText("SWT Image");
+		ImageData data;
+		if (args.length > 0) {
+			String fileName = args[0];
+			data = new ImageData(fileName);
+		} else {
+			data = createSampleImage(display);
 		}
-		if (swtImage2 != null) {
-			e.gc.drawImage(swtImage2, 10, y);
-		}
-	});
-	Frame frame = new Frame() {
-		private static final long serialVersionUID = 1L;
-
-		@Override
-		public void paint(Graphics g) {
-			Insets insets = getInsets();
-			if (awtImage != null) {
-				g.drawImage(awtImage, 10 + insets.left, 10 + insets.top, null);
+		final Image swtImage = new Image(display, data);
+		final BufferedImage awtImage = convertToAWT(data);
+		final Image swtImage2 = new Image(display, convertToSWT(awtImage));
+		shell.addListener(SWT.Paint, e -> {
+			int y = 10;
+			if (swtImage != null) {
+				e.gc.drawImage(swtImage, 10, y);
+				y += swtImage.getBounds().height + 10;
 			}
+			if (swtImage2 != null) {
+				e.gc.drawImage(swtImage2, 10, y);
+			}
+		});
+		Frame frame = new Frame() {
+			private static final long serialVersionUID = 1L;
+
+			@Override
+			public void paint(Graphics g) {
+				Insets insets = getInsets();
+				if (awtImage != null) {
+					g.drawImage(awtImage, 10 + insets.left, 10 + insets.top, null);
+				}
+			}
+		};
+		frame.setTitle("AWT Image");
+		shell.setLocation(50, 50);
+		Rectangle bounds = swtImage.getBounds();
+		shell.setSize(bounds.width + 50, bounds.height * 2 + 100);
+		Point size = shell.getSize();
+		Point location = shell.getLocation();
+		Insets insets = frame.getInsets();
+		frame.setLocation(location.x + size.x + 10, location.y);
+		frame.setSize(size.x - (insets.left + insets.right), size.y - (insets.top + insets.bottom));
+		frame.setVisible(true);
+		shell.open();
+		while (!shell.isDisposed()) {
+			if (!display.readAndDispatch())
+				display.sleep();
 		}
-	};
-	frame.setTitle("AWT Image");
-	shell.setLocation(50, 50);
-	Rectangle bounds = swtImage.getBounds();
-	shell.setSize(bounds.width + 50, bounds.height * 2 + 100);
-	Point size = shell.getSize();
-	Point location = shell.getLocation();
-	Insets insets = frame.getInsets();
-	frame.setLocation(location.x + size.x + 10, location.y);
-	frame.setSize(size.x - (insets.left + insets.right), size.y - (insets.top + insets.bottom));
-	frame.setVisible(true);
-	shell.open();
-	while (!shell.isDisposed()) {
-		if (!display.readAndDispatch()) display.sleep();
+		if (swtImage != null)
+			swtImage.dispose();
+		if (swtImage2 != null)
+			swtImage.dispose();
+		frame.dispose();
+		display.dispose();
+		/*
+		 * Note: If you are using JDK 1.3.x, you need to use System.exit(0) at the end
+		 * of your program to exit AWT. This is because in 1.3.x, AWT does not exit when
+		 * the frame is disposed, because the AWT thread is not a daemon. This was fixed
+		 * in JDK 1.4.x with the addition of the AWT Shutdown thread.
+		 */
 	}
-	if (swtImage != null) swtImage.dispose();
-	if (swtImage2 != null) swtImage.dispose();
-	frame.dispose();
-	display.dispose();
-	/* Note: If you are using JDK 1.3.x, you need to use System.exit(0) at the end of your program to exit AWT.
-	 * This is because in 1.3.x, AWT does not exit when the frame is disposed, because the AWT thread is not a daemon.
-	 * This was fixed in JDK 1.4.x with the addition of the AWT Shutdown thread.
-	 */
-}
 }

--- a/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet162.java
+++ b/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet162.java
@@ -31,65 +31,68 @@ import org.eclipse.swt.widgets.*;
 
 public class Snippet162 {
 
-	final static String[] ITEM_NAMES = {"first item", "second", "third", "fourth", "fifth"};
+	final static String[] ITEM_NAMES = { "first item", "second", "third", "fourth", "fifth" };
 
-public static void main (String [] args) {
-	Display display = new Display ();
-	final Image checkedImage = getStateImage (display, true);
-	final Image uncheckedImage = getStateImage (display, false);
+	public static void main(String[] args) {
+		Display display = new Display();
+		final Image checkedImage = getStateImage(display, true);
+		final Image uncheckedImage = getStateImage(display, false);
 
-	Shell shell = new Shell (display);
-	shell.setText("Snippet 162");
-	shell.setLayout (new FillLayout ());
+		Shell shell = new Shell(display);
+		shell.setText("Snippet 162");
+		shell.setLayout(new FillLayout());
 
-	final Table table = new Table (shell, SWT.FULL_SELECTION | SWT.BORDER);
-	for (int i = 0; i < ITEM_NAMES.length; i++) {
-		TableItem item = new TableItem (table, SWT.NONE);
-		item.setText (ITEM_NAMES[i]);
-		item.setImage (i % 2 == 0 ? checkedImage : uncheckedImage);
-	}
-	table.addSelectionListener(widgetDefaultSelectedAdapter(e -> {
-			TableItem item = (TableItem)e.item;
+		final Table table = new Table(shell, SWT.FULL_SELECTION | SWT.BORDER);
+		for (int i = 0; i < ITEM_NAMES.length; i++) {
+			TableItem item = new TableItem(table, SWT.NONE);
+			item.setText(ITEM_NAMES[i]);
+			item.setImage(i % 2 == 0 ? checkedImage : uncheckedImage);
+		}
+		table.addSelectionListener(widgetDefaultSelectedAdapter(e -> {
+			TableItem item = (TableItem) e.item;
 			item.setImage(item.getImage() == checkedImage ? uncheckedImage : checkedImage);
 		}));
 
-	table.getAccessible ().addAccessibleControlListener (new AccessibleControlAdapter () {
-		@Override
-		public void getRole(AccessibleControlEvent e) {
-			e.detail = ACC.ROLE_CHECKBUTTON;
-		}
-		@Override
-		public void getState (AccessibleControlEvent e) {
-			if (e.childID >= 0 && e.childID < table.getItemCount ()) {
-				TableItem item = table.getItem (e.childID);
-				if (item.getImage() == checkedImage) {
-					e.detail |= ACC.STATE_CHECKED;
+		table.getAccessible().addAccessibleControlListener(new AccessibleControlAdapter() {
+			@Override
+			public void getRole(AccessibleControlEvent e) {
+				e.detail = ACC.ROLE_CHECKBUTTON;
+			}
+
+			@Override
+			public void getState(AccessibleControlEvent e) {
+				if (e.childID >= 0 && e.childID < table.getItemCount()) {
+					TableItem item = table.getItem(e.childID);
+					if (item.getImage() == checkedImage) {
+						e.detail |= ACC.STATE_CHECKED;
+					}
 				}
 			}
+		});
+
+		shell.pack();
+		shell.open();
+		while (!shell.isDisposed()) {
+			if (!display.readAndDispatch())
+				display.sleep();
 		}
-	});
-
-	shell.pack();
-	shell.open ();
-	while (!shell.isDisposed ()) {
-		if (!display.readAndDispatch ()) display.sleep ();
+		checkedImage.dispose();
+		uncheckedImage.dispose();
+		display.dispose();
 	}
-	checkedImage.dispose ();
-	uncheckedImage.dispose ();
-	display.dispose ();
-}
 
-static Image getStateImage (Display display, boolean checked) {
-	Image image = new Image (display, 16, 16);
-	GC gc = new GC (image);
-	gc.setBackground (display.getSystemColor (SWT.COLOR_YELLOW));
-	gc.fillOval (0, 0, 16, 16);
-	if (checked) {
-		gc.setForeground (display.getSystemColor (SWT.COLOR_DARK_GREEN));
-		gc.drawLine (0, 0, 16, 16);
-		gc.drawLine (16, 0, 0, 16);
+	static Image getStateImage(Display display, boolean checked) {
+		ImageGcDrawer imageGcDrawer = (gc, imageWidth, imageHeight) -> {
+			gc.setBackground(display.getSystemColor(SWT.COLOR_YELLOW));
+			gc.fillOval(0, 0, imageWidth, imageHeight);
+			if (checked) {
+				gc.setForeground(display.getSystemColor(SWT.COLOR_DARK_GREEN));
+				gc.drawLine(0, 0, imageWidth, imageHeight);
+				gc.drawLine(imageWidth, 0, 0, imageHeight);
+			}
+		};
+		Image image = new Image(display, imageGcDrawer, 16, 16);
+
+		return image;
 	}
-	gc.dispose ();
-	return image;
-}
 }

--- a/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet165.java
+++ b/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet165.java
@@ -32,13 +32,14 @@ public class Snippet165 {
 
 public static void main (String [] args) {
 	Display display = new Display ();
-	Image image = new Image(display, 16, 16);
-	GC gc = new GC(image);
-	gc.setBackground(display.getSystemColor(SWT.COLOR_BLUE));
-	gc.fillRectangle(0, 0, 16, 16);
-	gc.setBackground(display.getSystemColor(SWT.COLOR_YELLOW));
-	gc.fillRectangle(3, 3, 10, 10);
-	gc.dispose();
+	ImageGcDrawer imageGcDrawer = (gc, imageWidth, imageHeight) -> {
+		gc.setBackground(display.getSystemColor(SWT.COLOR_BLUE));
+		gc.fillRectangle(0, 0, 16, 16);
+		gc.setBackground(display.getSystemColor(SWT.COLOR_YELLOW));
+		gc.fillRectangle(3, 3, 10, 10);
+	};
+	Image image = new Image(display, imageGcDrawer, 16, 16);
+
 	final Shell shell = new Shell (display);
 	shell.setText("Snippet 165");
 	shell.setLayout(new GridLayout());

--- a/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet200.java
+++ b/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet200.java
@@ -30,20 +30,21 @@ public class Snippet200 {
 public static void main(String[] args) {
 	Display display = new Display();
 	//define a pattern on an image
-	final Image image = new Image(display, 1000, 1000);
-	Color blue = display.getSystemColor(SWT.COLOR_BLUE);
-	Color yellow = display.getSystemColor(SWT.COLOR_YELLOW);
-	Color white = display.getSystemColor(SWT.COLOR_WHITE);
-	GC gc = new GC(image);
-	gc.setBackground(white);
-	gc.setForeground(yellow);
-	gc.fillGradientRectangle(0, 0, 1000, 1000, true);
-	for (int i=-500; i<1000; i+=10) {
-		gc.setForeground(blue);
-		gc.drawLine(i, 0, 500 + i, 1000);
-		gc.drawLine(500 + i, 0, i, 1000);
-	}
-	gc.dispose();
+	ImageGcDrawer imageGcDrawer = (gc, imageWidth, imageHeight) -> {
+		Color blue = display.getSystemColor(SWT.COLOR_BLUE);
+		Color yellow = display.getSystemColor(SWT.COLOR_YELLOW);
+		Color white = display.getSystemColor(SWT.COLOR_WHITE);
+		gc.setBackground(white);
+		gc.setForeground(yellow);
+		gc.fillGradientRectangle(0, 0, 1000, 1000, true);
+		for (int i=-500; i<1000; i+=10) {
+			gc.setForeground(blue);
+			gc.drawLine(i, 0, 500 + i, 1000);
+			gc.drawLine(500 + i, 0, i, 1000);
+		}
+	};
+	final Image image = new Image(display, imageGcDrawer, 1000, 1000);
+
 	final Pattern pattern;
 	try {
 		pattern = new Pattern(display, image);

--- a/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet205.java
+++ b/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet205.java
@@ -26,20 +26,25 @@ import org.eclipse.swt.*;
 import org.eclipse.swt.graphics.*;
 import org.eclipse.swt.widgets.*;
 
-
 public class Snippet205 {
 
 public static void main(String[] args) {
+
 	Display display = new Display();
 	final Shell shell = new Shell(display, SWT.SHELL_TRIM | SWT.DOUBLE_BUFFERED);
 	shell.setText("Embedding objects in text");
-	final Image[] images = {new Image(display, 32, 32), new Image(display, 20, 40), new Image(display, 40, 20)};
+	final Image[] images = new Image[3];
+	final Rectangle[] rects = { new Rectangle(0, 0, 32, 32), new Rectangle(0, 0, 20, 40),
+			new Rectangle(0, 0, 40, 20) };
 	int[] colors  = {SWT.COLOR_BLUE, SWT.COLOR_MAGENTA, SWT.COLOR_GREEN};
 	for (int i = 0; i < images.length; i++) {
-		GC gc = new GC(images[i]);
-		gc.setBackground(display.getSystemColor(colors[i]));
-		gc.fillRectangle(images[i].getBounds());
-		gc.dispose();
+		final int index = i;
+
+		ImageGcDrawer imageGcDrawer = (gc, imageWidth, imageHeight) -> {
+			gc.setBackground(display.getSystemColor(colors[index]));
+			gc.fillRectangle(rects[index]);
+		};
+		images[i] = new Image(display, imageGcDrawer, rects[i].width, rects[i].height);
 	}
 
 	final Button button = new Button(shell, SWT.PUSH);
@@ -50,9 +55,8 @@ public static void main(String[] args) {
 	final TextLayout layout = new TextLayout(display);
 	layout.setText(text);
 	for (int i = 0; i < images.length; i++) {
-		Rectangle bounds = images[i].getBounds();
 		TextStyle imageStyle = new TextStyle(null, null, null);
-		imageStyle.metrics = new GlyphMetrics(bounds.height, 0, bounds.width);
+		imageStyle.metrics = new GlyphMetrics(rects[i].height, 0, rects[i].width);
 		layout.setStyle(imageStyle, imageOffsets[i], imageOffsets[i]);
 	}
 	Rectangle bounds = button.getBounds();

--- a/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet207.java
+++ b/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet207.java
@@ -28,16 +28,16 @@ public class Snippet207 {
 	public static void main(String[] args) {
 		final Display display = new Display();
 
-		final Image image = new Image(display, 110, 60);
-		GC gc = new GC(image);
-		Font font = new Font(display, "Times", 30, SWT.BOLD);
-		gc.setFont(font);
-		gc.setBackground(display.getSystemColor(SWT.COLOR_RED));
-		gc.fillRectangle(0, 0, 110, 60);
-		gc.setForeground(display.getSystemColor(SWT.COLOR_WHITE));
-		gc.drawText("SWT", 10, 10, true);
-		font.dispose();
-		gc.dispose();
+		ImageGcDrawer imageGcDrawer = (gc, imageWidth, imageHeight) -> {
+			Font font = new Font(display, "Times", 30, SWT.BOLD);
+			gc.setFont(font);
+			gc.setBackground(display.getSystemColor(SWT.COLOR_RED));
+			gc.fillRectangle(0, 0, 110, 60);
+			gc.setForeground(display.getSystemColor(SWT.COLOR_WHITE));
+			gc.drawText("SWT", 10, 10, true);
+			font.dispose();
+		};
+		final Image image = new Image(display, imageGcDrawer, 110, 60);
 
 		final Rectangle rect = image.getBounds();
 		Shell shell = new Shell(display);

--- a/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet214.java
+++ b/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet214.java
@@ -46,13 +46,13 @@ public class Snippet214 {
 			button.setText ("Button " + i);
 		}
 		shell.addListener (SWT.Resize, event -> {
+			ImageGcDrawer imageGcDrawer = (gc, imageWidth, imageHeight) -> {
+				gc.setForeground (display.getSystemColor (SWT.COLOR_WHITE));
+				gc.setBackground (display.getSystemColor (SWT.COLOR_BLUE));
+				gc.fillGradientRectangle (0, 0, imageWidth, imageHeight, false);
+			};
 			Rectangle rect = shell.getClientArea ();
-			Image newImage = new Image (display, Math.max (1, rect.width), 1);
-			GC gc = new GC (newImage);
-			gc.setForeground (display.getSystemColor (SWT.COLOR_WHITE));
-			gc.setBackground (display.getSystemColor (SWT.COLOR_BLUE));
-			gc.fillGradientRectangle (rect.x, rect.y, rect.width, 1, false);
-			gc.dispose ();
+			Image newImage = new Image (display, imageGcDrawer, Math.max (1, rect.width), 1);
 			shell.setBackgroundImage (newImage);
 			if (oldImage != null) oldImage.dispose ();
 			oldImage = newImage;

--- a/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet218.java
+++ b/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet218.java
@@ -50,12 +50,12 @@ public class Snippet218 {
 		styledText.setForeground(display.getSystemColor (SWT.COLOR_BLUE));
 		styledText.addListener (SWT.Resize, event -> {
 			Rectangle rect = styledText.getClientArea ();
-			Image newImage = new Image (display, 1, Math.max (1, rect.height));
-			GC gc = new GC (newImage);
-			gc.setForeground (display.getSystemColor (SWT.COLOR_WHITE));
-			gc.setBackground (display.getSystemColor (SWT.COLOR_YELLOW));
-			gc.fillGradientRectangle (rect.x, rect.y, 1, rect.height, true);
-			gc.dispose ();
+			ImageGcDrawer imageGcDrawer = (gc, imageWidth, imageHeight) ->  {
+				gc.setForeground (display.getSystemColor (SWT.COLOR_WHITE));
+				gc.setBackground (display.getSystemColor (SWT.COLOR_YELLOW));
+				gc.fillGradientRectangle (rect.x, rect.y, 1, rect.height, true);
+			};
+			Image newImage = new Image (display, imageGcDrawer, 1, Math.max (1, rect.height));
 			styledText.setBackgroundImage (newImage);
 			if (oldImage != null) oldImage.dispose ();
 			oldImage = newImage;

--- a/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet220.java
+++ b/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet220.java
@@ -35,13 +35,13 @@ public static void main(String [] args) {
 	Shell shell = new Shell(display);
 	shell.setText("Snippet 220");
 	shell.setBounds(10, 10, 350, 200);
-	Image xImage = new Image (display, 16, 16);
-	GC gc = new GC(xImage);
-	gc.setForeground(display.getSystemColor(SWT.COLOR_RED));
-	gc.drawLine(1, 1, 14, 14);
-	gc.drawLine(1, 14, 14, 1);
-	gc.drawOval(2, 2, 11, 11);
-	gc.dispose();
+	ImageGcDrawer imageGcDrawer = (gc, imageWidth, imageHeight) -> {
+		gc.setForeground(display.getSystemColor(SWT.COLOR_RED));
+		gc.drawLine(1, 1, 14, 14);
+		gc.drawLine(1, 14, 14, 1);
+		gc.drawOval(2, 2, 11, 11);
+	};
+	Image xImage = new Image (display, imageGcDrawer, 16, 16);
 	final int IMAGE_MARGIN = 2;
 	final Tree tree = new Tree(shell, SWT.CHECK);
 	tree.setBounds(10, 10, 300, 150);

--- a/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet223.java
+++ b/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet223.java
@@ -22,9 +22,9 @@ package org.eclipse.swt.snippets;
  */
 
 import org.eclipse.swt.*;
+import org.eclipse.swt.graphics.*;
 import org.eclipse.swt.layout.*;
 import org.eclipse.swt.widgets.*;
-import org.eclipse.swt.graphics.*;
 
 public class Snippet223 {
 

--- a/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet246.java
+++ b/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet246.java
@@ -37,7 +37,7 @@ public class Snippet246 {
 
 		String executionPath = System.getProperty("user.dir");
 		Label label = new Label(shell, SWT.WRAP);
-		label.setText("File created as: " + executionPath.replace("\\", "/")+"/swt.png");
+		label.setText("File created as: " + executionPath.replace("\\", "/") + "/swt.png");
 		shell.pack();
 		shell.open();
 		while (!shell.isDisposed()) {
@@ -49,18 +49,19 @@ public class Snippet246 {
 
 	private static void createImage() {
 		Font font = new Font(display, "Comic Sans MS", 48, SWT.BOLD);
-		Image image = new Image(display, 174, 96);
-		GC gc = new GC(image);
-		gc.setBackground(display.getSystemColor(SWT.COLOR_WHITE));
-		gc.fillRectangle(image.getBounds());
-		gc.setFont(font);
-		gc.setForeground(display.getSystemColor(SWT.COLOR_RED));
-		gc.drawString("S", 3, 10);
-		gc.setForeground(display.getSystemColor(SWT.COLOR_GREEN));
-		gc.drawString("W", 50, 10);
-		gc.setForeground(display.getSystemColor(SWT.COLOR_BLUE));
-		gc.drawString("T", 124, 10);
-		gc.dispose();
+
+		ImageGcDrawer imageGcDrawer = (gc, imageWidth, imageHeight) -> {
+			gc.setBackground(display.getSystemColor(SWT.COLOR_WHITE));
+			gc.fillRectangle(new Rectangle(0, 0, 174, 96));
+			gc.setFont(font);
+			gc.setForeground(display.getSystemColor(SWT.COLOR_RED));
+			gc.drawString("S", 3, 10);
+			gc.setForeground(display.getSystemColor(SWT.COLOR_GREEN));
+			gc.drawString("W", 50, 10);
+			gc.setForeground(display.getSystemColor(SWT.COLOR_BLUE));
+			gc.drawString("T", 124, 10);
+		};
+		Image image = new Image(display, imageGcDrawer, 174, 96);
 
 		ImageLoader loader = new ImageLoader();
 		loader.data = new ImageData[] { image.getImageData() };

--- a/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet275.java
+++ b/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet275.java
@@ -25,44 +25,46 @@ import org.eclipse.swt.widgets.*;
 
 public class Snippet275 {
 
-static String value;
-public static void main (String[] args) {
-	final int INTERVAL = 888;
-	final Display display = new Display ();
-	final Image image = new Image (display, 750, 750);
-	GC gc = new GC (image);
-	gc.setBackground (display.getSystemColor (SWT.COLOR_RED));
-	gc.fillRectangle (image.getBounds ());
-	gc.dispose ();
+	static String value;
 
-	Shell shell = new Shell (display);
-	shell.setText("Snippet 275");
-	shell.setBounds (10, 10, 790, 790);
-	final Canvas canvas = new Canvas (shell, SWT.NONE);
-	canvas.setBounds (10, 10, 750, 750);
-	canvas.addListener (SWT.Paint, event -> {
-		value = String.valueOf (System.currentTimeMillis ());
-		event.gc.drawImage (image, 0, 0);
-		event.gc.drawString (value, 10, 10, true);
-	});
-	display.timerExec (INTERVAL, new Runnable () {
-		@Override
-		public void run () {
-			if (canvas.isDisposed ()) return;
-			// canvas.redraw (); // <-- bad, damages more than is needed
-			GC gc = new GC (canvas);
-			Point extent = gc.stringExtent (value + '0');
-			gc.dispose ();
-			canvas.redraw (10, 10, extent.x, extent.y, false);
-			display.timerExec (INTERVAL, this);
+	public static void main(String[] args) {
+		final int INTERVAL = 888;
+		final Display display = new Display();
+		ImageGcDrawer imageGcDrawer = (gc, imageWidth, imageHeight) -> {
+			gc.setBackground(display.getSystemColor(SWT.COLOR_RED));
+			gc.fillRectangle(new Rectangle(0, 0, imageWidth, imageHeight));
+		};
+		final Image image = new Image(display, imageGcDrawer, 750, 750);
+		Shell shell = new Shell(display);
+		shell.setText("Snippet 275");
+		shell.setBounds(10, 10, 790, 790);
+		final Canvas canvas = new Canvas(shell, SWT.NONE);
+		canvas.setBounds(10, 10, 750, 750);
+		canvas.addListener(SWT.Paint, event -> {
+			value = String.valueOf(System.currentTimeMillis());
+			event.gc.drawImage(image, 0, 0);
+			event.gc.drawString(value, 10, 10, true);
+		});
+		display.timerExec(INTERVAL, new Runnable() {
+			@Override
+			public void run() {
+				if (canvas.isDisposed())
+					return;
+				// canvas.redraw (); // <-- bad, damages more than is needed
+				GC gc = new GC(canvas);
+				Point extent = gc.stringExtent(value + '0');
+				gc.dispose();
+				canvas.redraw(10, 10, extent.x, extent.y, false);
+				display.timerExec(INTERVAL, this);
+			}
+		});
+		shell.open();
+		while (!shell.isDisposed()) {
+			if (!display.readAndDispatch())
+				display.sleep();
 		}
-	});
-	shell.open ();
-	while (!shell.isDisposed ()){
-		if (!display.readAndDispatch ()) display.sleep ();
+		image.dispose();
+		display.dispose();
 	}
-	image.dispose ();
-	display.dispose ();
-}
 
 }

--- a/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet34.java
+++ b/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet34.java
@@ -27,12 +27,12 @@ public class Snippet34 {
 
 public static void main (String[] args) {
 	Display display = new Display();
-	Image image = new Image (display, 16, 16);
 	Color color = display.getSystemColor (SWT.COLOR_RED);
-	GC gc = new GC (image);
-	gc.setBackground (color);
-	gc.fillRectangle (image.getBounds ());
-	gc.dispose ();
+	ImageGcDrawer imageGcDrawer = (gc, imageWidth, imageHeight) -> {
+		gc.setBackground (color);
+		gc.fillRectangle (new Rectangle(0,0,imageWidth, imageHeight));
+	};
+	Image image = new Image (display, imageGcDrawer, 16, 16);
 	Shell shell = new Shell (display);
 	shell.setText("Snippet 34");
 	Label label = new Label (shell, SWT.BORDER);

--- a/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet349.java
+++ b/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet349.java
@@ -146,12 +146,12 @@ public static void main(String [] args) {
 }
 
 static Image createImage(Display display, int width, int height) {
-	Image result = new Image(display, width, height);
-	GC gc = new GC(result);
-	for (int x = -height; x < width; x += 4) {
-		gc.drawLine(x, 0, x + height, height);
-	}
-	gc.dispose();
+	ImageGcDrawer imageGcDrawer = (gc, imageWidth, imageHeight) -> {
+		for (int x = -height; x < width; x += 4) {
+			gc.drawLine(x, 0, x + height, height);
+		}
+	};
+	Image result = new Image(display, imageGcDrawer, width, height);
 	return result;
 }
 }

--- a/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet36.java
+++ b/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet36.java
@@ -12,7 +12,6 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package org.eclipse.swt.snippets;
-
 /*
  * ToolBar example snippet: create a flat tool bar (images)
  *
@@ -27,12 +26,13 @@ public class Snippet36 {
 
 public static void main (String [] args) {
 	Display display = new Display();
-	Image image = new Image (display, 16, 16);
 	Color color = display.getSystemColor (SWT.COLOR_RED);
-	GC gc = new GC (image);
-	gc.setBackground (color);
-	gc.fillRectangle (image.getBounds ());
-	gc.dispose ();
+	ImageGcDrawer imageGcDrawer = (gc, imageWidth, imageHeight) -> {
+		gc.setBackground(color);
+		gc.fillRectangle(0, 0, imageWidth, imageHeight);
+
+	};
+	Image image = new Image(display, imageGcDrawer, 16, 16);
 	Shell shell = new Shell (display);
 	shell.setText("Snippet 36");
 	ToolBar toolBar = new ToolBar (shell, SWT.FLAT | SWT.BORDER);

--- a/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet365.java
+++ b/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet365.java
@@ -89,11 +89,13 @@ public class Snippet365 {
 		// Gradient background for Shell
 		shell.addListener(SWT.Resize, event -> {
 			Rectangle rect = shell.getClientArea();
-			Image newImage = new Image(display, Math.max(1, rect.width), 1);
+			ImageGcDrawer imageGcDrawer = (gc, imageWidth, imageHeight) ->  {
+				gc.setForeground(display.getSystemColor(SWT.COLOR_BLUE));
+				gc.setBackground(display.getSystemColor(SWT.COLOR_GREEN));
+				gc.fillGradientRectangle(0, 0, imageWidth, imageHeight, false);
+			};
+			Image newImage = new Image(display, imageGcDrawer, Math.max(1, rect.width), 1);
 			GC gc = new GC(newImage);
-			gc.setForeground(display.getSystemColor(SWT.COLOR_BLUE));
-			gc.setBackground(display.getSystemColor(SWT.COLOR_GREEN));
-			gc.fillGradientRectangle(rect.x, rect.y, rect.width, 1, false);
 			gc.dispose();
 			shell.setBackgroundImage(newImage);
 			if (oldImage != null)
@@ -457,13 +459,12 @@ public class Snippet365 {
 
 	private static Image getBackgroundImage(final Display display) {
 		if (newImage == null) {
-			Rectangle rect = new Rectangle(0, 0, 115, 5);
-			newImage = new Image(display, Math.max(1, rect.width), 1);
-			GC gc = new GC(newImage);
-			gc.setForeground(display.getSystemColor(SWT.COLOR_WHITE));
-			gc.setBackground(display.getSystemColor(SWT.COLOR_RED));
-			gc.fillGradientRectangle(rect.x, rect.y, rect.width, 1, false);
-			gc.dispose();
+			ImageGcDrawer imageGcDrawer = (gc, imageWidth, imageHeight) -> {
+				gc.setForeground(display.getSystemColor(SWT.COLOR_WHITE));
+				gc.setBackground(display.getSystemColor(SWT.COLOR_RED));
+				gc.fillGradientRectangle(0, 0, imageWidth, imageHeight, false);
+			};
+			newImage = new Image(display, imageGcDrawer, Math.max(1, 115), 1);
 		}
 		return newImage;
 	}

--- a/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet367.java
+++ b/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet367.java
@@ -138,13 +138,16 @@ public class Snippet367 {
 		createSeparator(shell);
 
 		new Label (shell, SWT.NONE).setText ("2. Painted image\n (default resolution)");
-		Image image = new Image (display, size.x, size.y);
-		GC gc = new GC (image);
-		try {
-			paintImage (gc, size);
-		} finally {
-			gc.dispose ();
-		}
+		final ImageGcDrawer customImageGcDrawer = (gc, imageWidth, imageHeight) -> paintImage (gc, new Point(imageWidth, imageHeight));
+		new ImageGcDrawer() {
+
+			@Override
+			public void drawOn(GC gc, int imageWidth, int imageHeight) {
+				paintImage (gc, new Point(imageWidth, imageHeight));
+			}
+		};
+
+		Image image = new Image(display, customImageGcDrawer, size.x, size.y);
 		Label imageLabel = new Label (shell, SWT.NONE);
 		imageLabel.setImage (image);
 		imageLabel.setLayoutData (new GridData (SWT.BEGINNING, SWT.BEGINNING, false, false, 2, 1));
@@ -154,15 +157,11 @@ public class Snippet367 {
 		new Label (shell, SWT.NONE).setText ("3. Painted image\n(multi-res, unzoomed paint)");
 		imageLabel = new Label (shell, SWT.NONE);
 		imageLabel.setImage (new Image (display, (ImageDataProvider) zoom -> {
-			Image temp = new Image (display, size.x * zoom / 100, size.y * zoom / 100);
-			GC gc1 = new GC (temp);
-			try {
-				paintImage (gc1, size);
-				return temp.getImageData ();
-			} finally {
-				gc1.dispose ();
-				temp.dispose ();
-			}
+
+			final ImageGcDrawer customImageGcDrawer1 = (gc, imageWidth, imageHeight) -> paintImage(gc, new Point(imageWidth, imageHeight));
+			Image temp = new Image(display, customImageGcDrawer1, size.x * zoom / 100, size.y * zoom / 100);
+			return temp.getImageData();
+
 		}));
 		imageLabel.setLayoutData (new GridData (SWT.BEGINNING, SWT.BEGINNING, false, false, 2, 1));
 
@@ -171,15 +170,9 @@ public class Snippet367 {
 		new Label (shell, SWT.NONE).setText ("4. Painted image\n(multi-res, zoomed paint)");
 		imageLabel = new Label (shell, SWT.NONE);
 		imageLabel.setImage (new Image (display, (ImageDataProvider) zoom -> {
-			Image temp = new Image (display, size.x * zoom / 100, size.y * zoom / 100);
-			GC gc1 = new GC (temp);
-			try {
-				paintImage2 (gc1, new Point (size.x * zoom / 100, size.y * zoom / 100), zoom / 100);
-				return temp.getImageData ();
-			} finally {
-				gc1.dispose ();
-				temp.dispose ();
-			}
+			final ImageGcDrawer customImageGcDrawer1 = (gc, imageWidth, imageHeight) -> paintImage2 (gc, new Point(imageWidth, imageHeight), zoom / 100);
+			Image temp = new Image (display, customImageGcDrawer1, size.x * zoom / 100, size.y * zoom / 100);
+			return temp.getImageData();
 		}));
 		imageLabel.setLayoutData (new GridData (SWT.BEGINNING, SWT.BEGINNING, false, false, 2, 1));
 

--- a/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet387.java
+++ b/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet387.java
@@ -88,15 +88,10 @@ public class Snippet387 {
 	}
 
 	private static Image createStaticImage(Display display, String text, boolean disposeGC) {
-		Image staticImage = new Image(display, IMAGE_WIDTH, IMAGE_HEIGHT);
-		GC imageGC = new GC(staticImage);
-		try {
-			drawImageContent(imageGC, text, IMAGE_WIDTH, IMAGE_HEIGHT);
-		} finally {
-			if (disposeGC) {
-				imageGC.dispose();
-			}
-		}
+		ImageGcDrawer imageGcDrawer = (gc, imageWidth, imageHeight) -> {
+			drawImageContent(gc, text, imageWidth, imageHeight);
+		};
+		Image staticImage = new Image(display, imageGcDrawer, IMAGE_WIDTH, IMAGE_HEIGHT);
 		return staticImage;
 	}
 

--- a/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet43.java
+++ b/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet43.java
@@ -32,14 +32,14 @@ public static void main (String [] args) {
 	Caret caret = new Caret (shell, SWT.NONE);
 	Color white = display.getSystemColor (SWT.COLOR_WHITE);
 	Color black = display.getSystemColor (SWT.COLOR_BLACK);
-	final Image image = new Image (display, 20, 20);
-	GC gc = new GC (image);
-	gc.setBackground (black);
-	gc.fillRectangle (0, 0, 20, 20);
-	gc.setForeground (white);
-	gc.drawLine (0, 0, 19, 19);
-	gc.drawLine (19, 0, 0, 19);
-	gc.dispose ();
+	ImageGcDrawer imageGcDrawer = (gc, imageWidth, imageHeight) -> {
+		gc.setBackground (black);
+		gc.fillRectangle (0, 0, 20, 20);
+		gc.setForeground (white);
+		gc.drawLine (0, 0, 19, 19);
+		gc.drawLine (19, 0, 0, 19);
+	};
+	final Image image = new Image (display, imageGcDrawer, 20, 20);
 	caret.setLocation (10, 10);
 	caret.setImage (image);
 	caret.setVisible (true);

--- a/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet47.java
+++ b/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet47.java
@@ -12,7 +12,6 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package org.eclipse.swt.snippets;
-
 /*
  * ToolBar example snippet: create tool bar (normal, hot and disabled images)
  *
@@ -30,26 +29,26 @@ public static void main (String [] args) {
 	Shell shell = new Shell (display);
 	shell.setText("Snippet 47");
 
-	Image image = new Image (display, 20, 20);
-	Color color = display.getSystemColor (SWT.COLOR_BLUE);
-	GC gc = new GC (image);
-	gc.setBackground (color);
-	gc.fillRectangle (image.getBounds ());
-	gc.dispose ();
+	ImageGcDrawer imageGcDrawer = (gc, imageWidth, imageHeight) -> {
+		Color color = display.getSystemColor(SWT.COLOR_BLUE);
+		gc.setBackground(color);
+		gc.fillRectangle(new Rectangle(0, 0, 20, 20));
+	};
+	Image image = new Image(display, imageGcDrawer, 20, 20);
 
-	Image disabledImage = new Image (display, 20, 20);
-	color = display.getSystemColor (SWT.COLOR_GREEN);
-	gc = new GC (disabledImage);
-	gc.setBackground (color);
-	gc.fillRectangle (disabledImage.getBounds ());
-	gc.dispose ();
+	imageGcDrawer = (gc, imageWidth, imageHeight) -> {
+		Color color = display.getSystemColor(SWT.COLOR_GREEN);
+		gc.setBackground(color);
+		gc.fillRectangle(new Rectangle(0, 0, 20, 20));
+	};
+	Image disabledImage = new Image(display, imageGcDrawer, 20, 20);
 
-	Image hotImage = new Image (display, 20, 20);
-	color = display.getSystemColor (SWT.COLOR_RED);
-	gc = new GC (hotImage);
-	gc.setBackground (color);
-	gc.fillRectangle (hotImage.getBounds ());
-	gc.dispose ();
+	imageGcDrawer = (gc, imageWidth, imageHeight) -> {
+		Color color = display.getSystemColor(SWT.COLOR_RED);
+		gc.setBackground(color);
+		gc.fillRectangle(new Rectangle(0, 0, 20, 20));
+	};
+	Image hotImage = new Image(display, imageGcDrawer, 20, 20);
 
 	ToolBar bar = new ToolBar (shell, SWT.BORDER | SWT.FLAT);
 	Rectangle clientArea = shell.getClientArea ();

--- a/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet48.java
+++ b/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet48.java
@@ -40,13 +40,13 @@ public static void main (String [] args) {
 	}
 	if (originalImage == null) {
 		int width = 150, height = 200;
-		originalImage = new Image (display, width, height);
-		GC gc = new GC (originalImage);
-		gc.fillRectangle (0, 0, width, height);
-		gc.drawLine (0, 0, width, height);
-		gc.drawLine (0, height, width, 0);
-		gc.drawText ("Default Image", 10, 10);
-		gc.dispose ();
+		ImageGcDrawer imageGcDrawer = (gc, imageWidth, imageHeight) -> {
+			gc.fillRectangle (0, 0, width, height);
+			gc.drawLine (0, 0, width, height);
+			gc.drawLine (0, height, width, 0);
+			gc.drawText ("Default Image", 10, 10);
+		};
+		originalImage = new Image (display, imageGcDrawer, width, height);
 	}
 	final Image image = originalImage;
 	final Point origin = new Point (0, 0);

--- a/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet7.java
+++ b/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet7.java
@@ -12,7 +12,6 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package org.eclipse.swt.snippets;
-
 /*
  * example snippet: create a table (lazy)
  *
@@ -28,11 +27,11 @@ public class Snippet7 {
 
 public static void main (String [] args) {
 	final Display display = new Display ();
-	final Image image = new Image (display, 16, 16);
-	GC gc = new GC (image);
-	gc.setBackground (display.getSystemColor (SWT.COLOR_RED));
-	gc.fillRectangle (image.getBounds ());
-	gc.dispose ();
+	ImageGcDrawer imageGcDrawer = (gc, imageWidth, imageHeight) -> {
+		gc.setBackground(display.getSystemColor(SWT.COLOR_RED));
+		gc.fillRectangle(new Rectangle(0, 0, imageWidth, imageHeight));
+	};
+	final Image image = new Image(display, imageGcDrawer, 16, 16);
 	final Shell shell = new Shell (display);
 	shell.setText ("Lazy Table");
 	shell.setLayout (new FillLayout ());

--- a/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet70.java
+++ b/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet70.java
@@ -31,17 +31,17 @@ public static void main (String [] args) {
 	Color white = display.getSystemColor (SWT.COLOR_WHITE);
 	Color black = display.getSystemColor (SWT.COLOR_BLACK);
 
-	Image image = new Image (display, 20, 20);
-	GC gc = new GC (image);
-	gc.setBackground (red);
-	gc.fillRectangle (5, 5, 10, 10);
-	gc.dispose ();
+	ImageGcDrawer imageGcDrawer = (gc, imageWidth, imageHeight) -> {
+		gc.setBackground (red);
+		gc.fillRectangle (5, 5, 10, 10);
+	};
+	Image image = new Image (display, imageGcDrawer, 20, 20);
 	ImageData imageData = image.getImageData ();
 
 	PaletteData palette = new PaletteData (new RGB (0, 0, 0),new RGB (0xFF, 0xFF, 0xFF));
 	ImageData maskData = new ImageData (20, 20, 1, palette);
 	Image mask = new Image (display, maskData);
-	gc = new GC (mask);
+	GC gc = new GC (mask);
 	gc.setBackground (black);
 	gc.fillRectangle (0, 0, 20, 20);
 	gc.setBackground (white);


### PR DESCRIPTION
This PR takes over a part to change all occurences of the `image(device, int, int)` constructor with the `image(device, gc, int, int)` constructor.  

All usages of the stated constructor are now replaced by an `ImageGcDrawer` and the `Image(device, gc int, int)` constructor afterwards, for almost all the snippets. This replacement has/could not be made for the snippets {387, 215, 292, 95, 139}. The details for them are commented here: https://github.com/vi-eclipse/Eclipse-Platform/issues/310#issuecomment-3472301957.
