### PR TITLE
Limit autoscale mode to quarter and exact only

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/widgets/ControlWin32Tests.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/widgets/ControlWin32Tests.java
@@ -111,7 +111,7 @@ class ControlWin32Tests {
 	}
 
 	@ParameterizedTest
-	@CsvSource({ "0.5, 100, true", "1.0, 200, true", "2.0, 200, true", "2.0, quarter, true", "0.5, 100, false",
+	@CsvSource({ "2.0, quarter, true", "0.5, 100, false",
 			"1.0, 200, false", "2.0, 200, false", "2.0, quarter, false", })
 	public void testAutoScaleImageData(float scaleFactor, String autoScale, boolean monitorSpecificScaling) {
 		Win32DPIUtils.setMonitorSpecificScaling(monitorSpecificScaling);

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/DPIUtil.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/DPIUtil.java
@@ -51,11 +51,15 @@ public class DPIUtil {
 
 	private static String autoScaleValue;
 
-	private static final Set<String> ALLOWED_AUTOSCALE_VALUES_FOR_UPDATE_ON_RUNTIME = Set.of("quarter", "exact", "false");
+	private static final Set<String> ALLOWED_AUTOSCALE_VALUES_FOR_UPDATE_ON_RUNTIME = Set.of("quarter", "exact");
+
 	/**
-	 * System property to enable to scale the application on runtime
-	 * when a DPI change is detected.
+	 * System property to enable to scale the application on runtime when a DPI
+	 * change is detected.
 	 * <ul>
+	 * <li>"force": the application is scaled on DPI changes even if an unsupported
+	 * value for swt.autoScale are defined. See allowed values
+	 * {@link #ALLOWED_AUTOSCALE_VALUES_FOR_UPDATE_ON_RUNTIME}.</li>
 	 * <li>"true": the application is scaled on DPI changes</li>
 	 * <li>"false": the application will remain in its initial scaling</li>
 	 * </ul>
@@ -140,25 +144,19 @@ static void setAutoScaleValue(String autoScaleValueArg) {
  * scaling.
  */
 public static boolean isSetupCompatibleToMonitorSpecificScaling() {
-	if (DPIUtil.getAutoScaleValue() == null) {
+	if (!"win32".equals(SWT.getPlatform())) {
 		return false;
 	}
-
-	if (ALLOWED_AUTOSCALE_VALUES_FOR_UPDATE_ON_RUNTIME.contains(DPIUtil.getAutoScaleValue().toLowerCase())) {
+	if (autoScaleValue == null || "force".equals(System.getProperty(SWT_AUTOSCALE_UPDATE_ON_RUNTIME))) {
 		return true;
 	}
-	try {
-		Integer.parseInt(DPIUtil.getAutoScaleValue());
-		return true;
-	} catch (NumberFormatException e) {
-		// unsupported value, use default
-	}
-	return false;
+	String value = autoScaleValue.toLowerCase(Locale.ROOT);
+	return ALLOWED_AUTOSCALE_VALUES_FOR_UPDATE_ON_RUNTIME.contains(value);
 }
 
 public static boolean isMonitorSpecificScalingActive() {
-	boolean updateOnRuntimeValue = Boolean.getBoolean (DPIUtil.SWT_AUTOSCALE_UPDATE_ON_RUNTIME);
-	return updateOnRuntimeValue;
+	String updateOnRuntimeValue = System.getProperty(SWT_AUTOSCALE_UPDATE_ON_RUNTIME);
+	return "force".equalsIgnoreCase(updateOnRuntimeValue) || "true".equalsIgnoreCase(updateOnRuntimeValue);
 }
 
 public static int pixelToPoint(int size, int zoom) {


### PR DESCRIPTION
swt applications will be limited to use autoscale modes quarter and exact only otherwise user will see an error message stating the incompatibility. Also the tests testing other autoscale values have been removed.

This PR will further affect: https://github.com/eclipse-platform/eclipse.platform.ui/pull/3475

- [x] Requires: https://github.com/eclipse-platform/eclipse.platform.swt/pull/2709