### PR TITLE
Add todo JUnit5 tags to GTK4 and wayland tests that need work still

### DIFF
--- a/tests/org.eclipse.swt.tests.gtk/ManualTests/org/eclipse/swt/tests/gtk/snippets/Bug336238_ShellSetBoundFailTest.java
+++ b/tests/org.eclipse.swt.tests.gtk/ManualTests/org/eclipse/swt/tests/gtk/snippets/Bug336238_ShellSetBoundFailTest.java
@@ -17,12 +17,14 @@ package org.eclipse.swt.tests.gtk.snippets;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.eclipse.swt.widgets.Shell;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 public class Bug336238_ShellSetBoundFailTest {
 
 	static int cycles = 100;
 
+	@Tag("gtk4-todo")
 	@Test
 	public void testSetBounds() {
 

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_browser_Browser.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_browser_Browser.java
@@ -85,6 +85,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.TestMethodOrder;
@@ -418,6 +419,7 @@ public void test_evalute_Cookies () {
 	assertFalse(res.isEmpty());
 }
 
+@Tag("gtk4-todo")
 @Test
 public void test_ClearAllSessionCookies () {
 	final AtomicBoolean loaded = new AtomicBoolean(false);
@@ -447,6 +449,7 @@ public void test_ClearAllSessionCookies () {
 	assertTrue(e2 == null || e2.isEmpty());
 }
 
+@Tag("gtk4-todo")
 @Test
 public void test_get_set_Cookies() {
 	final AtomicBoolean loaded = new AtomicBoolean(false);
@@ -806,6 +809,7 @@ public void test_OpenWindowListener_addAndRemove() {
 	for (int i = 0; i < 100; i++) browser.removeOpenWindowListener(listener);
 }
 
+@Tag("gtk4-todo")
 @Test
 public void test_OpenWindowListener_openHasValidEventDetails() {
 	AtomicBoolean openFiredCorrectly = new AtomicBoolean(false);
@@ -828,6 +832,7 @@ public void test_OpenWindowListener_openHasValidEventDetails() {
 }
 
 /** Test that a script 'window.open()' opens a child popup shell. */
+@Tag("gtk4-todo")
 @Test
 public void test_OpenWindowListener_open_ChildPopup() {
 	AtomicBoolean childCompleted = new AtomicBoolean(false);
@@ -865,6 +870,7 @@ public void test_OpenWindowListener_open_ChildPopup() {
 }
 
 /** Validate event order : Child's visibility should come before progress completed event */
+@Tag("gtk4-todo")
 @Test
 public void test_OpenWindow_Progress_Listener_ValidateEventOrder() {
 
@@ -1032,6 +1038,7 @@ public void test_StatusTextListener_addAndRemove() {
  * over the hyperlink (newer Webkit2+) browser.
  */
 @Test
+@Tag("gtk4-todo")
 public void test_StatusTextListener_hoverMouseOverLink() {
 	assumeFalse(isEdge, "no API in Edge for this");
 
@@ -1304,6 +1311,7 @@ public void test_VisibilityWindowListener_addAndRemove() {
 }
 
 /** Verify that if multiple child shells are open, no duplicate visibility events are sent. */
+@Tag("gtk4-todo")
 @Test
 public void test_VisibilityWindowListener_multiple_shells() {
 		AtomicBoolean secondChildCompleted = new AtomicBoolean(false);
@@ -1364,6 +1372,7 @@ public void test_VisibilityWindowListener_multiple_shells() {
  *  Validate that when javascript opens a new window and specifies size,
  *  it's size is passed to the visibility event correctly.
  */
+@Tag("gtk4-todo")
 @Test
 public void test_VisibilityWindowListener_eventSize() {
 

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_custom_StyledText.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_custom_StyledText.java
@@ -1166,6 +1166,7 @@ public void test_getLineHeight() {
 	assertTrue(text.getLineHeight() > 0);
 }
 
+@Tag("gtk4-todo")
 @Test
 public void test_getLineIndex () {
 	test_getLineIndex(text);
@@ -1252,6 +1253,7 @@ void test_getLineIndex (StyledText text) {
 	assertEquals(0, text.getLineIndex(100));
 }
 
+@Tag("gtk4-todo")
 @Test
 public void test_getLinePixel () {
 	test_getLinePixel(text);
@@ -5394,6 +5396,7 @@ public void test_insertInBlockSelection() {
 			+ System.lineSeparator()));
 }
 
+@Tag("gtk4-todo")
 @Test
 public void test_setStyleRanges_render() throws InterruptedException {
 	assumeFalse(SwtTestUtil.isCocoa, "Bug 553090 prevents test to work on Mac");
@@ -5424,6 +5427,7 @@ public void test_setStyleRanges_render() throws InterruptedException {
 /**
  * Test LineStyleListener which provides styles but no ranges.
  */
+@Tag("gtk4-todo")
 @Test
 public void test_lineStyleListener_styles_render() throws InterruptedException {
 	assumeFalse(SwtTestUtil.isCocoa, "Bug 536588 prevents test to work on Mac");
@@ -5449,6 +5453,7 @@ public void test_lineStyleListener_styles_render() throws InterruptedException {
 /**
  * Test LineStyleListener which provides styles and ranges.
  */
+@Tag("gtk4-todo")
 @Test
 public void test_lineStyleListener_stylesAndRanges_render() throws InterruptedException {
 	assumeFalse(SwtTestUtil.isCocoa, "Bug 536588 prevents test to work on Mac");
@@ -5475,6 +5480,7 @@ public void test_lineStyleListener_stylesAndRanges_render() throws InterruptedEx
 /**
  * Test LineStyleListener which provides invalid styles with invalid start or length.
  */
+@Tag("gtk4-todo")
 @Test
 public void test_lineStyleListener_invalidStyles_render() throws InterruptedException {
 	assumeFalse(SwtTestUtil.isCocoa, "Bug 536588 prevents test to work on Mac");
@@ -5658,6 +5664,7 @@ public void test_consistency_DragDetect () {
  * Such a problem was once caused with bug 547532 and discovered along bug 549110.
  * </p>
  */
+@Tag("gtk4-todo")
 @Test
 public void test_GlyphMetricsOnTab_Bug549110() throws InterruptedException {
 	assumeFalse(SwtTestUtil.isCocoa, "Bug 536588 prevents test to work on Mac");
@@ -5732,6 +5739,7 @@ public void test_InsertWhenDisabled() {
  * Bug 551335 - [StyledText] setStyleRanges reset less cache than necessary
  * Bug 551336 - [StyledText] resetting styles does not reset rendering
  */
+@Tag("gtk4-todo")
 @Test
 public void test_bug551335_lostStyles() throws InterruptedException {
 	assumeFalse(SwtTestUtil.isCocoa, "Bug 536588 prevents test to work on Mac");
@@ -5904,6 +5912,7 @@ public void test_arrowDownKeepsPositionAfterNewLine() {
  * Bug 565164 - SWT.BS event no longer working
  */
 @Test
+@Tag("gtk4-todo")
 public void test_backspaceAndDelete() throws InterruptedException {
 	assumeTrue(Boolean.parseBoolean(System.getenv("GITHUB_ACTIONS")),
 			"Display.post tests only run successfully on GitHub actions - see https://github.com/eclipse-platform/eclipse.platform.swt/issues/2571");

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_dnd_ByteArrayTransfer.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_dnd_ByteArrayTransfer.java
@@ -196,6 +196,7 @@ public class Test_org_eclipse_swt_dnd_ByteArrayTransfer extends ClipboardBase {
 
 	@Order(1)
 	@Test
+	@Tag("gtk4-todo")
 	@DisabledOnOs(value = OS.MAC, disabledReason = """
 			remote.getMyTypeContents doesn't work properly on macOS, this is
 			probably a test only issue on macOS

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Composite.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Composite.java
@@ -31,6 +31,7 @@ import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.Text;
 import org.eclipse.swt.widgets.Widget;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 
@@ -120,6 +121,7 @@ public void test_setVisibility_and_sizing() {
 }
 
 @Test
+@Tag("gtk4-wayland-todo")
 public void test_setFocus_toChild_afterOpen() {
 	if (SwtTestUtil.isCocoa) {
 		//TODO Fix Cocoa failure.
@@ -135,6 +137,7 @@ public void test_setFocus_toChild_afterOpen() {
 }
 
 @Test
+@Tag("gtk4-wayland-todo")
 public void test_setFocus_toChild_beforeOpen() {
 	if (SwtTestUtil.isCocoa) {
 		//TODO Fix Cocoa failure.
@@ -150,6 +153,7 @@ public void test_setFocus_toChild_beforeOpen() {
 }
 
 @Test
+@Tag("gtk4-wayland-todo")
 public void test_setFocus_withInvisibleChild() {
 	final AtomicReference<Boolean> wasSetFocusCalledOnInvisibleChildWidget = new AtomicReference<>(false);
 	Composite invisibleChildWidget = new Composite(composite, SWT.NONE) {
@@ -167,6 +171,7 @@ public void test_setFocus_withInvisibleChild() {
 }
 
 @Test
+@Tag("gtk4-wayland-todo")
 public void test_setFocus_withVisibleAndInvisibleChild() {
 	final AtomicReference<Boolean> wasSetFocusCalledOnInvisibleChildWidget = new AtomicReference<>(false);
 	Composite invisibleChildWidget = new Composite(composite, SWT.NONE) {

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Control.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Control.java
@@ -59,6 +59,7 @@ import org.eclipse.swt.widgets.Menu;
 import org.eclipse.swt.widgets.Monitor;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.Widget;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -521,6 +522,7 @@ public void test_isEnabled() {
 	assertFalse(control.isEnabled());
 }
 @Test
+@Tag("gtk4-wayland-todo")
 public void test_isFocusControl() {
 	if (shell.getVisible()) {
 		// Some tests, such as `Test_org_eclipse_swt_widgets_Text`, show their

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Display.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Display.java
@@ -46,6 +46,7 @@ import org.eclipse.swt.widgets.Monitor;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.Synchronizer;
 import org.eclipse.test.Screenshots;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.condition.DisabledOnOs;
@@ -332,6 +333,7 @@ public void test_getCursorControl() {
 	}
 }
 
+@Tag("gtk4-todo")
 @Test
 public void test_getCursorLocation() {
 	Display display = new Display();
@@ -1041,6 +1043,8 @@ public void test_mapLorg_eclipse_swt_widgets_ControlLorg_eclipse_swt_widgets_Con
 
 @Test
 @EnabledIfEnvironmentVariable(named = "GITHUB_ACTIONS", matches = "true", disabledReason = "Display.post tests only run successfully on GitHub actions - see https://github.com/eclipse-platform/eclipse.platform.swt/issues/2571")
+@Tag("gtk4-todo")
+@Tag("gtk3-wayland-todo")
 public void test_postLorg_eclipse_swt_widgets_Event() {
 	final int KEYCODE = SWT.SHIFT;
 
@@ -1201,6 +1205,7 @@ public void test_setAppNameLjava_lang_String() {
 	Display.setAppName("My Application Name");
 }
 
+@Tag("gtk4-todo")
 @Test
 public void test_setCursorLocationII(TestInfo info) {
 	Display display = new Display();
@@ -1227,6 +1232,7 @@ public void test_setCursorLocationII(TestInfo info) {
 	}
 }
 
+@Tag("gtk4-todo")
 @Test
 public void test_setCursorLocationLorg_eclipse_swt_graphics_Point(TestInfo info) {
 	Display display = new Display();
@@ -1332,6 +1338,7 @@ public void test_setSynchronizerLorg_eclipse_swt_widgets_Synchronizer() {
 	}
 }
 
+@Tag("gtk4-todo")
 @Test
 public void test_sleep() {
 	final Display display = new Display();

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_MenuItem.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_MenuItem.java
@@ -29,6 +29,7 @@ import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Menu;
 import org.eclipse.swt.widgets.MenuItem;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -194,6 +195,7 @@ public void test_setEnabledZ() {
 	assertFalse(menuItem.getEnabled());
 }
 
+@Tag("gtk4-todo")
 @Override
 @Test
 public void test_setImageLorg_eclipse_swt_graphics_Image() {

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Shell.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Shell.java
@@ -45,6 +45,7 @@ import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.Text;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -654,6 +655,7 @@ public void test_setBoundsLorg_eclipse_swt_graphics_Rectangle() {
  * Regression test for Bug 436841 - [GTK3] FocusOut/In and Activate/Deactivate
  * events when opening context menu. Only applicable on GTK x11.
  */
+@Tag("gtk4-todo")
 @Test
 public void test_activateEventSend() throws InterruptedException {
 	assumeTrue((SwtTestUtil.isGTK && SwtTestUtil.isX11()) || SwtTestUtil.isGTK4(),
@@ -706,6 +708,7 @@ public void test_activateEventSend() throws InterruptedException {
  *
  * Disabled on Wayland as there is no absolute positioning.
  */
+@Tag("gtk4-todo")
 @Test
 public void test_setBounds() throws Exception {
 	if (SwtTestUtil.isX11()) {
@@ -957,6 +960,7 @@ public void test_bug558652_scrollBarNPE() {
 	}
 }
 
+@Tag("gtk4-todo")
 @Test
 public void test_Issue450_NoShellActivateOnSetFocus() {
 	final String key = "org.eclipse.swt.internal.activateShellOnForceFocus";

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Text.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Text.java
@@ -1102,6 +1102,7 @@ public void test_setEditableZ() {
 	assertTrue(text.getEditable());
 }
 
+@Tag("gtk4-todo")
 @Override
 @Test
 public void test_setFontLorg_eclipse_swt_graphics_Font() {
@@ -1443,6 +1444,7 @@ public void test_consistency_DragDetect () {
 	consistencyEvent(30, 10, 50, 0, ConsistencyUtility.MOUSE_DRAG);
 }
 
+@Tag("gtk4-todo")
 @Tag("clipboard")
 @Test
 public void test_consistency_Segments () {
@@ -1566,6 +1568,7 @@ private void doSegmentsTest (boolean isListening) {
  * Bug 565164 - SWT.BS event no longer working
  */
 @Test
+@Tag("gtk4-todo")
 public void test_backspaceAndDelete() throws InterruptedException {
 	assumeTrue(Boolean.parseBoolean(System.getenv("GITHUB_ACTIONS")),
 			"Display.post tests only run successfully on GitHub actions - see https://github.com/eclipse-platform/eclipse.platform.swt/issues/2571");


### PR DESCRIPTION
Issue #2714 is to get tests running on GTK4 and wayland. One challenge is that some tests are known failures because work has not been completed in some narrow areas.

Rather than add `assumeFalse(GTK4)` which would disable the tests all the time, this PR marks the tests that are still to be done with `@Tag` so that we can update the CI to exclude these tests until someone has had a chance to review them more fully.

A subsequent commit will exclude these tagged tests on GitHub actions, unless a suitable label is set on the PR.

Part of https://github.com/eclipse-platform/eclipse.platform.swt/issues/2714