### PR TITLE
Adjusted computation of horizontal toolbar size.

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ToolBar.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ToolBar.java
@@ -255,6 +255,12 @@ Point computeSizeInPixels (Point hintInPoints, int zoom, boolean changed) {
 			OS.SendMessage (handle, OS.TB_GETITEMRECT, count - 1, rect);
 			width = Math.max (width, rect.right);
 			height = Math.max (height, rect.bottom);
+			// Adjust height for embedded controls (Combo, Text, etc.)
+			for (ToolItem item : items) {
+			    if (item != null && item.getControl() != null) {
+			        height = Math.max(height, item.getControl().getBoundsInPixels().height);
+			    }
+			}
 		}
 		OS.SetWindowPos (handle, 0, 0, 0, oldWidth, oldHeight, flags);
 		if (redraw) OS.ValidateRect (handle, null);

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ToolItem.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ToolItem.java
@@ -583,7 +583,7 @@ void resizeControl () {
 		control.setSize (itemRect.width, itemRect.height);
 		Rectangle rect = control.getBounds ();
 		rect.x = itemRect.x + (itemRect.width - rect.width) / 2;
-		rect.y = itemRect.y + (itemRect.height - rect.height) / 2;
+		rect.y = itemRect.y + Math.max(0, itemRect.height - rect.height) / 2;
 		control.setLocation (rect.x, rect.y);
 	}
 }


### PR DESCRIPTION
The first part ensures the toolbar becomes tall enough to fit controls like Combo or Text, whose height is often larger than the native toolbar button height returned by TB_GETITEMRECT. Without this check, the toolbar height is based only on Windows’ button metrics, which are smaller, causing embedded controls to be clipped. By taking the max of the toolbar height and each control’s actual height, the final toolbar size always accommodates the tallest embedded control.

In the second part, the original code centered the control vertically, but when the control (like a combo box) was taller than the toolbar item height, the centering calculation produced a negative offset, shifting the control upward and causing clipping. Your fix uses Math.max(0, …) to prevent negative offsets, ensuring the control is never positioned above the item’s top. As a result, taller controls are aligned safely without being cut off.

### To Reproduce

- Open ControlExample
- Open Toolbar Tab
- Enable ComboChild

**Expected behavior**
Combobox is displayed correctly

### Result
---
**Before Fix**
<img width="607" height="223" alt="image" src="https://github.com/user-attachments/assets/ff207390-47d3-4cff-a1c5-4fe8711b7646" />
---
**After Fix**
<img width="608" height="196" alt="image" src="https://github.com/user-attachments/assets/023027fc-7280-4731-b1d2-7c9dea7f11e2" />

Fixes https://github.com/eclipse-platform/eclipse.platform.swt/issues/935

