### PR TITLE
[Win32] Fix control bounds exceeding parent size

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/widgets/ControlWin32Tests.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/widgets/ControlWin32Tests.java
@@ -155,4 +155,205 @@ class ControlWin32Tests {
 		return new FontComparison(heightInPixels, currentHeightInPixels);
 	}
 
+	/**
+	 * Scenario:
+	 * <ul>
+	 * <li>parent has bounds with an offset (x != 0) to its parent
+	 * <li>child fills the composite, such that both their widths are equal
+	 * </ul>
+	 * Depending on how the offset of the parent (x value of bounds) is taken
+	 * into account when rounding during point-to-pixel conversion, the parent
+	 * composite may become one pixel too large or small for the child.
+	 */
+	@Test
+	void testChildFillsCompositeWithOffset() {
+		Win32DPIUtils.setMonitorSpecificScaling(true);
+		// pixel values at 125%: (2.5, 2.5, 2.5, 2.5) --> when rounding bottom right
+		// corner (pixel value (5, 5)) instead of width/height independently, will be
+		// rounded to (3, 3, 2, 2) --> too small for child
+		Rectangle parentBounds = new Rectangle(2, 2, 2, 2);
+		// pixel values at 125%: (0, 0, 2.5, 2.5) --> will be rounded to (0, 0, 3, 3)
+		Rectangle childBounds = new Rectangle(0, 0, 2, 2);
+
+		Display display = Display.getDefault();
+		Shell shell = new Shell(display);
+		Composite parent = new Composite(shell, SWT.NONE);
+		DPITestUtil.changeDPIZoom(shell, 125);
+		parent.setBounds(parentBounds);
+		Button child = new Button(parent, SWT.PUSH);
+		child.setBounds(childBounds);
+
+		Rectangle parentBoundsInPixels = parent.getBoundsInPixels();
+		Rectangle childBoundsInPixels = child.getBoundsInPixels();
+		assertEquals(parentBoundsInPixels.x, 3);
+		assertEquals(childBoundsInPixels.x, 0);
+		assertEquals(parentBoundsInPixels.width, childBoundsInPixels.width);
+		assertEquals(parentBoundsInPixels.height, childBoundsInPixels.height);
+		assertEquals(childBounds, child.getBounds());
+	}
+
+	/**
+	 * Scenario:
+	 * <ul>
+	 * <li>parent has bounds with an offset (x = 0) to its parent
+	 * <li>child has an offset (x != 0) to parent and exactly fills the rest of the
+	 * composite, such that child.x+child.width is equal to parent.x
+	 * </ul>
+	 * Depending on how the offset of the child (x value of bounds) is taken into
+	 * account when rounding during point-to-pixel conversion, the child may become
+	 * one pixel too large to fit into the parent.
+	 */
+	@Test
+	void testChildWithOffsetFillsComposite() {
+		Win32DPIUtils.setMonitorSpecificScaling(true);
+		// pixel values at 125%: (0, 0, 5, 5)
+		Rectangle parentBounds = new Rectangle(0, 0, 4, 4);
+		// pixel values at 125%: (2.5, 2.5, 2.5, 2.5) --> when rounding width/height
+		// independently instead of bottom right corner, will be rounded to
+		// (3, 3, 3, 3) --> too large for parent
+		Rectangle childBounds = new Rectangle(2, 2, 2, 2);
+
+		Display display = Display.getDefault();
+		Shell shell = new Shell(display);
+		Composite parent = new Composite(shell, SWT.NONE);
+		DPITestUtil.changeDPIZoom(shell, 125);
+		parent.setBounds(parentBounds);
+		Button child = new Button(parent, SWT.PUSH);
+
+		child.setBounds(childBounds);
+		assertChildFitsIntoParent(parent, child);
+		assertEquals(parentBounds, parent.getBounds());
+		assertEquals(childBounds, child.getBounds());
+
+		child.setSize(childBounds.width, childBounds.height);
+		assertChildFitsIntoParent(parent, child);
+		assertEquals(parentBounds, parent.getBounds());
+		assertEquals(childBounds, child.getBounds());
+	}
+
+	private void assertChildFitsIntoParent(Control parent, Control child) {
+		Rectangle parentBoundsInPixels = parent.getBoundsInPixels();
+		Rectangle childBoundsInPixels = child.getBoundsInPixels();
+		Rectangle childBounds = child.getBounds();
+		assertEquals(parentBoundsInPixels.width, childBoundsInPixels.x + childBoundsInPixels.width);
+		assertEquals(parentBoundsInPixels.height, childBoundsInPixels.y + childBoundsInPixels.height);
+		assertEquals(parent.getBounds().width, childBounds.x + childBounds.width);
+		assertEquals(parent.getBounds().height, childBounds.y + childBounds.height);
+	}
+
+	/**
+	 * Scenario: Layouting
+	 * <p>
+	 * Layouts use client area of composites to calculate the sizes of the contained
+	 * controls. The rounded values of that client area can lead to child bounds be
+	 * calculated larger than the actual available size. This serves as unit test
+	 * for that behavior in addition to the integration test
+	 * {@link #testChildFillsScrollableWithBadlyRoundedClientArea()}
+	 */
+	@Test
+	void testFitChildIntoParent() {
+		Win32DPIUtils.setMonitorSpecificScaling(true);
+		// pixel values at 125%: (0, 0, 5, 5)
+		Rectangle parentBounds = new Rectangle(0, 0, 4, 4);
+		// pixel values at 125%: (2.5, 2.5, 3.75, 3.75) --> rounded to (3, 3, 3, 3)
+		Rectangle childBounds = new Rectangle(2, 2, 3, 3);
+
+		Display display = Display.getDefault();
+		Shell shell = new Shell(display);
+		Composite parent = new Composite(shell, SWT.NONE);
+		DPITestUtil.changeDPIZoom(shell, 125);
+		parent.setBounds(parentBounds);
+		Button child = new Button(parent, SWT.PUSH);
+
+		child.setBounds(childBounds);
+		assertChildFitsIntoParent(parent, child);
+
+		child.setSize(childBounds.width, childBounds.height);
+		assertChildFitsIntoParent(parent, child);
+	}
+
+	// Ensure that the fitting logic does only apply at off-by-one calculation results
+	// and not for fitting actually larger childs into parts
+	@Test
+	void testFitChildIntoParent_limitedSizeDifference() {
+		Win32DPIUtils.setMonitorSpecificScaling(true);
+		// pixel values at 125%: (0, 0, 5, 5)
+		Rectangle parentBounds = new Rectangle(0, 0, 4, 4);
+		// pixel values at 125%: (2.5, 2.5, 5, 5) --> rounded to (3, 3, 5, 5)
+		Rectangle childBounds = new Rectangle(2, 2, 4, 4);
+
+		Display display = Display.getDefault();
+		Shell shell = new Shell(display);
+		Composite parent = new Composite(shell, SWT.NONE);
+		DPITestUtil.changeDPIZoom(shell, 125);
+		parent.setBounds(parentBounds);
+		Button child = new Button(parent, SWT.PUSH);
+
+		child.setBounds(childBounds);
+		assertChildNotFitsIntoParent(parent, child);
+
+		child.setSize(childBounds.width, childBounds.height);
+		assertChildNotFitsIntoParent(parent, child);
+	}
+
+	private void assertChildNotFitsIntoParent(Control parent, Control child) {
+		Rectangle parentBoundsInPixels = parent.getBoundsInPixels();
+		Rectangle childBoundsInPixels = child.getBoundsInPixels();
+		Rectangle childBounds = child.getBounds();
+		assertNotEquals(parentBoundsInPixels.width, childBoundsInPixels.x + childBoundsInPixels.width);
+		assertNotEquals(parentBoundsInPixels.height, childBoundsInPixels.y + childBoundsInPixels.height);
+		assertNotEquals(parent.getBounds().width, childBounds.x + childBounds.width);
+		assertNotEquals(parent.getBounds().height, childBounds.y + childBounds.height);
+	}
+
+	/**
+	 * Scenario: Layouting
+	 * <p>
+	 * Layouts use client area of composites to calculate the sizes of the contained
+	 * controls. The rounded values of that client area can lead to child bounds be
+	 * calculated larger than the actual available size.
+	 */
+	@Test
+	void testChildFillsScrollableWithBadlyRoundedClientArea() {
+		Win32DPIUtils.setMonitorSpecificScaling(true);
+		Display display = Display.getDefault();
+		Shell shell = new Shell(display);
+		Composite parent = new Composite(shell, SWT.H_SCROLL|SWT.V_SCROLL);
+		DPITestUtil.changeDPIZoom(shell, 125);
+		// Find parent bounds such that client area is rounded to a value that,
+		// when converted back to pixels, is one pixel too large
+		Rectangle parentBounds = new Rectangle(0, 0, 4, 4);
+		Rectangle clientAreaInPixels;
+		do {
+			do {
+				parentBounds.width += 1;
+				parentBounds.height += 1;
+				parent.setBounds(parentBounds);
+				Rectangle clientArea = parent.getClientArea();
+				clientAreaInPixels = Win32DPIUtils
+						.pointToPixel(new Rectangle(clientArea.x, clientArea.y, clientArea.width, clientArea.height), 125);
+			} while (clientAreaInPixels.width <= parent.getClientAreaInPixels().width && clientAreaInPixels.width < 50);
+			parentBounds.x += 1;
+			parentBounds.y += 1;
+			if (parentBounds.x >= 50) {
+				fail("No scrolable size with non-invertible point/pixel conversion for its client area could be created");
+			}
+		} while (clientAreaInPixels.width <= parent.getClientAreaInPixels().width);
+		Button child = new Button(parent, SWT.PUSH);
+		Rectangle childBounds = new Rectangle(0, 0, parent.getClientArea().width, parent.getClientArea().height);
+		child.setBounds(childBounds);
+
+		clientAreaInPixels  = parent.getClientAreaInPixels();
+		Rectangle childBoundsInPixels = child.getBoundsInPixels();
+		assertTrue(clientAreaInPixels.width <= childBoundsInPixels.x + childBoundsInPixels.width);
+		assertTrue(clientAreaInPixels.height <= childBoundsInPixels.y + childBoundsInPixels.height);
+
+		child.setSize(childBounds.width, childBounds.height);
+
+		clientAreaInPixels  = parent.getClientAreaInPixels();
+		childBoundsInPixels = child.getBoundsInPixels();
+		assertTrue(clientAreaInPixels.width <= childBoundsInPixels.x + childBoundsInPixels.width);
+		assertTrue(clientAreaInPixels.height <= childBoundsInPixels.y + childBoundsInPixels.height);
+	}
+
 }


