### PR TITLE
[GTK4] Let Display.post throw exceptions

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Display.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Display.java
@@ -4303,15 +4303,16 @@ long findFocusedWindow() {
  * @since 3.0
  */
 public boolean post (Event event) {
-	/*
-	 * GdkEvents are now strictly read-only
-	 * https://docs.gtk.org/gtk4/migrating-3to4.html#adapt-to-gdkevent-api-changes
-	 */
-	if (GTK.GTK4) return false;
 
 	synchronized (Device.class) {
 		if (isDisposed ()) error (SWT.ERROR_DEVICE_DISPOSED);
 		if (event == null) error (SWT.ERROR_NULL_ARGUMENT);
+
+		/*
+		 * GdkEvents are now strictly read-only
+		 * https://docs.gtk.org/gtk4/migrating-3to4.html#adapt-to-gdkevent-api-changes
+		 */
+		if (GTK.GTK4) return false;
 
 		int type = event.type;
 


### PR DESCRIPTION
While there is no Gtk 4 implementation, currently it's disabled as a very first thing thus no exception will be thrown even when display is disposed or event it null.
Move the Gtk 4 check down to keep behavior with exceptions.