### PR TITLE
Add missing performance input on win32

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -58,6 +58,7 @@ jobs:
       runner: windows-latest
       java: ${{ matrix.java }}
       native: win32.win32.x86_64
+      performance: ${{ contains(github.event.pull_request.labels.*.name, 'performance') }}
 
   build-macos:
     name: Build (macOS)


### PR DESCRIPTION
Fixup for https://github.com/eclipse-platform/eclipse.platform.swt/pull/2763

Part of https://github.com/eclipse-platform/eclipse.platform.swt/issues/2714

:cry: I had fixed this in draft https://github.com/eclipse-platform/eclipse.platform.swt/pull/2768 but failed to get it back into #2763 before merging it.