### PR DESCRIPTION
The invertibility of point/pixel conversions is limited as point values are int-based and with lower resolution than pixel values. In consequence, values need to be rounded when converted between the two, which inevitably leads to rounded values that do not fit for every use case. This adds test cases that demonstrate such use cases, including simple parent/child scenarios, in which the child is supposed to fill the parent, and including layouting scenarios incorporating the client area of a composite, and how the current implementation is not capable of producing proper results for them.

This change also adapts the methods for setting bounds/size of controls to deal with the limited invertibility. They shrink the calculated pixel values by at most the maximum error that can be made when transforming from point to pixel values, such that rounding errors due to layouts that calculated control bounds based on a composites client area are evened out. Without that, layouted controls may be up to one point too large to fit into the composite.

This is an extract of:
- https://github.com/eclipse-platform/eclipse.platform.swt/pull/2782

which would, in its current state, introduce a regression that needs to be further analyzed.

### How to reproduce
The different issues are demonstrated with the following snippet (conforms to the test cases and same as in #2782)):

```java
public static void main(String[] args) {
	System.setProperty("swt.autoScale.updateOnRuntime", "true");
	Display display = new Display();
	Shell shell = new Shell(display);
	shell.setSize(200, 200);
	int width = 11;
	int height = 11;

	Composite c1 = new Composite(shell, SWT.NONE);
	c1.addPaintListener(e -> {
		e.gc.setBackground(display.getSystemColor(SWT.COLOR_BLUE));
		e.gc.fillRectangle(0, 0, c1.getSize().x + 5, c1.getSize().x + 5);
	});
	c1.setBounds(11, 9, width, height);
	Label l1 = new Label(c1, SWT.BORDER);
	l1.setBounds(0, 0, width, height);

	Composite c2 = new Composite(shell, SWT.NONE);
	c2.addPaintListener(e -> {
		e.gc.setBackground(display.getSystemColor(SWT.COLOR_BLUE));
		e.gc.fillRectangle(0, 0, c2.getSize().x + 5, c2.getSize().x + 5);
	});
	c2.setBounds(10, 30, width, height);
	Label l2 = new Label(c2, SWT.BORDER);
	l2.setBounds(0, 0, width, height);

	width += 2;
	height += 2;
	Composite c3 = new Composite(shell, SWT.NONE);
	c3.addPaintListener(e -> {
		e.gc.setBackground(display.getSystemColor(SWT.COLOR_BLUE));
		e.gc.fillRectangle(0, 0, c3.getSize().x + 5, c3.getSize().y + 5);
	});
	c3.setBounds(13, 53, width, height);
	Label l3 = new Label(c3, SWT.BORDER);
	l3.setBounds(0, 0, width, height);

	Composite c4 = new Composite(shell, SWT.NONE);
	c4.addPaintListener(e -> {
		e.gc.setBackground(display.getSystemColor(SWT.COLOR_BLUE));
		e.gc.fillRectangle(0, 0, c4.getSize().x + 5, c4.getSize().y + 5);
	});
	GridLayout layout = new GridLayout(2, true);
	layout.marginBottom = 0;
	layout.marginTop = 0;
	layout.marginLeft = 0;
	layout.marginRight = 0;
	layout.marginHeight= 0;
	layout.marginWidth= 0;
	layout.horizontalSpacing = 0;
	c4.setLayout(layout);
	c4.setBounds(13, 100, 101, 50);
	System.out.println(c4.getBounds());
	System.out.println(c4.getClientArea());
	Label l4a = new Label(c4, SWT.BORDER);
	l4a.setBackground(display.getSystemColor(SWT.COLOR_GREEN));
	l4a.setLayoutData(new GridData(GridData.FILL_BOTH));
	Label l4b = new Label(c4, SWT.BORDER);
	l4b.setBackground(display.getSystemColor(SWT.COLOR_GREEN));
	l4b.setLayoutData(new GridData(GridData.FILL_BOTH));
	c4.layout();

	shell.open();
	while (!shell.isDisposed()) {
		if (!display.readAndDispatch())
			display.sleep();
	}

	display.dispose();
}
```

All scenarios except for the one with third composite (becoming too small to fit its parent) are fixed with this change.

Before at 125%:
<img width="234" height="242" alt="image" src="https://github.com/user-attachments/assets/17ccb914-5ad4-4004-9f76-4630b3ae064b" />

After at 125%:
<img width="234" height="242" alt="image" src="https://github.com/user-attachments/assets/51b8be5a-7b50-4a0b-a23e-6e34c70b0b00" />

### Further examples

This change improves layouting behavior and can, e.g., be seen in the Forms UI, such as used in the Manifest editor.

Before at 125%:
![forms_broken](https://github.com/user-attachments/assets/27e3044c-cae0-4576-a889-b03141352568)

After at 125%:
![forms_fixed](https://github.com/user-attachments/assets/e63f18d4-52df-4890-9636-f088454bdd28)
