### PR TITLE
[Gtk4] Silence more ATK warnings on the console

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Accessibility/gtk/org/eclipse/swt/accessibility/AccessibleObject.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Accessibility/gtk/org/eclipse/swt/accessibility/AccessibleObject.java
@@ -4601,6 +4601,7 @@ class AccessibleObject {
 	}
 
 	void addRelation (int type, Accessible target) {
+		if(GTK.GTK4) return; //TODO investigate proper way for GTK 4.x
 		AccessibleObject targetAccessibleObject = target.getAccessibleObject();
 		if (targetAccessibleObject != null) {
 			/*
@@ -4634,6 +4635,7 @@ class AccessibleObject {
 	}
 
 	void removeRelation (int type, Accessible target) {
+		if(GTK.GTK4) return; //TODO investigate proper way for GTK 4.x
 		AccessibleObject targetAccessibleObject = target.getAccessibleObject();
 		if (targetAccessibleObject != null) {
 			/*


### PR DESCRIPTION
Gtk 4.x backend will most likely need totally different implementation. For now let's have less noise in console.