### PR TITLE
[Win32] Apply accessibility setting to ImageDataProvider-based cursor

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Cursor.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Cursor.java
@@ -628,7 +628,8 @@ private static class ImageDataProviderCursorHandleProvider extends HotspotAwareC
 	@Override
 	public CursorHandle createHandle(Device device, int zoom) {
 		Image tempImage = new Image(device, this.provider);
-		ImageData source = tempImage.getImageData(zoom);
+		int scaledZoom = (int) (zoom * getPointerSizeScaleFactor());
+		ImageData source = tempImage.getImageData(scaledZoom);
 		tempImage.dispose();
 		return setupCursorFromImageData(device, source, null, getHotpotXInPixels(zoom), getHotpotYInPixels(zoom));
 	}


### PR DESCRIPTION
Cursors are scaled according to the accessibility settings of Windows. However, this setting is only applied to Cursor instances based on image data but not on those that are instantiated via an ImageDataProvider. This change also applies the scale factor in the latter case.

See:
- https://github.com/eclipse-gef/gef-classic/issues/872#issuecomment-3575191088

I consider this a safe change as it is simply an oversight in the existing implementation. The change has no effect in case the accessibility setting of Windows is not used. In case it is used, the quality of custom cursors based on an ImageDataProvider (as an example and in particuar for GEF) will have a better user experience.
This is why I would be in favor of still bringing this into the upcoming releae / RC2, even though we are already very late.

### How to test
Change the accessibility settings for the mouse cursor size in the Windows settings and check with any custom cursor that uses an `ImageDataProvider`, such as the shared cursors of GEF.
<img width="785" height="492" alt="image" src="https://github.com/user-attachments/assets/2f4cf639-30fe-43a5-82c0-495474f97fc7" />

### Before
https://github.com/user-attachments/assets/a62f6d5b-be74-4022-801c-5e6932727ee7

### After
https://github.com/user-attachments/assets/ccd88a96-9a7f-450f-9abd-b96d467b3eda

This is basically a follow up to the following PR which applied the accessibility setting to the image-data-based construction of cursors:
- https://github.com/eclipse-platform/eclipse.platform.swt/pull/2493

This depends on and thus has to be merged after:
- https://github.com/eclipse-platform/eclipse.platform.swt/pull/2830