### PR TITLE
Ensure window is fully activated on Wayland before continuing test

### DIFF
--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/SwtTestUtil.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/SwtTestUtil.java
@@ -252,7 +252,7 @@ public static boolean isBidi() {
 public static void openShell(Shell shell) {
 	if (shell != null && !shell.getVisible()) {
 		if (isGTK) {
-			if (isGTK4()) {
+			if (isGTK4() || isWayland()) {
 				waitAllEvents(() -> shell.open(), shell, Set.of(SWT.Paint, SWT.Activate, SWT.FocusIn), 1000);
 			} else {
 				waitEvent(() -> shell.open(), shell, SWT.Paint, 1000);

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Display.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Display.java
@@ -1051,13 +1051,12 @@ public void test_postLorg_eclipse_swt_widgets_Event() {
 
 		Shell shell = new Shell(display, SWT.NO_TRIM);
 		shell.setBounds(display.getBounds());
-		shell.open();
 
 		// The display.post needs to successfully obtain the focused window (at least on GTK3)
-		// so we can send events to it. This processEvents gives SWT/GTK time to draw/focus/etc
+		// so we can send events to it. This openShell gives SWT/GTK time to draw/focus/etc
 		// the window so that org.eclipse.swt.widgets.Display.findFocusedWindow()
 		// returns non-zero
-		SwtTestUtil.processEvents();
+		SwtTestUtil.openShell(shell);
 
 		Event event;
 


### PR DESCRIPTION
On GTK3 + wayland Display.post and some other operations, such as clipboard, cannot be issued until the window is fully activated. This change ensures that we have seen the paint, activate and focus in on Wayland in addition to GTK4.

Part of https://github.com/eclipse-platform/eclipse.platform.swt/issues/2714