### PR TITLE
Update Build SWT Natives launch to Java 21

### DIFF
--- a/bundles/org.eclipse.swt/Build-SWT-native-binaries-for-running-platform.launch
+++ b/bundles/org.eclipse.swt/Build-SWT-native-binaries-for-running-platform.launch
@@ -20,6 +20,6 @@
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_ATTR_USE_ARGFILE" value="false"/>
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_SHOW_CODEDETAILS_IN_EXCEPTION_MESSAGES" value="true"/>
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_CLASSPATH_ONLY_JAR" value="false"/>
-    <stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17/"/>
+    <stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21/"/>
     <stringAttribute key="org.eclipse.jdt.launching.WORKING_DIRECTORY" value="${git_work_tree:/org.eclipse.swt}/binaries/org.eclipse.swt.${target.ws}.${target.os}.${target.arch}"/>
 </launchConfiguration>


### PR DESCRIPTION
Eclipse SWT now uses Tycho 5.x which means we need to run Maven with Java 21

The change to Tycho 5 was a couple of months ago, but I didn't have Java 17 in my Installed JREs so Eclipse was automatically using Java21. Now with a Java17 JRE available I get the below error when launching `Build-SWT-native-binaries-for-running-platform`

<details>
<summary>error</summary>

```
[WARNING] Error injecting: org.eclipse.tycho.pomless.TychoTargetMapping
java.lang.TypeNotPresentException: Type org.eclipse.tycho.pomless.TychoTargetMapping not present
	at org.eclipse.sisu.space.URLClassSpace.loadClass(URLClassSpace.java:149)
	at org.eclipse.sisu.space.NamedClass.load(NamedClass.java:48)
	at org.eclipse.sisu.space.AbstractDeferredClass.get(AbstractDeferredClass.java:50)
	at com.google.inject.internal.ProviderInternalFactory.provision(ProviderInternalFactory.java:86)
	at com.google.inject.internal.InternalFactoryToInitializableAdapter.provision(InternalFactoryToInitializableAdapter.java:57)
	at com.google.inject.internal.ProviderInternalFactory$1.call(ProviderInternalFactory.java:67)
	at com.google.inject.internal.ProvisionListenerStackCallback$Provision.provision(ProvisionListenerStackCallback.java:109)
	at org.eclipse.sisu.bean.BeanScheduler$CycleActivator.onProvision(BeanScheduler.java:232)
	at com.google.inject.internal.ProvisionListenerStackCallback$Provision.provision(ProvisionListenerStackCallback.java:117)
	at com.google.inject.internal.ProvisionListenerStackCallback.provision(ProvisionListenerStackCallback.java:66)
	at com.google.inject.internal.ProviderInternalFactory.circularGet(ProviderInternalFactory.java:62)
	at com.google.inject.internal.InternalFactoryToInitializableAdapter.get(InternalFactoryToInitializableAdapter.java:47)
	at com.google.inject.internal.ProviderToInternalFactoryAdapter.get(ProviderToInternalFactoryAdapter.java:40)
	at com.google.inject.internal.SingletonScope$1.get(SingletonScope.java:169)
	at com.google.inject.internal.InternalFactoryToProviderAdapter.get(InternalFactoryToProviderAdapter.java:45)
	at com.google.inject.internal.InjectorImpl$1.get(InjectorImpl.java:1101)
	at org.eclipse.sisu.inject.LazyBeanEntry.getValue(LazyBeanEntry.java:83)
	at org.eclipse.sisu.wire.EntryListAdapter$ValueIterator.next(EntryListAdapter.java:113)
	at java.base/java.util.AbstractCollection.toArray(AbstractCollection.java:146)
	at java.base/java.util.ArrayList.<init>(ArrayList.java:181)
	at org.sonatype.maven.polyglot.PolyglotModelManager.getSortedMappings(PolyglotModelManager.java:50)
	at org.sonatype.maven.polyglot.PolyglotModelManager.findPom(PolyglotModelManager.java:87)
	at org.sonatype.maven.polyglot.TeslaModelProcessor.locatePom(TeslaModelProcessor.java:66)
	at org.apache.maven.cli.MavenCli.populateRequest(MavenCli.java:1345)
	at org.apache.maven.cli.MavenCli.populateRequest(MavenCli.java:1192)
	at org.apache.maven.cli.MavenCli.doMain(MavenCli.java:281)
	at org.apache.maven.cli.MavenCli.main(MavenCli.java:206)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:569)
	at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced(Launcher.java:255)
	at org.codehaus.plexus.classworlds.launcher.Launcher.launch(Launcher.java:201)
	at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode(Launcher.java:361)
	at org.codehaus.plexus.classworlds.launcher.Launcher.main(Launcher.java:314)
Caused by: java.lang.UnsupportedClassVersionError: org/eclipse/tycho/pomless/TychoTargetMapping has been compiled by a more recent version of the Java Runtime (class file version 65.0), this version of the Java Runtime only recognizes class file versions up to 61.0
	at java.base/java.lang.ClassLoader.defineClass1(Native Method)
	at java.base/java.lang.ClassLoader.defineClass(ClassLoader.java:1017)
	at java.base/java.security.SecureClassLoader.defineClass(SecureClassLoader.java:150)
	at java.base/java.net.URLClassLoader.defineClass(URLClassLoader.java:524)
	at java.base/java.net.URLClassLoader$1.run(URLClassLoader.java:427)
	at java.base/java.net.URLClassLoader$1.run(URLClassLoader.java:421)
	at java.base/java.security.AccessController.doPrivileged(AccessController.java:712)
	at java.base/java.net.URLClassLoader.findClass(URLClassLoader.java:420)
	at org.codehaus.plexus.classworlds.realm.ClassRealm.findClassInternal(ClassRealm.java:256)
	at org.codehaus.plexus.classworlds.realm.ClassRealm.loadClassFromSelf(ClassRealm.java:351)
	at org.codehaus.plexus.classworlds.strategy.SelfFirstStrategy.loadClass(SelfFirstStrategy.java:36)
	at org.codehaus.plexus.classworlds.realm.ClassRealm.unsynchronizedLoadClass(ClassRealm.java:225)
	at org.codehaus.plexus.classworlds.realm.ClassRealm.loadClass(ClassRealm.java:210)
	at org.codehaus.plexus.classworlds.realm.ClassRealm.loadClass(ClassRealm.java:205)
	at org.eclipse.sisu.space.URLClassSpace.loadClass(URLClassSpace.java:141)
	... 34 more
[ERROR] Error executing Maven.
[ERROR] Unable to provision, see the following errors:

1) [Guice/ErrorInCustomProvider]: TypeNotPresentException: Type TychoTargetMapping not present
  at ClassRealm[coreExtension>org.eclipse.tycho:tycho-build:5.0.0, parent: ClassRealm[plexus.core, parent: null]]
      \_ installed by: WireModule -> PlexusBindingModule
  while locating Mapping annotated with @Named("eclipse-target-definition")

Learn more:
  https://github.com/google/guice/wiki/ERROR_IN_CUSTOM_PROVIDER

1 error

======================
Full classname legend:
======================
Mapping:                 "org.sonatype.maven.polyglot.mapping.Mapping"
Named:                   "com.google.inject.name.Named"
PlexusBindingModule:     "org.eclipse.sisu.plexus.PlexusBindingModule"
TychoTargetMapping:      "org.eclipse.tycho.pomless.TychoTargetMapping"
WireModule:              "org.eclipse.sisu.wire.WireModule"
========================
End of classname legend:
========================

[ERROR] Caused by: Type org.eclipse.tycho.pomless.TychoTargetMapping not present
[ERROR] Caused by: org/eclipse/tycho/pomless/TychoTargetMapping has been compiled by a more recent version of the Java Runtime (class file version 65.0), this version of the Java Runtime only recognizes class file versions up to 61.0
```

</details>