### PR TITLE
Drop reference to archived repo

### DIFF
--- a/tests/org.eclipse.swt.tests/Readme.md
+++ b/tests/org.eclipse.swt.tests/Readme.md
@@ -2,4 +2,3 @@ org.eclipse.swt.tests
 =====================
 
 Requires the 'org.eclipse.test.performance' plug-in from the eclipse.releng repository.
-See https://github.com/eclipse-platform/eclipse.platform.releng for the clone URL of this repo.


### PR DESCRIPTION
All needed dependencies are installable from the same repository so no need for such special and wrong comment.