### PR TITLE
An attempt to fix test_evalute_Cookies

### DIFF
--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_browser_Browser.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_browser_Browser.java
@@ -404,19 +404,26 @@ public void test_evalute_Cookies () {
 	browser.addProgressListener(ProgressListener.completedAdapter(event -> loaded.set(true)));
 
 	// Using JavaScript Cookie API on local (file) URL gives DOM Exception 18
-	browser.setUrl("https://www.eclipse.org/swt");
+	String url = "https://eclipse.dev/eclipse/swt/";
+	browser.setUrl(url);
 	shell.open();
 	waitForPassCondition(loaded::get);
+
+	// Retrieve entire cookie store
+	String res = (String) browser.evaluate("return document.cookie;");
+	assertEquals("", res.strip(), "Expected no cookies on " + "https://eclipse.dev/eclipse/swt/");
 
 	// Set the cookies
 	// document.cookie behaves different from other global vars
 	browser.evaluate("document.cookie = \"cookie1=value1\";");
 	browser.evaluate("document.cookie = \"cookie2=value2\";");
 
-	// Retrieve entire cookie store
-	String res = (String) browser.evaluate("return document.cookie;");
+	waitForMilliseconds(1000);
 
-	assertFalse(res.isEmpty());
+	// Retrieve entire cookie store
+	res = (String) browser.evaluate("return document.cookie;");
+
+	assertFalse(res.isEmpty(), "Expected cookies but got nothing on " + url);
 }
 
 @Tag("gtk4-todo")


### PR DESCRIPTION
Just a guess the failure could be somehow related to redirect from https://www.eclipse.org/swt to https://eclipse.dev/eclipse/swt/.

See https://github.com/eclipse-platform/eclipse.platform.swt/issues/2804