### PR TITLE
Use shorter strings in the macOS matrix configuration

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -123,17 +123,11 @@ jobs:
       fail-fast: false
       matrix:
         java: ['21']
-        native: [cocoa.macosx.x86_64, cocoa.macosx.aarch64]
-        runner: [macos-15-intel, macos-latest]
-        exclude:
-          - runner: macos-latest
-            native: cocoa.macosx.x86_64
-          - runner: macos-15-intel
-            native: cocoa.macosx.aarch64
+        arch: [x86_64, aarch64]
     uses: ./.github/workflows/build.yml
     with:
-      runner: ${{ matrix.runner }}
+      runner: ${{ matrix.arch == 'x86_64' && 'macos-15-intel' || 'macos-latest' }}
       java: ${{ matrix.java }}
-      native: ${{ matrix.native }}
+      native: ${{ matrix.arch == 'x86_64' && 'cocoa.macosx.x86_64' || 'cocoa.macosx.aarch64' }}
       performance: ${{ contains(github.event.pull_request.labels.*.name, 'performance') }}
       runtodotests: ${{ contains(github.event.pull_request.labels.*.name, 'runtodotests') }}


### PR DESCRIPTION
By having the full names of runner and native it meant in many places GitHub displayed ... instead of the full matrix entry.

Therefore, use a simpler arch matrix and derive the runner/native values from it.