### PR TITLE
Replacing usages of Display#getDPI in snippets

### DIFF
--- a/examples/org.eclipse.swt.examples/src/org/eclipse/swt/examples/imageanalyzer/ImageAnalyzer.java
+++ b/examples/org.eclipse.swt.examples/src/org/eclipse/swt/examples/imageanalyzer/ImageAnalyzer.java
@@ -1166,6 +1166,7 @@ public class ImageAnalyzer {
 		if (image == null) return;
 
 		try {
+			final int DOTS_PER_INCH = 96;
 			// Ask the user to specify the printer.
 			PrintDialog dialog = new PrintDialog(shell, SWT.NONE);
 			if (printerData != null) dialog.setPrinterData(printerData);
@@ -1173,9 +1174,8 @@ public class ImageAnalyzer {
 			if (printerData == null) return;
 
 			Printer printer = new Printer(printerData);
-			Point screenDPI = display.getDPI();
 			Point printerDPI = printer.getDPI();
-			int scaleFactor = printerDPI.x / screenDPI.x;
+			int scaleFactor = printerDPI.x / DOTS_PER_INCH;
 			Rectangle trim = printer.computeTrim(0, 0, 0, 0);
 			if (printer.startJob(currentName)) {
 				if (printer.startPage()) {

--- a/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet361.java
+++ b/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet361.java
@@ -146,6 +146,7 @@ public class Snippet361 {
 	}
 
 	private static void performPrintAction(final Display display, final Shell shell) {
+		final int DOTS_PER_INCH = 96;
 		Rectangle r = composite.getBounds();
 		Point p = shell.toDisplay(r.x, r.y);
 		org.eclipse.swt.graphics.Image snapshotImage
@@ -159,9 +160,8 @@ public class Snippet361 {
 		data = dialog.open();
 		if (data != null) {
 			Printer printer = new Printer(data);
-			Point screenDPI = display.getDPI();
 			Point printerDPI = printer.getDPI();
-			int scaleFactor = printerDPI.x / screenDPI.x;
+			int scaleFactor = printerDPI.x / DOTS_PER_INCH;
 			Rectangle trim = printer.computeTrim(0, 0, 0, 0);
 			if (printer.startJob("Print Image")) {
 				ImageData imageData = snapshotImage.getImageData();

--- a/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet367.java
+++ b/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet367.java
@@ -185,7 +185,7 @@ public class Snippet367 {
 
 		createSeparator(shell);
 
-		new Label (shell, SWT.NONE).setText ("5. 50x50 box\n(Display#getDPI(): " + display.getDPI().x + ")");
+		new Label (shell, SWT.NONE).setText ("5. 50x50 box");
 		Label box= new Label (shell, SWT.NONE);
 		box.setBackground(display.getSystemColor(SWT.COLOR_WIDGET_DARK_SHADOW));
 		box.setLayoutData (new GridData (50, 50));


### PR DESCRIPTION
Having the scale factor being based on the screen DPI leads to unexpected result e.g. Image too big/small. Having a screen dpi independent factor leads to consistent results