### PR TITLE
Use fix value for Inset when tree item has both checkbox and image

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TreeItem.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TreeItem.java
@@ -440,7 +440,7 @@ RECT getBounds (int index, boolean getText, boolean getImage, boolean fullText, 
 		if (getImage && !fullImage) {
 			if (OS.SendMessage (hwnd, OS.TVM_GETIMAGELIST, OS.TVSIL_NORMAL, 0) != 0) {
 				Point size = parent.getImageSize ();
-				rect.left -= size.x + DPIUtil.pointToPixel(Tree.INSET, getZoom());
+				rect.left -= size.x + Tree.INSET;
 				if (!getText) rect.right = rect.left + size.x;
 			} else {
 				if (!getText) rect.right = rect.left;


### PR DESCRIPTION
The inset value defines a gap between text and image on a tree item, but due to multiple zoom level it was set to convert that value as per zoom level but with the combination of image and checkbox, it moves the image too much on the left resulting in cutoff checkbox. It is better to use fix value for INSET just for this case

This screenshot is on 150%
<img width="346" height="372" alt="Image" src="https://github.com/user-attachments/assets/98338b92-6920-4782-8142-a203ffd5ff40" />

**Reproduction**
Steps to reproduce the behavior:
1. Open the IDE on a 150% monitor
2. Open the Runtime configuration dialog
3. Switch to the Plug-ins tab
4. From drop down select "Features selected below"

**Expected Behavior**
No cut-off checkboxes