### PR TITLE
[Win32] Partially revert rectangle size rounding

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/Rectangle.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/Rectangle.java
@@ -464,12 +464,12 @@ public static sealed class OfFloat extends Rectangle permits Rectangle.WithMonit
 	}
 
 	public void setWidth(float width) {
-		this.width = sizeRounding.round(width + getX()) - x;
+		this.width = sizeRounding.round(width);
 		this.residualWidth = width - this.width;
 	}
 
 	public void setHeight(float height) {
-		this.height = sizeRounding.round(height + getY()) - y;
+		this.height = sizeRounding.round(height);
 		this.residualHeight = height - this.height;
 	}
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/Win32DPIUtils.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/Win32DPIUtils.java
@@ -159,13 +159,16 @@ public class Win32DPIUtils {
 
 	private static Rectangle pixelToPoint(Rectangle rect, int zoom, RoundingMode sizeRounding) {
 		if (zoom == 100 || rect == null) return rect;
+		if (rect instanceof Rectangle.OfFloat) {
+			return scaleBounds(rect, 100, zoom);
+		}
 		Rectangle.OfFloat floatRect = Rectangle.OfFloat.from(rect);
 		Point.OfFloat scaledTopLeft = pixelToPoint(floatRect.getTopLeft(), zoom);
 		Point.OfFloat scaledBottomRight = pixelToPoint(floatRect.getBottomRight(), zoom);
-		float scaledX = scaledTopLeft.getX();
-		float scaleyY = scaledTopLeft.getY();
-		float scaledWidth = scaledBottomRight.getX() - scaledTopLeft.getX();
-		float scaledHeight = scaledBottomRight.getY() - scaledTopLeft.getY();
+		float scaledX = scaledTopLeft.x;
+		float scaleyY = scaledTopLeft.y;
+		float scaledWidth = scaledBottomRight.x - scaledTopLeft.x;
+		float scaledHeight = scaledBottomRight.y - scaledTopLeft.y;
 		return new Rectangle.OfFloat(scaledX, scaleyY, scaledWidth, scaledHeight, RoundingMode.ROUND, sizeRounding);
 	}
 
@@ -280,13 +283,16 @@ public class Win32DPIUtils {
 
 	private static Rectangle pointToPixel(Rectangle rect, int zoom, RoundingMode sizeRounding) {
 		if (zoom == 100 || rect == null) return rect;
+		if (rect instanceof Rectangle.OfFloat) {
+			return scaleBounds(rect, zoom, 100);
+		}
 		Rectangle.OfFloat floatRect = Rectangle.OfFloat.from(rect);
 		Point.OfFloat scaledTopLeft = pointToPixel(floatRect.getTopLeft(), zoom);
 		Point.OfFloat scaledBottomRight = pointToPixel(floatRect.getBottomRight(), zoom);
-		float scaledX = scaledTopLeft.getX();
-		float scaleyY = scaledTopLeft.getY();
-		float scaledWidth = scaledBottomRight.getX() - scaledTopLeft.getX();
-		float scaledHeight = scaledBottomRight.getY() - scaledTopLeft.getY();
+		float scaledX = scaledTopLeft.x;
+		float scaleyY = scaledTopLeft.y;
+		float scaledWidth = scaledBottomRight.x - scaledTopLeft.x;
+		float scaledHeight = scaledBottomRight.y - scaledTopLeft.y;
 		return new Rectangle.OfFloat(scaledX, scaleyY, scaledWidth, scaledHeight, RoundingMode.ROUND, sizeRounding);
 	}
 


### PR DESCRIPTION
With a recent change (https://github.com/eclipse-platform/eclipse.platform.swt/pull/2720), the rounding of rectangles width/height was adapted to be based on the precise (float) coordinates of the top left and bottom right corner of the rectangle instead of rounding top left location and width/height individually in the rectangle. The reason was that otherwise two rectangles placed next to each other and scaled from pixel to point or vice versa could overlap or have a gap between them when the resulting values were rounded. So the change was beneficial (i.e., improved precision) when scaling values from pixel to point or vice versa if they are all defined in the same coordinate system (with the same origin), as then equal coordinates are rounded equally.
However, the coordinates used in SWT are usually in different coordinate systems with the origin often being the position of the parent control. So one consequence of the change was that a parent with a child, both of the same size, may not fit into each other anymore if the parent has an offset (with respect to its parent) that is taken into account when rounding the Rectangle values.

For that reason, this change reverts the behavior change of Rectangle and the point/pixel conversion logic to the previous state.

Fixes https://github.com/eclipse-platform/eclipse.platform.swt/issues/2746

