### PR TITLE
Disable ByteArrayTransfer tests on GTK3 wayland

### DIFF
--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_dnd_ByteArrayTransfer.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_dnd_ByteArrayTransfer.java
@@ -48,6 +48,7 @@ import org.junit.jupiter.api.condition.OS;
  * {@link MyTypeTransfer}
  */
 @Tag("clipboard")
+@Tag("gtk3-wayland-todo")
 @TestMethodOrder(OrderAnnotation.class) // run tests needing button presses first
 public class Test_org_eclipse_swt_dnd_ByteArrayTransfer extends ClipboardBase {
 	private MyTypeTransfer myTypeTransfer;


### PR DESCRIPTION
Add the `@Tag("gtk3-wayland-todo")` to all the ByteArrayTransfer tests because it looks like they crash the JVM.

Part of https://github.com/eclipse-platform/eclipse.platform.swt/issues/2714