### PR TITLE
Improve enablement when running under GitHub actions/Jenkins

### DIFF
--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/ClipboardBase.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/ClipboardBase.java
@@ -47,8 +47,8 @@ public class ClipboardBase {
 	 * <code>true</code>: skip tests <code>false</code>: don't skip tests
 	 * <code>null</code>: unknown whether to skip tests yet
 	 */
-	private static Boolean skipTestsRequiringButtonPress = (Boolean.parseBoolean(System.getenv("GITHUB_ACTIONS"))
-			|| System.getenv("JOB_NAME") != null) ? true : null;
+	private static Boolean skipTestsRequiringButtonPress = (SwtTestUtil.isRunningOnGitHubActions()
+			|| SwtTestUtil.isRunningOnJenkins()) ? true : null;
 	private static int uniqueId = 1;
 	protected Display display;
 	protected Shell shell;

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/SwtTestUtil.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/SwtTestUtil.java
@@ -52,6 +52,7 @@ import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Listener;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.test.Screenshots;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 
 public class SwtTestUtil {
 	/**
@@ -101,9 +102,41 @@ public class SwtTestUtil {
 	public final static boolean isWindowsOS = System.getProperty("os.name").startsWith("Windows");
 	public final static boolean isLinux = System.getProperty("os.name").equals("Linux");
 
+	private static boolean checkEnvVarMatches(String name, String regex) {
+		String value = System.getenv(name);
+		if (value == null) {
+			return false;
+		}
+		return value.matches(regex);
+	}
 
-	/** Useful if you want some tests not to run on Jenkins with user "genie.platform" */
-	public final static boolean isRunningOnContinousIntegration = isGTK && ("genie.platform".equalsIgnoreCase(System.getProperty("user.name")));
+	public static final String GITHUB_DETECT_ENV_VAR = "GITHUB_ACTIONS";
+	public static final String GITHUB_DETECT_REGEX = "true";
+
+	/**
+	 * Return true if we are probably running on GitHub Actions.
+	 *
+	 * To enable or disable tests on Jenkins with annotations use
+	 * {@link EnabledIfEnvironmentVariable} and related classes with
+	 * {@link #GITHUB_DETECT_ENV_VAR} and {@link #GITHUB_DETECT_REGEX}
+	 */
+	public static boolean isRunningOnGitHubActions() {
+		return checkEnvVarMatches(GITHUB_DETECT_ENV_VAR, GITHUB_DETECT_REGEX);
+	}
+
+	public static final String JENKINS_DETECT_ENV_VAR = "JOB_NAME";
+	public static final String JENKINS_DETECT_REGEX = ".*";
+
+	/**
+	 * Return true if we are probably running on Jenkins.
+	 *
+	 * To enable or disable tests on Jenkins with annotations use
+	 * {@link EnabledIfEnvironmentVariable} and related classes with
+	 * {@link #JENKINS_DETECT_ENV_VAR} and {@link #JENKINS_DETECT_REGEX}
+	 */
+	public static boolean isRunningOnJenkins() {
+		return checkEnvVarMatches(JENKINS_DETECT_ENV_VAR, JENKINS_DETECT_REGEX);
+	}
 
 	/**
 	 * Return whether running on x11. This is dynamically set at runtime and cannot

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_custom_StyledText.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_custom_StyledText.java
@@ -14,6 +14,8 @@
 package org.eclipse.swt.tests.junit;
 
 
+import static org.eclipse.swt.tests.junit.SwtTestUtil.JENKINS_DETECT_ENV_VAR;
+import static org.eclipse.swt.tests.junit.SwtTestUtil.JENKINS_DETECT_REGEX;
 import static org.eclipse.swt.tests.junit.SwtTestUtil.hasPixel;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -25,7 +27,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import java.util.ArrayList;
 import java.util.Random;
@@ -80,6 +81,7 @@ import org.eclipse.swt.widgets.Widget;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
 
 /**
  * Automated Test Suite for class org.eclipse.swt.custom.StyledText
@@ -5913,9 +5915,8 @@ public void test_arrowDownKeepsPositionAfterNewLine() {
  */
 @Test
 @Tag("gtk4-todo")
+@DisabledIfEnvironmentVariable(named = JENKINS_DETECT_ENV_VAR, matches = JENKINS_DETECT_REGEX, disabledReason = "Display.post tests don't run reliably on Jenkins - see https://github.com/eclipse-platform/eclipse.platform.swt/issues/2571")
 public void test_backspaceAndDelete() throws InterruptedException {
-	assumeTrue(Boolean.parseBoolean(System.getenv("GITHUB_ACTIONS")),
-			"Display.post tests only run successfully on GitHub actions - see https://github.com/eclipse-platform/eclipse.platform.swt/issues/2571");
 	shell.open();
 	text.setSize(10, 50);
 	// The display.post needs to successfully obtain the focused window (at least on GTK3)

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Display.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Display.java
@@ -14,6 +14,8 @@
  *******************************************************************************/
 package org.eclipse.swt.tests.junit;
 
+import static org.eclipse.swt.tests.junit.SwtTestUtil.JENKINS_DETECT_ENV_VAR;
+import static org.eclipse.swt.tests.junit.SwtTestUtil.JENKINS_DETECT_REGEX;
 import static org.eclipse.swt.tests.junit.SwtTestUtil.assertSWTProblem;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -49,8 +51,8 @@ import org.eclipse.test.Screenshots;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
 import org.junit.jupiter.api.condition.DisabledOnOs;
-import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 
 /**
  * Automated Test Suite for class org.eclipse.swt.widgets.Display
@@ -1042,7 +1044,7 @@ public void test_mapLorg_eclipse_swt_widgets_ControlLorg_eclipse_swt_widgets_Con
 }
 
 @Test
-@EnabledIfEnvironmentVariable(named = "GITHUB_ACTIONS", matches = "true", disabledReason = "Display.post tests only run successfully on GitHub actions - see https://github.com/eclipse-platform/eclipse.platform.swt/issues/2571")
+@DisabledIfEnvironmentVariable(named = JENKINS_DETECT_ENV_VAR, matches = JENKINS_DETECT_REGEX, disabledReason = "Display.post tests don't run reliably on Jenkins - see https://github.com/eclipse-platform/eclipse.platform.swt/issues/2571")
 @Tag("gtk4-todo")
 @Tag("gtk3-wayland-todo")
 public void test_postLorg_eclipse_swt_widgets_Event() {

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Text.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Text.java
@@ -13,11 +13,12 @@
  *******************************************************************************/
 package org.eclipse.swt.tests.junit;
 
+import static org.eclipse.swt.tests.junit.SwtTestUtil.JENKINS_DETECT_ENV_VAR;
+import static org.eclipse.swt.tests.junit.SwtTestUtil.JENKINS_DETECT_REGEX;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.ModifyListener;
@@ -37,6 +38,7 @@ import org.eclipse.swt.widgets.Widget;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
 
 /**
  * Automated Test Suite for class org.eclipse.swt.widgets.Text
@@ -1569,9 +1571,8 @@ private void doSegmentsTest (boolean isListening) {
  */
 @Test
 @Tag("gtk4-todo")
+@DisabledIfEnvironmentVariable(named = JENKINS_DETECT_ENV_VAR, matches = JENKINS_DETECT_REGEX, disabledReason = "Display.post tests don't run reliably on Jenkins - see https://github.com/eclipse-platform/eclipse.platform.swt/issues/2571")
 public void test_backspaceAndDelete() throws InterruptedException {
-	assumeTrue(Boolean.parseBoolean(System.getenv("GITHUB_ACTIONS")),
-			"Display.post tests only run successfully on GitHub actions - see https://github.com/eclipse-platform/eclipse.platform.swt/issues/2571");
 	shell.open();
 	text.setSize(10, 50);
 	// The display.post needs to successfully obtain the focused window (at least on GTK3)


### PR DESCRIPTION
Previous commits aimed to disable tests when running on Jenkins and/or GitHub actions. However the conditions were too aggressive in some cases, causing tests to be skipped even when run locally by devs. This change aims to improve the enablements so that tests are only skipped on CI.

`isRunningOnContinousIntegration` was unused, hence removed as it is related to this PR.

Part of https://github.com/eclipse-platform/eclipse.platform.swt/issues/2714