### PR TITLE
[Win32] Update Cursor size when accessibility setting changes

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Cursor.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Cursor.java
@@ -320,14 +320,15 @@ public static Long win32_getHandle (Cursor cursor, int zoom) {
 	if (cursor.isDisposed()) {
 		return 0L;
 	}
-	if (cursor.zoomLevelToHandle.get(zoom) != null) {
-		return cursor.zoomLevelToHandle.get(zoom).getHandle();
+	int zoomWithPointerSizeScaleFactor = (int) (zoom * getPointerSizeScaleFactor());
+	if (cursor.zoomLevelToHandle.get(zoomWithPointerSizeScaleFactor) != null) {
+		return cursor.zoomLevelToHandle.get(zoomWithPointerSizeScaleFactor).getHandle();
 	}
 
-	CursorHandle handle = cursor.cursorHandleProvider.createHandle(cursor.device, zoom);
-	cursor.setHandleForZoomLevel(handle, zoom);
+	CursorHandle handle = cursor.cursorHandleProvider.createHandle(cursor.device, zoomWithPointerSizeScaleFactor);
+	cursor.setHandleForZoomLevel(handle, zoomWithPointerSizeScaleFactor);
 
-	return cursor.zoomLevelToHandle.get(zoom).getHandle();
+	return cursor.zoomLevelToHandle.get(zoomWithPointerSizeScaleFactor).getHandle();
 }
 
 private void setHandleForZoomLevel(CursorHandle handle, Integer zoom) {
@@ -628,10 +629,9 @@ private static class ImageDataProviderCursorHandleProvider extends HotspotAwareC
 	@Override
 	public CursorHandle createHandle(Device device, int zoom) {
 		Image tempImage = new Image(device, this.provider);
-		int scaledZoom = (int) (zoom * getPointerSizeScaleFactor());
-		ImageData source = tempImage.getImageData(scaledZoom);
+		ImageData source = tempImage.getImageData(zoom);
 		tempImage.dispose();
-		return setupCursorFromImageData(device, source, null, getHotpotXInPixels(scaledZoom), getHotpotYInPixels(scaledZoom));
+		return setupCursorFromImageData(device, source, null, getHotpotXInPixels(zoom), getHotpotYInPixels(zoom));
 	}
 }
 
@@ -647,11 +647,9 @@ private static class ImageDataCursorHandleProvider extends HotspotAwareCursorHan
 
 	@Override
 	public CursorHandle createHandle(Device device, int zoom) {
-		float accessibilityFactor = getPointerSizeScaleFactor();
-		int scaledZoom = (int) (zoom * accessibilityFactor);
-		ImageData scaledSource = DPIUtil.scaleImageData(device, this.source, scaledZoom, DEFAULT_ZOOM);
-		return setupCursorFromImageData(device, scaledSource, null, getHotpotXInPixels(scaledZoom),
-				getHotpotYInPixels(scaledZoom));
+		ImageData scaledSource = DPIUtil.scaleImageData(device, this.source, zoom, DEFAULT_ZOOM);
+		return setupCursorFromImageData(device, scaledSource, null, getHotpotXInPixels(zoom),
+				getHotpotYInPixels(zoom));
 	}
 }
 
@@ -680,8 +678,7 @@ private static class ImageDataWithMaskCursorHandleProvider extends ImageDataCurs
 
 	@Override
 	public CursorHandle createHandle(Device device, int zoom) {
-		int scaledZoom = (int) (zoom * getPointerSizeScaleFactor());
-		float scaledZoomFactor = scaledZoom / 100f;
+		float scaledZoomFactor = zoom / 100f;
 		int scaledSourceWidth = Math.round(this.source.width * scaledZoomFactor);
 		int scaledSourceHeight = Math.round(this.source.height * scaledZoomFactor);
 		ImageData scaledSource = this.source.scaledTo(scaledSourceWidth, scaledSourceHeight);
@@ -691,8 +688,8 @@ private static class ImageDataWithMaskCursorHandleProvider extends ImageDataCurs
 			int scaledMaskHeight = Math.round(this.mask.height * scaledZoomFactor);
 			scaledMask = this.mask.scaledTo(scaledMaskWidth, scaledMaskHeight);
 		}
-		return setupCursorFromImageData(device, scaledSource, scaledMask, getHotpotXInPixels(scaledZoom),
-				getHotpotYInPixels(scaledZoom));
+		return setupCursorFromImageData(device, scaledSource, scaledMask, getHotpotXInPixels(zoom),
+				getHotpotYInPixels(zoom));
 	}
 }
 


### PR DESCRIPTION
currently cursor handle is created per zoom. So when cursor is created at 100% zoom it will be reused even if you change the cursor size from accessibility setting. With this change we create a new cursor handle with the key combination of (zoom x accessibilityFactor).

Fixes: https://github.com/eclipse-platform/eclipse.platform.swt/issues/2833

### To Reproduce


- Open Snippet386 and choose one of the constructors using ImageData
- Hover over the "Scale" area once such that the cursor appears
- Change the accessibility settings of your system to use a different cursor size
- Hover over the "Scale" area again

**Previous Behavior:** 

You will see that the cursor still has the "old" size (i.e., without the accessibility setting change) when hovering over that area.

**Expected behavior:**
Cursor sizes should dynamically adapt to changed accessibility settings.