### PR TITLE
 Adapt  tests to use new GC#drawImage API wherever a full image is drawn

### DIFF
--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_GC.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_GC.java
@@ -278,8 +278,7 @@ public void test_drawImage_nonAutoScalableGC_bug_2504() throws InterruptedExcept
     canvas.setSize(canvasWidth, canvasHeight);
     AtomicBoolean paintListenerCalled = new AtomicBoolean();
     canvas.addPaintListener(e -> {
-        e.gc.drawImage(image, 0, 0, bounds.width, bounds.height,
-                       0, 0, canvasWidth, canvasHeight);
+		e.gc.drawImage(image, 0, 0, canvasWidth, canvasHeight);
         paintListenerCalled.set(true);
     });
 

--- a/tests/org.eclipse.swt.tests/ManualTests/org/eclipse/swt/tests/manual/SnippetDrawAlpha.java
+++ b/tests/org.eclipse.swt.tests/ManualTests/org/eclipse/swt/tests/manual/SnippetDrawAlpha.java
@@ -81,7 +81,7 @@ public class SnippetDrawAlpha {
 		Image resultImage = new Image(device, resultData);
 		GC gc = new GC(resultImage);
 		gc.setAntialias(SWT.ON);
-		gc.drawImage(original, 0, 0, width, height,
+		gc.drawImage(original,
 				/*
 				 * E.g. destWidth here is effectively DPIUtil.autoScaleDown
 				 * (scaledWidth), but avoiding rounding errors. Nevertheless, we

--- a/tests/org.eclipse.swt.tests/ManualTests/org/eclipse/swt/tests/manual/SnippetDrawAlphaTwoPass.java
+++ b/tests/org.eclipse.swt.tests/ManualTests/org/eclipse/swt/tests/manual/SnippetDrawAlphaTwoPass.java
@@ -103,14 +103,14 @@ public class SnippetDrawAlphaTwoPass {
 
 		GC gc = new GC(result);
 		gc.setAntialias(SWT.ON);
-		gc.drawImage(original, 0, 0, width, height, 0, 0, scaledWidth, scaledHeight);
+		gc.drawImage(original, 0, 0, scaledWidth, scaledHeight);
 		gc.dispose();
 
 		if (resultMaskData != null) {
 			resultMask = new Image(device, resultMaskData);
 			gc = new GC(resultMask);
 			gc.setAntialias(SWT.ON);
-			gc.drawImage(originalMask, 0, 0, width, height, 0, 0, scaledWidth, scaledHeight);
+			gc.drawImage(originalMask, 0, 0, scaledWidth, scaledHeight);
 			gc.dispose();
 		}
 


### PR DESCRIPTION
This change replaces the old drawImage API call in tests with the newer, simplified drawImage overload that takes fewer parameters