### PR TITLE
Improve ImageDataAtSizeProvider for zoom-based use case

### DIFF
--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_GC.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_GC.java
@@ -441,17 +441,7 @@ public void test_drawImageLorg_eclipse_swt_graphics_ImageIIII_ImageDataProvider(
 
 @Test
 public void test_drawImageLorg_eclipse_swt_graphics_ImageIIII_ImageDataAtSizeProvider_invalid() {
-	ImageDataAtSizeProvider provider = new ImageDataAtSizeProvider() {
-		@Override
-		public ImageData getImageData(int zoom) {
-			return new ImageData(1 * zoom / 100, 1 * zoom / 100, 32, new PaletteData(0xFF0000, 0xFF00, 0xFF));
-		}
-
-		@Override
-		public ImageData getImageData(int width, int height) {
-			return null;
-		}
-	};
+	ImageDataAtSizeProvider provider = (width, height) -> null;
 	Image image = new Image(display, provider);
 	Image drawToImage = new Image(display, 1, 1);
 	try {
@@ -474,26 +464,19 @@ public void test_drawImageLorg_eclipse_swt_graphics_ImageIIII_ImageDataAtSizePro
 	gc.setAntialias(SWT.OFF);
 	RGB drawnRgb = new RGB(255, 255, 255);
 	RGB undrawnRgb = new RGB(0, 0, 0);
-	ImageDataAtSizeProvider imageDataAtSizeProvider = new ImageDataAtSizeProvider() {
-		@Override
-		public ImageData getImageData(int width, int height) {
-			PaletteData palette = new PaletteData(0xFF0000, 0xFF00, 0xFF);
-			int drawnPixel = palette.getPixel(drawnRgb);
-			ImageData imageData = new ImageData(width, height, 32, palette);
-			for (int i = 0; i < width; i++) {
-				imageData.setPixel(i, 0, drawnPixel);
-				imageData.setPixel(i, height - 1, drawnPixel);
-			}
-			for (int i = 0; i < height; i++) {
-				imageData.setPixel(0, i, drawnPixel);
-				imageData.setPixel(width - 1, i, drawnPixel);
-			}
-			return imageData;
+	ImageDataAtSizeProvider imageDataAtSizeProvider = (width1, height1) -> {
+		PaletteData palette = new PaletteData(0xFF0000, 0xFF00, 0xFF);
+		int drawnPixel = palette.getPixel(drawnRgb);
+		ImageData imageData = new ImageData(width1, height1, 32, palette);
+		for (int i = 0; i < width1; i++) {
+			imageData.setPixel(i, 0, drawnPixel);
+			imageData.setPixel(i, height1 - 1, drawnPixel);
 		}
-		@Override
-		public ImageData getImageData(int zoom) {
-			return new ImageData(1 * zoom / 100, 1 * zoom / 100, 32, new PaletteData(0xFF0000, 0xFF00, 0xFF));
+		for (int i = 0; i < height1; i++) {
+			imageData.setPixel(0, i, drawnPixel);
+			imageData.setPixel(width1 - 1, i, drawnPixel);
 		}
+		return imageData;
 	};
 	Image image = styleImage(new Image(display, imageDataAtSizeProvider), styleFlag);
 

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_Image.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_Image.java
@@ -42,10 +42,12 @@ import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.GC;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.graphics.ImageData;
+import org.eclipse.swt.graphics.ImageDataAtSizeProvider;
 import org.eclipse.swt.graphics.ImageDataProvider;
 import org.eclipse.swt.graphics.ImageFileNameProvider;
 import org.eclipse.swt.graphics.ImageGcDrawer;
 import org.eclipse.swt.graphics.PaletteData;
+import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.graphics.RGB;
 import org.eclipse.swt.graphics.Rectangle;
 import org.eclipse.swt.internal.DPIUtil;
@@ -428,6 +430,25 @@ public void test_ConstructorLorg_eclipse_swt_graphics_Device_ImageDataProvider()
 		return null;
 	};
 	image = new Image(display, provider4);
+	image.dispose();
+}
+
+@Test
+public void test_ConstructorLorg_eclipse_swt_graphics_Device_ImageDataAtSizeProvider() {
+	int imageSize = 10;
+	ImageDataAtSizeProvider provider = new ImageDataAtSizeProvider() {
+		@Override
+		public Point getDefaultSize() {
+			return new Point(imageSize, imageSize);
+		}
+		@Override
+		public ImageData getImageData(int width, int height) {
+			return new ImageData(width, height, 32, new PaletteData(0xFF0000, 0xFF00, 0xFF));
+		}
+	};
+	Image image = new Image(display, provider);
+	assertEquals(imageSize, image.getBounds().width);
+	assertEquals(imageSize * 2, image.getImageData(200).width);
 	image.dispose();
 }
 


### PR DESCRIPTION
The ImageDataAtSizeProvider so far required a custom implementation of the existing getImageData(zoom) method, even though in many use cases the image data are only retrieved at specified size and not a specified zoom. This change extends the implementation such a default size can be provided and the size-based retrieval is automatically called with that default size when calling the zoom-based retrieval method. This relieves interface implementations from providing a custom implementation of the zoom-based retrieval method.

In addition, a default implementation for the zoom-based data retrieval and the default size specification is added, such that for those use cases where image data will not retrieved at zoom at all, dummy data are returned to reduce potential overheads of creating unnecessary data. This allows to treat the interface as a functional interface that can be implemented as a lambda, as only a single method for which an implementation is required remains.

Finally, the contract of the interface is extended to explain the intended use cases for the interface.