### PR TITLE
[GTK] TreeItem.setExpanded() / getExpanded() inconsistency

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/TreeItem.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/TreeItem.java
@@ -1224,16 +1224,19 @@ public void setExpanded (boolean expanded) {
 	checkWidget();
 	long path = GTK.gtk_tree_model_get_path (parent.modelHandle, handle);
 	// Do nothing when the item is a leaf or already expanded
-	if (expanded != GTK.gtk_tree_view_row_expanded (parent.handle, path) && GTK.gtk_tree_model_iter_n_children (parent.modelHandle, handle) != 0) {
-		if (expanded) {
-			OS.g_signal_handlers_block_matched (parent.handle, OS.G_SIGNAL_MATCH_DATA, 0, 0, 0, 0, TEST_EXPAND_ROW);
-			GTK.gtk_tree_view_expand_row (parent.handle, path, false);
-			OS.g_signal_handlers_unblock_matched (parent.handle, OS.G_SIGNAL_MATCH_DATA, 0, 0, 0, 0, TEST_EXPAND_ROW);
-		} else {
-			OS.g_signal_handlers_block_matched (parent.handle, OS.G_SIGNAL_MATCH_DATA, 0, 0, 0, 0, TEST_COLLAPSE_ROW);
-			GTK.gtk_widget_realize (parent.handle);
-			GTK.gtk_tree_view_collapse_row (parent.handle, path);
-			OS.g_signal_handlers_unblock_matched (parent.handle, OS.G_SIGNAL_MATCH_DATA, 0, 0, 0, 0, TEST_COLLAPSE_ROW);
+	boolean hasChildren = GTK.gtk_tree_model_iter_n_children (parent.modelHandle, handle) != 0;
+	if (hasChildren) {
+		if (expanded != GTK.gtk_tree_view_row_expanded (parent.handle, path)) {
+			if (expanded) {
+				OS.g_signal_handlers_block_matched (parent.handle, OS.G_SIGNAL_MATCH_DATA, 0, 0, 0, 0, TEST_EXPAND_ROW);
+				GTK.gtk_tree_view_expand_row (parent.handle, path, false);
+				OS.g_signal_handlers_unblock_matched (parent.handle, OS.G_SIGNAL_MATCH_DATA, 0, 0, 0, 0, TEST_EXPAND_ROW);
+			} else {
+				OS.g_signal_handlers_block_matched (parent.handle, OS.G_SIGNAL_MATCH_DATA, 0, 0, 0, 0, TEST_COLLAPSE_ROW);
+				GTK.gtk_widget_realize (parent.handle);
+				GTK.gtk_tree_view_collapse_row (parent.handle, path);
+				OS.g_signal_handlers_unblock_matched (parent.handle, OS.G_SIGNAL_MATCH_DATA, 0, 0, 0, 0, TEST_COLLAPSE_ROW);
+			}
 		}
 		isExpanded = expanded;
 	}

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_TreeItem.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_TreeItem.java
@@ -765,7 +765,7 @@ public void test_setExpandedZ() {
 	assertFalse(treeItem.getExpanded());
 
 
-	new TreeItem(treeItem, SWT.NULL);
+	TreeItem ti1 = new TreeItem(treeItem, SWT.NULL);
 	treeItem.setExpanded(true);
 	assertTrue(treeItem.getExpanded());
 	treeItem.setExpanded(false);
@@ -773,8 +773,49 @@ public void test_setExpandedZ() {
 
 	TreeItem ti = new TreeItem(treeItem, SWT.NULL);
 	ti.setExpanded(true);
+	// leaf is never expanded
+	assertFalse(ti.getExpanded());
 	treeItem.setExpanded(false);
 	assertFalse(ti.getExpanded());
+
+	TreeItem ti2 = new TreeItem(ti1, SWT.NULL);
+	assertFalse(ti2.getExpanded());
+
+	// Expand all levels from top to bottom
+	treeItem.setExpanded(true);
+	ti1.setExpanded(true);
+	ti2.setExpanded(true);
+
+	assertTrue(treeItem.getExpanded());
+	assertTrue(ti1.getExpanded());
+	assertFalse(ti2.getExpanded());
+
+	// Collapse all levels, starting with parent (like JFace does it in AbstractTreeViewer.internalCollapseToLevel(Widget, int))
+	treeItem.setExpanded(false);
+	ti1.setExpanded(false);
+	ti2.setExpanded(false);
+
+	assertFalse(treeItem.getExpanded());
+	assertFalse(ti1.getExpanded());
+	assertFalse(ti2.getExpanded());
+
+	// Expand all levels from bottom to top
+	ti2.setExpanded(true);
+	ti1.setExpanded(true);
+	treeItem.setExpanded(true);
+
+	assertTrue(treeItem.getExpanded());
+	assertTrue(ti1.getExpanded());
+	assertFalse(ti2.getExpanded());
+
+	// Collapse all levels, starting with last child
+	ti2.setExpanded(false);
+	ti1.setExpanded(false);
+	treeItem.setExpanded(false);
+
+	assertFalse(treeItem.getExpanded());
+	assertFalse(ti1.getExpanded());
+	assertFalse(ti2.getExpanded());
 }
 
 @Test


### PR DESCRIPTION
Always update SWT "isExpanded" state for non-leaf TreeItem elements, independently whether GTK state already matches new state or not.

Fixes https://github.com/eclipse-platform/eclipse.platform.swt/issues/2887