### PR TITLE
Quick fix for print exception of Snippet 292

### DIFF
--- a/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet292.java
+++ b/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet292.java
@@ -54,7 +54,10 @@ public class Snippet292 {
 		button.setText ("Snapshot");
 		button.addListener (SWT.Selection, e -> {
 			Image image = label.getImage ();
-			if (image != null) image.dispose ();
+			if (image != null) {
+				label.setImage(null);
+				image.dispose ();
+			}
 			Rectangle rect = group.getBounds();
 			image = new Image (display, rect.width, rect.height);
 			GC gc = new GC (image);


### PR DESCRIPTION
This PR results from the expected behavior of the print in Snippet 292 to redraw the control to the GC by clicking the button.

The problem is that after the first click, the label points to the image, where the group printed itself into it via the GC. Clicking a second time, the image gets disposed. Hence, when the group wants to prints again, the label cannot print its image, as it was disposed.

The quick fix for it is to force the label not pointing to the image, if it has one.

The question why the label is invoked to print its image, whereby not being in the hierarchy of the control (the group) is likely to be connected to an undocumented flag "OS.PW_RENDERFULLCONTENT" in OS.printWindow() which leads back to
https://github.com/eclipse-platform/eclipse.platform.swt/issues/373.