### PR TITLE
[GTK] Fix NPE on POST requests when response has no Content-Type

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT WebKit/gtk/org/eclipse/swt/browser/WebKit.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT WebKit/gtk/org/eclipse/swt/browser/WebKit.java
@@ -2200,19 +2200,21 @@ public boolean setUrl (String url, String postData, String[] headers) {
 					{ // Extract result meta data
 						// Get Media Type from Content-Type
 						String content_type = conn.getContentType();
-						int parameterSeparatorIndex = content_type.indexOf(';');
-						mime_type = parameterSeparatorIndex > 0 ? content_type.substring(0, parameterSeparatorIndex) : content_type;
+						if (content_type != null) {
+							int parameterSeparatorIndex = content_type.indexOf(';');
+							mime_type = parameterSeparatorIndex > 0 ? content_type.substring(0, parameterSeparatorIndex) : content_type;
 
-						// Get Encoding if defined
-						if (content_type.indexOf(';') > 0) {
-							String [] attrs = content_type.split(";");
-							for (String attr : attrs) {
-								int i = attr.indexOf('=');
-								if (i > 0) {
-									String key = attr.substring(0, i).trim();
-									String value = attr.substring(i + 1).trim();
-									if ("charset".equalsIgnoreCase(key)) { //$NON-NLS-1$
-										encoding_type = value;
+							// Get Encoding if defined
+							if (content_type.indexOf(';') > 0) {
+								String [] attrs = content_type.split(";");
+								for (String attr : attrs) {
+									int i = attr.indexOf('=');
+									if (i > 0) {
+										String key = attr.substring(0, i).trim();
+										String value = attr.substring(i + 1).trim();
+										if ("charset".equalsIgnoreCase(key)) { //$NON-NLS-1$
+											encoding_type = value;
+										}
 									}
 								}
 							}


### PR DESCRIPTION
The NPE was output to System.err because nothing catches it, but its running on a thread. The code worked, but System.err would have

```
Exception in thread "Thread-2" java.lang.NullPointerException: Cannot invoke "String.indexOf(int)" because "content_type" is null
	at org.eclipse.swt.browser.WebKit.lambda$14(WebKit.java:2186)
	at java.base/java.lang.Thread.run(Thread.java:1583)
```

or similar.