### PR TITLE
Introduce a new `Image(Display,Point)` constructor

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/graphics/Image.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/graphics/Image.java
@@ -320,6 +320,56 @@ public Image(Device device, int width, int height) {
 }
 
 /**
+ * Constructs an empty instance of this class with the width
+ * (the x coordinate) and height (the y coordinate) of the
+ * specified point. The result may be drawn upon by creating
+ * a GC and using any of its drawing operations, as shown in
+ * the following example:
+ * <pre>
+ *    Image i = new Image(device, boundsRectangle);
+ *    GC gc = new GC(i);
+ *    gc.drawRectangle(0, 0, 50, 50);
+ *    gc.dispose();
+ * </pre>
+ * <p>
+ * Note: Some platforms may have a limitation on the size
+ * of image that can be created (size depends on width, height,
+ * and depth). For example, Windows 95, 98, and ME do not allow
+ * images larger than 16M.
+ * </p>
+ * <p>
+ * You must dispose the image when it is no longer required.
+ * </p>
+ *
+ * @param device the device on which to create the image
+ * @param size a point specifying the image's width and height (must not be null)
+ *
+ * @exception IllegalArgumentException <ul>
+ *    <li>ERROR_NULL_ARGUMENT - if device is null and there is no current device</li>
+ *    <li>ERROR_NULL_ARGUMENT - if the bounds point is null</li>
+ *    <li>ERROR_INVALID_ARGUMENT - if either the points width or height is negative</li>
+ * </ul>
+ * @exception SWTError <ul>
+ *    <li>ERROR_NO_HANDLES if a handle could not be obtained for image creation</li>
+ * </ul>
+ *
+ * @see #dispose()
+ * @since 3.133
+ */
+public Image(Device device, Point size) {
+	super(device);
+	if (size == null) SWT.error(SWT.ERROR_NULL_ARGUMENT);
+	NSAutoreleasePool pool = null;
+	if (!NSThread.isMainThread()) pool = (NSAutoreleasePool) new NSAutoreleasePool().alloc().init();
+	try {
+		init(size.x, size.y);
+		init();
+	} finally {
+		if (pool != null) pool.release();
+	}
+}
+
+/**
  * Constructs a new instance of this class based on the
  * provided image, with an appearance that varies depending
  * on the value of the flag. The possible flag values are:
@@ -529,7 +579,7 @@ private void createRepFromSourceAndApplyFlag(NSBitmapImageRep srcRep, int srcWid
  *
  * @see #dispose()
  *
- * @deprecated use {@link Image#Image(Device, int, int)} instead
+ * @deprecated use {@link Image#Image(Device, int, int)} or {@link Image#Image(Device, Point)} instead
  */
 @Deprecated(since = "2025-06", forRemoval = true)
 public Image(Device device, Rectangle bounds) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/graphics/Image.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/graphics/Image.java
