### PR TITLE
Ensure that rounding mode of Point.OfFloat is never null

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/Point.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/Point.java
@@ -143,7 +143,7 @@ public static sealed class OfFloat extends Point permits Point.WithMonitor {
 
 	public OfFloat(int x, int y) {
 		super(x, y);
-		this.roundingMode = null;
+		this.roundingMode = RoundingMode.ROUND;
 	}
 
 	public OfFloat(float x, float y) {

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_Point.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_Point.java
@@ -73,4 +73,24 @@ public void test_toString() {
 	assertTrue(p.toString().length() > 0);
 	assertEquals("Point {3, 4}", p.toString());
 }
+
+@Test
+public void test_OfFloat_clone() {
+	Point.OfFloat pointOfInt = new Point.OfFloat(3, 4);
+	Point.OfFloat clonedPointOfInt = pointOfInt.clone();
+	assertEquals(pointOfInt, clonedPointOfInt);
+	assertEquals(pointOfInt.x, clonedPointOfInt.x);
+	assertEquals(pointOfInt.getX(), clonedPointOfInt.getX());
+	assertEquals(pointOfInt.y, clonedPointOfInt.y);
+	assertEquals(pointOfInt.getY(), clonedPointOfInt.getY());
+
+	Point.OfFloat pointOfFloat = new Point.OfFloat(3.4f, 3.5f);
+	Point.OfFloat clonedPointOfFloat = pointOfFloat.clone();
+	assertEquals(pointOfFloat, clonedPointOfFloat);
+	assertEquals(pointOfFloat.x, clonedPointOfFloat.x);
+	assertEquals(pointOfFloat.getX(), clonedPointOfFloat.getX());
+	assertEquals(pointOfFloat.y, clonedPointOfFloat.y);
+	assertEquals(pointOfFloat.getY(), clonedPointOfFloat.getY());
+}
+
 }


### PR DESCRIPTION
When initializing a Point.OfFloat with integer values, the rounding mode is currently set to null. This can lead to NPEs when cloning such points, as clone() uses the rounding mode to initialize a new instance, which expects the rounding mode to not be null. Setting values on the point with setX() and setY() will fail likewise.

This change ensures that the rounding mode will never be initialized
with null.