### PR TITLE
Replacement of Image(device, int, int) constructor in examples/snippets

### DIFF
--- a/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet10.java
+++ b/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet10.java
@@ -32,12 +32,12 @@ public class Snippet10 {
 		shell.setText("Advanced Graphics");
 		FontData fd = shell.getFont().getFontData()[0];
 		final Font font = new Font(display, fd.getName(), 60, SWT.BOLD | SWT.ITALIC);
-		final Image image = new Image(display, 640, 480);
+		final ImageGcDrawer imageGcDrawer = (gc, imageWidth, imageHeight) -> {
+			gc.setBackground(display.getSystemColor(SWT.COLOR_RED));
+			gc.fillOval(0, 0, imageWidth, imageHeight);
+		};
+		final Image image = new Image(display,imageGcDrawer, 640, 480);
 		final Rectangle rect = image.getBounds();
-		GC gc = new GC(image);
-		gc.setBackground(display.getSystemColor(SWT.COLOR_RED));
-		gc.fillOval(rect.x, rect.y, rect.width, rect.height);
-		gc.dispose();
 		shell.addListener(SWT.Paint, event -> {
 			GC gc1 = event.gc;
 			Transform tr = new Transform(display);

--- a/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet104.java
+++ b/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet104.java
@@ -29,12 +29,12 @@ public class Snippet104 {
 public static void main(String[] args) {
 	final Display display = new Display();
 	final int [] count = new int [] {4};
-	final Image image = new Image(display, 300, 300);
-	GC gc = new GC(image);
-	gc.setBackground(display.getSystemColor(SWT.COLOR_CYAN));
-	gc.fillRectangle(image.getBounds());
-	gc.drawText("Splash Screen", 10, 10);
-	gc.dispose();
+	ImageGcDrawer imageGcDrawer = (gc, imageWidth, imageHeight) -> {
+		gc.setBackground(display.getSystemColor(SWT.COLOR_CYAN));
+		gc.fillRectangle(0, 0, imageWidth, imageHeight);
+		gc.drawText("Splash Screen", 10, 10);
+	};
+	final Image image = new Image(display, imageGcDrawer, 300, 300);
 	final Shell splash = new Shell(SWT.ON_TOP);
 	final ProgressBar bar = new ProgressBar(splash, SWT.NONE);
 	bar.setMaximum(count[0]);

--- a/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet112.java
+++ b/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet112.java
@@ -28,12 +28,12 @@ public class Snippet112 {
 
 public static void main (String [] args) {
 	Display display = new Display ();
-	final Image image = new Image (display, 20, 20);
-	Color color = display.getSystemColor (SWT.COLOR_RED);
-	GC gc = new GC (image);
-	gc.setBackground (color);
-	gc.fillRectangle (image.getBounds ());
-	gc.dispose ();
+	final ImageGcDrawer imageGcDrawer = (gc, imageWidth, imageHeight) -> {
+		Color color = display.getSystemColor (SWT.COLOR_RED);
+		gc.setBackground(color);
+		gc.fillRectangle(0, 0, imageWidth, imageHeight);
+	};
+	final Image image = new Image (display, imageGcDrawer, 20, 20);
 
 	Shell shell = new Shell (display);
 	shell.setText("Snippet 112");

--- a/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet138.java
+++ b/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet138.java
@@ -29,17 +29,17 @@ public class Snippet138 {
 	public static void main(String[] args) {
 		Display display = new Display();
 
-		Image small = new Image(display, 16, 16);
-		GC gc = new GC(small);
-		gc.setBackground(display.getSystemColor(SWT.COLOR_RED));
-		gc.fillArc(0, 0, 16, 16, 45, 270);
-		gc.dispose();
+		final ImageGcDrawer imageGcDrawer = (gc, imageWidth, imageHeight) -> {
+			gc.setBackground(display.getSystemColor(SWT.COLOR_RED));
+			gc.fillArc(0, 0, imageWidth, imageHeight, 45, 270);
+		};
+		Image small = new Image(display, imageGcDrawer, 16, 16);
 
-		Image large = new Image(display, 32, 32);
-		gc = new GC(large);
-		gc.setBackground(display.getSystemColor(SWT.COLOR_RED));
-		gc.fillArc(0, 0, 32, 32, 45, 270);
-		gc.dispose();
+		final ImageGcDrawer imageGcDrawer1 = (gc, imageWidth, imageHeight) -> {
+			gc.setBackground(display.getSystemColor(SWT.COLOR_RED));
+			gc.fillArc(0, 0, imageWidth, imageHeight, 45, 270);
+		};
+		Image large = new Image(display, imageGcDrawer1, 32, 32);
 
 		/* Provide different resolutions for icons to get
 		 * high quality rendering wherever the OS needs

--- a/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet141.java
+++ b/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet141.java
@@ -46,7 +46,7 @@ public class Snippet141 {
 		shellBackground = shell.getBackground();
 
 		FileDialog dialog = new FileDialog(shell);
-		dialog.setFilterExtensions(new String[] {"*.gif"});
+		dialog.setFilterExtensions("*.gif");
 		String fileName = dialog.open();
 		final AtomicBoolean stopAnimation = new AtomicBoolean(false);
 		if (fileName != null) {
@@ -59,11 +59,14 @@ public class Snippet141 {
 						@SuppressWarnings("unused")
 						public void run() {
 							/* Create an off-screen image to draw on, and fill it with the shell background. */
-							Image offScreenImage = new Image(display, loader.logicalScreenWidth, loader.logicalScreenHeight);
+							int width = loader.logicalScreenWidth;
+							int height = loader.logicalScreenHeight;
+							ImageGcDrawer offscreenDrawer = (gc, imageWidth, imageHeight) -> {
+								gc.setBackground(shellBackground);
+								gc.fillRectangle(0, 0, imageWidth, imageHeight);
+							};
+							Image offScreenImage = new Image(display, offscreenDrawer, width, height);
 							GC offScreenImageGC = new GC(offScreenImage);
-							offScreenImageGC.setBackground(shellBackground);
-							offScreenImageGC.fillRectangle(0, 0, loader.logicalScreenWidth, loader.logicalScreenHeight);
-
 							try {
 								/* Create the first image and draw it on the off-screen image. */
 								int imageDataIndex = 0;

--- a/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet143.java
+++ b/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet143.java
@@ -32,11 +32,11 @@ public static void main(String[] args) {
 	Shell shell = new Shell (display);
 	shell.setText("Snippet 143");
 	Image image = new Image (display, 16, 16);
-	Image image2 = new Image (display, 16, 16);
-	GC gc = new GC(image2);
-	gc.setBackground(display.getSystemColor(SWT.COLOR_BLACK));
-	gc.fillRectangle(image2.getBounds());
-	gc.dispose();
+	ImageGcDrawer imgc = (gc, iwidth, iheight) -> {
+		gc.setBackground(display.getSystemColor(SWT.COLOR_BLACK));
+		gc.fillRectangle(0, 0, iwidth, iheight);
+	};
+	Image image2 = new Image(display, imgc, 16, 16);
 	final Tray tray = display.getSystemTray ();
 	if (tray == null) {
 		System.out.println ("The system tray is not available");

--- a/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet156.java
+++ b/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet156.java
@@ -121,17 +121,16 @@ static ImageData convertToSWT(BufferedImage bufferedImage) {
 }
 
 static ImageData createSampleImage(Display display) {
-	Image image = new Image(display, 100, 100);
-	Rectangle bounds = image.getBounds();
-	GC gc = new GC(image);
-	gc.setBackground(display.getSystemColor(SWT.COLOR_BLUE));
-	gc.fillRectangle(bounds);
-	gc.setBackground(display.getSystemColor(SWT.COLOR_GREEN));
-	gc.fillOval(0, 0, bounds.width, bounds.height);
-	gc.setForeground(display.getSystemColor(SWT.COLOR_RED));
-	gc.drawLine(0, 0, bounds.width, bounds.height);
-	gc.drawLine(bounds.width, 0, 0, bounds.height);
-	gc.dispose();
+	ImageGcDrawer imageGcDrawer = (gc, imageWidth, imageHeight) -> {
+		gc.setBackground(display.getSystemColor(SWT.COLOR_BLUE));
+		gc.fillRectangle(0, 0, imageWidth, imageHeight);
+		gc.setBackground(display.getSystemColor(SWT.COLOR_GREEN));
+		gc.fillOval(0, 0, imageWidth, imageHeight);
+		gc.setForeground(display.getSystemColor(SWT.COLOR_RED));
+		gc.drawLine(0, 0, imageWidth, imageHeight);
+		gc.drawLine(imageWidth, 0, 0, imageHeight);
+	};
+	Image image = new Image(display, imageGcDrawer, 100, 100);
 	ImageData data = image.getImageData();
 	image.dispose();
 	return data;

--- a/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet162.java
+++ b/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet162.java
@@ -80,16 +80,16 @@ public static void main (String [] args) {
 }
 
 static Image getStateImage (Display display, boolean checked) {
-	Image image = new Image (display, 16, 16);
-	GC gc = new GC (image);
-	gc.setBackground (display.getSystemColor (SWT.COLOR_YELLOW));
-	gc.fillOval (0, 0, 16, 16);
-	if (checked) {
-		gc.setForeground (display.getSystemColor (SWT.COLOR_DARK_GREEN));
-		gc.drawLine (0, 0, 16, 16);
-		gc.drawLine (16, 0, 0, 16);
-	}
-	gc.dispose ();
+	ImageGcDrawer imageGcDrawer = (gc, imageWidth, imageHeight) -> {
+		gc.setBackground(display.getSystemColor(SWT.COLOR_YELLOW));
+		gc.fillOval(0, 0, imageWidth, imageHeight);
+		if (checked) {
+			gc.setForeground(display.getSystemColor(SWT.COLOR_DARK_GREEN));
+			gc.drawLine(0, 0, imageWidth, imageHeight);
+			gc.drawLine(imageWidth, 0, 0, imageHeight);
+		}
+	};
+	Image image = new Image(display, imageGcDrawer, 16, 16);
 	return image;
 }
 }

--- a/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet165.java
+++ b/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet165.java
@@ -32,13 +32,13 @@ public class Snippet165 {
 
 public static void main (String [] args) {
 	Display display = new Display ();
-	Image image = new Image(display, 16, 16);
-	GC gc = new GC(image);
-	gc.setBackground(display.getSystemColor(SWT.COLOR_BLUE));
-	gc.fillRectangle(0, 0, 16, 16);
-	gc.setBackground(display.getSystemColor(SWT.COLOR_YELLOW));
-	gc.fillRectangle(3, 3, 10, 10);
-	gc.dispose();
+	ImageGcDrawer imageGcDrawer = (gc, imageWidth, imageHeight) -> {
+		gc.setBackground(display.getSystemColor(SWT.COLOR_BLUE));
+		gc.fillRectangle(0, 0, 16, 16);
+		gc.setBackground(display.getSystemColor(SWT.COLOR_YELLOW));
+		gc.fillRectangle(3, 3, 10, 10);
+	};
+	Image image = new Image(display, imageGcDrawer, 16, 16);
 	final Shell shell = new Shell (display);
 	shell.setText("Snippet 165");
 	shell.setLayout(new GridLayout());

--- a/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet200.java
+++ b/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet200.java
@@ -30,20 +30,20 @@ public class Snippet200 {
 public static void main(String[] args) {
 	Display display = new Display();
 	//define a pattern on an image
-	final Image image = new Image(display, 1000, 1000);
-	Color blue = display.getSystemColor(SWT.COLOR_BLUE);
-	Color yellow = display.getSystemColor(SWT.COLOR_YELLOW);
-	Color white = display.getSystemColor(SWT.COLOR_WHITE);
-	GC gc = new GC(image);
-	gc.setBackground(white);
-	gc.setForeground(yellow);
-	gc.fillGradientRectangle(0, 0, 1000, 1000, true);
-	for (int i=-500; i<1000; i+=10) {
-		gc.setForeground(blue);
-		gc.drawLine(i, 0, 500 + i, 1000);
-		gc.drawLine(500 + i, 0, i, 1000);
-	}
-	gc.dispose();
+	ImageGcDrawer imageGcDrawer = (gc, imageWidth, imageHeight) -> {
+		Color blue = display.getSystemColor(SWT.COLOR_BLUE);
+		Color yellow = display.getSystemColor(SWT.COLOR_YELLOW);
+		Color white = display.getSystemColor(SWT.COLOR_WHITE);
+		gc.setBackground(white);
+		gc.setForeground(yellow);
+		gc.fillGradientRectangle(0, 0, 1000, 1000, true);
+		for (int i=-500; i<1000; i+=10) {
+			gc.setForeground(blue);
+			gc.drawLine(i, 0, 500 + i, 1000);
+			gc.drawLine(500 + i, 0, i, 1000);
+		}
+	};
+	final Image image = new Image(display, imageGcDrawer, 1000, 1000);
 	final Pattern pattern;
 	try {
 		pattern = new Pattern(display, image);

--- a/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet205.java
+++ b/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet205.java
@@ -33,13 +33,16 @@ public static void main(String[] args) {
 	Display display = new Display();
 	final Shell shell = new Shell(display, SWT.SHELL_TRIM | SWT.DOUBLE_BUFFERED);
 	shell.setText("Embedding objects in text");
-	final Image[] images = {new Image(display, 32, 32), new Image(display, 20, 40), new Image(display, 40, 20)};
+	final Image[] images = new Image[3];
+	final Rectangle[] rects = { new Rectangle(0, 0, 32, 32), new Rectangle(0, 0, 20, 40), new Rectangle(0, 0, 40, 20) };
 	int[] colors  = {SWT.COLOR_BLUE, SWT.COLOR_MAGENTA, SWT.COLOR_GREEN};
 	for (int i = 0; i < images.length; i++) {
-		GC gc = new GC(images[i]);
-		gc.setBackground(display.getSystemColor(colors[i]));
-		gc.fillRectangle(images[i].getBounds());
-		gc.dispose();
+		final int index = i;
+		ImageGcDrawer imageGcDrawer = (gc, imageWidth, imageHeight) -> {
+			gc.setBackground(display.getSystemColor(colors[index]));
+			gc.fillRectangle(rects[index]);
+		};
+		images[i] = new Image(display, imageGcDrawer, rects[i].width, rects[i].height);
 	}
 
 	final Button button = new Button(shell, SWT.PUSH);

--- a/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet207.java
+++ b/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet207.java
@@ -28,16 +28,16 @@ public class Snippet207 {
 	public static void main(String[] args) {
 		final Display display = new Display();
 
-		final Image image = new Image(display, 110, 60);
-		GC gc = new GC(image);
-		Font font = new Font(display, "Times", 30, SWT.BOLD);
-		gc.setFont(font);
-		gc.setBackground(display.getSystemColor(SWT.COLOR_RED));
-		gc.fillRectangle(0, 0, 110, 60);
-		gc.setForeground(display.getSystemColor(SWT.COLOR_WHITE));
-		gc.drawText("SWT", 10, 10, true);
-		font.dispose();
-		gc.dispose();
+		ImageGcDrawer imageGcDrawer = (gc, imageWidth, imageHeight) -> {
+			Font font = new Font(display, "Times", 30, SWT.BOLD);
+			gc.setFont(font);
+			gc.setBackground(display.getSystemColor(SWT.COLOR_RED));
+			gc.fillRectangle(0, 0, 110, 60);
+			gc.setForeground(display.getSystemColor(SWT.COLOR_WHITE));
+			gc.drawText("SWT", 10, 10, true);
+			font.dispose();
+		};
+		final Image image = new Image(display, imageGcDrawer, 110, 60);
 
 		final Rectangle rect = image.getBounds();
 		Shell shell = new Shell(display);

--- a/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet214.java
+++ b/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet214.java
@@ -46,8 +46,13 @@ public class Snippet214 {
 			button.setText ("Button " + i);
 		}
 		shell.addListener (SWT.Resize, event -> {
+			ImageGcDrawer imageGcDrawer = (gc, imageWidth, imageHeight) -> {
+				gc.setForeground (display.getSystemColor (SWT.COLOR_WHITE));
+				gc.setBackground (display.getSystemColor (SWT.COLOR_BLUE));
+				gc.fillGradientRectangle (0, 0, imageWidth, imageHeight, false);
+			};
 			Rectangle rect = shell.getClientArea ();
-			Image newImage = new Image (display, Math.max (1, rect.width), 1);
+			Image newImage = new Image (display, imageGcDrawer, Math.max (1, rect.width), 1);
 			GC gc = new GC (newImage);
 			gc.setForeground (display.getSystemColor (SWT.COLOR_WHITE));
 			gc.setBackground (display.getSystemColor (SWT.COLOR_BLUE));

--- a/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet218.java
+++ b/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet218.java
@@ -50,12 +50,12 @@ public class Snippet218 {
 		styledText.setForeground(display.getSystemColor (SWT.COLOR_BLUE));
 		styledText.addListener (SWT.Resize, event -> {
 			Rectangle rect = styledText.getClientArea ();
-			Image newImage = new Image (display, 1, Math.max (1, rect.height));
-			GC gc = new GC (newImage);
-			gc.setForeground (display.getSystemColor (SWT.COLOR_WHITE));
-			gc.setBackground (display.getSystemColor (SWT.COLOR_YELLOW));
-			gc.fillGradientRectangle (rect.x, rect.y, 1, rect.height, true);
-			gc.dispose ();
+			ImageGcDrawer imageGcDrawer = (gc, imageWidth, imageHeight) ->  {
+				gc.setForeground (display.getSystemColor (SWT.COLOR_WHITE));
+				gc.setBackground (display.getSystemColor (SWT.COLOR_YELLOW));
+				gc.fillGradientRectangle (rect.x, rect.y, 1, rect.height, true);
+			};
+			Image newImage = new Image (display, imageGcDrawer, 1, Math.max (1, rect.height));
 			styledText.setBackgroundImage (newImage);
 			if (oldImage != null) oldImage.dispose ();
 			oldImage = newImage;

--- a/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet220.java
+++ b/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet220.java
@@ -35,13 +35,13 @@ public static void main(String [] args) {
 	Shell shell = new Shell(display);
 	shell.setText("Snippet 220");
 	shell.setBounds(10, 10, 350, 200);
-	Image xImage = new Image (display, 16, 16);
-	GC gc = new GC(xImage);
-	gc.setForeground(display.getSystemColor(SWT.COLOR_RED));
-	gc.drawLine(1, 1, 14, 14);
-	gc.drawLine(1, 14, 14, 1);
-	gc.drawOval(2, 2, 11, 11);
-	gc.dispose();
+	ImageGcDrawer imageGcDrawer = (gc, imageWidth, imageHeight) -> {
+		gc.setForeground(display.getSystemColor(SWT.COLOR_RED));
+		gc.drawLine(1, 1, 14, 14);
+		gc.drawLine(1, 14, 14, 1);
+		gc.drawOval(2, 2, 11, 11);
+	};
+	Image xImage = new Image (display, imageGcDrawer, 16, 16);
 	final int IMAGE_MARGIN = 2;
 	final Tree tree = new Tree(shell, SWT.CHECK);
 	tree.setBounds(10, 10, 300, 150);

--- a/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet246.java
+++ b/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet246.java
@@ -49,18 +49,18 @@ public class Snippet246 {
 
 	private static void createImage() {
 		Font font = new Font(display, "Comic Sans MS", 48, SWT.BOLD);
-		Image image = new Image(display, 174, 96);
-		GC gc = new GC(image);
-		gc.setBackground(display.getSystemColor(SWT.COLOR_WHITE));
-		gc.fillRectangle(image.getBounds());
-		gc.setFont(font);
-		gc.setForeground(display.getSystemColor(SWT.COLOR_RED));
-		gc.drawString("S", 3, 10);
-		gc.setForeground(display.getSystemColor(SWT.COLOR_GREEN));
-		gc.drawString("W", 50, 10);
-		gc.setForeground(display.getSystemColor(SWT.COLOR_BLUE));
-		gc.drawString("T", 124, 10);
-		gc.dispose();
+		ImageGcDrawer imageGcDrawer = (gc, imageWidth, imageHeight) -> {
+			gc.setBackground(display.getSystemColor(SWT.COLOR_WHITE));
+			gc.fillRectangle(new Rectangle(0, 0, 174, 96));
+			gc.setFont(font);
+			gc.setForeground(display.getSystemColor(SWT.COLOR_RED));
+			gc.drawString("S", 3, 10);
+			gc.setForeground(display.getSystemColor(SWT.COLOR_GREEN));
+			gc.drawString("W", 50, 10);
+			gc.setForeground(display.getSystemColor(SWT.COLOR_BLUE));
+			gc.drawString("T", 124, 10);
+		};
+		Image image = new Image(display, imageGcDrawer, 174, 96);
 
 		ImageLoader loader = new ImageLoader();
 		loader.data = new ImageData[] { image.getImageData() };

--- a/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet275.java
+++ b/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet275.java
@@ -29,11 +29,11 @@ static String value;
 public static void main (String[] args) {
 	final int INTERVAL = 888;
 	final Display display = new Display ();
-	final Image image = new Image (display, 750, 750);
-	GC gc = new GC (image);
-	gc.setBackground (display.getSystemColor (SWT.COLOR_RED));
-	gc.fillRectangle (image.getBounds ());
-	gc.dispose ();
+	ImageGcDrawer imageGcDrawer = (gc, imageWidth, imageHeight) -> {
+		gc.setBackground(display.getSystemColor(SWT.COLOR_RED));
+		gc.fillRectangle(0, 0, imageWidth, imageHeight);
+	};
+	final Image image = new Image(display, imageGcDrawer, 750, 750);
 
 	Shell shell = new Shell (display);
 	shell.setText("Snippet 275");

--- a/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet34.java
+++ b/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet34.java
@@ -27,12 +27,12 @@ public class Snippet34 {
 
 public static void main (String[] args) {
 	Display display = new Display();
-	Image image = new Image (display, 16, 16);
-	Color color = display.getSystemColor (SWT.COLOR_RED);
-	GC gc = new GC (image);
-	gc.setBackground (color);
-	gc.fillRectangle (image.getBounds ());
-	gc.dispose ();
+	ImageGcDrawer imageGcDrawer = (gc, imageWidth, imageHeight) -> {
+		Color color = display.getSystemColor (SWT.COLOR_RED);
+		gc.setBackground(color);
+		gc.fillRectangle(0, 0, imageWidth, imageHeight);
+	};
+	Image image = new Image(display, imageGcDrawer, 16, 16);
 	Shell shell = new Shell (display);
 	shell.setText("Snippet 34");
 	Label label = new Label (shell, SWT.BORDER);

--- a/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet349.java
+++ b/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet349.java
@@ -146,12 +146,12 @@ public static void main(String [] args) {
 }
 
 static Image createImage(Display display, int width, int height) {
-	Image result = new Image(display, width, height);
-	GC gc = new GC(result);
-	for (int x = -height; x < width; x += 4) {
-		gc.drawLine(x, 0, x + height, height);
-	}
-	gc.dispose();
+	ImageGcDrawer imageGcDrawer = (gc, imageWidth, imageHeight) -> {
+		for (int x = -height; x < width; x += 4) {
+			gc.drawLine(x, 0, x + height, height);
+		}
+	};
+	Image result = new Image(display, imageGcDrawer, width, height);
 	return result;
 }
 }

--- a/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet36.java
+++ b/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet36.java
@@ -27,12 +27,12 @@ public class Snippet36 {
 
 public static void main (String [] args) {
 	Display display = new Display();
-	Image image = new Image (display, 16, 16);
-	Color color = display.getSystemColor (SWT.COLOR_RED);
-	GC gc = new GC (image);
-	gc.setBackground (color);
-	gc.fillRectangle (image.getBounds ());
-	gc.dispose ();
+	ImageGcDrawer imageGcDrawer = (gc, imageWidth, imageHeight) -> {
+		Color color = display.getSystemColor (SWT.COLOR_RED);
+		gc.setBackground(color);
+		gc.fillRectangle(0, 0, imageWidth, imageHeight);
+	};
+	Image image = new Image(display, imageGcDrawer, 16, 16);
 	Shell shell = new Shell (display);
 	shell.setText("Snippet 36");
 	ToolBar toolBar = new ToolBar (shell, SWT.FLAT | SWT.BORDER);

--- a/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet365.java
+++ b/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet365.java
@@ -89,12 +89,12 @@ public class Snippet365 {
 		// Gradient background for Shell
 		shell.addListener(SWT.Resize, event -> {
 			Rectangle rect = shell.getClientArea();
-			Image newImage = new Image(display, Math.max(1, rect.width), 1);
-			GC gc = new GC(newImage);
-			gc.setForeground(display.getSystemColor(SWT.COLOR_BLUE));
-			gc.setBackground(display.getSystemColor(SWT.COLOR_GREEN));
-			gc.fillGradientRectangle(rect.x, rect.y, rect.width, 1, false);
-			gc.dispose();
+			ImageGcDrawer imageGcDrawer = (gc, imageWidth, imageHeight) ->  {
+				gc.setForeground(display.getSystemColor(SWT.COLOR_BLUE));
+				gc.setBackground(display.getSystemColor(SWT.COLOR_GREEN));
+				gc.fillGradientRectangle(rect.x, rect.y, rect.width, 1, false);
+			};
+			Image newImage = new Image(display, imageGcDrawer, Math.max(1, rect.width), 1);
 			shell.setBackgroundImage(newImage);
 			if (oldImage != null)
 				oldImage.dispose();
@@ -135,11 +135,11 @@ public class Snippet365 {
 				// Custom
 				customGroup.setBackground(display.getSystemColor(SWT.COLOR_TRANSPARENT));
 				cLabel.setBackground(display.getSystemColor(SWT.COLOR_TRANSPARENT));
-				cTab.setBackground(Display.getDefault().getSystemColor(SWT.COLOR_TRANSPARENT));
-				gradientCTab.setBackground(Display.getDefault().getSystemColor(SWT.COLOR_TRANSPARENT));
-				sashForm.setBackground(Display.getDefault().getSystemColor(SWT.COLOR_TRANSPARENT));
+				cTab.setBackground(display.getSystemColor(SWT.COLOR_TRANSPARENT));
+				gradientCTab.setBackground(display.getSystemColor(SWT.COLOR_TRANSPARENT));
+				sashForm.setBackground(display.getSystemColor(SWT.COLOR_TRANSPARENT));
 				for (Control control : sashForm.getChildren()) {
-					control.setBackground(Display.getDefault().getSystemColor(SWT.COLOR_TRANSPARENT));
+					control.setBackground(display.getSystemColor(SWT.COLOR_TRANSPARENT));
 				}
 				// Default
 				push.setBackground(display.getSystemColor(SWT.COLOR_TRANSPARENT));
@@ -185,9 +185,9 @@ public class Snippet365 {
 				customGroup.setBackground(display.getSystemColor(SWT.COLOR_WIDGET_BACKGROUND));
 				cLabel.setBackground((Color) null);
 				styledText.setBackground((Color) null);
-				sashForm.setBackground(Display.getDefault().getSystemColor(SWT.COLOR_WIDGET_BACKGROUND));
+				sashForm.setBackground(display.getSystemColor(SWT.COLOR_WIDGET_BACKGROUND));
 				for (Control control : sashForm.getChildren()) {
-					control.setBackground(Display.getDefault().getSystemColor(SWT.COLOR_WIDGET_BACKGROUND));
+					control.setBackground(display.getSystemColor(SWT.COLOR_WIDGET_BACKGROUND));
 				}
 				cTab.setBackground(display.getSystemColor(SWT.COLOR_WIDGET_BACKGROUND));
 
@@ -458,12 +458,12 @@ public class Snippet365 {
 	private static Image getBackgroundImage(final Display display) {
 		if (newImage == null) {
 			Rectangle rect = new Rectangle(0, 0, 115, 5);
-			newImage = new Image(display, Math.max(1, rect.width), 1);
-			GC gc = new GC(newImage);
-			gc.setForeground(display.getSystemColor(SWT.COLOR_WHITE));
-			gc.setBackground(display.getSystemColor(SWT.COLOR_RED));
-			gc.fillGradientRectangle(rect.x, rect.y, rect.width, 1, false);
-			gc.dispose();
+			ImageGcDrawer imageGcDrawer = (gc, imageWidth, imageHeight) -> {
+				gc.setForeground(display.getSystemColor(SWT.COLOR_WHITE));
+				gc.setBackground(display.getSystemColor(SWT.COLOR_RED));
+				gc.fillGradientRectangle(rect.x , rect.y, rect.width, 1, false);
+			};
+			newImage = new Image(display, imageGcDrawer, Math.max(1, 115), 1);
 		}
 		return newImage;
 	}

--- a/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet367.java
+++ b/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet367.java
@@ -138,13 +138,10 @@ public class Snippet367 {
 		createSeparator(shell);
 
 		new Label (shell, SWT.NONE).setText ("2. Painted image\n (default resolution)");
-		Image image = new Image (display, size.x, size.y);
-		GC gc = new GC (image);
-		try {
-			paintImage (gc, size);
-		} finally {
-			gc.dispose ();
-		}
+	    ImageGcDrawer customImageGcDrawer = (gc, imageWidth, imageHeight) -> {
+			paintImage (gc, new Point(imageWidth, imageHeight));
+		};
+		Image image = new Image(display, customImageGcDrawer, size.x, size.y);
 		Label imageLabel = new Label (shell, SWT.NONE);
 		imageLabel.setImage (image);
 		imageLabel.setLayoutData (new GridData (SWT.BEGINNING, SWT.BEGINNING, false, false, 2, 1));
@@ -154,14 +151,14 @@ public class Snippet367 {
 		new Label (shell, SWT.NONE).setText ("3. Painted image\n(multi-res, unzoomed paint)");
 		imageLabel = new Label (shell, SWT.NONE);
 		imageLabel.setImage (new Image (display, (ImageDataProvider) zoom -> {
-			Image temp = new Image (display, size.x * zoom / 100, size.y * zoom / 100);
-			GC gc1 = new GC (temp);
+			ImageGcDrawer customImageGcDrawer1 = (gc, imageWidth, imageHeight) -> {
+				paintImage(gc, new Point(imageWidth, imageHeight));
+			};
+			Image temp = new Image(display, customImageGcDrawer1, size.x * zoom / 100, size.y * zoom / 100);
 			try {
-				paintImage (gc1, size);
-				return temp.getImageData ();
+				return temp.getImageData();
 			} finally {
-				gc1.dispose ();
-				temp.dispose ();
+				temp.dispose();
 			}
 		}));
 		imageLabel.setLayoutData (new GridData (SWT.BEGINNING, SWT.BEGINNING, false, false, 2, 1));
@@ -171,14 +168,14 @@ public class Snippet367 {
 		new Label (shell, SWT.NONE).setText ("4. Painted image\n(multi-res, zoomed paint)");
 		imageLabel = new Label (shell, SWT.NONE);
 		imageLabel.setImage (new Image (display, (ImageDataProvider) zoom -> {
-			Image temp = new Image (display, size.x * zoom / 100, size.y * zoom / 100);
-			GC gc1 = new GC (temp);
+			ImageGcDrawer customImageGcDrawer1 = (gc, imageWidth, imageHeight) -> {
+				paintImage2 (gc, new Point(imageWidth, imageHeight), zoom / 100);
+			};
+			Image temp = new Image (display, customImageGcDrawer1, size.x * zoom / 100, size.y * zoom / 100);
 			try {
-				paintImage2 (gc1, new Point (size.x * zoom / 100, size.y * zoom / 100), zoom / 100);
-				return temp.getImageData ();
+				return temp.getImageData();
 			} finally {
-				gc1.dispose ();
-				temp.dispose ();
+				temp.dispose();
 			}
 		}));
 		imageLabel.setLayoutData (new GridData (SWT.BEGINNING, SWT.BEGINNING, false, false, 2, 1));

--- a/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet387.java
+++ b/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet387.java
@@ -88,15 +88,10 @@ public class Snippet387 {
 	}
 
 	private static Image createStaticImage(Display display, String text, boolean disposeGC) {
-		Image staticImage = new Image(display, IMAGE_WIDTH, IMAGE_HEIGHT);
-		GC imageGC = new GC(staticImage);
-		try {
-			drawImageContent(imageGC, text, IMAGE_WIDTH, IMAGE_HEIGHT);
-		} finally {
-			if (disposeGC) {
-				imageGC.dispose();
-			}
-		}
+		ImageGcDrawer imageGcDrawer = (gc, imageWidth, imageHeight) -> {
+			drawImageContent(gc, text, imageWidth, imageHeight);
+		};
+		Image staticImage = new Image(display, imageGcDrawer, IMAGE_WIDTH, IMAGE_HEIGHT);
 		return staticImage;
 	}
 

--- a/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet43.java
+++ b/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet43.java
@@ -32,14 +32,14 @@ public static void main (String [] args) {
 	Caret caret = new Caret (shell, SWT.NONE);
 	Color white = display.getSystemColor (SWT.COLOR_WHITE);
 	Color black = display.getSystemColor (SWT.COLOR_BLACK);
-	final Image image = new Image (display, 20, 20);
-	GC gc = new GC (image);
-	gc.setBackground (black);
-	gc.fillRectangle (0, 0, 20, 20);
-	gc.setForeground (white);
-	gc.drawLine (0, 0, 19, 19);
-	gc.drawLine (19, 0, 0, 19);
-	gc.dispose ();
+	ImageGcDrawer imageGcDrawer = (gc, imageWidth, imageHeight) -> {
+		gc.setBackground (black);
+		gc.fillRectangle (0, 0, 20, 20);
+		gc.setForeground (white);
+		gc.drawLine (0, 0, 19, 19);
+		gc.drawLine (19, 0, 0, 19);
+	};
+	final Image image = new Image (display, imageGcDrawer, 20, 20);
 	caret.setLocation (10, 10);
 	caret.setImage (image);
 	caret.setVisible (true);

--- a/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet47.java
+++ b/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet47.java
@@ -30,26 +30,26 @@ public static void main (String [] args) {
 	Shell shell = new Shell (display);
 	shell.setText("Snippet 47");
 
-	Image image = new Image (display, 20, 20);
-	Color color = display.getSystemColor (SWT.COLOR_BLUE);
-	GC gc = new GC (image);
-	gc.setBackground (color);
-	gc.fillRectangle (image.getBounds ());
-	gc.dispose ();
+	ImageGcDrawer imageGcDrawer = (gc, imageWidth, imageHeight) -> {
+		Color color = display.getSystemColor(SWT.COLOR_BLUE);
+		gc.setBackground(color);
+		gc.fillRectangle(new Rectangle(0, 0, 20, 20));
+	};
+	Image image = new Image(display, imageGcDrawer, 20, 20);
 
-	Image disabledImage = new Image (display, 20, 20);
-	color = display.getSystemColor (SWT.COLOR_GREEN);
-	gc = new GC (disabledImage);
-	gc.setBackground (color);
-	gc.fillRectangle (disabledImage.getBounds ());
-	gc.dispose ();
+	imageGcDrawer = (gc, imageWidth, imageHeight) -> {
+		Color color = display.getSystemColor(SWT.COLOR_GREEN);
+		gc.setBackground(color);
+		gc.fillRectangle(new Rectangle(0, 0, 20, 20));
+	};
+	Image disabledImage = new Image(display, imageGcDrawer, 20, 20);
 
-	Image hotImage = new Image (display, 20, 20);
-	color = display.getSystemColor (SWT.COLOR_RED);
-	gc = new GC (hotImage);
-	gc.setBackground (color);
-	gc.fillRectangle (hotImage.getBounds ());
-	gc.dispose ();
+	imageGcDrawer = (gc, imageWidth, imageHeight) -> {
+		Color color = display.getSystemColor(SWT.COLOR_RED);
+		gc.setBackground(color);
+		gc.fillRectangle(new Rectangle(0, 0, 20, 20));
+	};
+	Image hotImage = new Image(display, imageGcDrawer, 20, 20);
 
 	ToolBar bar = new ToolBar (shell, SWT.BORDER | SWT.FLAT);
 	Rectangle clientArea = shell.getClientArea ();

--- a/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet48.java
+++ b/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet48.java
@@ -40,13 +40,13 @@ public static void main (String [] args) {
 	}
 	if (originalImage == null) {
 		int width = 150, height = 200;
-		originalImage = new Image (display, width, height);
-		GC gc = new GC (originalImage);
-		gc.fillRectangle (0, 0, width, height);
-		gc.drawLine (0, 0, width, height);
-		gc.drawLine (0, height, width, 0);
-		gc.drawText ("Default Image", 10, 10);
-		gc.dispose ();
+		ImageGcDrawer imageGcDrawer = (gc, imageWidth, imageHeight) -> {
+			gc.fillRectangle (0, 0, width, height);
+			gc.drawLine (0, 0, width, height);
+			gc.drawLine (0, height, width, 0);
+			gc.drawText ("Default Image", 10, 10);
+		};
+		originalImage = new Image (display, imageGcDrawer, width, height);
 	}
 	final Image image = originalImage;
 	final Point origin = new Point (0, 0);

--- a/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet7.java
+++ b/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet7.java
@@ -28,11 +28,11 @@ public class Snippet7 {
 
 public static void main (String [] args) {
 	final Display display = new Display ();
-	final Image image = new Image (display, 16, 16);
-	GC gc = new GC (image);
-	gc.setBackground (display.getSystemColor (SWT.COLOR_RED));
-	gc.fillRectangle (image.getBounds ());
-	gc.dispose ();
+	ImageGcDrawer imageGcDrawer = (gc, imageWidth, imageHeight) -> {
+		gc.setBackground(display.getSystemColor(SWT.COLOR_RED));
+		gc.fillRectangle(0, 0, imageWidth, imageHeight);
+	};
+	final Image image = new Image(display, imageGcDrawer, 16, 16);
 	final Shell shell = new Shell (display);
 	shell.setText ("Lazy Table");
 	shell.setLayout (new FillLayout ());

--- a/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet70.java
+++ b/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet70.java
@@ -31,17 +31,17 @@ public static void main (String [] args) {
 	Color white = display.getSystemColor (SWT.COLOR_WHITE);
 	Color black = display.getSystemColor (SWT.COLOR_BLACK);
 
-	Image image = new Image (display, 20, 20);
-	GC gc = new GC (image);
-	gc.setBackground (red);
-	gc.fillRectangle (5, 5, 10, 10);
-	gc.dispose ();
+	ImageGcDrawer imageGcDrawer = (gc, imageWidth, imageHeight) -> {
+		gc.setBackground (red);
+		gc.fillRectangle (5, 5, 10, 10);
+	};
+	Image image = new Image (display, imageGcDrawer, 20, 20);
 	ImageData imageData = image.getImageData ();
 
 	PaletteData palette = new PaletteData (new RGB (0, 0, 0),new RGB (0xFF, 0xFF, 0xFF));
 	ImageData maskData = new ImageData (20, 20, 1, palette);
 	Image mask = new Image (display, maskData);
-	gc = new GC (mask);
+	GC gc = new GC (mask);
 	gc.setBackground (black);
 	gc.fillRectangle (0, 0, 20, 20);
 	gc.setBackground (white);


### PR DESCRIPTION
This PR takes over a part to change all occurences of the image(device, int, int) constructor with the image(device, gc, int, int) constructor.


Within examples/snippets, almost all usages of the stated constructor are now replaced by an ImageGcDrawer and the Image(device, gc int, int) constructor afterwards. This replacement has/could not be made for the snippets {387, 215, 292, 95, 139} and partially not for 141. The details for them are commented here: https://github.com/vi-eclipse/Eclipse-Platform/issues/310#issuecomment-3472301957.