### PR TITLE
Add Rectangle.of(Point,Point) supporting OfFloat

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/Rectangle.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/Rectangle.java
@@ -377,10 +377,39 @@ public Rectangle union (Rectangle rect) {
  * @since 3.131
  */
 public static Rectangle of(Point topLeft, int width, int height) {
-	if (topLeft instanceof Point.WithMonitor monitorAwareTopLeft) {
-		return new Rectangle.WithMonitor(monitorAwareTopLeft.getX(), monitorAwareTopLeft.getY(), width, height, monitorAwareTopLeft.getMonitor());
+	return Rectangle.of(topLeft, new Point(width, height));
+}
+
+/**
+ * Creates a new {@code Rectangle} using the specified top-left point and the
+ * dimensions point defining the width and height.
+ * <p>
+ * If the provided {@code Point} instances carry additional contextual
+ * information, an extended {@code Rectangle} type may be returned to preserve
+ * that context. Otherwise, a standard {@code Rectangle} is returned.
+ * </p>
+ *
+ * @param topLeft   the top-left corner of the rectangle
+ * @param dimension the point defining the width and height of the rectangle
+ * @return a new {@code Rectangle} instance appropriate for the given point and
+ *         dimensions
+ * @since 3.133
+ */
+public static Rectangle of(Point topLeft, Point dimension) {
+	final float x = (topLeft instanceof Point.OfFloat p) ? p.getX() : topLeft.x;
+	final float y = (topLeft instanceof Point.OfFloat p) ? p.getY() : topLeft.y;
+	final float w = (dimension instanceof Point.OfFloat p) ? p.getX() : dimension.x;
+	final float h = (dimension instanceof Point.OfFloat p) ? p.getY() : dimension.y;
+
+	if (topLeft instanceof Point.WithMonitor pm) {
+		return new Rectangle.WithMonitor(x, y, w, h, pm.getMonitor());
 	}
-	return new Rectangle(topLeft.x, topLeft.y, width, height);
+
+	if (topLeft instanceof Point.OfFloat || dimension instanceof Point.OfFloat) {
+		return new Rectangle.OfFloat(x, y, w, h);
+	}
+
+	return new Rectangle(topLeft.x, topLeft.y, dimension.x, dimension.y);
 }
 
 /**

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_Rectangle.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_Rectangle.java
@@ -298,4 +298,66 @@ public void test_unionLorg_eclipse_swt_graphics_Rectangle() {
 	assertSWTProblem("Incorrect exception thrown for rectangle == null", SWT.ERROR_NULL_ARGUMENT, e);
 }
 
+@Test
+void test_bothPointsAreOfFloat() {
+    Point.OfFloat topLeft = new Point.OfFloat(10.5f, 20.5f);
+    Point.OfFloat dimension = new Point.OfFloat(30.5f, 40.5f);
+
+    Rectangle rect = Rectangle.of(topLeft, dimension);
+
+    assertTrue(rect instanceof Rectangle.OfFloat);
+    Rectangle.OfFloat f = (Rectangle.OfFloat) rect;
+
+    assertEquals(10.5f, f.getX());
+    assertEquals(20.5f, f.getY());
+    assertEquals(30.5f, f.getWidth());
+    assertEquals(40.5f, f.getHeight());
+}
+
+@Test
+void testOnlyTopLeftIsOfFloat() {
+    Point.OfFloat topLeft = new Point.OfFloat(5.5f, 15.5f);
+    Point dimension = new Point(100, 200);
+
+    Rectangle rect = Rectangle.of(topLeft, dimension);
+
+    assertTrue(rect instanceof Rectangle.OfFloat);
+    Rectangle.OfFloat f = (Rectangle.OfFloat) rect;
+
+    assertEquals(5.5f, f.getX());
+    assertEquals(15.5f, f.getY());
+    assertEquals(100, f.getWidth());
+    assertEquals(200, f.getHeight());
+}
+
+@Test
+void testOnlyDimensionIsOfFloat() {
+    Point topLeft = new Point(7, 9);
+    Point.OfFloat dimension = new Point.OfFloat(55.5f, 66.5f);
+
+    Rectangle rect = Rectangle.of(topLeft, dimension);
+
+    assertTrue(rect instanceof Rectangle.OfFloat);
+    Rectangle.OfFloat f = (Rectangle.OfFloat) rect;
+
+    assertEquals(7, f.getX());
+    assertEquals(9, f.getY());
+    assertEquals(55.5f, f.getWidth());
+    assertEquals(66.5f, f.getHeight());
+}
+
+@Test
+void testNeitherPointIsOfFloat() {
+    Point topLeft = new Point(1, 2);
+    Point dimension = new Point(10, 20);
+
+    Rectangle rect = Rectangle.of(topLeft, dimension);
+
+    assertFalse(rect instanceof Rectangle.OfFloat);
+    assertEquals(1, rect.x);
+    assertEquals(2, rect.y);
+    assertEquals(10, rect.width);
+    assertEquals(20, rect.height);
+}
+
 }


### PR DESCRIPTION
When the size point is Point.OfFloat, return Rectangle.OfFloat to retain sub-pixel precision; otherwise return the classic Rectangle.

This is introduced as needed to be used in https://github.com/eclipse-platform/eclipse.platform.ui/pull/3597