### PR TITLE
 Adapt  Snippets to use new GC#drawImage API wherever a full image is drawn

### DIFF
--- a/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet10.java
+++ b/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet10.java
@@ -43,7 +43,7 @@ public class Snippet10 {
 			Transform tr = new Transform(display);
 			tr.translate(50, 120);
 			tr.rotate(-30);
-			gc1.drawImage(image, 0, 0, rect.width, rect.height, 0, 0, rect.width / 2, rect.height / 2);
+			gc1.drawImage(image, 0, 0, rect.width / 2, rect.height / 2);
 			gc1.setAlpha(100);
 			gc1.setTransform(tr);
 			Path path = new Path(display);

--- a/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet141.java
+++ b/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet141.java
@@ -72,10 +72,6 @@ public class Snippet141 {
 								image = new Image(display, imageData);
 								offScreenImageGC.drawImage(
 									image,
-									0,
-									0,
-									imageData.width,
-									imageData.height,
 									imageData.x,
 									imageData.y,
 									imageData.width,
@@ -97,16 +93,8 @@ public class Snippet141 {
 										break;
 									case SWT.DM_FILL_PREVIOUS:
 										/* Restore the previous image before drawing. */
-										offScreenImageGC.drawImage(
-											image,
-											0,
-											0,
-											imageData.width,
-											imageData.height,
-											imageData.x,
-											imageData.y,
-											imageData.width,
-											imageData.height);
+										offScreenImageGC.drawImage(image, imageData.x, imageData.y, imageData.width,
+												imageData.height);
 										break;
 									}
 
@@ -114,16 +102,8 @@ public class Snippet141 {
 									imageData = imageDataArray[imageDataIndex];
 									image.dispose();
 									image = new Image(display, imageData);
-									offScreenImageGC.drawImage(
-										image,
-										0,
-										0,
-										imageData.width,
-										imageData.height,
-										imageData.x,
-										imageData.y,
-										imageData.width,
-										imageData.height);
+									offScreenImageGC.drawImage(image, imageData.x, imageData.y, imageData.width,
+											imageData.height);
 
 									/* Draw the off-screen image to the shell. */
 									shellGC.drawImage(offScreenImage, 0, 0);

--- a/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet180.java
+++ b/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet180.java
@@ -47,9 +47,8 @@ public static void main(String[] args) {
 	//define the shape of the shell using setRegion
 	shell.setRegion(region);
 	shell.addPaintListener(e -> {
-		Rectangle bounds = image.getBounds();
 		Point size = shell.getSize();
-		e.gc.drawImage(image, 0, 0, bounds.width, bounds.height, 10, 10, size.x-20, size.y-20);
+		e.gc.drawImage(image, 10, 10, size.x-20, size.y-20);
 	});
 	shell.addListener(SWT.KeyDown, e -> {
 		if (e.character == SWT.ESC) {

--- a/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet288.java
+++ b/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet288.java
@@ -124,19 +124,11 @@ public class Snippet288 {
 							0,
 							0,
 							fullWidth,
-							fullHeight,
-							0,
-							0,
-							fullWidth,
 							fullHeight);
 						break;
 					}
 					Image newFrame = new Image(display, imageData);
 					gc.drawImage(newFrame,
-							0,
-							0,
-							imageData.width,
-							imageData.height,
 							imageData.x,
 							imageData.y,
 							imageData.width,

--- a/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet355.java
+++ b/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet355.java
@@ -33,9 +33,9 @@ public class Snippet355 {
 			int height = rect.height;
 			GC gc = e.gc;
 			int x = 10, y = 10;
-			gc.drawImage (image, 0, 0, width, height, x, y, width, height);
-			gc.drawImage (image, 0, 0, width, height, x+width, y, (int)Math.round(width * 0.5), (int)Math.round(height * 0.5));
-			gc.drawImage (image, 0, 0, width, height, x+width+(int)Math.round(width * 0.5), y, width * 2, height * 2);
+			gc.drawImage (image, x, y, width, height);
+			gc.drawImage (image, x+width, y, (int)Math.round(width * 0.5), (int)Math.round(height * 0.5));
+			gc.drawImage (image, x+width+(int)Math.round(width * 0.5), y, width * 2, height * 2);
 		});
 		shell.setSize (600, 400);
 		shell.open ();

--- a/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet361.java
+++ b/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet361.java
@@ -171,10 +171,6 @@ public class Snippet361 {
 				if (printer.startPage()) {
 					printerGC.drawImage(
 						printerImage,
-						0,
-						0,
-						imageData.width,
-						imageData.height,
 						-trim.x,
 						-trim.y,
 						scaleFactor * imageData.width,


### PR DESCRIPTION
This change replaces the old `drawImage` API call in Snippets with the newer, simplified `drawImage` overload that takes fewer parameters