### PR TITLE
SuppressWarnings on use of System.runFinalization (in Browser test)

### DIFF
--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_browser_Browser.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_browser_Browser.java
@@ -2842,7 +2842,7 @@ private static Boolean checkInternet(String url) {
 
 private static void printMemoryUse() {
 	System.gc();
-	System.runFinalization();
+	runFinalization();
 	long max = Runtime.getRuntime().maxMemory();
 	long total = Runtime.getRuntime().totalMemory();
 	long free = Runtime.getRuntime().freeMemory();
@@ -2853,6 +2853,15 @@ private static void printMemoryUse() {
 	System.out.printf(Locale.GERMAN, "%n%,16d bytes free heap", free);
 	System.out.printf(Locale.GERMAN, "%n%,16d bytes used heap", used);
 	System.out.println("\n#################################################\n");
+}
+
+/**
+ * Finalization is deprecated for removal in Java, as of now there is no actual
+ * removal date planned. The method exists to narrowly suppress warnings.
+ */
+@SuppressWarnings("removal")
+private static void runFinalization() {
+	System.runFinalization();
 }
 
 


### PR DESCRIPTION
Finalization is deprecated for removal in Java, as of now there is no actual removal date planned so simply suppressing the warning seems most suitable.

Follow-up to remove warnings in SWT workspace with update to Java 21 in https://github.com/eclipse-platform/eclipse.platform.swt/pull/2824