### PR TITLE
[GTK] Simplify _setBackground() and _setForeground() in Control widget

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Control.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Control.java
@@ -5187,21 +5187,17 @@ private void _setBackground (Color color) {
 	if (color != null && color.isDisposed ()) {
 		error(SWT.ERROR_INVALID_ARGUMENT);
 	}
-	boolean set = false;
 	GdkRGBA rgba = null;
 	if (color != null) {
 		rgba = color.handle;
 		backgroundAlpha = color.getAlpha();
 	}
-	set = true;
-	if (set) {
-		if (color == null) {
-			state &= ~BACKGROUND;
-		} else {
-			state |= BACKGROUND;
-		}
-		setBackgroundGdkRGBA (rgba);
+	if (color == null) {
+		state &= ~BACKGROUND;
+	} else {
+		state |= BACKGROUND;
 	}
+	setBackgroundGdkRGBA (rgba);
 	redrawChildren ();
 }
 
@@ -5539,8 +5535,7 @@ public void setForeground (Color color) {
 	if (color != null && color.isDisposed ()) {
 		error(SWT.ERROR_INVALID_ARGUMENT);
 	}
-	boolean set = false;
-	set = !getForeground().equals(color);
+	boolean set = !getForeground().equals(color);
 	if (set) {
 		if (color == null) {
 			state &= ~FOREGROUND;


### PR DESCRIPTION
The local variable "set" is always set to true in _setBackground() and is therefore redundant. This is because some widgets might have a default color, so it must always be set.

For _setForeground(), the initial value of the local variable is immediately overridden and can therefore be skipped as well.