### PR TITLE
Removed layout calls in handleDPIChange methods

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/CoolBar.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/CoolBar.java
@@ -1242,6 +1242,5 @@ void handleDPIChange(Event event, float scalingFactor) {
 		}
 	}
 	setItemLayoutInPixels(itemOrder, indices, scaledSizes);
-	updateLayout(true);
 }
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TabFolder.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TabFolder.java
@@ -1138,6 +1138,5 @@ void handleDPIChange(Event event, float scalingFactor) {
 	for (int i = 0; i < getItemCount(); i++) {
 		items[i].notifyListeners(SWT.ZoomChanged, event);
 	}
-	layout(true, true);
 }
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ToolBar.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ToolBar.java
@@ -1805,6 +1805,6 @@ void handleDPIChange(Event event, float scalingFactor) {
 	setDisabledImageList(getDisabledImageList());
 	setHotImageList(getHotImageList());
 	OS.SendMessage(handle, OS.TB_AUTOSIZE, 0, 0);
-	layout(true);
+	clearSizeCache(true);
 }
 }


### PR DESCRIPTION
This PR removes layout calls in handleDPIChange methods of different widgets since Shell:layout called at the end of DPIChange event triggers layout for all the children in order hence these layouts are not needed.