### PR TITLE
  Adapt Clabel to use new GC#drawImage API

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CLabel.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CLabel.java
@@ -574,8 +574,7 @@ void onPaint(PaintEvent event) {
 
 	// draw the image
 	if (img != null) {
-		gc.drawImage(img, 0, 0, imageRect.width, imageHeight,
-						x, imageY, imageRect.width, imageHeight);
+		gc.drawImage(img, x, imageY, imageRect.width, imageHeight);
 		x +=  imageRect.width + GAP;
 		extent.x -= imageRect.width + GAP;
 	}


### PR DESCRIPTION
 
 This change replaces the old API call in CLabel with the newer, simplified drawImage overload that takes fewer parameters and no longer requires the caller to provide the image dimensions.

### Steps to reproduce
1)Run CustomControlExample 
2)The below images are drawn with the drawImage API they remain the same as before

<img width="1298" height="714" alt="image" src="https://github.com/user-attachments/assets/754bf8c6-8c5a-45b7-a63b-01793ed4fd6c" />
