### PR TITLE
Make DPIChangeExecution execute with a higher priority

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT PI/win32/library/os.c
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/win32/library/os.c
@@ -8470,6 +8470,22 @@ fail:
 }
 #endif
 
+#ifndef NO_SendMessageCallback
+JNIEXPORT jlong JNICALL OS_NATIVE(SendMessageCallback)
+	(JNIEnv *env, jclass that, jlong arg0, jint arg1, jlong arg2, jcharArray arg3, jlong arg4, jlong arg5)
+{
+	jchar *lparg3=NULL;
+	jlong rc = 0;
+	OS_NATIVE_ENTER(env, that, SendMessageCallback_FUNC);
+	if (arg3) if ((lparg3 = (*env)->GetCharArrayElements(env, arg3, NULL)) == NULL) goto fail;
+	rc = (jlong)SendMessageCallback((HWND)arg0, arg1, (WPARAM)arg2, (LPARAM)lparg3, (SENDASYNCPROC)arg4, (LONG_PTR)arg5);
+fail:
+	if (arg3 && lparg3) (*env)->ReleaseCharArrayElements(env, arg3, lparg3, 0);
+	OS_NATIVE_EXIT(env, that, SendMessageCallback_FUNC);
+	return rc;
+}
+#endif
+
 #ifndef NO_SetActiveWindow
 JNIEXPORT jlong JNICALL OS_NATIVE(SetActiveWindow)
 	(JNIEnv *env, jclass that, jlong arg0)

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/win32/library/os_stats.h
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/win32/library/os_stats.h
@@ -625,6 +625,7 @@ typedef enum {
 	SendMessage__JIJ_3C_FUNC,
 	SendMessage__JIJ_3I_FUNC,
 	SendMessage__JI_3I_3I_FUNC,
+	SendMessageCallback_FUNC,
 	SetActiveWindow_FUNC,
 	SetBkColor_FUNC,
 	SetBkMode_FUNC,

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/win32/org/eclipse/swt/internal/win32/OS.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/win32/org/eclipse/swt/internal/win32/OS.java
@@ -4117,6 +4117,14 @@ public static final native long SendMessage (long hWnd, int Msg, long wParam, ch
  * @param hWnd cast=(HWND)
  * @param wParam cast=(WPARAM)
  * @param lParam cast=(LPARAM)
+ * @param lpResultCallBack cast=(SENDASYNCPROC)
+ * @param dwData cast=(LONG_PTR)
+ */
+public static final native long SendMessageCallback(long hWnd, int Msg, long wParam, char [] lParam, long lpResultCallBack, long dwData);
+/**
+ * @param hWnd cast=(HWND)
+ * @param wParam cast=(WPARAM)
+ * @param lParam cast=(LPARAM)
  */
 public static final native long SendMessage (long hWnd, int Msg, long wParam, int [] lParam);
 /**


### PR DESCRIPTION
This PR introduces the usage of a separate thread to start processing the DPI Change events by executing the handlers using Display#syncExec to provide higher priority to the DPIChangeExecuting tasks.

It doesn't fix the issue in https://github.com/vi-eclipse/Eclipse-Platform/issues/530 but executes the DPI Change tasks with a higher priority making sure the execution happens quicker.