### PR TITLE
[GTK] Replacing usages of Display#getDPI from gtk

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/graphics/Device.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/graphics/Device.java
@@ -723,8 +723,8 @@ protected void init () {
 		}
 	}
 	defaultFont = OS.pango_font_description_copy (defaultFont);
-	Point dpi = getDPI(), screenDPI = getScreenDPI();
-	if (dpi.y != screenDPI.y) {
+	Point screenDPI = getScreenDPI();
+	if (this.dpi.y != screenDPI.y) {
 		int size = OS.pango_font_description_get_size(defaultFont);
 		OS.pango_font_description_set_size(defaultFont, size * dpi.y / screenDPI.y);
 	}


### PR DESCRIPTION
This is a preparatory commit to remove all **possible** usages of getDPI from gtk. Since getDPI is set to be deprecated.

PR for Deprecation: https://github.com/eclipse-platform/eclipse.platform.swt/pull/2872