### PR TITLE
[Win32] Fix hotspot of Cursor with accessibility scale factor

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Cursor.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Cursor.java
@@ -631,7 +631,7 @@ private static class ImageDataProviderCursorHandleProvider extends HotspotAwareC
 		int scaledZoom = (int) (zoom * getPointerSizeScaleFactor());
 		ImageData source = tempImage.getImageData(scaledZoom);
 		tempImage.dispose();
-		return setupCursorFromImageData(device, source, null, getHotpotXInPixels(zoom), getHotpotYInPixels(zoom));
+		return setupCursorFromImageData(device, source, null, getHotpotXInPixels(scaledZoom), getHotpotYInPixels(scaledZoom));
 	}
 }
 
@@ -650,8 +650,8 @@ private static class ImageDataCursorHandleProvider extends HotspotAwareCursorHan
 		float accessibilityFactor = getPointerSizeScaleFactor();
 		int scaledZoom = (int) (zoom * accessibilityFactor);
 		ImageData scaledSource = DPIUtil.scaleImageData(device, this.source, scaledZoom, DEFAULT_ZOOM);
-		return setupCursorFromImageData(device, scaledSource, null, getHotpotXInPixels(zoom),
-				getHotpotYInPixels(zoom));
+		return setupCursorFromImageData(device, scaledSource, null, getHotpotXInPixels(scaledZoom),
+				getHotpotYInPixels(scaledZoom));
 	}
 }
 
@@ -680,7 +680,8 @@ private static class ImageDataWithMaskCursorHandleProvider extends ImageDataCurs
 
 	@Override
 	public CursorHandle createHandle(Device device, int zoom) {
-		float scaledZoomFactor = zoom * getPointerSizeScaleFactor() / 100f;
+		int scaledZoom = (int) (zoom * getPointerSizeScaleFactor());
+		float scaledZoomFactor = scaledZoom / 100f;
 		int scaledSourceWidth = Math.round(this.source.width * scaledZoomFactor);
 		int scaledSourceHeight = Math.round(this.source.height * scaledZoomFactor);
 		ImageData scaledSource = this.source.scaledTo(scaledSourceWidth, scaledSourceHeight);
@@ -690,8 +691,8 @@ private static class ImageDataWithMaskCursorHandleProvider extends ImageDataCurs
 			int scaledMaskHeight = Math.round(this.mask.height * scaledZoomFactor);
 			scaledMask = this.mask.scaledTo(scaledMaskWidth, scaledMaskHeight);
 		}
-		return setupCursorFromImageData(device, scaledSource, scaledMask, getHotpotXInPixels(zoom),
-				getHotpotYInPixels(zoom));
+		return setupCursorFromImageData(device, scaledSource, scaledMask, getHotpotXInPixels(scaledZoom),
+				getHotpotYInPixels(scaledZoom));
 	}
 }
 


### PR DESCRIPTION
When a scale factor for cursors is applied via the accessibility settings, this factor currently only affects the cursor size itself but not the hotspot position calculation. In consequence, the hotspot is only scaled by the monitor zoom and not the accessibility scale factor, thus being misplaced.

This change adapts the zoom to be used when scaling the hotspot coordinates.

This is an extract of https://github.com/eclipse-platform/eclipse.platform.swt/pull/2850 fixing a separate issue (according to https://github.com/eclipse-platform/eclipse.platform.swt/pull/2850#discussion_r2585350097) via a separate commit/PR. Change has already been successfully tested with #2850.