### PR TITLE
Fix some GTK4 deprecation warning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,4 @@ pom.tycho
 
 /binaries/org.eclipse.swt.*/src/
 tmpdir/
-‎build_gtk.sh
+build_gtk.sh

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/gtk4.c
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/gtk4.c
@@ -1027,7 +1027,7 @@ JNIEXPORT void JNICALL GTK4_NATIVE(gtk_1css_1provider_1load_1from_1data)
 	jbyte *lparg1=NULL;
 	GTK4_NATIVE_ENTER(env, that, gtk_1css_1provider_1load_1from_1data_FUNC);
 	if (arg1) if ((lparg1 = (*env)->GetByteArrayElements(env, arg1, NULL)) == NULL) goto fail;
-	gtk_css_provider_load_from_data((GtkCssProvider *)arg0, (const gchar *)lparg1, (gssize)arg2);
+	gtk_css_provider_load_from_string((GtkCssProvider *)arg0, (const gchar *)lparg1);
 fail:
 	if (arg1 && lparg1) (*env)->ReleaseByteArrayElements(env, arg1, lparg1, 0);
 	GTK4_NATIVE_EXIT(env, that, gtk_1css_1provider_1load_1from_1data_FUNC);
@@ -2716,7 +2716,13 @@ JNIEXPORT jboolean JNICALL GTK4_NATIVE(gtk_1widget_1translate_1coordinates)
 	GTK4_NATIVE_ENTER(env, that, gtk_1widget_1translate_1coordinates_FUNC);
 	if (arg4) if ((lparg4 = (*env)->GetDoubleArrayElements(env, arg4, NULL)) == NULL) goto fail;
 	if (arg5) if ((lparg5 = (*env)->GetDoubleArrayElements(env, arg5, NULL)) == NULL) goto fail;
-	rc = (jboolean)gtk_widget_translate_coordinates((GtkWidget *)arg0, (GtkWidget *)arg1, arg2, arg3, (double *)lparg4, (double *)lparg5);
+	{
+		graphene_point_t src_point = { (float)arg2, (float)arg3 };
+		graphene_point_t dest_point;
+		rc = (jboolean)gtk_widget_compute_point((GtkWidget *)arg0, (GtkWidget *)arg1, &src_point, &dest_point);
+		if (rc && lparg4) *lparg4 = (jdouble)dest_point.x;
+		if (rc && lparg5) *lparg5 = (jdouble)dest_point.y;
+	}
 fail:
 	if (arg5 && lparg5) (*env)->ReleaseDoubleArrayElements(env, arg5, lparg5, 0);
 	if (arg4 && lparg4) (*env)->ReleaseDoubleArrayElements(env, arg4, lparg4, 0);

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/os.c
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/os.c
@@ -9011,7 +9011,25 @@ JNIEXPORT void JNICALL GTK_NATIVE(gtk_1widget_1get_1allocation)
 	GtkAllocation _arg1, *lparg1=NULL;
 	GTK_NATIVE_ENTER(env, that, gtk_1widget_1get_1allocation_FUNC);
 	if (arg1) if ((lparg1 = &_arg1) == NULL) goto fail;
+#if GTK_CHECK_VERSION(4,0,0)
+	{
+		graphene_rect_t bounds;
+		if (gtk_widget_compute_bounds((GtkWidget *)arg0, (GtkWidget *)arg0, &bounds)) {
+			lparg1->x = (int)bounds.origin.x;
+			lparg1->y = (int)bounds.origin.y;
+			lparg1->width = (int)bounds.size.width;
+			lparg1->height = (int)bounds.size.height;
+		} else {
+			/* If compute_bounds fails, set allocation to zero */
+			lparg1->x = 0;
+			lparg1->y = 0;
+			lparg1->width = 0;
+			lparg1->height = 0;
+		}
+	}
+#else
 	gtk_widget_get_allocation((GtkWidget *)arg0, (GtkAllocation *)lparg1);
+#endif
 fail:
 	if (arg1 && lparg1) setGtkAllocationFields(env, arg1, lparg1);
 	GTK_NATIVE_EXIT(env, that, gtk_1widget_1get_1allocation_FUNC);


### PR DESCRIPTION
- Replace gtk_widget_get_allocation with gtk_widget_compute_bounds (with GTK4 version check)
- Replace gtk_css_provider_load_from_data with gtk_css_provider_load_from_string
- Replace gtk_widget_translate_coordinates with gtk_widget_compute_point

These changes reduce GTK4 deprecation warnings from 159 to 156.

---------