### PR TITLE
Add setAutoscaleDisabled API to provide a better means to disabling autoscaling at widget level

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Control.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Control.java
@@ -3527,6 +3527,26 @@ NSTouch findTouchWithId(NSArray touches, NSObject identity) {
 	return null;
 }
 
+/**
+ * Sets the autoscaling mode for this widget. The capability is not supported on
+ * every platform, such that calling this method may not have an effect on
+ * unsupported platforms. The return value indicates if the autoscale mode was
+ * set properly. With {@link #isAutoScalable()}, the autoscale enablement can
+ * also be evaluated at any later point in time.
+ * <p>
+ * Currently, this is only supported on Windows.
+ * </p>
+ *
+ * @param autoscalingMode the autoscaling mode to set
+ *
+ * @return {@code false} if the operation was called on an unsupported platform
+ *
+ * @since 3.133
+ */
+public boolean setAutoscalingMode(AutoscalingMode autoscalingMode) {
+	return false;
+}
+
 void setBackground () {
 	if (!drawsBackground()) return;
 	Control control = findBackgroundControl ();

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/AutoscalingMode.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/AutoscalingMode.java
@@ -1,0 +1,28 @@
+package org.eclipse.swt.graphics;
+
+/**
+ * Defines the autoscaling behavior used when rendering or computing layout for
+ * controls that support DPI‑aware scaling.
+ * <p>
+ * This mode determines whether SWT takes care of the scaling of widgets with
+ * respect to the zoom level of the monitor.
+ * </p>
+ *
+ * <ul>
+ * <li><b>{@link #ENABLED}</b> – Autoscaling is explicitly enabled. Values (such
+ * as coordinates, dimensions, or layout metrics) will be adjusted according to
+ * the effective scaling factor.</li>
+ *
+ * <li><b>{@link #DISABLED}</b> – Autoscaling is explicitly disabled. Values
+ * will be used as‑is without applying any scaling transformations.</li>
+ *
+ * <li><b>{@link #DISABLED_INHERITED}</b> – Autoscaling is disabled for this
+ * control and this is inherited by its children. Child controls will also be
+ * initialized with DISABLED_INHERITED AutoscalingMode.</li>
+ * </ul>
+ *
+ * @since 3.133
+ */
+public enum AutoscalingMode {
+	ENABLED, DISABLED, DISABLED_INHERITED
+}

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Control.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Control.java
@@ -5143,6 +5143,26 @@ void gtk_label_set_align(long label, float xAlign, float yAlign) {
 	GTK.gtk_label_set_yalign(label, yAlign);
 }
 
+/**
+ * Sets the autoscaling mode for this widget. The capability is not supported on
+ * every platform, such that calling this method may not have an effect on
+ * unsupported platforms. The return value indicates if the autoscale mode was
+ * set properly. With {@link #isAutoScalable()}, the autoscale enablement can
+ * also be evaluated at any later point in time.
+ * <p>
+ * Currently, this is only supported on Windows.
+ * </p>
+ *
+ * @param autoscalingMode the autoscaling mode to set
+ *
+ * @return {@code false} if the operation was called on an unsupported platform
+ *
+ * @since 3.133
+ */
+public boolean setAutoscalingMode(AutoscalingMode autoscalingMode) {
+	return false;
+}
+
 void setBackground () {
 	if ((state & BACKGROUND) == 0 && backgroundImage == null) {
 		if ((state & PARENT_BACKGROUND) != 0) {


### PR DESCRIPTION
This PR provides a new API `setAutoscaleDisabled` to provide a better means of disabling autoscaling at widget level across all the platforms. The current implementation is intended to return a false when this method is called in cocoa and GTK and only perform an action win32 and return since we do not support widget level autoscaling control on GTK and cocoa yet.

The convention of the method is as follows:
1. Takes a boolean parameter for disabling or enabling autoscale
2. returns true if successful (in case of win32) otherwise false (in case of GTK and cocoa)

Things to be done:
- Usage of different autoscaling modes as enabled, disabled and disabled_cascaded, etc
- Testing with GEF to see how it impacts.

depends on https://github.com/eclipse-platform/eclipse.platform.swt/pull/2930