### PR TITLE
Archive all log and dump files when running build on GitHub actions

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -98,4 +98,6 @@ jobs:
         if-no-files-found: warn
         path: |
           ${{ github.workspace }}/**/target/surefire-reports/*.xml
-          ${{ github.workspace }}/**/hs_err_pid*.log
+          ${{ github.workspace }}/**/*.log
+          ${{ github.workspace }}/**/*.dump
+          ${{ github.workspace }}/**/*.dumpstream


### PR DESCRIPTION
When the JVM crashes while running forked tests, the java crash handler writes to stdout/stderr which corrupts the communication channel back to surefire. This can be seen with an exception such as the following in the log.

`
org.apache.maven.surefire.booter.SurefireBooterForkException: The forked VM terminated without properly saying goodbye. VM crash or System.exit called? `

and/or

`
Warning:  Corrupted channel by directly writing to native stream in forked JVM 1. See FAQ web page and the dump file /home/runner/work/eclipse.platform.swt/eclipse.platform.swt/tests/org.eclipse.swt.tests/target/surefire-reports/2025-11-08T13-28-47_617-jvmRun1.dumpstream `

Information about the crash can end up in various log and dump files. Therefore, save all these files to enable easier diagnosing of errors.

Because of enabling GTK4 and wayland testing we are exposing a number of these crashes on the GitHub action runners.

Part of https://github.com/eclipse-platform/eclipse.platform.swt/issues/2714