### PR TITLE
Document Display.test_sleep's false positive problem

### DIFF
--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Display.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Display.java
@@ -1338,6 +1338,12 @@ public void test_setSynchronizerLorg_eclipse_swt_widgets_Synchronizer() {
 	}
 }
 
+/*
+ * this test false passes on GTK4 when not run in isolation. The test probably
+ * needs some work to ensure it is a valid test, such as making sure that it is
+ * the display.wake that wakes the first display.sleep call. Also checking the
+ * first call to display.sleep does return true.
+ */
 @Tag("gtk4-todo")
 @Test
 public void test_sleep() {


### PR DESCRIPTION
As this test has been tagged gtk4-todo, the intention is to make the test stop false positive results as part of gtk4-todo work.

See https://github.com/eclipse-platform/eclipse.platform.swt/pull/2757 for where the `@Tag`s were added.

Part of https://github.com/eclipse-platform/eclipse.platform.swt/issues/2714