### PR TITLE
Fix image handle creation to use correct native zoom

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/GC.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/GC.java
@@ -1062,7 +1062,7 @@ private class DrawImageOperation extends ImageOperation {
 
 	private void drawImageInPixels(Image image, Point location) {
 		if (image.isDisposed()) SWT.error(SWT.ERROR_INVALID_ARGUMENT);
-		ImageHandle handle = image.getHandle(getZoom(), getZoom());
+		ImageHandle handle = image.getHandle(getZoom(), data.nativeZoom);
 		drawImage(image, 0, 0, -1, -1, location.x, location.y, -1, -1, true, handle);
 	}
 }
@@ -1279,7 +1279,7 @@ private class DrawImageToImageOperation extends ImageOperation {
 
 	@Override
 	void apply() {
-		ImageHandle handle = getImage().getHandle(getZoom(), getZoom());
+		ImageHandle handle = getImage().getHandle(getZoom(), data.nativeZoom);
 		drawImage(getImage(), source.x, source.y, source.width, source.height, destination.x, destination.y, destination.width, destination.height, simple, handle);
 	}
 }


### PR DESCRIPTION
In some cases where an image handle is passed to drawImage, the handle was created with nativeZoom set to Gc::getZoom(). This caused incorrect font sizes when drawing text with an imageGCDrawer.
This change ensures that the image handle is created with the correct nativeZoom value from the GC, fixing the font size issue.

**Steps to reproduce**

Open a runtime workspace at 175% primary monitor zoom with monitor-specific scaling disabled. The line number ruler will have text cut off without this change



| Before  | After  |
|:------------------------:|:------------------:|
| ![Before](https://github.com/user-attachments/assets/d41a21de-9c42-45f7-81a8-558d9531c236) | ![After](https://github.com/user-attachments/assets/1d2a875d-4b7a-46e9-9391-cb802bbc07c2) |

