### PR TITLE
Remove zoom parameter from CoordinateSystemMapper#mapMonitorBounds()

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/CoordinateSystemMapper.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/CoordinateSystemMapper.java
@@ -25,7 +25,7 @@ interface CoordinateSystemMapper {
 
 	Point map(Control from, Control to, int x, int y);
 
-	Rectangle mapMonitorBounds(Rectangle rectangle, int zoom);
+	Rectangle mapMonitorBounds(Rectangle.WithMonitor rectangle);
 
 	Point translateFromDisplayCoordinates(Point point);
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Display.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Display.java
@@ -2225,16 +2225,10 @@ Monitor getMonitor (long hmonitor) {
 	OS.GetMonitorInfo (hmonitor, lpmi);
 	Monitor monitor = new Monitor ();
 	monitor.handle = hmonitor;
-	Rectangle boundsInPixels = new Rectangle(lpmi.rcMonitor_left, lpmi.rcMonitor_top, lpmi.rcMonitor_right - lpmi.rcMonitor_left,lpmi.rcMonitor_bottom - lpmi.rcMonitor_top);
-	Rectangle clientAreaInPixels = new Rectangle(lpmi.rcWork_left, lpmi.rcWork_top, lpmi.rcWork_right - lpmi.rcWork_left, lpmi.rcWork_bottom - lpmi.rcWork_top);
 	int [] dpiX = new int[1];
 	int [] dpiY = new int[1];
 	int result = OS.GetDpiForMonitor (monitor.handle, OS.MDT_EFFECTIVE_DPI, dpiX, dpiY);
 	result = (result == OS.S_OK) ? DPIUtil.mapDPIToZoom (dpiX[0]) : 100;
-
-	int autoscaleZoom = DPIUtil.getZoomForAutoscaleProperty(result);
-	monitor.setBounds(coordinateSystemMapper.mapMonitorBounds(boundsInPixels, autoscaleZoom));
-	monitor.setClientArea(coordinateSystemMapper.mapMonitorBounds(clientAreaInPixels, autoscaleZoom));
 	if (result == 0) {
 		System.err.println("***WARNING: GetDpiForMonitor: SWT could not get valid monitor scaling factor.");
 		result = 100;
@@ -2244,6 +2238,12 @@ Monitor getMonitor (long hmonitor) {
 	 * to scaling issue on OS Win8.1 and above, for more details refer bug 537614.
 	 */
 	monitor.zoom = result;
+	Rectangle.WithMonitor boundsInPixels = new Rectangle.WithMonitor(lpmi.rcMonitor_left, lpmi.rcMonitor_top, lpmi.rcMonitor_right - lpmi.rcMonitor_left,lpmi.rcMonitor_bottom - lpmi.rcMonitor_top, monitor);
+	Rectangle.WithMonitor clientAreaInPixels = new Rectangle.WithMonitor(lpmi.rcWork_left, lpmi.rcWork_top, lpmi.rcWork_right - lpmi.rcWork_left, lpmi.rcWork_bottom - lpmi.rcWork_top, monitor);
+
+	monitor.setBounds(coordinateSystemMapper.mapMonitorBounds(boundsInPixels));
+	monitor.setClientArea(coordinateSystemMapper.mapMonitorBounds(clientAreaInPixels));
+
 	return monitor;
 }
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/MultiZoomCoordinateSystemMapper.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/MultiZoomCoordinateSystemMapper.java
@@ -84,7 +84,9 @@ class MultiZoomCoordinateSystemMapper implements CoordinateSystemMapper {
 	}
 
 	@Override
-	public Rectangle mapMonitorBounds(Rectangle rect, int zoom) {
+	public Rectangle mapMonitorBounds(Rectangle.WithMonitor rect) {
+		Monitor monitor = rect.getMonitor();
+		int zoom = getApplicableMonitorZoom(monitor);
 		Rectangle bounds = Win32DPIUtils.pixelToPoint(rect, zoom);
 		bounds.x = rect.x;
 		bounds.y = rect.y;

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/SingleZoomCoordinateSystemMapper.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/SingleZoomCoordinateSystemMapper.java
@@ -71,8 +71,8 @@ class SingleZoomCoordinateSystemMapper implements CoordinateSystemMapper {
 	}
 
 	@Override
-	public Rectangle mapMonitorBounds(Rectangle rect, int zoom) {
-		return Win32DPIUtils.pixelToPoint(rect, zoom);
+	public Rectangle mapMonitorBounds(Rectangle.WithMonitor rect) {
+		return Win32DPIUtils.pixelToPoint(rect, DPIUtil.getDeviceZoom());
 	}
 
 	@Override


### PR DESCRIPTION
The CoordinateSystemMapper#mapMonitorBounds() method currently accepts a zoom value and that is wrong for SingleZoomCoordinateMapper since it should always use the global zoom (DPIUtil#getDeviceZoom()) instead of monitor zoom. This commit changes how zoom is passed through Rectangle with monitor for MultiZoomCoordinateMapper while that monitor will be ignored for SingleZoomCoordinateMapper.

### How to Test

- Run the following snippet with no VM argument (monitor-specific scaling off) with two monitors connected (250% and 150%)
```
import org.eclipse.swt.*;
import org.eclipse.swt.graphics.*;
import org.eclipse.swt.widgets.*;

public class OpenNewShellExample {

    public static void main(String[] args) {
        Display display = new Display();
        Shell mainShell = new Shell(display);
        mainShell.setText("Main Shell");
        mainShell.setSize(300, 200);

        Button openButton = new Button(mainShell, SWT.PUSH);
        openButton.setText("Open New Shell");
        openButton.setBounds(80, 70, 140, 30);

        openButton.addListener(SWT.Selection, e -> {
            Rectangle mainShellRect = mainShell.getMonitor().getBounds();
            Shell newShell = new Shell(mainShell);
            newShell.setText("New Shell");
            newShell.setSize(mainShellRect.width, mainShellRect.height);

            Label infoLabel = new Label(newShell, SWT.NONE);
            infoLabel.setLocation(100, 100);
            infoLabel.setSize(300, 20);
            infoLabel.setText("New Shell Size: " + mainShellRect.width + "x" + mainShellRect.height);
            newShell.open();
        });

        mainShell.open();
        while (!mainShell.isDisposed()) {
            if (!display.readAndDispatch())
                display.sleep();
        }
        display.dispose();
    }
}
```
- Keep the shell on primary monitor and click "Open New Shell" button
- A new shell will open with the same size of primary monitor (Global Zoom)
- Close the new shell
- Move the first shell to secondary monitor 
- Click "Open New Shell" button again.
- The new shell that open should be the same size as the original zoom since monitor-specific scaling is not turned on.


### Results

**Before**
At 250%
<img width="3814" height="2387" alt="image" src="https://github.com/user-attachments/assets/d26e78c4-0648-4886-a350-5870e8763644" />

at 150%
<img width="3822" height="2151" alt="image" src="https://github.com/user-attachments/assets/d2f7d2cc-4d4d-404e-bb11-d2f30ac13ee7" />

Notice that zoom is adapted of monitor even though monitor-specific scaling is turned off.

**After**
At 250% (Primary)
<img width="3814" height="2387" alt="image" src="https://github.com/user-attachments/assets/14f7d018-28da-4ac3-bcc0-73b4028325f6" />

At 150% (Secondary) 
<img width="1902" height="1071" alt="image" src="https://github.com/user-attachments/assets/bbc447ab-bbee-460a-a2ce-01d12379296a" />

Therefore the size remain same (which is correct behaviour)