### PR TITLE
Make DPIUtil#isMonitorSpecificScalingActive() yield true only on Windows

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/DPIUtil.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/DPIUtil.java
@@ -155,6 +155,9 @@ public static boolean isSetupCompatibleToMonitorSpecificScaling() {
 }
 
 public static boolean isMonitorSpecificScalingActive() {
+	if (!"win32".equals(SWT.getPlatform())) {
+		return false;
+	}
 	String updateOnRuntimeValue = System.getProperty(SWT_AUTOSCALE_UPDATE_ON_RUNTIME);
 	return "force".equalsIgnoreCase(updateOnRuntimeValue) || "true".equalsIgnoreCase(updateOnRuntimeValue);
 }


### PR DESCRIPTION
Currently, `DPIUtil#isMonitorSpecificScalingActive()` returns true if the according system property has an appropriate value. However, monitor-specific scaling will effectively never be active when using Linux or MacOS, as it is only implemented for Windows. Returning "true" on a non-supported platform is inconsistent and puts the burden to take into account if the OS is supported at all to the consumers. This change thus adapts the method to always return "false" on non-supported platforms. This also conforms to the documentation of the system property in the DPIUtil class. This is effectively the same as `DPIUtil#isSetupCompatibleToMonitorSpecificScaling()` does.