### PR TITLE
[GTK4] Skip drawing of fixedHandle

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Control.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Control.java
@@ -3834,7 +3834,17 @@ void cairoClipRegion (long cairo) {
 	eventRegion = actualRegion;
 }
 
+@Override
+void snapshotToDraw(long handle, long snapshot) {
+	if (GTK.GTK4 && handle == fixedHandle) {
+		// The fixedHandle has nothing to draw itself, so skip drawing on this handle
+		// and let Display.snapshotDrawProc call gtk_widget_snapshot_child on
+		// the child widgets
+		return;
+	}
 
+	super.snapshotToDraw(handle, snapshot);
+}
 
 @Override
 void gtk4_draw(long widget, long cairo, Rectangle bounds) {


### PR DESCRIPTION
The fixedHandle does not have any drawable components, and as written today, what gtk4_draw does on fixedHandle is draw the whole Widget, then Display.snapshotDrawProc iterates through all the children, of which the normal handle will be one (at least in StyledText case) and gtk4_draw will be called again on the same widget.

This fixes caret drawing, because on the first time through gtk4_draw the caret is drawn, but then on the second time the gtk4_draw draws over the freshly drawn caret.

This is option 1 in https://github.com/eclipse-platform/eclipse.platform.swt/issues/2812#issuecomment-3577503275

Fixes https://github.com/eclipse-platform/eclipse.platform.swt/issues/2812
