### PR TITLE
[Win32] Adapt further places to round up when computing control size

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/Rectangle.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/Rectangle.java
@@ -426,7 +426,7 @@ public static sealed class OfFloat extends Rectangle permits Rectangle.WithMonit
 		this(x, y, width, height, RoundingMode.ROUND, RoundingMode.ROUND);
 	}
 
-	private OfFloat(float x, float y, float width, float height, RoundingMode locationRounding, RoundingMode sizeRounding) {
+	public OfFloat(float x, float y, float width, float height, RoundingMode locationRounding, RoundingMode sizeRounding) {
 		this.locationRounding = locationRounding;
 		this.sizeRounding = sizeRounding;
 		setX(x);

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/Win32DPIUtils.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/Win32DPIUtils.java
@@ -131,7 +131,7 @@ public class Win32DPIUtils {
 		return pixelToPoint(point, zoom, RoundingMode.ROUND);
 	}
 
-	public static Point pixelToPointAsConservativeSize(Point point, int zoom) {
+	public static Point pixelToPointAsSufficientlyLargeSize(Point point, int zoom) {
 		return pixelToPoint(point, zoom, RoundingMode.UP);
 	}
 
@@ -150,16 +150,23 @@ public class Win32DPIUtils {
 	}
 
 	public static Rectangle pixelToPoint(Rectangle rect, int zoom) {
+		return pixelToPoint(rect, zoom, RoundingMode.ROUND);
+	}
+
+	public static Rectangle pixelToPointWithSufficientlyLargeSize(Rectangle rect, int zoom) {
+		return pixelToPoint(rect, zoom, RoundingMode.UP);
+	}
+
+	private static Rectangle pixelToPoint(Rectangle rect, int zoom, RoundingMode sizeRounding) {
 		if (zoom == 100 || rect == null) return rect;
 		Rectangle.OfFloat floatRect = Rectangle.OfFloat.from(rect);
 		Point.OfFloat scaledTopLeft = pixelToPoint(floatRect.getTopLeft(), zoom);
 		Point.OfFloat scaledBottomRight = pixelToPoint(floatRect.getBottomRight(), zoom);
-		Rectangle.OfFloat scaledRect = floatRect.clone();
-		scaledRect.setX(scaledTopLeft.getX());
-		scaledRect.setY(scaledTopLeft.getY());
-		scaledRect.setWidth(scaledBottomRight.getX() - scaledTopLeft.getX());
-		scaledRect.setHeight(scaledBottomRight.getY() - scaledTopLeft.getY());
-		return scaledRect;
+		float scaledX = scaledTopLeft.getX();
+		float scaleyY = scaledTopLeft.getY();
+		float scaledWidth = scaledBottomRight.getX() - scaledTopLeft.getX();
+		float scaledHeight = scaledBottomRight.getY() - scaledTopLeft.getY();
+		return new Rectangle.OfFloat(scaledX, scaleyY, scaledWidth, scaledHeight, RoundingMode.ROUND, sizeRounding);
 	}
 
 	public static Rectangle pixelToPoint(Drawable drawable, Rectangle rect, int zoom) {
@@ -252,6 +259,10 @@ public class Win32DPIUtils {
 	}
 
 	public static Point pointToPixelAsSize(Point point, int zoom) {
+		return pointToPixel(point, zoom, RoundingMode.ROUND);
+	}
+
+	public static Point pointToPixelAsSufficientlyLargeSize(Point point, int zoom) {
 		return pointToPixel(point, zoom, RoundingMode.UP);
 	}
 
@@ -260,16 +271,23 @@ public class Win32DPIUtils {
 	}
 
 	public static Rectangle pointToPixel(Rectangle rect, int zoom) {
+		return pointToPixel(rect, zoom, RoundingMode.ROUND);
+	}
+
+	public static Rectangle pointToPixelWithSufficientlyLargeSize(Rectangle rect, int zoom) {
+		return pointToPixel(rect, zoom, RoundingMode.UP);
+	}
+
+	private static Rectangle pointToPixel(Rectangle rect, int zoom, RoundingMode sizeRounding) {
 		if (zoom == 100 || rect == null) return rect;
 		Rectangle.OfFloat floatRect = Rectangle.OfFloat.from(rect);
 		Point.OfFloat scaledTopLeft = pointToPixel(floatRect.getTopLeft(), zoom);
 		Point.OfFloat scaledBottomRight = pointToPixel(floatRect.getBottomRight(), zoom);
-		Rectangle.OfFloat scaledRect = floatRect.clone();
-		scaledRect.setX(scaledTopLeft.getX());
-		scaledRect.setY(scaledTopLeft.getY());
-		scaledRect.setWidth(scaledBottomRight.getX() - scaledTopLeft.getX());
-		scaledRect.setHeight(scaledBottomRight.getY() - scaledTopLeft.getY());
-		return scaledRect;
+		float scaledX = scaledTopLeft.getX();
+		float scaleyY = scaledTopLeft.getY();
+		float scaledWidth = scaledBottomRight.getX() - scaledTopLeft.getX();
+		float scaledHeight = scaledBottomRight.getY() - scaledTopLeft.getY();
+		return new Rectangle.OfFloat(scaledX, scaleyY, scaledWidth, scaledHeight, RoundingMode.ROUND, sizeRounding);
 	}
 
 	public static Rectangle pointToPixel(Drawable drawable, Rectangle rect, int zoom) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Button.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Button.java
@@ -326,7 +326,7 @@ int computeLeftMargin () {
 Point computeSizeInPixels (Point hintInPoints, boolean changed) {
 	checkWidget ();
 	int zoom = getZoom();
-	Point hintInPixels = Win32DPIUtils.pointToPixelAsSize(hintInPoints, zoom);
+	Point hintInPixels = Win32DPIUtils.pointToPixelAsSufficientlyLargeSize(hintInPoints, zoom);
 	int width = 0, height = 0, border = getBorderWidthInPixels ();
 	if ((style & SWT.ARROW) != 0) {
 		if ((style & (SWT.UP | SWT.DOWN)) != 0) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Combo.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Combo.java
@@ -596,7 +596,7 @@ public void clearSelection () {
 Point computeSizeInPixels (Point hintInPoints, boolean changed) {
 	checkWidget ();
 	int zoom = getZoom();
-	Point hintInPixels = Win32DPIUtils.pointToPixelAsSize(hintInPoints, zoom);
+	Point hintInPixels = Win32DPIUtils.pointToPixelAsSufficientlyLargeSize(hintInPoints, zoom);
 	int width = 0, height = 0;
 	if (hintInPoints.x == SWT.DEFAULT) {
 		long newFont, oldFont = 0;

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Composite.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Composite.java
@@ -229,7 +229,7 @@ Point computeSizeInPixels (Point hintInPoints, boolean changed) {
 	 * Since computeTrim can be overridden by subclasses, we cannot
 	 * call computeTrimInPixels directly.
 	 */
-	Rectangle trim = Win32DPIUtils.pointToPixel(computeTrim (0, 0, sizeInPoints.x, sizeInPoints.y), getZoom());
+	Rectangle trim = Win32DPIUtils.pointToPixelWithSufficientlyLargeSize(computeTrim (0, 0, sizeInPoints.x, sizeInPoints.y), getZoom());
 	return new Point (trim.width, trim.height);
 }
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Control.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Control.java
@@ -621,14 +621,14 @@ public Point computeSize (int wHint, int hHint, boolean changed){
 	int zoom = getZoom();
 	//We should never return a size that is to small, RoundingMode.UP ensures we at worst case report
 	//a size that is a bit too large by half a point
-	return Win32DPIUtils.pixelToPointAsConservativeSize(computeSizeInPixels(new Point.OfFloat(wHint, hHint, RoundingMode.UP), changed), zoom);
+	return Win32DPIUtils.pixelToPointAsSufficientlyLargeSize(computeSizeInPixels(new Point(wHint, hHint), changed), zoom);
 }
 
 Point computeSizeInPixels (Point hintInPoints, boolean changed) {
 	int width = DEFAULT_WIDTH;
 	int height = DEFAULT_HEIGHT;
 	int zoom = getZoom();
-	Point hintInPixels = Win32DPIUtils.pointToPixelAsSize(hintInPoints, zoom);
+	Point hintInPixels = Win32DPIUtils.pointToPixelAsSufficientlyLargeSize(hintInPoints, zoom);
 	if (hintInPoints.x != SWT.DEFAULT) width = hintInPixels.x;
 	if (hintInPoints.y != SWT.DEFAULT) height = hintInPixels.y;
 	int border = getBorderWidthInPixels ();

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/CoolBar.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/CoolBar.java
@@ -143,7 +143,7 @@ protected void checkSubclass () {
 @Override
 Point computeSizeInPixels (Point hintInPoints, boolean changed) {
 	int zoom = getZoom();
-	Point hintInPixels = Win32DPIUtils.pointToPixelAsSize(hintInPoints, zoom);
+	Point hintInPixels = Win32DPIUtils.pointToPixelAsSufficientlyLargeSize(hintInPoints, zoom);
 	int width = 0, height = 0;
 	int border = getBorderWidthInPixels ();
 	int newWidth = hintInPoints.x == SWT.DEFAULT ? 0x3FFF : hintInPixels.x + (border * 2);

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/CoolItem.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/CoolItem.java
@@ -186,16 +186,16 @@ protected void checkSubclass () {
 public Point computeSize (int wHint, int hHint) {
 	checkWidget ();
 	int zoom = getZoom();
-	wHint = (wHint != SWT.DEFAULT ? DPIUtil.pointToPixel(wHint, zoom) : wHint);
-	hHint = (hHint != SWT.DEFAULT ? DPIUtil.pointToPixel(hHint, zoom) : hHint);
-	return Win32DPIUtils.pixelToPointAsConservativeSize(computeSizeInPixels(wHint, hHint), zoom);
+	return Win32DPIUtils.pixelToPointAsSufficientlyLargeSize(computeSizeInPixels(new Point(wHint, hHint)), zoom);
 }
-Point computeSizeInPixels (int wHint, int hHint) {
+Point computeSizeInPixels (Point sizeHintInPoints) {
+	int zoom = getZoom();
+	Point sizeHintInPixels = Win32DPIUtils.pointToPixelAsSufficientlyLargeSize(sizeHintInPoints, zoom);
 	int index = parent.indexOf (this);
 	if (index == -1) return new Point (0, 0);
-	int width = wHint, height = hHint;
-	if (wHint == SWT.DEFAULT) width = 32;
-	if (hHint == SWT.DEFAULT) height = 32;
+	int width = sizeHintInPixels.x, height = sizeHintInPixels.y;
+	if (sizeHintInPoints.x == SWT.DEFAULT) width = 32;
+	if (sizeHintInPoints.y == SWT.DEFAULT) height = 32;
 	if ((parent.style & SWT.VERTICAL) != 0) {
 		height += parent.getMargin (index);
 	} else {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/DateTime.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/DateTime.java
@@ -222,7 +222,7 @@ protected void checkSubclass () {
 Point computeSizeInPixels (Point hintInPoints, boolean changed) {
 	checkWidget ();
 	int zoom = getZoom();
-	Point hintInPixels = Win32DPIUtils.pointToPixelAsSize(hintInPoints, zoom);
+	Point hintInPixels = Win32DPIUtils.pointToPixelAsSufficientlyLargeSize(hintInPoints, zoom);
 	int width = 0, height = 0;
 	if (hintInPoints.x == SWT.DEFAULT || hintInPoints.y == SWT.DEFAULT) {
 		if ((style & SWT.CALENDAR) != 0) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ExpandBar.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ExpandBar.java
@@ -129,7 +129,7 @@ static int checkStyle (int style) {
 @Override
 Point computeSizeInPixels (Point hintInPoints, boolean changed) {
 	int zoom = getZoom();
-	Point hintInPixels = Win32DPIUtils.pointToPixelAsSize(hintInPoints, zoom);
+	Point hintInPixels = Win32DPIUtils.pointToPixelAsSufficientlyLargeSize(hintInPoints, zoom);
 	int height = 0, width = 0;
 	if (hintInPoints.x == SWT.DEFAULT || hintInPoints.y == SWT.DEFAULT) {
 		if (itemCount > 0) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Label.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Label.java
@@ -134,7 +134,7 @@ static int checkStyle (int style) {
 Point computeSizeInPixels (Point hintInPoints, boolean changed) {
 	checkWidget ();
 	int zoom = getZoom();
-	Point hintInPixels = Win32DPIUtils.pointToPixelAsSize(hintInPoints, zoom);
+	Point hintInPixels = Win32DPIUtils.pointToPixelAsSufficientlyLargeSize(hintInPoints, zoom);
 	int width = 0, height = 0, border = getBorderWidthInPixels ();
 	if ((style & SWT.SEPARATOR) != 0) {
 		int lineWidth = getSystemMetrics (OS.SM_CXBORDER);

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Link.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Link.java
@@ -162,7 +162,7 @@ long callWindowProc (long hwnd, int msg, long wParam, long lParam) {
 Point computeSizeInPixels (Point hintInPoints, boolean changed) {
 	checkWidget ();
 	int zoom = getZoom();
-	Point hintInPixels = Win32DPIUtils.pointToPixelAsSize(hintInPoints, zoom);
+	Point hintInPixels = Win32DPIUtils.pointToPixelAsSufficientlyLargeSize(hintInPoints, zoom);
 	int width, height;
 	/*
 	 * When the text is empty, LM_GETIDEALSIZE returns zero width and height,

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/List.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/List.java
@@ -217,7 +217,7 @@ static int checkStyle (int style) {
 Point computeSizeInPixels (Point hintInPoints, boolean changed) {
 	checkWidget ();
 	int zoom = getZoom();
-	Point hintInPixels = Win32DPIUtils.pointToPixelAsSize(hintInPoints, zoom);
+	Point hintInPixels = Win32DPIUtils.pointToPixelAsSufficientlyLargeSize(hintInPoints, zoom);
 	int width = 0, height = 0;
 	if (hintInPoints.x == SWT.DEFAULT) {
 		if ((style & SWT.H_SCROLL) != 0) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ProgressBar.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ProgressBar.java
@@ -123,7 +123,7 @@ static int checkStyle (int style) {
 Point computeSizeInPixels (Point hintInPoints, boolean changed) {
 	checkWidget ();
 	int zoom = getZoom();
-	Point hintInPixels = Win32DPIUtils.pointToPixelAsSize(hintInPoints, zoom);
+	Point hintInPixels = Win32DPIUtils.pointToPixelAsSufficientlyLargeSize(hintInPoints, zoom);
 	int border = getBorderWidthInPixels ();
 	int width = border * 2, height = border * 2;
 	if ((style & SWT.HORIZONTAL) != 0) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Sash.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Sash.java
@@ -130,7 +130,7 @@ static int checkStyle (int style) {
 Point computeSizeInPixels (Point hintInPoints, boolean changed) {
 	checkWidget ();
 	int zoom = getZoom();
-	Point hintInPixels = Win32DPIUtils.pointToPixelAsSize(hintInPoints, zoom);
+	Point hintInPixels = Win32DPIUtils.pointToPixelAsSufficientlyLargeSize(hintInPoints, zoom);
 	int border = getBorderWidthInPixels ();
 	int width = border * 2, height = border * 2;
 	if ((style & SWT.HORIZONTAL) != 0) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Scale.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Scale.java
@@ -148,7 +148,7 @@ static int checkStyle (int style) {
 Point computeSizeInPixels (Point hintInPoints, boolean changed) {
 	checkWidget ();
 	int zoom = getZoom();
-	Point hintInPixels = Win32DPIUtils.pointToPixelAsSize(hintInPoints, zoom);
+	Point hintInPixels = Win32DPIUtils.pointToPixelAsSufficientlyLargeSize(hintInPoints, zoom);
 	int border = getBorderWidthInPixels ();
 	int width = border * 2, height = border * 2;
 	RECT rect = new RECT ();

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Scrollable.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Scrollable.java
@@ -121,8 +121,8 @@ long callWindowProc (long hwnd, int msg, long wParam, long lParam) {
 public Rectangle computeTrim (int x, int y, int width, int height) {
 	checkWidget ();
 	int zoom = getZoom();
-	Rectangle rectangle = Win32DPIUtils.pointToPixel(new Rectangle(x, y, width, height), zoom);
-	return Win32DPIUtils.pixelToPoint(computeTrimInPixels(rectangle.x, rectangle.y, rectangle.width, rectangle.height), zoom);
+	Rectangle rectangle = Win32DPIUtils.pointToPixelWithSufficientlyLargeSize(new Rectangle(x, y, width, height), zoom);
+	return Win32DPIUtils.pixelToPointWithSufficientlyLargeSize(computeTrimInPixels(rectangle.x, rectangle.y, rectangle.width, rectangle.height), zoom);
 }
 
 Rectangle computeTrimInPixels (int x, int y, int width, int height) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Slider.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Slider.java
@@ -181,7 +181,7 @@ static int checkStyle (int style) {
 Point computeSizeInPixels (Point hintInPoints, boolean changed) {
 	checkWidget ();
 	int zoom = getZoom();
-	Point hintInPixels = Win32DPIUtils.pointToPixelAsSize(hintInPoints, zoom);
+	Point hintInPixels = Win32DPIUtils.pointToPixelAsSufficientlyLargeSize(hintInPoints, zoom);
 	int border = getBorderWidthInPixels ();
 	int width = border * 2, height = border * 2;
 	if ((style & SWT.HORIZONTAL) != 0) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Spinner.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Spinner.java
@@ -261,7 +261,7 @@ void addVerifyListener (VerifyListener listener) {
 Point computeSizeInPixels (Point hintInPoints, boolean changed) {
 	checkWidget ();
 	int zoom = getZoom();
-	Point hintInPixels = Win32DPIUtils.pointToPixelAsSize(hintInPoints, zoom);
+	Point hintInPixels = Win32DPIUtils.pointToPixelAsSufficientlyLargeSize(hintInPoints, zoom);
 	int width = 0, height = 0;
 	if (hintInPoints.x == SWT.DEFAULT || hintInPoints.y == SWT.DEFAULT) {
 		long newFont, oldFont = 0;

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Table.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Table.java
@@ -1429,7 +1429,7 @@ public void clearAll () {
 @Override
 Point computeSizeInPixels (Point hintInPoints, boolean changed) {
 	int zoom = getZoom();
-	Point hintInPixels = Win32DPIUtils.pointToPixelAsSize(hintInPoints, zoom);
+	Point hintInPixels = Win32DPIUtils.pointToPixelAsSufficientlyLargeSize(hintInPoints, zoom);
 	if (fixScrollWidth) setScrollWidth (null, true);
 	//This code is intentionally commented
 //	if (itemHeight == -1 && hooks (SWT.MeasureItem)) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Text.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Text.java
@@ -706,7 +706,7 @@ public void clearSelection () {
 Point computeSizeInPixels (Point hintInPoints, boolean changed) {
 	checkWidget ();
 	int zoom = getZoom();
-	Point hintInPixels = Win32DPIUtils.pointToPixelAsSize(hintInPoints, zoom);
+	Point hintInPixels = Win32DPIUtils.pointToPixelAsSufficientlyLargeSize(hintInPoints, zoom);
 	int height = 0, width = 0;
 	if (hintInPoints.x == SWT.DEFAULT || hintInPoints.y == SWT.DEFAULT) {
 		long newFont, oldFont = 0;

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ToolBar.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ToolBar.java
@@ -211,7 +211,7 @@ void clearSizeCache(boolean changed) {
 @Override
 Point computeSizeInPixels (Point hintInPoints, boolean changed) {
 	int zoom = getZoom();
-	Point hintInPixels = Win32DPIUtils.pointToPixelAsSize(hintInPoints, zoom);
+	Point hintInPixels = Win32DPIUtils.pointToPixelAsSufficientlyLargeSize(hintInPoints, zoom);
 	int count = (int)OS.SendMessage (handle, OS.TB_BUTTONCOUNT, 0, 0);
 	if (count == this._count && hintInPixels.x == this._wHint && hintInPixels.y == this._hHint) {
 		// Return already cached values calculated previously

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Tree.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Tree.java
@@ -1826,7 +1826,7 @@ long CompareFunc (long lParam1, long lParam2, long lParamSort) {
 @Override
 Point computeSizeInPixels (Point hintInPoints, boolean changed) {
 	int zoom = getZoom();
-	Point hintInPixels = Win32DPIUtils.pointToPixelAsSize(hintInPoints, zoom);
+	Point hintInPixels = Win32DPIUtils.pointToPixelAsSufficientlyLargeSize(hintInPoints, zoom);
 	int width = 0, height = 0;
 	if (hwndHeader != 0) {
 		HDITEM hdItem = new HDITEM ();


### PR DESCRIPTION
Several places in the computations of preferred sizes of controls used commercial rounding instead of rounding up in pixel/point calculations. This change further adapts additional places to ensure that the calculated size will be large enough and and subsequent point-to-pixel calculation when setting the bounds according the computations does not lead to smaller results.

This is a follow up to:
- https://github.com/eclipse-platform/eclipse.platform.swt/pull/2717

I did not find any visual differences yet, so consider this a unification/cleanup to ensure that every conversion involved in `computeSize()` calculations rounds up.