### PR TITLE
 Adapt Examples to new GC#drawImage API when a full image is drawn

### DIFF
--- a/examples/org.eclipse.swt.examples/src/org/eclipse/swt/examples/accessibility/CTableColumn.java
+++ b/examples/org.eclipse.swt.examples/src/org/eclipse/swt/examples/accessibility/CTableColumn.java
@@ -507,8 +507,6 @@ void paint (GC gc) {
 		int drawHeight = Math.min (imageBounds.height, headerHeight - 2 * padding);
 		gc.drawImage (
 			super.getImage (),
-			0, 0,
-			imageBounds.width, imageBounds.height,
 			startX, (headerHeight - drawHeight) / 2,
 			imageBounds.width, drawHeight);
 		startX += imageBounds.width + CTable.MARGIN_IMAGE;

--- a/examples/org.eclipse.swt.examples/src/org/eclipse/swt/examples/accessibility/CTableItem.java
+++ b/examples/org.eclipse.swt.examples/src/org/eclipse/swt/examples/accessibility/CTableItem.java
@@ -1448,13 +1448,8 @@ boolean paint (GC gc, CTableColumn column, boolean backgroundOnly) {
 
 		/* draw the image */
 		if (image != null) {
-			Rectangle imageBounds = image.getBounds ();
-			gc.drawImage (
-				image,
-				0, 0,									/* source x, y */
-				imageBounds.width, imageBounds.height,	/* source width, height */
-				imageArea.x, imageArea.y,				/* dest x, y */
-				imageArea.width, imageArea.height);		/* dest width, height */
+			gc.drawImage(image, imageArea.x, imageArea.y, /* dest x, y */
+					imageArea.width, imageArea.height); /* dest width, height */
 		}
 
 		/* draw the text */

--- a/examples/org.eclipse.swt.examples/src/org/eclipse/swt/examples/browserexample/BrowserExample.java
+++ b/examples/org.eclipse.swt.examples/src/org/eclipse/swt/examples/browserexample/BrowserExample.java
@@ -28,7 +28,6 @@ import org.eclipse.swt.browser.VisibilityWindowListener;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.graphics.ImageData;
 import org.eclipse.swt.graphics.Point;
-import org.eclipse.swt.graphics.Rectangle;
 import org.eclipse.swt.layout.FillLayout;
 import org.eclipse.swt.layout.FormAttachment;
 import org.eclipse.swt.layout.FormData;
@@ -189,10 +188,9 @@ public class BrowserExample {
 			data.right = new FormAttachment(100, -5);
 			canvas.setLayoutData(data);
 
-			final Rectangle rect = images[0].getBounds();
 			canvas.addListener(SWT.Paint, e -> {
 				Point pt = ((Canvas)e.widget).getSize();
-				e.gc.drawImage(images[index], 0, 0, rect.width, rect.height, 0, 0, pt.x, pt.y);
+				e.gc.drawImage(images[index], 0, 0, pt.x, pt.y);
 			});
 			canvas.addListener(SWT.MouseDown, e -> browser.setUrl(getResourceString("Startup")));
 

--- a/examples/org.eclipse.swt.examples/src/org/eclipse/swt/examples/graphics/AlphaTab.java
+++ b/examples/org.eclipse.swt.examples/src/org/eclipse/swt/examples/graphics/AlphaTab.java
@@ -14,8 +14,13 @@
 
 package org.eclipse.swt.examples.graphics;
 
-import org.eclipse.swt.*;
-import org.eclipse.swt.graphics.*;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.graphics.Device;
+import org.eclipse.swt.graphics.Font;
+import org.eclipse.swt.graphics.GC;
+import org.eclipse.swt.graphics.Image;
+import org.eclipse.swt.graphics.Path;
+import org.eclipse.swt.graphics.Point;
 
 /**
  * This tab demonstrates alpha blending. It draws various shapes and images as
@@ -104,21 +109,16 @@ public class AlphaTab extends AnimatedGraphicsTab {
 			alphaImg2 = GraphicsExample.loadImage(device, GraphicsExample.class, "alpha_img2.png");
 		}
 
-		Rectangle rect = alphaImg1.getBounds();
 
 		gc.setAlpha(alphaValue);
-		gc.drawImage(alphaImg1, rect.x, rect.y, rect.width, rect.height,
-				width/2, height/2, width/4, height/4);
+		gc.drawImage(alphaImg1, width / 2, height / 2, width / 4, height / 4);
 
-		gc.drawImage(alphaImg1, rect.x, rect.y, rect.width, rect.height,
-				0, 0, width/4, height/4);
+		gc.drawImage(alphaImg1, 0, 0, width / 4, height / 4);
 
-		gc.setAlpha(255-alphaValue);
-		gc.drawImage(alphaImg2, rect.x, rect.y, rect.width, rect.height,
-				width/2, 0, width/4, height/4);
+		gc.setAlpha(255 - alphaValue);
+		gc.drawImage(alphaImg2, width / 2, 0, width / 4, height / 4);
 
-		gc.drawImage(alphaImg2, rect.x, rect.y, rect.width, rect.height,
-				0, 3*height/4, width/4, height/4);
+		gc.drawImage(alphaImg2, 0, 3 * height / 4, width / 4, height / 4);
 
 		// pentagon
 		gc.setBackground(device.getSystemColor(SWT.COLOR_DARK_MAGENTA));

--- a/examples/org.eclipse.swt.examples/src/org/eclipse/swt/examples/graphics/GraphicsExample.java
+++ b/examples/org.eclipse.swt.examples/src/org/eclipse/swt/examples/graphics/GraphicsExample.java
@@ -328,7 +328,7 @@ static Image createThumbnail(Device device, String name) {
 		result = new Image(device, 16, 16);
 		GC gc = new GC(result);
 		Rectangle dest = result.getBounds();
-		gc.drawImage(image, src.x, src.y, src.width, src.height, dest.x, dest.y, dest.width, dest.height);
+		gc.drawImage(image, dest.x, dest.y, dest.width, dest.height);
 		gc.dispose();
 	}
 	if (result != null) {

--- a/examples/org.eclipse.swt.examples/src/org/eclipse/swt/examples/graphics/ImageScaleTab.java
+++ b/examples/org.eclipse.swt.examples/src/org/eclipse/swt/examples/graphics/ImageScaleTab.java
@@ -14,7 +14,10 @@
 
 package org.eclipse.swt.examples.graphics;
 
-import org.eclipse.swt.graphics.*;
+import org.eclipse.swt.graphics.Device;
+import org.eclipse.swt.graphics.GC;
+import org.eclipse.swt.graphics.Image;
+import org.eclipse.swt.graphics.Rectangle;
 
 /**
  * This tab demonstrates how an image can be scaled.
@@ -45,9 +48,8 @@ public void paint(GC gc, int width, int height) {
 	Device device = gc.getDevice();
 	Image image = GraphicsExample.loadImage(device, GraphicsExample.class, "houses.png");
 
-	Rectangle bounds = image.getBounds();
 	Rectangle canvasBounds = example.canvas.getBounds();
-	gc.drawImage(image, 0, 0, bounds.width, bounds.height, 0, 0, canvasBounds.width, canvasBounds.height);
+	gc.drawImage(image, 0, 0, canvasBounds.width, canvasBounds.height);
 
 	image.dispose();
 }

--- a/examples/org.eclipse.swt.examples/src/org/eclipse/swt/examples/graphics/IntroTab.java
+++ b/examples/org.eclipse.swt.examples/src/org/eclipse/swt/examples/graphics/IntroTab.java
@@ -13,10 +13,17 @@
  *******************************************************************************/
 package org.eclipse.swt.examples.graphics;
 
-import java.util.*;
+import java.util.Random;
 
-import org.eclipse.swt.*;
-import org.eclipse.swt.graphics.*;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.graphics.Device;
+import org.eclipse.swt.graphics.Font;
+import org.eclipse.swt.graphics.FontData;
+import org.eclipse.swt.graphics.GC;
+import org.eclipse.swt.graphics.Image;
+import org.eclipse.swt.graphics.Path;
+import org.eclipse.swt.graphics.Point;
+import org.eclipse.swt.graphics.Rectangle;
 
 public class IntroTab extends AnimatedGraphicsTab {
 
@@ -96,8 +103,7 @@ public void paint(GC gc, int width, int height) {
 	Path path = new Path(device);
 	path.addString(text, x, y, font);
 	gc.setClipping(path);
-	Rectangle rect = image.getBounds();
-	gc.drawImage(image, 0, 0, rect.width, rect.height, 0, 0, width, height);
+	gc.drawImage(image, 0, 0, width, height);
 	gc.setClipping((Rectangle)null);
 	gc.setForeground(device.getSystemColor(SWT.COLOR_BLUE));
 	gc.drawPath(path);

--- a/examples/org.eclipse.swt.examples/src/org/eclipse/swt/examples/imageanalyzer/ImageAnalyzer.java
+++ b/examples/org.eclipse.swt.examples/src/org/eclipse/swt/examples/imageanalyzer/ImageAnalyzer.java
@@ -937,10 +937,6 @@ public class ImageAnalyzer {
 								imageData = event.imageData;
 								imageCanvasGC.drawImage(
 									image,
-									0,
-									0,
-									imageData.width,
-									imageData.height,
 									imageData.x,
 									imageData.y,
 									imageData.width,
@@ -1464,10 +1460,6 @@ public class ImageAnalyzer {
 			// Draw the current image onto the off-screen image.
 			offScreenImageGC.drawImage(
 				image,
-				0,
-				0,
-				imageData.width,
-				imageData.height,
 				imageData.x,
 				imageData.y,
 				imageData.width,
@@ -1492,16 +1484,7 @@ public class ImageAnalyzer {
 						imageData.height);
 				} else if (imageData.disposalMethod == SWT.DM_FILL_PREVIOUS) {
 					// Restore the previous image before drawing.
-					offScreenImageGC.drawImage(
-						image,
-						0,
-						0,
-						imageData.width,
-						imageData.height,
-						imageData.x,
-						imageData.y,
-						imageData.width,
-						imageData.height);
+					offScreenImageGC.drawImage(image, imageData.x, imageData.y, imageData.width, imageData.height);
 				}
 
 				// Get the next image data.
@@ -1512,15 +1495,7 @@ public class ImageAnalyzer {
 
 				// Draw the new image data.
 				offScreenImageGC.drawImage(
-					image,
-					0,
-					0,
-					imageData.width,
-					imageData.height,
-					imageData.x,
-					imageData.y,
-					imageData.width,
-					imageData.height);
+						image, imageData.x, imageData.y, imageData.width, imageData.height);
 
 				// Draw the off-screen image to the screen.
 				imageCanvasGC.drawImage(offScreenImage, 0, 0);
@@ -1781,10 +1756,6 @@ public class ImageAnalyzer {
 		/* Draw the image */
 		gc.drawImage(
 			paintImage,
-			0,
-			0,
-			imageData.width,
-			imageData.height,
 			ix + imageData.x,
 			iy + imageData.y,
 			w,
@@ -1796,10 +1767,6 @@ public class ImageAnalyzer {
 			Image maskImage = new Image(display, maskImageData);
 			gc.drawImage(
 				maskImage,
-				0,
-				0,
-				imageData.width,
-				imageData.height,
 				w + 10 + ix + imageData.x,
 				iy + imageData.y,
 				w,


### PR DESCRIPTION
This change replaces the old drawImage API call in Examples with the newer, simplified drawImage overload that takes fewer parameters