### PR TITLE
[GTK4] release OS resources for Shell during destroyWidget

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Control.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Control.java
@@ -4825,18 +4825,19 @@ void releaseWidget () {
 @Override
 void destroyWidget() {
 	if (GTK.GTK4) {
-		// Remove widget from hierarchy  by removing it from parent container
-		if (parent != null) {
-			long currHandle = topHandle();
-
-			if (GTK.GTK_IS_WINDOW(currHandle)) {
-				GTK4.gtk_window_destroy(currHandle);
-			} else {
-				if (fixedHandle != 0) {
-					OS.swt_fixed_remove(parent.parentingHandle(), fixedHandle);
-				}
+		long currHandle = topHandle();
+		if (GTK.GTK_IS_WINDOW(currHandle)) {
+			// GTK windows don't have a parent, so destroy it now
+			GTK4.gtk_window_destroy(currHandle);
+		} else if (parent != null) {
+			if (fixedHandle != 0) {
+				// Remove widget from hierarchy by removing it from parent container
+				OS.swt_fixed_remove(parent.parentingHandle(), fixedHandle);
 			}
+		} else {
+			assert false : "widgets must have a parent or be a GtkWindow";
 		}
+
 		releaseHandle();
 	} else {
 		super.destroyWidget();


### PR DESCRIPTION
Fixes https://github.com/eclipse-platform/eclipse.platform.swt/issues/2741

I tried hard to write a reliable test to detect such memory leaks, and I will be able to pull out some of the stuff I learned, but as of now I don't have a specific automatic test for this.