### PR TITLE
Ensure Consistent DPI Awareness in getDPI() for Font Calculation

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/FontDialog.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/FontDialog.java
@@ -278,14 +278,24 @@ public FontData open () {
 }
 
 private int getDPI() {
-	long hDC = OS.GetDC (0);
-	// We need to use OS.GetDeviceCaps, which is static throughout application
-	// lifecycle (System DPI Aware), because we use
-	// DPI_AWARENESS_CONTEXT_UNAWARE_GDISCALED which always depends on the DPI at
-	// application startup
-	int dpi = OS.GetDeviceCaps(hDC, OS.LOGPIXELSY);
-	OS.ReleaseDC (0, hDC);
-	return dpi;
+	long currentDpiAwarenessContext = OS.GetThreadDpiAwarenessContext();
+	try {
+		if (parent.getDisplay().isRescalingAtRuntime()) {
+			currentDpiAwarenessContext = OS.SetThreadDpiAwarenessContext(OS.DPI_AWARENESS_CONTEXT_UNAWARE_GDISCALED);
+		}
+		long hDC = OS.GetDC(0);
+		// We need to use OS.GetDeviceCaps, which is static throughout application
+		// lifecycle (System DPI Aware), because we use
+		// DPI_AWARENESS_CONTEXT_UNAWARE_GDISCALED which always depends on the DPI at
+		// application startup
+		int dpi = OS.GetDeviceCaps(hDC, OS.LOGPIXELSY);
+		OS.ReleaseDC(0, hDC);
+		return dpi;
+	} finally {
+		if (parent.getDisplay().isRescalingAtRuntime()) {
+			OS.SetThreadDpiAwarenessContext(currentDpiAwarenessContext);
+		}
+	}
 }
 
 /**


### PR DESCRIPTION
The DPI computed in getDPI() is used to determine the font height for the `OS.ChooseFont `dialog. Following the change in https://github.com/eclipse-platform/eclipse.platform.swt/pull/1593, the thread DPI awareness is set to `OS.DPI_AWARENESS_CONTEXT_UNAWARE_GDISCALED` before opening the `ChooseFont` dialog. This commit ensures the same DPI awareness is applied in` getDPI()` for consistent font size calculation.

### Steps to reproduce

1)Open the font dialog from the "Colors and Fonts" preference page of the Eclipse IDE .
2)Without this change when opening the FontDialog on a monitor with zoom 200% and an initial font with size 10, the font size selected in the dialog is 20.

Fixes #2866