### PR TITLE
Deprecating Display#getDPI

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Printing/cocoa/org/eclipse/swt/printing/Printer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Printing/cocoa/org/eclipse/swt/printing/Printer.java
@@ -623,6 +623,7 @@ public Point getDPI() {
 	}
 }
 
+@SuppressWarnings("deprecation")
 Point getIndependentDPI() {
 	return super.getDPI();
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT Printing/win32/org/eclipse/swt/printing/PDFDocument.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Printing/win32/org/eclipse/swt/printing/PDFDocument.java
@@ -215,6 +215,7 @@ public class PDFDocument implements Drawable {
 		int screenDpiX = 96;
 		int screenDpiY = 96;
 		if (this.device != null) {
+			@SuppressWarnings("deprecation")
 			Point dpi = this.device.getDPI();
 			screenDpiX = dpi.x;
 			screenDpiY = dpi.y;
@@ -427,6 +428,7 @@ public class PDFDocument implements Drawable {
 		int screenDpiX = 96;
 		int screenDpiY = 96;
 		if (device != null) {
+			@SuppressWarnings("deprecation")
 			Point dpi = device.getDPI();
 			screenDpiX = dpi.x;
 			screenDpiY = dpi.y;

--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/graphics/Device.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/graphics/Device.java
@@ -391,7 +391,18 @@ public int getDepth () {
  * @exception SWTException <ul>
  *    <li>ERROR_DEVICE_DISPOSED - if the receiver has been disposed</li>
  * </ul>
+ *
+ * @deprecated <p>This method returns a single global DPI value
+ * that does not reflect per-monitor DPI settings on modern operating systems.
+ * In environments with different scaling factors across monitors, it may provide
+ * a misleading or meaningless result, as it does not correspond to the actual DPI
+ * of any specific monitor.</p>
+ *
+ * <p>Note: While deprecated for general {@code Device} instances like {@code Display},
+ * this method may still be validly used when called on a {@code Printer} instance,
+ * where a single global DPI value is meaningful and expected.</p>
  */
+@Deprecated
 public Point getDPI () {
 	checkDevice ();
 	return getScreenDPI();

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/graphics/Device.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/graphics/Device.java
@@ -455,7 +455,18 @@ public int getDepth () {
  * @exception SWTException <ul>
  *    <li>ERROR_DEVICE_DISPOSED - if the receiver has been disposed</li>
  * </ul>
+ *
+ * @deprecated <p>This method returns a single global DPI value
+ * that does not reflect per-monitor DPI settings on modern operating systems.
+ * In environments with different scaling factors across monitors, it may provide
+ * a misleading or meaningless result, as it does not correspond to the actual DPI
+ * of any specific monitor.</p>
+ *
+ * <p>Note: While deprecated for general {@code Device} instances like {@code Display},
+ * this method may still be validly used when called on a {@code Printer} instance,
+ * where a single global DPI value is meaningful and expected.</p>
  */
+@Deprecated
 public Point getDPI () {
 	checkDevice ();
 	return getScreenDPI();

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Display.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Display.java
@@ -5052,7 +5052,9 @@ String debugInfoForIndex(long index) {
 }
 
 void dpiChanged(int newScaleFactor) {
-	DPIUtil.setDeviceZoom (DPIUtil.mapDPIToZoom(getDPI().x * newScaleFactor));
+	@SuppressWarnings("deprecation")
+	int dpiX = getDPI().x;
+	DPIUtil.setDeviceZoom (DPIUtil.mapDPIToZoom(dpiX * newScaleFactor));
 	Shell[] shells = getShells();
 	for (int i = 0; i < shells.length; i++) {
 		shells[i].layout(true, true);

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Device.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Device.java
@@ -519,7 +519,18 @@ public int getDepth () {
  * @exception SWTException <ul>
  *    <li>ERROR_DEVICE_DISPOSED - if the receiver has been disposed</li>
  * </ul>
+ *
+ * @deprecated <p>This method returns a single global DPI value
+ * that does not reflect per-monitor DPI settings on modern operating systems.
+ * In environments with different scaling factors across monitors, it may provide
+ * a misleading or meaningless result, as it does not correspond to the actual DPI
+ * of any specific monitor.</p>
+ *
+ * <p>Note: While deprecated for general {@code Device} instances like {@code Display},
+ * this method may still be validly used when called on a {@code Printer} instance,
+ * where a single global DPI value is meaningful and expected.</p>
  */
+@Deprecated
 public Point getDPI () {
 	checkDevice ();
 	long hDC = internal_new_GC (null);

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Display.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Display.java
@@ -1553,6 +1553,7 @@ public void test_wake() {
 /* custom */
 boolean disposeExecRan;
 
+@SuppressWarnings("deprecation")
 @Test
 public void test_getDPI() {
 	Display display = new Display();


### PR DESCRIPTION
Having the scale factor being based on the screen DPI leads to unexpected result e.g. Image too big/small. Having a screen dpi independent factor leads to consistent results.