### PR TITLE
[Win32] Correct bounds/size value of child shells

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/widgets/ControlWin32Tests.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/widgets/ControlWin32Tests.java
@@ -356,4 +356,16 @@ class ControlWin32Tests {
 		assertTrue(clientAreaInPixels.height <= childBoundsInPixels.y + childBoundsInPixels.height);
 	}
 
+	@Test
+	void testChildShellGetSize() {
+		Win32DPIUtils.setMonitorSpecificScaling(true);
+		Display display = Display.getDefault();
+		Shell shell = new Shell(display);
+		shell.nativeZoom = 150;
+		Shell childShell = new Shell(shell);
+		childShell.nativeZoom = 100;
+		childShell.setSize(300, 300);
+		assertEquals(300, childShell.getSizeInPixels().x);
+	}
+
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Control.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Control.java
@@ -4886,7 +4886,7 @@ int getShellZoom() {
 	return nativeZoom;
 }
 
-private int computeGetBoundsZoom() {
+int computeGetBoundsZoom() {
 	if (parent != null && !autoScaleDisabled) {
 		return parent.getZoom();
 	}

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Shell.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Shell.java
@@ -2787,4 +2787,14 @@ LRESULT WM_WINDOWPOSCHANGING (long wParam, long lParam) {
 	return result;
 }
 
+@Override
+int computeBoundsZoom() {
+	return getZoom();
+}
+
+@Override
+int computeGetBoundsZoom() {
+	return getZoom();
+}
+
 }


### PR DESCRIPTION
In point/pixel conversions for bounds/sizes of controls, the parent control's zoom is used to adhere to the most appropriate context when having auto-scale disabled controls. This, however, leads to child shells using the zoom of the parent shells, which can be placed on a different monitor with a different zoom, such that the bounds/sizes of such child shells are wrongly scaled.

With this change, shells always use their own zoom for bounds/sizes calculations instead of the one of a potential parent shell.

Fixes https://github.com/eclipse-platform/eclipse.platform.swt/issues/2862

### How to test
As described in https://github.com/eclipse-platform/eclipse.platform.swt/issues/2862:
> I noticed it in the IDE (requires two monitors with different zoom):
> 1. Open the Eclipse IDE on the first screen.
> 2. Open the preference dialog and move it to the second screen (size is correctly adapted)
> 3. Close the preference dialog (wrong size is saved)
> 4. Reopen the preference dialog (dialog has wrong size)
>
> If monitor 1= 200% and monitor 2= 100%, the dialog shrinks to half its size each time.

With primary monitor 100% and secondary 175% (and the preferences opening on secondary), it looks like this:

#### Before
![childshell_wrongsize](https://github.com/user-attachments/assets/5bd8c714-7743-4227-82dc-1134140f40c1)

#### After
![childshell_correctsize](https://github.com/user-attachments/assets/145af16b-cdd0-4b65-8d31-3404adbfa1fb)
