### PR TITLE
Remove SWT Test Results badge from README

### DIFF
--- a/.github/workflows/junit.yml
+++ b/.github/workflows/junit.yml
@@ -45,35 +45,3 @@ jobs:
           event_file: artifacts/Event File/event.json
           event_name: ${{ github.event.workflow_run.event }}
           files: "artifacts/**/*.xml"
-      - name: Set badge color
-        if: github.ref == 'refs/heads/master'
-        shell: bash
-        run: |
-          case ${{ fromJSON( steps.test-results.outputs.json ).conclusion }} in
-            success)
-              echo "BADGE_COLOR=31c653" >> $GITHUB_ENV
-              ;;
-            failure)
-              echo "BADGE_COLOR=800000" >> $GITHUB_ENV
-              ;;
-            neutral)
-              echo "BADGE_COLOR=696969" >> $GITHUB_ENV
-              ;;
-          esac
-
-      - name: Create badge
-        if: github.ref == 'refs/heads/master'
-        uses: emibcn/badge-action@808173dd03e2f30c980d03ee49e181626088eee8
-        with:
-          label: Tests
-          status: '${{ fromJSON( steps.test-results.outputs.json ).stats.tests }} tests, ${{ fromJSON( steps.test-results.outputs.json ).stats.runs }} runs: ${{ fromJSON( steps.test-results.outputs.json ).conclusion }}'
-          color: ${{ env.BADGE_COLOR }}
-          path: badge.svg
-
-      - name: Upload badge to Gist
-        if: github.ref == 'refs/heads/master'
-        uses: andymckay/append-gist-action@ab30bf28df67017c7ad696500b218558c7c04db3
-        with:
-          token: ${{ secrets.GIST_TOKEN }}
-          gistURL: https://gist.githubusercontent.com/eclipse-releng-bot/78d110a601baa4ef777ccb472f584038
-          file: badge.svg

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 [![SWT Matrix Build](https://github.com/eclipse-platform/eclipse.platform.swt/actions/workflows/maven.yml/badge.svg)](https://github.com/eclipse-platform/eclipse.platform.swt/actions/workflows/maven.yml)
 [![Publish Unit Test Results](https://github.com/eclipse-platform/eclipse.platform.swt/actions/workflows/junit.yml/badge.svg)](https://github.com/eclipse-platform/eclipse.platform.swt/actions/workflows/junit.yml)
-![SWT Matrix Tests](https://gist.githubusercontent.com/eclipse-releng-bot/78d110a601baa4ef777ccb472f584038/raw/badge.svg)
 [![License](https://img.shields.io/github/license/eclipse-platform/eclipse.platform)](https://github.com/eclipse-platform/eclipse.platform.swt/blob/master/LICENSE)
 
 # About


### PR DESCRIPTION
This badge has been incorrect since its inception and keeping it maintained properly going forward would require some additional work in the context of https://github.com/eclipse-platform/eclipse.platform.swt/pull/2764

Therefore, this removes the badge.

Fixes https://github.com/eclipse-platform/eclipse.platform.swt/issues/2783

Part of https://github.com/eclipse-platform/eclipse.platform.swt/issues/2714