### PR TITLE
[GTK] Fix ImageList.createPixbuf to not do wrong scaling

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/internal/ImageList.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/internal/ImageList.java
@@ -176,6 +176,13 @@ public static long createPixbuf(Image image) {
 		}
 	}
 	Cairo.cairo_surface_destroy(surface);
+	if (GTK.GTK4) {
+		//Scaling needed as the image surface will be different from the image size depending on the display scale
+		long scaledPixbuf = GDK.gdk_pixbuf_scale_simple(pixbuf, image.getBounds().width, image.getBounds().height, GDK.GDK_INTERP_BILINEAR);
+		OS.g_object_unref(pixbuf);
+		pixbuf = scaledPixbuf;
+	}
+
 	return pixbuf;
 }
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Label.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Label.java
@@ -256,7 +256,7 @@ void createHandle (int index) {
 			labelHandle = GTK.gtk_label_new_with_mnemonic(null);
 			if (labelHandle == 0) error(SWT.ERROR_NO_HANDLES);
 
-			imageHandle = GTK.gtk_image_new();
+			imageHandle = GTK4.gtk_picture_new();
 			if (imageHandle == 0) error(SWT.ERROR_NO_HANDLES);
 
 			GTK4.gtk_box_append(handle, labelHandle);
@@ -650,7 +650,7 @@ public void setImage (Image image) {
 			long pixbuf = ImageList.createPixbuf(image);
 			long texture = GDK.gdk_texture_new_for_pixbuf(pixbuf);
 			OS.g_object_unref(pixbuf);
-			GTK4.gtk_image_set_from_paintable(imageHandle, texture);
+			GTK4.gtk_picture_set_paintable(imageHandle, texture);
 		} else {
 			GTK3.gtk_image_set_from_surface(imageHandle, image.surface);
 		}
@@ -658,7 +658,7 @@ public void setImage (Image image) {
 		gtk_widget_show (imageHandle);
 	} else {
 		if (GTK.GTK4) {
-			GTK4.gtk_image_set_from_paintable(imageHandle, 0);
+			GTK4.gtk_picture_set_paintable(imageHandle, 0);
 		} else {
 			GTK3.gtk_image_set_from_surface(imageHandle, 0);
 		}


### PR DESCRIPTION
Difference comes from Gtk 4 working in logical points while Cairo works in pixels. For proper size of the pixbuf scale to the original image size.
Change Label to use GtkPicture instead of GtkImage to prevent downscaling (revert of
https://github.com/eclipse-platform/eclipse.platform.swt/commit/4c13551c541f8dbffd219d62b1bf78135d79cd3b ) as SWT shows images in labels at their real size and not as "icon" size.