### PR TITLE
Make TreeItem.getExpanded consistent across platforms #2834

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/TreeItem.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/TreeItem.java
@@ -535,10 +535,7 @@ public boolean getChecked () {
  */
 public boolean getExpanded () {
 	checkWidget();
-	long path = GTK.gtk_tree_model_get_path (parent.modelHandle, handle);
-	boolean answer = GTK.gtk_tree_view_row_expanded (parent.handle, path);
-	GTK.gtk_tree_path_free (path);
-	return answer;
+	return isExpanded;
 }
 
 /**
@@ -1226,7 +1223,8 @@ public void setChecked (boolean checked) {
 public void setExpanded (boolean expanded) {
 	checkWidget();
 	long path = GTK.gtk_tree_model_get_path (parent.modelHandle, handle);
-	if (expanded != GTK.gtk_tree_view_row_expanded (parent.handle, path)) {
+	// Do nothing when the item is a leaf or already expanded
+	if (expanded != GTK.gtk_tree_view_row_expanded (parent.handle, path) && GTK.gtk_tree_model_iter_n_children (parent.modelHandle, handle) != 0) {
 		if (expanded) {
 			OS.g_signal_handlers_block_matched (parent.handle, OS.G_SIGNAL_MATCH_DATA, 0, 0, 0, 0, TEST_EXPAND_ROW);
 			GTK.gtk_tree_view_expand_row (parent.handle, path, false);
@@ -1237,9 +1235,9 @@ public void setExpanded (boolean expanded) {
 			GTK.gtk_tree_view_collapse_row (parent.handle, path);
 			OS.g_signal_handlers_unblock_matched (parent.handle, OS.G_SIGNAL_MATCH_DATA, 0, 0, 0, 0, TEST_COLLAPSE_ROW);
 		}
+		isExpanded = expanded;
 	}
 	GTK.gtk_tree_path_free (path);
-	isExpanded = expanded;
 }
 
 

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_TreeItem.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_TreeItem.java
@@ -536,12 +536,21 @@ public void test_getBoundsI() {
 @Test
 public void test_getExpanded() {
 	assertFalse(treeItem.getExpanded());
+	// do nothing when the item is a leaf
+	treeItem.setExpanded(true);
+	assertFalse(treeItem.getExpanded());
 	// there must be at least one subitem before you can set the treeitem expanded
 	new TreeItem(treeItem, 0);
 	treeItem.setExpanded(true);
 	assertTrue(treeItem.getExpanded());
 	treeItem.setExpanded(false);
 	assertFalse(treeItem.getExpanded());
+	treeItem.setExpanded(true);
+	treeItem.removeAll();
+	assertTrue(treeItem.getExpanded());
+	// do nothing when the item is a leaf
+	treeItem.setExpanded(false);
+	assertTrue(treeItem.getExpanded());
 }
 
 @Test


### PR DESCRIPTION
When the children of a previously expanded TreeItem are removed, the call to getExpanded() should continue to return "true". On both Linux and MacOS, this property is not persisted and therefore stored in a local variable. But on Linux, a call to getExpanded() still returns the result from a call to the GTK API.

To harmonize the behavior between the different operating systems, following changes are done:

1) The call to getExpanded() now always returns the local variable, similar to how it's done for MacOS.

2) The call to setExpanded() doesn't modify the tree item if it is already expanded or a leaf node.