### PR TITLE
[Win32] Ensure that default spaces inside controls are large enough

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/Win32DPIUtils.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/Win32DPIUtils.java
@@ -269,6 +269,10 @@ public class Win32DPIUtils {
 		return pointToPixel(point, zoom, RoundingMode.UP);
 	}
 
+	public static int pointToPixelAsSufficientlyLargeSize(int value, int zoom) {
+		return (int) Math.ceil(value * DPIUtil.getScalingFactor(zoom));
+	}
+
 	public static Point pointToPixelAsLocation(Point point, int zoom) {
 		return pointToPixel(point, zoom, RoundingMode.ROUND);
 	}

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Button.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Button.java
@@ -362,10 +362,10 @@ Point computeSizeInPixels (Point hintInPoints, int zoom, boolean changed) {
 					Rectangle rect = Win32DPIUtils.scaleBounds(image.getBounds(), this.getZoom(), 100);
 					width = rect.width;
 					if (hasText && text.length () != 0) {
-						width += DPIUtil.pointToPixel(MARGIN * 2, getZoom());;
+						width += Win32DPIUtils.pointToPixelAsSufficientlyLargeSize(MARGIN * 2, getZoom());;
 					}
 					height = rect.height;
-					extra = DPIUtil.pointToPixel(MARGIN * 2, getZoom());;
+					extra = Win32DPIUtils.pointToPixelAsSufficientlyLargeSize(MARGIN * 2, getZoom());;
 				}
 			}
 			if (hasText) {
@@ -379,7 +379,7 @@ Point computeSizeInPixels (Point hintInPoints, int zoom, boolean changed) {
 				if (length == 0) {
 					height = Math.max (height, lptm.tmHeight);
 				} else {
-					extra = Math.max (DPIUtil.pointToPixel(MARGIN * 2, getZoom()), lptm.tmAveCharWidth);
+					extra = Math.max (Win32DPIUtils.pointToPixelAsSufficientlyLargeSize(MARGIN * 2, getZoom()), lptm.tmAveCharWidth);
 					char [] buffer = text.toCharArray ();
 					RECT rect = new RECT ();
 					int flags = OS.DT_CALCRECT | OS.DT_SINGLELINE;

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Table.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Table.java
@@ -4861,7 +4861,7 @@ boolean setScrollWidth (TableItem item, boolean force) {
 		if (hStateList != 0) {
 			int [] cx = new int [1], cy = new int [1];
 			OS.ImageList_GetIconSize (hStateList, cx, cy);
-			newWidth += cx [0] + DPIUtil.pointToPixel(INSET, getZoom());
+			newWidth += cx [0] + Win32DPIUtils.pointToPixelAsSufficientlyLargeSize(INSET, getZoom());
 		}
 		long hImageList = OS.SendMessage (handle, OS.LVM_GETIMAGELIST, OS.LVSIL_SMALL, 0);
 		if (hImageList != 0) {
@@ -4881,7 +4881,7 @@ boolean setScrollWidth (TableItem item, boolean force) {
 			*/
 			newWidth++;
 		}
-		newWidth += DPIUtil.pointToPixel(INSET * 2, getZoom()) + DPIUtil.pointToPixel(VISTA_EXTRA, getZoom());
+		newWidth += Win32DPIUtils.pointToPixelAsSufficientlyLargeSize(INSET * 2, getZoom()) + DPIUtil.pointToPixel(VISTA_EXTRA, getZoom());
 		int oldWidth = (int)OS.SendMessage (handle, OS.LVM_GETCOLUMNWIDTH, 0, 0);
 		if (newWidth > oldWidth) {
 			setScrollWidth (newWidth);
@@ -6963,7 +6963,7 @@ LRESULT wmNotifyHeader (NMHDR hdr, long wParam, long lParam) {
 							}
 						}
 
-						int x = rects[i].left + DPIUtil.pointToPixel(INSET + 2, getZoom());
+						int x = rects[i].left + Win32DPIUtils.pointToPixelAsSufficientlyLargeSize(INSET + 2, getZoom());
 						if (columns[i].image != null) {
 							GCData data = new GCData();
 							data.device = display;
@@ -7304,7 +7304,7 @@ LRESULT wmNotifyToolTip (NMTTCUSTOMDRAW nmcd, long lParam) {
 						int zoom = getZoom();
 						rect = Win32DPIUtils.pixelToPoint(rect, zoom);
 						gc.drawImage (image, rect.x, rect.y, rect.width, rect.height, DPIUtil.pixelToPoint(x, zoom), DPIUtil.pixelToPoint(y, zoom), DPIUtil.pixelToPoint(size.x, zoom), DPIUtil.pixelToPoint(size.y, zoom));
-						x += size.x + DPIUtil.pointToPixel(INSET + (pinfo.iSubItem == 0 ? -2 : 4), zoom);
+						x += size.x + Win32DPIUtils.pointToPixelAsSufficientlyLargeSize(INSET + (pinfo.iSubItem == 0 ? -2 : 4), zoom);
 					} else {
 						x += DPIUtil.pointToPixel(INSET + 2, getZoom());
 					}

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TableItem.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TableItem.java
@@ -296,7 +296,7 @@ RECT getBounds (int row, int column, boolean getText, boolean getImage, boolean 
 					}
 				}
 				if (!getImage) rect.left = rect.right;
-				rect.right += width + DPIUtil.pointToPixel(Table.INSET * 2, getZoom());
+				rect.right += width + Win32DPIUtils.pointToPixelAsSufficientlyLargeSize(Table.INSET * 2, getZoom());
 			}
 		} else {
 			if (getText) {
@@ -373,7 +373,7 @@ RECT getBounds (int row, int column, boolean getText, boolean getImage, boolean 
 					iconRect.top = column;
 					iconRect.left = OS.LVIR_ICON;
 					if (OS.SendMessage (hwnd, OS. LVM_GETSUBITEMRECT, row, iconRect) != 0) {
-						rect.left = iconRect.right + DPIUtil.pointToPixel(Table.INSET / 2, getZoom());
+						rect.left = iconRect.right + Win32DPIUtils.pointToPixelAsSufficientlyLargeSize(Table.INSET / 2, getZoom());
 					}
 				}
 			} else {
@@ -400,7 +400,7 @@ RECT getBounds (int row, int column, boolean getText, boolean getImage, boolean 
 					char [] buffer = string.toCharArray ();
 					int flags = OS.DT_NOPREFIX | OS.DT_SINGLELINE | OS.DT_CALCRECT;
 					OS.DrawText (hDC, buffer, buffer.length, textRect, flags);
-					rect.right += textRect.right - textRect.left + DPIUtil.pointToPixel(Table.INSET * 3 + 2, getZoom());
+					rect.right += textRect.right - textRect.left + Win32DPIUtils.pointToPixelAsSufficientlyLargeSize(Table.INSET * 3 + 2, getZoom());
 				}
 			}
 		}
@@ -696,9 +696,9 @@ Rectangle getTextBoundsInPixels (int index) {
 	if (itemIndex == -1) return new Rectangle (0, 0, 0, 0);
 	RECT rect = getBounds (itemIndex, index, true, false, true);
 	rect.left += 2;
-	if (index != 0) rect.left += DPIUtil.pointToPixel(Table.INSET, getZoom());
+	if (index != 0) rect.left += Win32DPIUtils.pointToPixelAsSufficientlyLargeSize(Table.INSET, getZoom());
 	rect.left = Math.min (rect.left, rect.right);
-	rect.right = rect.right - DPIUtil.pointToPixel(Table.INSET, getZoom());
+	rect.right = rect.right - Win32DPIUtils.pointToPixelAsSufficientlyLargeSize(Table.INSET, getZoom());
 	int width = Math.max (0, rect.right - rect.left);
 	int height = Math.max (0, rect.bottom - rect.top);
 	return new Rectangle (rect.left, rect.top, width, height);

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Tree.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Tree.java
@@ -748,7 +748,7 @@ LRESULT CDDS_ITEMPOSTPAINT (NMTVCUSTOMDRAW nmcd, long wParam, long lParam) {
 						}
 					}
 				}
-				rect.left += DPIUtil.pointToPixel(INSET - 1, zoom) ;
+				rect.left += Win32DPIUtils.pointToPixelAsSufficientlyLargeSize(INSET - 1, zoom) ;
 				if (drawImage) {
 					Image image = null;
 					if (index == 0) {
@@ -757,8 +757,8 @@ LRESULT CDDS_ITEMPOSTPAINT (NMTVCUSTOMDRAW nmcd, long wParam, long lParam) {
 						Image [] images  = item.images;
 						if (images != null) image = images [index];
 					}
-					int inset = i != 0 ? DPIUtil.pointToPixel(INSET, zoom) : 0;
-					int offset = i != 0 ? DPIUtil.pointToPixel(INSET, zoom) : DPIUtil.pointToPixel(INSET + 2, zoom);
+					int inset = i != 0 ? Win32DPIUtils.pointToPixelAsSufficientlyLargeSize(INSET, zoom) : 0;
+					int offset = i != 0 ? Win32DPIUtils.pointToPixelAsSufficientlyLargeSize(INSET, zoom) : Win32DPIUtils.pointToPixelAsSufficientlyLargeSize(INSET + 2, zoom);
 					if (image != null) {
 						Rectangle bounds = image.getBounds (); // Points
 						if (size == null) size = Win32DPIUtils.pixelToPointAsSize (getImageSize (), zoom); // To Points
@@ -5488,7 +5488,7 @@ public void showColumn (TreeColumn column) {
 			SCROLLINFO info = new SCROLLINFO();
 			info.cbSize = SCROLLINFO.sizeof;
 			info.fMask = OS.SIF_POS;
-			info.nPos = Math.max(0, headerRect.left - DPIUtil.pointToPixel(INSET / 2, getZoom()));
+			info.nPos = Math.max(0, headerRect.left - Win32DPIUtils.pointToPixelAsSufficientlyLargeSize(INSET / 2, getZoom()));
 			OS.SetScrollInfo(hwndParent, OS.SB_HORZ, info, true);
 			setScrollWidth();
 		} else if (scrollBecauseRight) {
@@ -7930,7 +7930,7 @@ LRESULT wmNotifyHeader (NMHDR hdr, long wParam, long lParam) {
 							}
 						}
 
-						int x = rects[i].left + DPIUtil.pointToPixel(INSET + 2, getZoom());
+						int x = rects[i].left + Win32DPIUtils.pointToPixelAsSufficientlyLargeSize(INSET + 2, getZoom());
 						if (columns[i].image != null) {
 							GCData data = new GCData();
 							data.device = display;
@@ -8248,7 +8248,7 @@ LRESULT wmNotifyToolTip (NMTTCUSTOMDRAW nmcd, long lParam) {
 							data.background = OS.GetBkColor (nmcd.hdc);
 							data.font = Font.win32_new (display, hFont);
 							GC gc = createNewGC(nmcd.hdc, data);
-							int x = cellRect [0].left + DPIUtil.pointToPixel(INSET, getZoom());
+							int x = cellRect [0].left + Win32DPIUtils.pointToPixelAsSufficientlyLargeSize(INSET, getZoom());
 							if (index [0] != 0) x -= gridWidth;
 							Image image = item [0].getImage (index [0]);
 							if (image != null || index [0] == 0) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TreeItem.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TreeItem.java
@@ -440,7 +440,7 @@ RECT getBounds (int index, boolean getText, boolean getImage, boolean fullText, 
 		if (getImage && !fullImage) {
 			if (OS.SendMessage (hwnd, OS.TVM_GETIMAGELIST, OS.TVSIL_NORMAL, 0) != 0) {
 				Point size = parent.getImageSize ();
-				rect.left -= size.x + Tree.INSET;
+				rect.left -= size.x + Win32DPIUtils.pointToPixelAsSufficientlyLargeSize(Tree.INSET, getZoom());
 				if (!getText) rect.right = rect.left + size.x;
 			} else {
 				if (!getText) rect.right = rect.left;
@@ -492,7 +492,7 @@ RECT getBounds (int index, boolean getText, boolean getImage, boolean fullText, 
 			}
 			if (getText) {
 				if (fullText && clip) {
-					rect.left = rect.right + DPIUtil.pointToPixel(Tree.INSET, getZoom());
+					rect.left = rect.right + Win32DPIUtils.pointToPixelAsSufficientlyLargeSize(Tree.INSET, getZoom());
 					rect.right = headerRect.right;
 				} else {
 					String string = index == 0 ? text : strings != null ? strings [index] : null;
@@ -513,10 +513,10 @@ RECT getBounds (int index, boolean getText, boolean getImage, boolean fullText, 
 							OS.ReleaseDC (hwnd, hNewDC);
 						}
 						if (getImage) {
-							rect.right += textRect.right - textRect.left + DPIUtil.pointToPixel(Tree.INSET * 3, getZoom());
+							rect.right += textRect.right - textRect.left + Win32DPIUtils.pointToPixelAsSufficientlyLargeSize(Tree.INSET * 3, getZoom());
 						} else {
-							rect.left = rect.right + DPIUtil.pointToPixel(Tree.INSET, getZoom());
-							rect.right = rect.left + (textRect.right - textRect.left) + DPIUtil.pointToPixel(Tree.INSET, getZoom());
+							rect.left = rect.right + Win32DPIUtils.pointToPixelAsSufficientlyLargeSize(Tree.INSET, getZoom());
+							rect.right = rect.left + (textRect.right - textRect.left) + Win32DPIUtils.pointToPixelAsSufficientlyLargeSize(Tree.INSET, getZoom());
 						}
 					}
 				}
@@ -915,7 +915,7 @@ Rectangle getTextBoundsInPixels (int index) {
 	if (!parent.checkData (this, true)) error (SWT.ERROR_WIDGET_DISPOSED);
 	RECT rect = getBounds (index, true, false, true);
 	rect.left = Math.min (rect.left, rect.right);
-	rect.right = rect.right + DPIUtil.pointToPixel(Tree.INSET, getZoom()); // Add INSET margin to avoid truncation of text seen with "Segoe UI" font
+	rect.right = rect.right + Win32DPIUtils.pointToPixelAsSufficientlyLargeSize(Tree.INSET, getZoom()); // Add INSET margin to avoid truncation of text seen with "Segoe UI" font
 	int width = Math.max (0, rect.right - rect.left);
 	int height = Math.max (0, rect.bottom - rect.top);
 	return new Rectangle (rect.left, rect.top, width, height);


### PR DESCRIPTION
When computing the sizes for buttons, table and tree items, some magic values for spaces defined as point values are used. As the size computation is done in pixels, they are converted to pixel values. As they need to be rounded, they may become too small when converted to pixels.

This change adapts according places to always round such values up, so that spaces are large enough. That conforms to what we already did for actual computeSize() methods to ensure that sufficient space is provided for controls.

Note that for the table implementation, the change is effectively a no-op right now, as the INSET value of `4` will be an integer value for every fractional "quarter" zoom, so that the used rounding method is irrelevant. It is just adapted for the sake of consistency and to be prepared for the case that this value may be changed at some point in the future.

This also reverts the following change which accidentally used point values in a pixel context:
- https://github.com/eclipse-platform/eclipse.platform.swt/pull/2731

### Before
At 175% zoom:
<img width="444" height="495" alt="image" src="https://github.com/user-attachments/assets/a26d96eb-07fb-4335-9611-e13284f5934a" />

### After
At 175% zoom:
<img width="443" height="496" alt="image" src="https://github.com/user-attachments/assets/82626211-f31b-4894-9eca-86928d366dec" />
