### PR TITLE
Add timeout to Test_org_eclipse_swt_custom_BusyIndicator

### DIFF
--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_custom_BusyIndicator.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_custom_BusyIndicator.java
@@ -30,10 +30,12 @@ import org.eclipse.swt.graphics.Cursor;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 public class Test_org_eclipse_swt_custom_BusyIndicator {
 
 	@Test
+	@Timeout(value = 30)
 	public void testShowWhile() {
 		Shell shell = new Shell();
 		Display display = shell.getDisplay();
@@ -91,6 +93,7 @@ public class Test_org_eclipse_swt_custom_BusyIndicator {
 	}
 
 	@Test
+	@Timeout(value = 30)
 	public void testShowWhileWithFuture() {
 		ExecutorService executor = Executors.newSingleThreadExecutor();
 		try {


### PR DESCRIPTION
It seem recently Test_org_eclipse_swt_custom_BusyIndicator is hang in the build forever sometimes.

This now adds a timeout so we can see if it is really hanging there or somewhere else.