### PR TITLE
Use OS#Polygon in GC#drawRectangleInPixels

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/GC.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/GC.java
@@ -2309,36 +2309,7 @@ private class DrawRectangleOperation extends Operation {
 }
 
 private void drawRectangleInPixels (int x, int y, int width, int height) {
-	checkGC(DRAW);
-	long gdipGraphics = data.gdipGraphics;
-	if (gdipGraphics != 0) {
-		if (width < 0) {
-			x = x + width;
-			width = -width;
-		}
-		if (height < 0) {
-			y = y + height;
-			height = -height;
-		}
-		Gdip.Graphics_TranslateTransform(gdipGraphics, data.gdipXOffset, data.gdipYOffset, Gdip.MatrixOrderPrepend);
-		Gdip.Graphics_DrawRectangle(gdipGraphics, data.gdipPen, x, y, width, height);
-		Gdip.Graphics_TranslateTransform(gdipGraphics, -data.gdipXOffset, -data.gdipYOffset, Gdip.MatrixOrderPrepend);
-		return;
-	}
-	if ((data.style & SWT.MIRRORED) != 0) {
-		/*
-		* Note that Rectangle() subtracts one pixel in MIRRORED mode when
-		* the pen was created with CreatePen() and its width is 0 or 1.
-		*/
-		if (data.lineWidth > 1) {
-			if ((data.lineWidth % 2) == 1) x++;
-		} else {
-			if (data.hPen != 0 && OS.GetObject(data.hPen, 0, 0) != OS.LOGPEN_sizeof()) {
-				x++;
-			}
-		}
-	}
-	OS.Rectangle (handle, x, y, x + width + 1, y + height + 1);
+	drawPolygonInPixels(new int[] {x, y, x + width + 1, y, x + width + 1, y + height + 1, x, y + height + 1});
 }
 
 /**


### PR DESCRIPTION
This PR addresses the following issue: https://github.com/vi-eclipse/Eclipse-Platform/issues/555

To analyse the problem, consider a zoom factor of **175%.**

#### Context
Before the introduction of `ImageGcDrawer`, SWT created all images at 100% zoom and scaled them afterwards. Since scaling happened post-drawing, the image data preserved the expected geometry and visual alignment, even when consumers used two slightly different conventions (`width` vs `width - 1`).

After `ImageGcDrawer` was added, SWT now creates the image at the target zoom directly, rather than scaling from 100%. This produces sharper results but exposes a long-standing behavioural mismatch in how rectangles are drawn.

#### Root Cause
`GC.drawRectangle` delegates to OS.Rectangle, whose Win32 documentation states:
```The supplied right/bottom coordinates represent the limits of the interior; the bottom/right border pixels are excluded.```
Example: drawing (0, 0, 210, 210) produces:
- Left border: 1 px
- Interior width: 209 px
- Right border: excluded

However, the actual behaviour differs.
Passing `(0,0,210,210)` results in:
- Left border: 1 px
- Interior: 208 px
- Right border: 1 px

The total painted width becomes 210 px, contrary to the documentation.

This discrepancy was masked before because the rectangle was drawn at 100% and later scaled. But now that we draw directly at scaled resolutions:
- Consumers often write:
```gc.drawRectangle(x, y, width - 1, height - 1);```
intending to compensate for border thickness.
- After scaling, this subtraction `(-1)` becomes incorrect, because it represents points, not pixels. For example: `(120 - 1) * 1.75 = 208.25`, truncated to 208, causing visible shifts.

### Observation Snippet
```
public class SnippetGC {
	public static void main(String[] args) {
		Display display = new Display();

		Shell shell = new Shell(display);

		Table table = new Table(shell, SWT.FILL);
		table.setBounds(0, 0, 1000, 1000);

		Image image = new Image(display, 120, 120);
		GC gc = new GC(image);
		gc.setAdvanced(true);
		Color color = new Color(255, 0, 0);
		gc.setBackground(color);
		Rectangle rect = image.getBounds();
		gc.fillRectangle(rect.x, rect.y, rect.width, rect.height);
		if (color.equals(display.getSystemColor(SWT.COLOR_BLACK))) {
			gc.setForeground(display.getSystemColor(SWT.COLOR_WHITE));
		}
		gc.drawRectangle(rect.x, rect.y, rect.width - 1, rect.height - 1);
		gc.dispose();

		TableItem item = new TableItem(table, SWT.FILL);
		item.setImage(image);

		shell.open();
		while (!shell.isDisposed()) {
			if (!display.readAndDispatch())
				display.sleep();
		}
		image.dispose();
		display.dispose();
	}
}
```
With this snippet, if you run it on master, you'll see the outline is inside the filled red rectangle. This happens because when we do `(120 - 1) * 1.75`, we get approximately 208 and then `GC#drawRectangle` applies `x + width + 1` leading to 209. According to the `OS.Rectangle` documentation it should add a right border after 209 making it overall 210 px wide — but it does not. Hence `OS.Rectangle` is not behaving as documented in this context and we have the right and the bottom border a pixel extra inside.

#### Proposed Fix
Since a rectangle is also a polygon, use OS.Polygon by calling `GCdrawPolygon` instead of `OS.Rectangle`. The polygon approach aligns with the intended semantics and produces the correct visual result under zoom.

#### Notes and Limitations
- This is a workaround rather than a perfect solution: consumers are still commonly calling the API with `width - 1` (which is incorrect for logical/point coordinates) instead of width.

- The polygon workaround improves behaviour for the observed cases (e.g., 175% zoom) but may not be perfect at very high zoom levels (e.g., 350%).

- A full, robust fix would require adjusting consumers to pass the correct values (i.e., use width/height as logical sizes) or otherwise revisiting the API semantics.