@@ -214,8 +214,49 @@ Image(Device device) {
  * @see #dispose()
  */
 public Image(Device device, int width, int height) {
+	this(device, new Point(width, height));
+}
+
+/**
+ * Constructs an empty instance of this class with the width
+ * (the x coordinate) and height (the y coordinate) of the
+ * specified point. The result may be drawn upon by creating
+ * a GC and using any of its drawing operations, as shown in
+ * the following example:
+ * <pre>
+ *    Image i = new Image(device, boundsRectangle);
+ *    GC gc = new GC(i);
+ *    gc.drawRectangle(0, 0, 50, 50);
+ *    gc.dispose();
+ * </pre>
+ * <p>
+ * Note: Some platforms may have a limitation on the size
+ * of image that can be created (size depends on width, height,
+ * and depth). For example, Windows 95, 98, and ME do not allow
+ * images larger than 16M.
+ * </p>
+ * <p>
+ * You must dispose the image when it is no longer required.
+ * </p>
+ *
+ * @param device the device on which to create the image
+ * @param size a point specifying the image's width and height (must not be null)
+ *
+ * @exception IllegalArgumentException <ul>
+ *    <li>ERROR_NULL_ARGUMENT - if device is null and there is no current device</li>
+ *    <li>ERROR_NULL_ARGUMENT - if the bounds point is null</li>
+ *    <li>ERROR_INVALID_ARGUMENT - if either the points width or height is negative</li>
+ * </ul>
+ * @exception SWTError <ul>
+ *    <li>ERROR_NO_HANDLES if a handle could not be obtained for image creation</li>
+ * </ul>
+ *
+ * @see #dispose()
+ * @since 3.133
+ */
+public Image(Device device, Point size) {
 	super(device);
-	Point size = new Point(width, height);
+	if (size == null) SWT.error(SWT.ERROR_NULL_ARGUMENT);
 	init(size.x, size.y);
 	init();
 }
@@ -406,7 +447,7 @@ public Image(Device device, Image srcImage, int flag) {
  *
  * @see #dispose()
  *
- * @deprecated use {@link Image#Image(Device, int, int)} instead
+ * @deprecated use {@link Image#Image(Device, int, int)} or {@link Image#Image(Device, Point)} instead
  */
 @Deprecated(since = "2025-06", forRemoval = true)
 public Image(Device device, Rectangle bounds) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Image.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Image.java
@@ -248,6 +248,51 @@ public Image(Device device, int width, int height) {
 }
 
 /**
+ * Constructs an empty instance of this class with the width
+ * (the x coordinate) and height (the y coordinate) of the
+ * specified point. The result may be drawn upon by creating
+ * a GC and using any of its drawing operations, as shown in
+ * the following example:
+ * <pre>
+ *    Image i = new Image(device, boundsRectangle);
+ *    GC gc = new GC(i);
+ *    gc.drawRectangle(0, 0, 50, 50);
+ *    gc.dispose();
+ * </pre>
+ * <p>
+ * Note: Some platforms may have a limitation on the size
+ * of image that can be created (size depends on width, height,
+ * and depth). For example, Windows 95, 98, and ME do not allow
+ * images larger than 16M.
+ * </p>
+ * <p>
+ * You must dispose the image when it is no longer required.
+ * </p>
+ *
+ * @param device the device on which to create the image
+ * @param size a point specifying the image's width and height (must not be null)
+ *
+ * @exception IllegalArgumentException <ul>
+ *    <li>ERROR_NULL_ARGUMENT - if device is null and there is no current device</li>
+ *    <li>ERROR_NULL_ARGUMENT - if the bounds point is null</li>
+ *    <li>ERROR_INVALID_ARGUMENT - if either the points width or height is negative</li>
+ * </ul>
+ * @exception SWTError <ul>
+ *    <li>ERROR_NO_HANDLES if a handle could not be obtained for image creation</li>
+ * </ul>
+ *
+ * @see #dispose()
+ * @since 3.133
+ */
+public Image(Device device, Point size) {
+	super(device);
+	if (size == null) SWT.error(SWT.ERROR_NULL_ARGUMENT);
+	this.imageProvider = new PlainImageProviderWrapper(size.x, size.y);
+	init();
+	this.device.registerResourceWithZoomSupport(this);
+}
+
+/**
  * Constructs a new instance of this class based on the
  * provided image, with an appearance that varies depending
  * on the value of the flag. The possible flag values are:
@@ -393,7 +438,7 @@ public Image(Device device, Image srcImage, int flag) {
  *
  * @see #dispose()
  *
- * @deprecated use {@link Image#Image(Device, int, int)} instead
+ * @deprecated use {@link Image#Image(Device, int, int)} or {@link Image#Image(Device, Point)} instead
  */
 @Deprecated(since = "2025-06", forRemoval = true)
 public Image(Device device, Rectangle bounds) {

--- a/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet292.java
+++ b/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet292.java
@@ -58,8 +58,7 @@ public class Snippet292 {
 				label.setImage(null);
 				image.dispose ();
 			}
-			Rectangle rect = group.getBounds();
-			image = new Image (display, rect.width, rect.height);
+			image = new Image (display, group.getSize());
 			GC gc = new GC (image);
 			boolean success = group.print (gc);
 			gc.dispose ();

--- a/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet95.java
+++ b/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet95.java
@@ -44,8 +44,7 @@ public static void main(String[] args) {
 	button.addListener(SWT.Selection, event -> {
 		Point tableSize = table.getSize();
 		GC gc = new GC(table);
-		final Image image =
-			new Image(display, tableSize.x, tableSize.y);
+		final Image image = new Image(display, tableSize);
 		gc.copyArea(image, 0, 0);
 		gc.dispose();
 

--- a/tests/org.eclipse.swt.tests.gtk/ManualTests/org/eclipse/swt/tests/gtk/snippets/Bug278882_ToolBarBackgroundImageTest.java
+++ b/tests/org.eclipse.swt.tests.gtk/ManualTests/org/eclipse/swt/tests/gtk/snippets/Bug278882_ToolBarBackgroundImageTest.java
@@ -40,7 +40,7 @@ public class Bug278882_ToolBarBackgroundImageTest {
 		Image originalImage = toolBar.getBackgroundImage();
 
 		Point p = toolBar.getSize();
-		Image bg = new Image(display, p.x, p.y);
+		Image bg = new Image(display, p);
 
 		GC gc = new GC(bg);
 		gc.setBackground(display.getSystemColor(SWT.COLOR_BLACK));

--- a/tests/org.eclipse.swt.tests.gtk/ManualTests/org/eclipse/swt/tests/gtk/snippets/Bug530969_ControlPrint.java
+++ b/tests/org.eclipse.swt.tests.gtk/ManualTests/org/eclipse/swt/tests/gtk/snippets/Bug530969_ControlPrint.java
@@ -71,7 +71,7 @@ public class Bug530969_ControlPrint {
 		shell.setSize(cSize);
 
 		shell.open();
-		Image canvas = new Image(display, cSize.x, cSize.y);
+		Image canvas = new Image(display, cSize);
 		GC gc = new GC(canvas);
 		composite.print(gc);
 

--- a/tests/org.eclipse.swt.tests.gtk/ManualTests/org/eclipse/swt/tests/gtk/snippets/Bug531667_CanvasPrint_does_not_work.java
+++ b/tests/org.eclipse.swt.tests.gtk/ManualTests/org/eclipse/swt/tests/gtk/snippets/Bug531667_CanvasPrint_does_not_work.java
@@ -80,8 +80,7 @@ public class Bug531667_CanvasPrint_does_not_work {
 	}
 
 	private static void snapshot(Display display, Composite composite, String filename) {
-		Rectangle bounds = composite.getBounds();
-		Image image = new Image(display, bounds.width, bounds.height);
+		Image image = new Image(display, composite.getSize());
 		GC gc = new GC(image);
 		composite.print(gc);
 		gc.dispose();

--- a/tests/org.eclipse.swt.tests.gtk/ManualTests/org/eclipse/swt/tests/gtk/snippets/Bug547529_ControlPrintBroken.java
+++ b/tests/org.eclipse.swt.tests.gtk/ManualTests/org/eclipse/swt/tests/gtk/snippets/Bug547529_ControlPrintBroken.java
@@ -83,8 +83,7 @@ class Bug547529_ControlPrintBroken {
 	}
 
 	private static void snapshot(Display display, Composite composite, String filename) {
-		Rectangle bounds = composite.getBounds();
-		Image image = new Image(display, bounds.width, bounds.height);
+		Image image = new Image(display, composite.getSize());
 		GC gc = new GC(image);
 		composite.print(gc);
 		gc.dispose();

--- a/tests/org.eclipse.swt.tests.gtk/ManualTests/org/eclipse/swt/tests/gtk/snippets/Bug547529_ImageLoaderStriping.java
+++ b/tests/org.eclipse.swt.tests.gtk/ManualTests/org/eclipse/swt/tests/gtk/snippets/Bug547529_ImageLoaderStriping.java
@@ -19,7 +19,6 @@ import org.eclipse.swt.graphics.GC;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.graphics.ImageData;
 import org.eclipse.swt.graphics.ImageLoader;
-import org.eclipse.swt.graphics.Rectangle;
 import org.eclipse.swt.layout.FillLayout;
 import org.eclipse.swt.layout.RowLayout;
 import org.eclipse.swt.widgets.Button;
@@ -69,8 +68,7 @@ public class Bug547529_ImageLoaderStriping {
 	}
 
 	private static void saveImage(Control control, String filename, int format) {
-		Rectangle bounds = control.getBounds();
-		Image image = new Image(control.getDisplay(), bounds.width, bounds.height);
+		Image image = new Image(control.getDisplay(), control.getSize());
 		GC gc = new GC(image);
 		control.print(gc);
 		gc.dispose();

--- a/tests/org.eclipse.swt.tests.gtk/ManualTests/org/eclipse/swt/tests/gtk/snippets/Bug547557_ShellPrintGC.java
+++ b/tests/org.eclipse.swt.tests.gtk/ManualTests/org/eclipse/swt/tests/gtk/snippets/Bug547557_ShellPrintGC.java
@@ -20,7 +20,6 @@ import org.eclipse.swt.graphics.GC;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.graphics.ImageData;
 import org.eclipse.swt.graphics.ImageLoader;
-import org.eclipse.swt.graphics.Rectangle;
 import org.eclipse.swt.layout.RowLayout;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Display;
@@ -61,8 +60,7 @@ public class Bug547557_ShellPrintGC {
 	}
 
 	private static void saveImage(Shell shell, String filename, int format) {
-		Rectangle bounds = shell.getBounds();
-		Image image = new Image(shell.getDisplay(), bounds.width, bounds.height);
+		Image image = new Image(shell.getDisplay(), shell.getSize());
 		// Printing the client area will result in a warning and only the client area being printed
 //		Image image = new Image(shell.getDisplay(), shell.getClientArea());
 		GC gc = new GC(image);

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_Image.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_Image.java
@@ -188,6 +188,34 @@ public void test_ConstructorLorg_eclipse_swt_graphics_DeviceLorg_eclipse_swt_gra
 }
 
 @Test
+public void test_ConstructorLorg_eclipse_swt_graphics_DeviceLorg_eclipse_swt_graphics_Point() {
+	Image image;
+	IllegalArgumentException e;
+
+	e = assertThrows(IllegalArgumentException.class, () -> new Image(display, new Point(-1, 10)));
+	assertSWTProblem("Incorrect exception thrown for width < 0", SWT.ERROR_INVALID_ARGUMENT, e);
+
+	e = assertThrows(IllegalArgumentException.class, () -> new Image(display, new Point(0, 10)));
+	assertSWTProblem("Incorrect exception thrown for width == 0", SWT.ERROR_INVALID_ARGUMENT, e);
+
+	e = assertThrows(IllegalArgumentException.class, () -> new Image(display, new Point(10, -1)));
+	assertSWTProblem("Incorrect exception thrown for height < 0", SWT.ERROR_INVALID_ARGUMENT, e);
+
+	e = assertThrows(IllegalArgumentException.class, () -> new Image(display, new Point(10, 0)));
+	assertSWTProblem("Incorrect exception thrown for height == 0", SWT.ERROR_INVALID_ARGUMENT, e);
+
+	e = assertThrows(IllegalArgumentException.class, () -> new Image(display, (Point) null));
+	assertSWTProblem("Incorrect exception thrown for size == null", SWT.ERROR_NULL_ARGUMENT, e);
+
+	// valid images
+	image = new Image(null, new Point(10, 10));
+	image.dispose();
+
+	image = new Image(display, new Point(10, 10));
+	image.dispose();
+}
+
+@Test
 public void test_ConstructorLorg_eclipse_swt_graphics_DeviceLorg_eclipse_swt_graphics_ImageData() {
 	IllegalArgumentException e;
 


### PR DESCRIPTION
The deprecation of the `Image(Display,Rectangle)` constructor in 1d596634e2c455bab1e0346abd72bd7a11a05d19 introduces a lot of verbosity.

Where one could previously create an image via:
> new Image(display, widget.getBounds())

One now has to store the bounds in a local variable and then call:
> new Image(display, r.width, r.height)

This approach is also error prone, as one might easily mix up the order of parameters. With this new constructor, this problem can be avoided as one can simply call:

> new Image(display, widget.getSize())