### PR TITLE
Do not call addListener in Widget::registerDPIChangeListener #2733

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Widget.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Widget.java
@@ -189,7 +189,7 @@ public Widget (Widget parent, int style) {
 
 void registerDPIChangeListener() {
 	if (display.isRescalingAtRuntime()) {
-		this.addListener(SWT.ZoomChanged, event -> {
+		this._addListener(SWT.ZoomChanged, event -> {
 			float scalingFactor = 1f * DPIUtil.getZoomForAutoscaleProperty(event.detail) / DPIUtil.getZoomForAutoscaleProperty(nativeZoom);
 			handleDPIChange(event, scalingFactor);
 		});


### PR DESCRIPTION
The method is not final, which may cause issues if a subclass overrides it because it ends up being called upon instantiation, when the object is not fully initialized

Fixes https://github.com/eclipse-platform/eclipse.platform.swt/issues/2733