### PR TITLE
Do not call addListener in constructors of CCombo and StyledText #2733

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CCombo.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CCombo.java
@@ -173,7 +173,18 @@ public CCombo (Composite parent, int style) {
 	}
 
 	initAccessible();
-	addListener(SWT.ZoomChanged, this::handleDPIChange);
+
+	// Add listener asynchronously in order to delay execution. This works because
+	// other DPI changes are also executed asynchronously but if we choose to revert
+	// back to synchronous execution of the listeners then this async call may be
+	// executed too late and zoom change events may happen too early and not get
+	// propagated.
+	// See https://github.com/eclipse-platform/eclipse.platform.swt/issues/2733
+	getDisplay().asyncExec(() -> {
+		if (!isDisposed()) {
+			addListener(SWT.ZoomChanged, this::handleDPIChange);
+		}
+	});
 }
 static int checkStyle (int style) {
 	int mask = SWT.BORDER | SWT.READ_ONLY | SWT.FLAT | SWT.LEFT_TO_RIGHT | SWT.RIGHT_TO_LEFT | SWT.LEAD | SWT.CENTER | SWT.TRAIL;

--- a/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/StyledText.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/StyledText.java
@@ -758,7 +758,18 @@ public StyledText(Composite parent, int style) {
 	initializeAccessible();
 	setData("DEFAULT_DROP_TARGET_EFFECT", new StyledTextDropTargetEffect(this));
 	if (IS_MAC) setData(STYLEDTEXT_KEY);
-	addListener(SWT.ZoomChanged, this::handleDPIChange);
+
+	// Add listener asynchronously in order to delay execution. This works because
+	// other DPI changes are also executed asynchronously but if we choose to revert
+	// back to synchronous execution of the listeners then this async call may be
+	// executed too late and zoom change events may happen too early and not get
+	// propagated.
+	// See https://github.com/eclipse-platform/eclipse.platform.swt/issues/2733
+	getDisplay().asyncExec(() -> {
+		if (!isDisposed()) {
+			addListener(SWT.ZoomChanged, this::handleDPIChange);
+		}
+	});
 }
 /**
  * Adds an extended modify listener. An ExtendedModify event is sent by the


### PR DESCRIPTION
The method is not final, which may cause issues if a subclass overrides it because it ends up being called upon instantiation, when the object is not fully initialized

Since these 2 classes are not in the same package as other subclasses of Widget, I had to resort to expanding the functionality in TypedListener.

Fixes https://github.com/eclipse-platform/eclipse.platform.swt/issues/2733