### PR TITLE
Adapt usages in SWT to new GC#drawImage API

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CLabel.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CLabel.java
@@ -574,8 +574,7 @@ void onPaint(PaintEvent event) {
 
 	// draw the image
 	if (img != null) {
-		gc.drawImage(img, 0, 0, imageRect.width, imageHeight,
-						x, imageY, imageRect.width, imageHeight);
+		gc.drawImage(img, x, imageY, imageRect.width, imageHeight);
 		x +=  imageRect.width + GAP;
 		extent.x -= imageRect.width + GAP;
 	}

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/ImageData.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/ImageData.java
@@ -2616,34 +2616,30 @@ static void fillGradientRectangle(GC gc, Device device,
 	RGB fromRGB, RGB toRGB,
 	int redBits, int greenBits, int blueBits, int zoom) {
 	/* Create the bitmap and tile it */
-	ImageDataProvider imageDataProvider = imageZoom -> {
-		int scaledWidth = DPIUtil.pointToPixel(width, imageZoom);
-		int scaledHeight = DPIUtil.pointToPixel(height, imageZoom);
-		return createGradientBand(scaledWidth, scaledHeight, vertical, fromRGB, toRGB, redBits, greenBits,
+
+	ImageDataAtSizeProvider imageDataAtSizeProvider = (imageWidth, imageHeight) -> {
+		return createGradientBand(imageWidth, imageHeight, vertical, fromRGB, toRGB, redBits, greenBits,
 				blueBits);
 	};
-	Image image = new Image(device, imageDataProvider);
+	Image image = new Image(device, imageDataAtSizeProvider);
 	ImageData band = image.getImageData(zoom);
 	if ((band.width == 1) || (band.height == 1)) {
-			gc.drawImage(image, 0, 0, DPIUtil.pixelToPoint(band.width, zoom), DPIUtil.pixelToPoint(band.height, zoom),
-					DPIUtil.pixelToPoint(x, zoom), DPIUtil.pixelToPoint(y, zoom), DPIUtil.pixelToPoint(width, zoom),
-					DPIUtil.pixelToPoint(height, zoom));
+		gc.drawImage(image, DPIUtil.pixelToPoint(x, zoom), DPIUtil.pixelToPoint(y, zoom),
+				DPIUtil.pixelToPoint(width, zoom), DPIUtil.pixelToPoint(height, zoom));
 		} else {
 		if (vertical) {
 			for (int dx = 0; dx < width; dx += band.width) {
 				int blitWidth = width - dx;
 				if (blitWidth > band.width) blitWidth = band.width;
-					gc.drawImage(image, 0, 0, DPIUtil.pixelToPoint(blitWidth, zoom), DPIUtil.pixelToPoint(band.height, zoom),
-							DPIUtil.pixelToPoint(dx + x, zoom), DPIUtil.pixelToPoint(y, zoom), DPIUtil.pixelToPoint(blitWidth, zoom),
-							DPIUtil.pixelToPoint(band.height, zoom));
+				gc.drawImage(image, DPIUtil.pixelToPoint(dx + x, zoom), DPIUtil.pixelToPoint(y, zoom),
+						DPIUtil.pixelToPoint(blitWidth, zoom), DPIUtil.pixelToPoint(band.height, zoom));
 				}
 		} else {
 			for (int dy = 0; dy < height; dy += band.height) {
 				int blitHeight = height - dy;
 				if (blitHeight > band.height) blitHeight = band.height;
-					gc.drawImage(image, 0, 0, DPIUtil.pixelToPoint(band.width, zoom), DPIUtil.pixelToPoint(blitHeight, zoom),
-							DPIUtil.pixelToPoint(x, zoom), DPIUtil.pixelToPoint(dy + y, zoom), DPIUtil.pixelToPoint(band.width, zoom),
-							DPIUtil.pixelToPoint(blitHeight, zoom));
+				gc.drawImage(image, DPIUtil.pixelToPoint(x, zoom), DPIUtil.pixelToPoint(dy + y, zoom),
+						DPIUtil.pixelToPoint(band.width, zoom), DPIUtil.pixelToPoint(blitHeight, zoom));
 				}
 		}
 	}

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Table.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Table.java
@@ -7302,8 +7302,7 @@ LRESULT wmNotifyToolTip (NMTTCUSTOMDRAW nmcd, long lParam) {
 						Point size = imageList == null ? new Point (rect.width, rect.height) : Win32DPIUtils.pointToPixelAsSize(imageList.getImageSize(), getZoom());
 						int y = imageRect.top + Math.max (0, (imageRect.bottom - imageRect.top - size.y) / 2);
 						int zoom = getZoom();
-						rect = Win32DPIUtils.pixelToPoint(rect, zoom);
-						gc.drawImage (image, rect.x, rect.y, rect.width, rect.height, DPIUtil.pixelToPoint(x, zoom), DPIUtil.pixelToPoint(y, zoom), DPIUtil.pixelToPoint(size.x, zoom), DPIUtil.pixelToPoint(size.y, zoom));
+						gc.drawImage (image, DPIUtil.pixelToPoint(x, zoom), DPIUtil.pixelToPoint(y, zoom), DPIUtil.pixelToPoint(size.x, zoom), DPIUtil.pixelToPoint(size.y, zoom));
 						x += size.x + INSET + (pinfo.iSubItem == 0 ? -2 : 4);
 					} else {
 						x += INSET + 2;

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Tree.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Tree.java
@@ -522,7 +522,6 @@ LRESULT CDDS_ITEMPOSTPAINT (NMTVCUSTOMDRAW nmcd, long wParam, long lParam) {
 								if (images != null) image = images [index];
 							}
 							if (image != null) {
-								Rectangle bounds = image.getBounds (); // Points
 								if (size == null) size = Win32DPIUtils.pixelToPointAsSize (getImageSize (), zoom); // To Points
 								if (!ignoreDrawForeground) {
 									GCData data = new GCData();
@@ -530,7 +529,7 @@ LRESULT CDDS_ITEMPOSTPAINT (NMTVCUSTOMDRAW nmcd, long wParam, long lParam) {
 									GC gc = createNewGC(hDC, data);
 									RECT iconRect = item.getBounds (index, false, true, false, false, true, hDC); // Pixels
 									gc.setClipping (Win32DPIUtils.pixelToPoint(new Rectangle(iconRect.left, iconRect.top, iconRect.right - iconRect.left, iconRect.bottom - iconRect.top), zoom));
-									gc.drawImage (image, 0, 0, bounds.width, bounds.height, DPIUtil.pixelToPoint(iconRect.left, zoom), DPIUtil.pixelToPoint(iconRect.top, zoom), size.x, size.y);
+									gc.drawImage (image, DPIUtil.pixelToPoint(iconRect.left, zoom), DPIUtil.pixelToPoint(iconRect.top, zoom), size.x, size.y);
 									OS.SelectClipRgn (hDC, 0);
 									gc.dispose ();
 								}
@@ -760,7 +759,6 @@ LRESULT CDDS_ITEMPOSTPAINT (NMTVCUSTOMDRAW nmcd, long wParam, long lParam) {
 					int inset = i != 0 ? INSET : 0;
 					int offset = i != 0 ? INSET : INSET + 2;
 					if (image != null) {
-						Rectangle bounds = image.getBounds (); // Points
 						if (size == null) size = Win32DPIUtils.pixelToPointAsSize (getImageSize (), zoom); // To Points
 						if (!ignoreDrawForeground) {
 							//int y1 = rect.top + (index == 0 ? (getItemHeight () - size.y) / 2 : 0);
@@ -770,7 +768,7 @@ LRESULT CDDS_ITEMPOSTPAINT (NMTVCUSTOMDRAW nmcd, long wParam, long lParam) {
 							data.device = display;
 							GC gc = createNewGC(hDC, data);
 							gc.setClipping (Win32DPIUtils.pixelToPoint(new Rectangle(x1, rect.top, rect.right - x1, rect.bottom - rect.top), zoom));
-							gc.drawImage (image, 0, 0, bounds.width, bounds.height, DPIUtil.pixelToPoint(x1, zoom), DPIUtil.pixelToPoint(y1, zoom), size.x, size.y);
+							gc.drawImage (image, DPIUtil.pixelToPoint(x1, zoom), DPIUtil.pixelToPoint(y1, zoom), size.x, size.y);
 							OS.SelectClipRgn (hDC, 0);
 							gc.dispose ();
 						}
@@ -8256,9 +8254,8 @@ LRESULT wmNotifyToolTip (NMTTCUSTOMDRAW nmcd, long lParam) {
 								RECT imageRect = item [0].getBounds (index [0], false, true, false, false, false, hDC);
 								if (imageList == null) size.x = imageRect.right - imageRect.left;
 								if (image != null) {
-									Rectangle rect = image.getBounds (); // Points
 									int zoom = getZoom();
-									gc.drawImage (image, rect.x, rect.y, rect.width, rect.height, DPIUtil.pixelToPoint(x, zoom), DPIUtil.pixelToPoint(imageRect.top, zoom), DPIUtil.pixelToPoint(size.x, zoom), DPIUtil.pixelToPoint(size.y, zoom));
+									gc.drawImage (image, DPIUtil.pixelToPoint(x, zoom), DPIUtil.pixelToPoint(imageRect.top, zoom), DPIUtil.pixelToPoint(size.x, zoom), DPIUtil.pixelToPoint(size.y, zoom));
 									x += INSET + (index [0] == 0 ? 1 : 0);
 								}
 								x += size.x;

--- a/examples/org.eclipse.swt.examples/src/org/eclipse/swt/examples/accessibility/CTableColumn.java
+++ b/examples/org.eclipse.swt.examples/src/org/eclipse/swt/examples/accessibility/CTableColumn.java
@@ -507,8 +507,6 @@ void paint (GC gc) {
 		int drawHeight = Math.min (imageBounds.height, headerHeight - 2 * padding);
 		gc.drawImage (
 			super.getImage (),
-			0, 0,
-			imageBounds.width, imageBounds.height,
 			startX, (headerHeight - drawHeight) / 2,
 			imageBounds.width, drawHeight);
 		startX += imageBounds.width + CTable.MARGIN_IMAGE;

--- a/examples/org.eclipse.swt.examples/src/org/eclipse/swt/examples/accessibility/CTableItem.java
+++ b/examples/org.eclipse.swt.examples/src/org/eclipse/swt/examples/accessibility/CTableItem.java
@@ -1448,13 +1448,8 @@ boolean paint (GC gc, CTableColumn column, boolean backgroundOnly) {
 
 		/* draw the image */
 		if (image != null) {
-			Rectangle imageBounds = image.getBounds ();
-			gc.drawImage (
-				image,
-				0, 0,									/* source x, y */
-				imageBounds.width, imageBounds.height,	/* source width, height */
-				imageArea.x, imageArea.y,				/* dest x, y */
-				imageArea.width, imageArea.height);		/* dest width, height */
+			gc.drawImage(image, imageArea.x, imageArea.y, /* dest x, y */
+					imageArea.width, imageArea.height); /* dest width, height */
 		}
 
 		/* draw the text */

--- a/examples/org.eclipse.swt.examples/src/org/eclipse/swt/examples/browserexample/BrowserExample.java
+++ b/examples/org.eclipse.swt.examples/src/org/eclipse/swt/examples/browserexample/BrowserExample.java
@@ -28,7 +28,6 @@ import org.eclipse.swt.browser.VisibilityWindowListener;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.graphics.ImageData;
 import org.eclipse.swt.graphics.Point;
-import org.eclipse.swt.graphics.Rectangle;
 import org.eclipse.swt.layout.FillLayout;
 import org.eclipse.swt.layout.FormAttachment;
 import org.eclipse.swt.layout.FormData;
@@ -189,10 +188,9 @@ public class BrowserExample {
 			data.right = new FormAttachment(100, -5);
 			canvas.setLayoutData(data);
 
-			final Rectangle rect = images[0].getBounds();
 			canvas.addListener(SWT.Paint, e -> {
 				Point pt = ((Canvas)e.widget).getSize();
-				e.gc.drawImage(images[index], 0, 0, rect.width, rect.height, 0, 0, pt.x, pt.y);
+				e.gc.drawImage(images[index], 0, 0, pt.x, pt.y);
 			});
 			canvas.addListener(SWT.MouseDown, e -> browser.setUrl(getResourceString("Startup")));
 

--- a/examples/org.eclipse.swt.examples/src/org/eclipse/swt/examples/graphics/AdvancedGraphics.java
+++ b/examples/org.eclipse.swt.examples/src/org/eclipse/swt/examples/graphics/AdvancedGraphics.java
@@ -77,7 +77,7 @@ public class AdvancedGraphics {
 			tr.translate(rect.width / 4, rect.height / 2);
 			tr.rotate(-30);
 			if (image != null) {
-				gc.drawImage(image, 0, 0, rect.width, rect.height, 0, 0, rect.width, rect.height);
+				gc.drawImage(image, 0, 0);
 			}
 			gc.setAlpha(100);
 			gc.setTransform(tr);

--- a/examples/org.eclipse.swt.examples/src/org/eclipse/swt/examples/graphics/AlphaTab.java
+++ b/examples/org.eclipse.swt.examples/src/org/eclipse/swt/examples/graphics/AlphaTab.java
@@ -14,8 +14,13 @@
 
 package org.eclipse.swt.examples.graphics;
 
-import org.eclipse.swt.*;
-import org.eclipse.swt.graphics.*;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.graphics.Device;
+import org.eclipse.swt.graphics.Font;
+import org.eclipse.swt.graphics.GC;
+import org.eclipse.swt.graphics.Image;
+import org.eclipse.swt.graphics.Path;
+import org.eclipse.swt.graphics.Point;
 
 /**
  * This tab demonstrates alpha blending. It draws various shapes and images as
@@ -104,21 +109,16 @@ public class AlphaTab extends AnimatedGraphicsTab {
 			alphaImg2 = GraphicsExample.loadImage(device, GraphicsExample.class, "alpha_img2.png");
 		}
 
-		Rectangle rect = alphaImg1.getBounds();
 
 		gc.setAlpha(alphaValue);
-		gc.drawImage(alphaImg1, rect.x, rect.y, rect.width, rect.height,
-				width/2, height/2, width/4, height/4);
+		gc.drawImage(alphaImg1, width / 2, height / 2, width / 4, height / 4);
 
-		gc.drawImage(alphaImg1, rect.x, rect.y, rect.width, rect.height,
-				0, 0, width/4, height/4);
+		gc.drawImage(alphaImg1, 0, 0, width / 4, height / 4);
 
-		gc.setAlpha(255-alphaValue);
-		gc.drawImage(alphaImg2, rect.x, rect.y, rect.width, rect.height,
-				width/2, 0, width/4, height/4);
+		gc.setAlpha(255 - alphaValue);
+		gc.drawImage(alphaImg2, width / 2, 0, width / 4, height / 4);
 
-		gc.drawImage(alphaImg2, rect.x, rect.y, rect.width, rect.height,
-				0, 3*height/4, width/4, height/4);
+		gc.drawImage(alphaImg2, 0, 3 * height / 4, width / 4, height / 4);
 
 		// pentagon
 		gc.setBackground(device.getSystemColor(SWT.COLOR_DARK_MAGENTA));

--- a/examples/org.eclipse.swt.examples/src/org/eclipse/swt/examples/graphics/GraphicsExample.java
+++ b/examples/org.eclipse.swt.examples/src/org/eclipse/swt/examples/graphics/GraphicsExample.java
@@ -328,7 +328,7 @@ static Image createThumbnail(Device device, String name) {
 		result = new Image(device, 16, 16);
 		GC gc = new GC(result);
 		Rectangle dest = result.getBounds();
-		gc.drawImage(image, src.x, src.y, src.width, src.height, dest.x, dest.y, dest.width, dest.height);
+		gc.drawImage(image, dest.x, dest.y, dest.width, dest.height);
 		gc.dispose();
 	}
 	if (result != null) {

--- a/examples/org.eclipse.swt.examples/src/org/eclipse/swt/examples/graphics/ImageScaleTab.java
+++ b/examples/org.eclipse.swt.examples/src/org/eclipse/swt/examples/graphics/ImageScaleTab.java
@@ -14,7 +14,10 @@
 
 package org.eclipse.swt.examples.graphics;
 
-import org.eclipse.swt.graphics.*;
+import org.eclipse.swt.graphics.Device;
+import org.eclipse.swt.graphics.GC;
+import org.eclipse.swt.graphics.Image;
+import org.eclipse.swt.graphics.Rectangle;
 
 /**
  * This tab demonstrates how an image can be scaled.
@@ -45,9 +48,8 @@ public void paint(GC gc, int width, int height) {
 	Device device = gc.getDevice();
 	Image image = GraphicsExample.loadImage(device, GraphicsExample.class, "houses.png");
 
-	Rectangle bounds = image.getBounds();
 	Rectangle canvasBounds = example.canvas.getBounds();
-	gc.drawImage(image, 0, 0, bounds.width, bounds.height, 0, 0, canvasBounds.width, canvasBounds.height);
+	gc.drawImage(image, 0, 0, canvasBounds.width, canvasBounds.height);
 
 	image.dispose();
 }

--- a/examples/org.eclipse.swt.examples/src/org/eclipse/swt/examples/graphics/IntroTab.java
+++ b/examples/org.eclipse.swt.examples/src/org/eclipse/swt/examples/graphics/IntroTab.java
@@ -13,10 +13,17 @@
  *******************************************************************************/
 package org.eclipse.swt.examples.graphics;
 
-import java.util.*;
+import java.util.Random;
 
-import org.eclipse.swt.*;
-import org.eclipse.swt.graphics.*;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.graphics.Device;
+import org.eclipse.swt.graphics.Font;
+import org.eclipse.swt.graphics.FontData;
+import org.eclipse.swt.graphics.GC;
+import org.eclipse.swt.graphics.Image;
+import org.eclipse.swt.graphics.Path;
+import org.eclipse.swt.graphics.Point;
+import org.eclipse.swt.graphics.Rectangle;
 
 public class IntroTab extends AnimatedGraphicsTab {
 
@@ -96,8 +103,7 @@ public void paint(GC gc, int width, int height) {
 	Path path = new Path(device);
 	path.addString(text, x, y, font);
 	gc.setClipping(path);
-	Rectangle rect = image.getBounds();
-	gc.drawImage(image, 0, 0, rect.width, rect.height, 0, 0, width, height);
+	gc.drawImage(image, 0, 0, width, height);
 	gc.setClipping((Rectangle)null);
 	gc.setForeground(device.getSystemColor(SWT.COLOR_BLUE));
 	gc.drawPath(path);

--- a/examples/org.eclipse.swt.examples/src/org/eclipse/swt/examples/imageanalyzer/ImageAnalyzer.java
+++ b/examples/org.eclipse.swt.examples/src/org/eclipse/swt/examples/imageanalyzer/ImageAnalyzer.java
@@ -936,10 +936,6 @@ public class ImageAnalyzer {
 								imageData = event.imageData;
 								imageCanvasGC.drawImage(
 									image,
-									0,
-									0,
-									imageData.width,
-									imageData.height,
 									imageData.x,
 									imageData.y,
 									imageData.width,
@@ -1186,10 +1182,6 @@ public class ImageAnalyzer {
 					Image printerImage = new Image(printer, imageData);
 					gc.drawImage(
 						printerImage,
-						0,
-						0,
-						imageData.width,
-						imageData.height,
 						-trim.x,
 						-trim.y,
 						scaleFactor * imageData.width,
@@ -1463,10 +1455,6 @@ public class ImageAnalyzer {
 			// Draw the current image onto the off-screen image.
 			offScreenImageGC.drawImage(
 				image,
-				0,
-				0,
-				imageData.width,
-				imageData.height,
 				imageData.x,
 				imageData.y,
 				imageData.width,
@@ -1491,16 +1479,7 @@ public class ImageAnalyzer {
 						imageData.height);
 				} else if (imageData.disposalMethod == SWT.DM_FILL_PREVIOUS) {
 					// Restore the previous image before drawing.
-					offScreenImageGC.drawImage(
-						image,
-						0,
-						0,
-						imageData.width,
-						imageData.height,
-						imageData.x,
-						imageData.y,
-						imageData.width,
-						imageData.height);
+					offScreenImageGC.drawImage(image, imageData.x, imageData.y, imageData.width, imageData.height);
 				}
 
 				// Get the next image data.
@@ -1511,15 +1490,7 @@ public class ImageAnalyzer {
 
 				// Draw the new image data.
 				offScreenImageGC.drawImage(
-					image,
-					0,
-					0,
-					imageData.width,
-					imageData.height,
-					imageData.x,
-					imageData.y,
-					imageData.width,
-					imageData.height);
+						image, imageData.x, imageData.y, imageData.width, imageData.height);
 
 				// Draw the off-screen image to the screen.
 				imageCanvasGC.drawImage(offScreenImage, 0, 0);
@@ -1780,10 +1751,6 @@ public class ImageAnalyzer {
 		/* Draw the image */
 		gc.drawImage(
 			paintImage,
-			0,
-			0,
-			imageData.width,
-			imageData.height,
 			ix + imageData.x,
 			iy + imageData.y,
 			w,
@@ -1795,10 +1762,6 @@ public class ImageAnalyzer {
 			Image maskImage = new Image(display, maskImageData);
 			gc.drawImage(
 				maskImage,
-				0,
-				0,
-				imageData.width,
-				imageData.height,
 				w + 10 + ix + imageData.x,
 				iy + imageData.y,
 				w,

--- a/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet10.java
+++ b/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet10.java
@@ -43,7 +43,7 @@ public class Snippet10 {
 			Transform tr = new Transform(display);
 			tr.translate(50, 120);
 			tr.rotate(-30);
-			gc1.drawImage(image, 0, 0, rect.width, rect.height, 0, 0, rect.width / 2, rect.height / 2);
+			gc1.drawImage(image, 0, 0, rect.width / 2, rect.height / 2);
 			gc1.setAlpha(100);
 			gc1.setTransform(tr);
 			Path path = new Path(display);

--- a/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet141.java
+++ b/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet141.java
@@ -72,10 +72,6 @@ public class Snippet141 {
 								image = new Image(display, imageData);
 								offScreenImageGC.drawImage(
 									image,
-									0,
-									0,
-									imageData.width,
-									imageData.height,
 									imageData.x,
 									imageData.y,
 									imageData.width,
@@ -97,16 +93,8 @@ public class Snippet141 {
 										break;
 									case SWT.DM_FILL_PREVIOUS:
 										/* Restore the previous image before drawing. */
-										offScreenImageGC.drawImage(
-											image,
-											0,
-											0,
-											imageData.width,
-											imageData.height,
-											imageData.x,
-											imageData.y,
-											imageData.width,
-											imageData.height);
+										offScreenImageGC.drawImage(image, imageData.x, imageData.y, imageData.width,
+												imageData.height);
 										break;
 									}
 
@@ -114,16 +102,8 @@ public class Snippet141 {
 									imageData = imageDataArray[imageDataIndex];
 									image.dispose();
 									image = new Image(display, imageData);
-									offScreenImageGC.drawImage(
-										image,
-										0,
-										0,
-										imageData.width,
-										imageData.height,
-										imageData.x,
-										imageData.y,
-										imageData.width,
-										imageData.height);
+									offScreenImageGC.drawImage(image, imageData.x, imageData.y, imageData.width,
+											imageData.height);
 
 									/* Draw the off-screen image to the shell. */
 									shellGC.drawImage(offScreenImage, 0, 0);

--- a/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet180.java
+++ b/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet180.java
@@ -47,9 +47,8 @@ public static void main(String[] args) {
 	//define the shape of the shell using setRegion
 	shell.setRegion(region);
 	shell.addPaintListener(e -> {
-		Rectangle bounds = image.getBounds();
 		Point size = shell.getSize();
-		e.gc.drawImage(image, 0, 0, bounds.width, bounds.height, 10, 10, size.x-20, size.y-20);
+		e.gc.drawImage(image, 10, 10, size.x-20, size.y-20);
 	});
 	shell.addListener(SWT.KeyDown, e -> {
 		if (e.character == SWT.ESC) {

--- a/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet288.java
+++ b/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet288.java
@@ -124,19 +124,11 @@ public class Snippet288 {
 							0,
 							0,
 							fullWidth,
-							fullHeight,
-							0,
-							0,
-							fullWidth,
 							fullHeight);
 						break;
 					}
 					Image newFrame = new Image(display, imageData);
 					gc.drawImage(newFrame,
-							0,
-							0,
-							imageData.width,
-							imageData.height,
 							imageData.x,
 							imageData.y,
 							imageData.width,

--- a/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet355.java
+++ b/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet355.java
@@ -33,9 +33,9 @@ public class Snippet355 {
 			int height = rect.height;
 			GC gc = e.gc;
 			int x = 10, y = 10;
-			gc.drawImage (image, 0, 0, width, height, x, y, width, height);
-			gc.drawImage (image, 0, 0, width, height, x+width, y, (int)Math.round(width * 0.5), (int)Math.round(height * 0.5));
-			gc.drawImage (image, 0, 0, width, height, x+width+(int)Math.round(width * 0.5), y, width * 2, height * 2);
+			gc.drawImage (image, x, y, width, height);
+			gc.drawImage (image, x+width, y, (int)Math.round(width * 0.5), (int)Math.round(height * 0.5));
+			gc.drawImage (image, x+width+(int)Math.round(width * 0.5), y, width * 2, height * 2);
 		});
 		shell.setSize (600, 400);
 		shell.open ();

--- a/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet361.java
+++ b/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet361.java
@@ -171,10 +171,6 @@ public class Snippet361 {
 				if (printer.startPage()) {
 					printerGC.drawImage(
 						printerImage,
-						0,
-						0,
-						imageData.width,
-						imageData.height,
 						-trim.x,
 						-trim.y,
 						scaleFactor * imageData.width,

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_GC.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_GC.java
@@ -278,8 +278,7 @@ public void test_drawImage_nonAutoScalableGC_bug_2504() throws InterruptedExcept
     canvas.setSize(canvasWidth, canvasHeight);
     AtomicBoolean paintListenerCalled = new AtomicBoolean();
     canvas.addPaintListener(e -> {
-        e.gc.drawImage(image, 0, 0, bounds.width, bounds.height,
-                       0, 0, canvasWidth, canvasHeight);
+		e.gc.drawImage(image, 0, 0, canvasWidth, canvasHeight);
         paintListenerCalled.set(true);
     });
 

--- a/tests/org.eclipse.swt.tests/ManualTests/org/eclipse/swt/tests/manual/SnippetDrawAlpha.java
+++ b/tests/org.eclipse.swt.tests/ManualTests/org/eclipse/swt/tests/manual/SnippetDrawAlpha.java
@@ -81,7 +81,7 @@ public class SnippetDrawAlpha {
 		Image resultImage = new Image(device, resultData);
 		GC gc = new GC(resultImage);
 		gc.setAntialias(SWT.ON);
-		gc.drawImage(original, 0, 0, width, height,
+		gc.drawImage(original,
 				/*
 				 * E.g. destWidth here is effectively DPIUtil.autoScaleDown
 				 * (scaledWidth), but avoiding rounding errors. Nevertheless, we

--- a/tests/org.eclipse.swt.tests/ManualTests/org/eclipse/swt/tests/manual/SnippetDrawAlphaTwoPass.java
+++ b/tests/org.eclipse.swt.tests/ManualTests/org/eclipse/swt/tests/manual/SnippetDrawAlphaTwoPass.java
@@ -103,14 +103,14 @@ public class SnippetDrawAlphaTwoPass {
 
 		GC gc = new GC(result);
 		gc.setAntialias(SWT.ON);
-		gc.drawImage(original, 0, 0, width, height, 0, 0, scaledWidth, scaledHeight);
+		gc.drawImage(original, 0, 0, scaledWidth, scaledHeight);
 		gc.dispose();
 
 		if (resultMaskData != null) {
 			resultMask = new Image(device, resultMaskData);
 			gc = new GC(resultMask);
 			gc.setAntialias(SWT.ON);
-			gc.drawImage(originalMask, 0, 0, width, height, 0, 0, scaledWidth, scaledHeight);
+			gc.drawImage(originalMask, 0, 0, scaledWidth, scaledHeight);
 			gc.dispose();
 		}
 


### PR DESCRIPTION
The previous drawImage method required specifying the full source and destination rectangles, which meant the caller needed to know the image size up front. This change replaces the old API calls with the newer, simplified drawImage overload that takes fewer parameters and no longer requires the caller to provide the image dimensions.