### PR TITLE
Make "SWT Matrix Tests" badge the current one

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![SWT Matrix Build](https://github.com/eclipse-platform/eclipse.platform.swt/actions/workflows/maven.yml/badge.svg)](https://github.com/eclipse-platform/eclipse.platform.swt/actions/workflows/maven.yml)
 [![Publish Unit Test Results](https://github.com/eclipse-platform/eclipse.platform.swt/actions/workflows/junit.yml/badge.svg)](https://github.com/eclipse-platform/eclipse.platform.swt/actions/workflows/junit.yml)
-![SWT Matrix Tests](https://gist.githubusercontent.com/eclipse-releng-bot/78d110a601baa4ef777ccb472f584038/raw/71510599eb84e852f3e135aa7a3ddf33854ca716/badge.svg)
+![SWT Matrix Tests](https://gist.githubusercontent.com/eclipse-releng-bot/78d110a601baa4ef777ccb472f584038/raw/badge.svg)
 [![License](https://img.shields.io/github/license/eclipse-platform/eclipse.platform)](https://github.com/eclipse-platform/eclipse.platform.swt/blob/master/LICENSE)
 
 # About


### PR DESCRIPTION
As part of working on https://github.com/eclipse-platform/eclipse.platform.swt/pull/2764 I was considering how to display badges going forward to align with test results per platform. As it turns out the "SWT Matrix Tests" has been stuck on an arbitrary old badge for many years now.

This PR updates it, but as it has been wrong for a long time, perhaps removing it entirely makes more sense, but for now I update it. There was push back in https://github.com/eclipse-platform/eclipse.platform.swt/pull/1897 against removing it.

Part of https://github.com/eclipse-platform/eclipse.platform.swt/issues/2714