### PR TITLE
throw no more handles if a timer could not be created

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Display.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Display.java
@@ -5343,6 +5343,7 @@ public <T, E extends Exception> T syncCall(SwtCallable<T, E> callable) throws E 
  * @exception SWTException <ul>
  *    <li>ERROR_THREAD_INVALID_ACCESS - if not called from the thread that created the receiver</li>
  *    <li>ERROR_DEVICE_DISPOSED - if the receiver has been disposed</li>
+ *    <li>ERROR_NO_HANDLES if a handle could not be obtained for timer creation</li>
  * </ul>
  *
  * @see #asyncExec
@@ -5390,14 +5391,13 @@ public void timerExec (int milliseconds, Runnable runnable) {
 	}
 	NSNumber userInfo = NSNumber.numberWithInt(index);
 	NSTimer timer = NSTimer.scheduledTimerWithTimeInterval(milliseconds / 1000.0, timerDelegate, OS.sel_timerProc_, userInfo, false);
+	if (timer == null) SWT.error (SWT.ERROR_NO_HANDLES);
 	NSRunLoop runLoop = NSRunLoop.currentRunLoop();
 	runLoop.addTimer(timer, OS.NSModalPanelRunLoopMode);
 	runLoop.addTimer(timer, OS.NSEventTrackingRunLoopMode);
 	timer.retain();
-	if (timer != null) {
-		nsTimers [index] = timer;
-		timerList [index] = runnable;
-	}
+	nsTimers [index] = timer;
+	timerList [index] = runnable;
 }
 
 long timerProc (long id, long sel, long timerID) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Display.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Display.java
@@ -5661,6 +5661,7 @@ public boolean sleep () {
  * @exception SWTException <ul>
  *    <li>ERROR_THREAD_INVALID_ACCESS - if not called from the thread that created the receiver</li>
  *    <li>ERROR_DEVICE_DISPOSED - if the receiver has been disposed</li>
+ *    <li>ERROR_NO_HANDLES if a handle could not be obtained for timer creation</li>
  * </ul>
  *
  * @see #asyncExec
@@ -5702,10 +5703,9 @@ public void timerExec (int milliseconds, Runnable runnable) {
 	} else {
 		timerId = GDK.gdk_threads_add_timeout (milliseconds, timerProc, index);
 	}
-	if (timerId != 0) {
-		timerIds [index] = timerId;
-		timerList [index] = runnable;
-	}
+	if (timerId == 0) SWT.error (SWT.ERROR_NO_HANDLES);
+	timerIds [index] = timerId;
+	timerList [index] = runnable;
 }
 
 long timerProc (long i) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Display.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Display.java
@@ -4949,6 +4949,7 @@ public <T, E extends Exception> T syncCall(SwtCallable<T, E> callable) throws E 
  * @exception SWTException <ul>
  *    <li>ERROR_THREAD_INVALID_ACCESS - if not called from the thread that created the receiver</li>
  *    <li>ERROR_DEVICE_DISPOSED - if the receiver has been disposed</li>
+ *    <li>ERROR_NO_HANDLES if a handle could not be obtained for timer creation</li>
  * </ul>
  *
  * @see #asyncExec
@@ -4990,10 +4991,9 @@ public void timerExec (int milliseconds, Runnable runnable) {
 		}
 	}
 	long newTimerID = OS.SetTimer (hwndMessage, timerId, milliseconds, 0);
-	if (newTimerID != 0) {
-		timerList [index] = runnable;
-		timerIds [index] = newTimerID;
-	}
+	if (newTimerID == 0) SWT.error (SWT.ERROR_NO_HANDLES);
+	timerList [index] = runnable;
+	timerIds [index] = newTimerID;
 }
 
 boolean translateAccelerator (MSG msg, Control control) {


### PR DESCRIPTION
At the moment the code silently fails on calling timerExec if there are no handles left or it fails for other reasons.

Relates to https://github.com/eclipse-platform/eclipse.platform.swt/issues/2806 where we can see that we are running out of handles, but the timerExec does not report a failure.

