### PR TITLE
Throw ERROR_UNSUPPORTED_FORMAT when SVGRasterizer could not be loaded

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/image/SVGFileFormat.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/image/SVGFileFormat.java
@@ -31,8 +31,18 @@ import org.eclipse.swt.internal.DPIUtil.*;
 public class SVGFileFormat extends FileFormat {
 
 	/** The instance of the registered {@link SVGRasterizer}. */
-	private static final SVGRasterizer RASTERIZER = ServiceLoader
-			.load(SVGRasterizer.class, SVGFileFormat.class.getClassLoader()).findFirst().orElse(null);
+	private static final SVGRasterizer RASTERIZER;
+
+	static {
+		SVGRasterizer rasterizer = null;
+		try {
+			rasterizer = ServiceLoader
+					.load(SVGRasterizer.class, SVGFileFormat.class.getClassLoader()).findFirst().orElse(null);
+		} catch (ServiceConfigurationError e) {
+			// rasterizer not in classpath or could not be instantiated
+		}
+		RASTERIZER = rasterizer;
+	}
 
 	@Override
 	boolean isFileFormat(LEDataInputStream stream) throws IOException {


### PR DESCRIPTION
Trying to load an SVG while the JSVG rasterizer is not in the classpath throws a ServiceConfigurationError. This error should be caught and transformed into an SWTError, as specified by the contract of the ImageLoader.

By catching the ServiceConfigurationError, the RASTERIZER field is initialized with NULL. In this state, calling any method of the SVGFileFormat class automatically throws the expected SWTError.

To reproduce, load an SVG while `org.eclipse.swt.svg` is in the classpath, but `com.github.weisj.jsvg` is not. This call should fail with a:

> Provider org.eclipse.swt.svg.JSVGRasterizer could not be instantiated

Due to a NoClassDefFoundError when trying to load the JSVGRasterizer class, caused by the unresolvable dependency.