### PR TITLE
[Win32] Remove unnecessary special case for Cursor image data retrieval

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Cursor.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Cursor.java
@@ -627,14 +627,9 @@ private static class ImageDataProviderCursorHandleProvider extends HotspotAwareC
 
 	@Override
 	public CursorHandle createHandle(Device device, int zoom) {
-		ImageData source;
-		if (zoom == DEFAULT_ZOOM) {
-			source = this.provider.getImageData(DEFAULT_ZOOM);
-		} else {
-			Image tempImage = new Image(device, this.provider);
-			source = tempImage.getImageData(zoom);
-			tempImage.dispose();
-		}
+		Image tempImage = new Image(device, this.provider);
+		ImageData source = tempImage.getImageData(zoom);
+		tempImage.dispose();
 		return setupCursorFromImageData(device, source, null, getHotpotXInPixels(zoom), getHotpotYInPixels(zoom));
 	}
 }


### PR DESCRIPTION
A special case for retrieving image data for a cursor directly from the ImageDataProvider when requesting at 100% was unnecessarily added and not removed during a refactoring as it was late in the development cycle and no regression risk wanted to be taken. This now cleans up the according code and makes the image data always be retrieved from an image instance instead of the ImageDataProvider directly.

According to: https://github.com/eclipse-platform/eclipse.platform.swt/pull/2390#discussion_r2260255140