### PR TITLE
Exclude TODO tests by default, include them with runtodotests label

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,11 @@ on:
         type: boolean
         required: false
         default: false
+      runtodotests:
+        description: "Run TODO tagged tests too (one of true, false)"
+        type: boolean
+        required: false
+        default: false
 
 jobs:
   build:
@@ -66,6 +71,7 @@ jobs:
         --fail-at-end
         -DskipNativeTests=false
         -DfailIfNoTests=false
+        ${{ (inputs.runtodotests == false && contains(inputs.native, 'linux')) && '-DexcludedGroups=gtk3-todo' || '' }}
         clean install
     - name: Performance tests
       if: ${{ inputs.performance }}

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -46,6 +46,7 @@ jobs:
       java: ${{ matrix.java }}
       native: gtk.linux.x86_64
       performance: ${{ contains(github.event.pull_request.labels.*.name, 'performance') }}
+      runtodotests: ${{ contains(github.event.pull_request.labels.*.name, 'runtodotests') }}
 
   build-windows:
     name: Build (Windows)
@@ -59,6 +60,7 @@ jobs:
       java: ${{ matrix.java }}
       native: win32.win32.x86_64
       performance: ${{ contains(github.event.pull_request.labels.*.name, 'performance') }}
+      runtodotests: ${{ contains(github.event.pull_request.labels.*.name, 'runtodotests') }}
 
   build-macos:
     name: Build (macOS)
@@ -79,3 +81,4 @@ jobs:
       java: ${{ matrix.java }}
       native: ${{ matrix.native }}
       performance: ${{ contains(github.event.pull_request.labels.*.name, 'performance') }}
+      runtodotests: ${{ contains(github.event.pull_request.labels.*.name, 'runtodotests') }}


### PR DESCRIPTION
In https://github.com/eclipse-platform/eclipse.platform.swt/pull/2757 the idea of using `@Tag("gtk4-todo")` was introduced to tag tests that are known TODO as such. This commit adds todos to the exclude groups list when running such tests.
    
There are not actually any GTK3 x11 todos yet, so this commit on its own may not make sense until GTK4 + wayland tests are enabled in a subsequent commit
    
Apply the label runtodotests to the PR and the todo tests will not be excluded.
    
Part of https://github.com/eclipse-platform/eclipse.platform.swt/issues/2714

In draft until dependent PR https://github.com/eclipse-platform/eclipse.platform.swt/pull/2764 is merged.
