### PR TITLE
[GTK4] Clamp height of combo drop-down arrow to client area height

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CCombo.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CCombo.java
@@ -1187,6 +1187,9 @@ void internalLayout (boolean changed) {
 	int width = rect.width;
 	int height = rect.height;
 	Point arrowSize = arrow.computeSize (SWT.DEFAULT, height, changed);
+	// clamp the height of the arrow to the maximum of the client area
+	// https://github.com/eclipse-platform/eclipse.platform.swt/issues/2817
+	arrowSize.y = Math.min(height, arrowSize.y);
 	text.setBounds (0, 0, width - arrowSize.x, height);
 	arrow.setBounds (width - arrowSize.x, 0, arrowSize.x, arrowSize.y);
 }


### PR DESCRIPTION
Fixes https://github.com/eclipse-platform/eclipse.platform.swt/issues/2817

Note that this fix is needed for GTK4, but affects all platforms as it is in swt custom's CCombo. I am leaving this as draft for the moment because the preferred fix is probably fixing computeSizeInPixels of Button.