### PR TITLE
Remove hidden character and document why build_gtk.sh is ignored.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,5 @@ pom.tycho
 
 /binaries/org.eclipse.swt.*/src/
 tmpdir/
-‎build_gtk.sh
+# temp build script used by copilot instructions: https://github.com/eclipse-platform/eclipse.platform.swt/blob/c3318b8e7ebc9e34de80afc4f3e5ec15cc7ca112/.github/workflows/copilot-setup-steps.yml#L43
+/build_gtk.sh


### PR DESCRIPTION
Fixes https://github.com/eclipse-platform/eclipse.platform.swt/commit/d3574fc9206c5dac700c14dfb9c44de28c9811d6#r172100008