### PR TITLE
[win32] Inline Widget#getNativeZoom

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/widgets/ControlWin32Tests.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/widgets/ControlWin32Tests.java
@@ -138,7 +138,7 @@ class ControlWin32Tests {
 	private FontComparison updateFont(int scalingFactor) {
 		Shell shell = new Shell(Display.getDefault());
 		Control control = new Composite(shell, SWT.NONE);
-		int zoom = shell.getNativeZoom();
+		int zoom = shell.nativeZoom;
 		int newZoom = zoom * scalingFactor;
 
 		Font oldFont = control.getFont();

--- a/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/widgets/WidgetWin32Tests.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/widgets/WidgetWin32Tests.java
@@ -32,7 +32,7 @@ class WidgetWin32Tests {
 	public void testWidgetZoomShouldChangeOnZoomLevelChange() {
 		Display display = Display.getDefault();
 		Shell shell = new Shell(display);
-		int zoom = shell.getNativeZoom();
+		int zoom = shell.nativeZoom;
 		int scaledZoom = zoom * 2;
 
 		Button button = new Button(shell, SWT.PUSH);
@@ -50,7 +50,7 @@ class WidgetWin32Tests {
 	public void testButtonPointsAfterZooming() throws NoSuchMethodException, IllegalAccessException {
 		Display display = Display.getDefault();
 		Shell shell = new Shell(display);
-		int zoom = shell.getNativeZoom();
+		int zoom = shell.nativeZoom;
 
 		int scaledZoom = zoom * 2;
 
@@ -72,7 +72,7 @@ class WidgetWin32Tests {
 	public void testImagePixelsWithDoubleZoomLevel() {
 		Display display = Display.getDefault();
 		Shell shell = new Shell(display);
-		int zoom = shell.getNativeZoom();
+		int zoom = shell.nativeZoom;
 		int scaledZoom = zoom * 2;
 
 		InputStream inputStream = WidgetWin32Tests.class.getResourceAsStream("folder.png");
@@ -99,7 +99,7 @@ class WidgetWin32Tests {
 	public void testButtonFontAfterZooming() {
 		Display display = Display.getDefault();
 		Shell shell = new Shell(display);
-		int zoom = shell.getNativeZoom();
+		int zoom = shell.nativeZoom;
 
 		int scaledZoom = zoom * 2;
 
@@ -126,7 +126,7 @@ class WidgetWin32Tests {
 	public void testCoolItemAfterZooming() {
 		Display display = Display.getDefault();
 		Shell shell = new Shell(display);
-		int zoom = shell.getNativeZoom();
+		int zoom = shell.nativeZoom;
 		int scaledZoom = zoom * 2;
 
 
@@ -164,7 +164,7 @@ class WidgetWin32Tests {
 	public void testExpandItemAfterZooming() {
 		Display display = Display.getDefault();
 		Shell shell = new Shell(display);
-		int zoom = shell.getNativeZoom();
+		int zoom = shell.nativeZoom;
 		int scaledZoom = zoom * 2;
 
 		shell.setBounds(0, 0, 100, 160);
@@ -191,7 +191,7 @@ class WidgetWin32Tests {
 	public void testTabFolderSizeAfterZooming() {
 		Display display = Display.getDefault();
 		Shell shell = new Shell(display);
-		int zoom = shell.getNativeZoom();
+		int zoom = shell.nativeZoom;
 		int scaledZoom = zoom * 2;
 
 		shell.setBounds(0, 0, 100, 160);
@@ -220,7 +220,7 @@ class WidgetWin32Tests {
 		Display display = Display.getDefault();
 
 		Shell shell = new Shell(display);
-		int zoom = shell.getNativeZoom();
+		int zoom = shell.nativeZoom;
 		int scaledZoom = zoom * 2;
 		shell.setBounds(0, 0, 100, 160);
 		shell.setLayout(new FillLayout());
@@ -257,7 +257,7 @@ class WidgetWin32Tests {
 	public void testTreeAfterZooming() {
 		Display display = Display.getDefault();
 		Shell shell = new Shell(display);
-		int zoom =  shell.getNativeZoom();
+		int zoom =  shell.nativeZoom;
 		int scaledZoom = zoom * 2;
 
 		shell.setBounds(0, 0, 100, 160);
@@ -293,7 +293,7 @@ class WidgetWin32Tests {
 	public void testCaretInStyledTextAfterZooming() {
 		Display display = Display.getDefault();
 		Shell shell = new Shell(display);
-		int zoom = shell.getNativeZoom();
+		int zoom = shell.nativeZoom;
 		int scaledZoom = zoom * 2;
 
 		shell.setBounds(0, 0, 100, 160);

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Caret.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Caret.java
@@ -140,7 +140,7 @@ private OptionalInt getSystemCaretWidthInPixelsForCurrentMonitor() {
 	int [] buffer = new int [1];
 	if (OS.SystemParametersInfo (OS.SPI_GETCARETWIDTH, 0, buffer, 0)) {
 		int width = DPIUtil.pixelToPoint(buffer [0], Win32DPIUtils.getPrimaryMonitorZoomAtStartup());
-		int widthInPixels = DPIUtil.pointToPixel(width, getNativeZoom());
+		int widthInPixels = DPIUtil.pointToPixel(width, nativeZoom);
 		return OptionalInt.of(widthInPixels);
 	}
 	return OptionalInt.empty();
@@ -160,7 +160,7 @@ public Font getFont () {
 	checkWidget();
 	if (font == null) {
 		long hFont = defaultFont ();
-		return Font.win32_new (display, hFont, getNativeZoom());
+		return Font.win32_new (display, hFont, nativeZoom);
 	}
 	return font;
 }
@@ -486,7 +486,7 @@ public void setFont (Font font) {
 	if (font != null && font.isDisposed ()) {
 		error (SWT.ERROR_INVALID_ARGUMENT);
 	}
-	this.font = font == null ? null : Font.win32_new(font, getNativeZoom());
+	this.font = font == null ? null : Font.win32_new(font, nativeZoom);
 	if (hasFocus ()) setIMEFont ();
 }
 
@@ -517,7 +517,7 @@ public void setImage (Image image) {
 void setIMEFont () {
 	if (!OS.IsDBLocale) return;
 	long hFont = 0;
-	if (font != null) hFont = SWTFontProvider.getFontHandle(font, getNativeZoom());
+	if (font != null) hFont = SWTFontProvider.getFontHandle(font, nativeZoom);
 	if (hFont == 0) hFont = defaultFont ();
 	long hwnd = parent.handle;
 	long hIMC = OS.ImmGetContext (hwnd);

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Composite.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Composite.java
@@ -1412,7 +1412,7 @@ LRESULT WM_GETFONT (long wParam, long lParam) {
 	if (result != null) return result;
 	long code = callWindowProc (handle, OS.WM_GETFONT, wParam, lParam);
 	if (code != 0) return new LRESULT (code);
-	return new LRESULT (font != null ? SWTFontProvider.getFontHandle(font, getNativeZoom()) : defaultFont ());
+	return new LRESULT (font != null ? SWTFontProvider.getFontHandle(font, nativeZoom) : defaultFont ());
 }
 
 @Override
@@ -1518,7 +1518,7 @@ LRESULT WM_PAINT (long wParam, long lParam) {
 					Control control = findBackgroundControl ();
 					if (control == null) control = this;
 					data.background = control.getBackgroundPixel ();
-					data.font = SWTFontProvider.getFont(display, OS.SendMessage (handle, OS.WM_GETFONT, 0, 0), getNativeZoom());
+					data.font = SWTFontProvider.getFont(display, OS.SendMessage (handle, OS.WM_GETFONT, 0, 0), nativeZoom);
 					data.uiState = (int)OS.SendMessage (handle, OS.WM_QUERYUISTATE, 0, 0);
 					if ((style & SWT.NO_BACKGROUND) != 0) {
 						/* This code is intentionally commented because it may be slow to copy bits from the screen */

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Control.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Control.java
@@ -736,7 +736,7 @@ int defaultBackground () {
 }
 
 long defaultFont() {
-	return SWTFontProvider.getSystemFontHandle(display, getNativeZoom());
+	return SWTFontProvider.getSystemFontHandle(display, nativeZoom);
 }
 
 int defaultForeground () {
@@ -1352,7 +1352,7 @@ public Font getFont () {
 	if (font != null) return font;
 	long hFont = OS.SendMessage (handle, OS.WM_GETFONT, 0, 0);
 	if (hFont == 0) hFont = defaultFont ();
-	return SWTFontProvider.getFont(display, hFont, getNativeZoom());
+	return SWTFontProvider.getFont(display, hFont, nativeZoom);
 }
 
 /**
@@ -1791,7 +1791,7 @@ public long internal_new_GC (GCData data) {
 			}
 		}
 		data.device = display;
-		data.nativeZoom = getNativeZoom();
+		data.nativeZoom = nativeZoom;
 		int foreground = getForegroundPixel ();
 		if (foreground != OS.GetTextColor (hDC)) data.foreground = foreground;
 		Control control = findBackgroundControl ();
@@ -3424,7 +3424,7 @@ public void setCursor (Cursor cursor) {
 }
 
 void setDefaultFont () {
-	long hFont = SWTFontProvider.getSystemFontHandle(display, getNativeZoom());
+	long hFont = SWTFontProvider.getSystemFontHandle(display, nativeZoom);
 	OS.SendMessage (handle, OS.WM_SETFONT, hFont, 0);
 }
 
@@ -3526,7 +3526,7 @@ public void setFont (Font font) {
 	Font newFont = font;
 	if (newFont != null) {
 		if (newFont.isDisposed()) error(SWT.ERROR_INVALID_ARGUMENT);
-		newFont = Font.win32_new(newFont, getNativeZoom());
+		newFont = Font.win32_new(newFont, nativeZoom);
 	}
 	long hFont = 0;
 	if (newFont != null) {
@@ -4864,7 +4864,7 @@ public boolean setParent (Composite parent) {
 
 @Override
 GC createNewGC(long hDC, GCData data) {
-	data.nativeZoom = getNativeZoom();
+	data.nativeZoom = nativeZoom;
 	if (autoScaleDisabled && data.font != null) {
 		data.font = SWTFontProvider.getFont(display, data.font.getFontData()[0], 100);
 	}
@@ -6038,7 +6038,7 @@ void handleDPIChange(Event event, float scalingFactor) {
 	if (this.autoScaleDisabled) {
 		this.nativeZoom = 100;
 	}
-	resizeFont(this, getNativeZoom());
+	resizeFont(this, nativeZoom);
 
 	Image image = backgroundImage;
 	if (image != null) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ExpandBar.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ExpandBar.java
@@ -507,7 +507,7 @@ void setBackgroundPixel (int pixel) {
 @Override
 public void setFont (Font font) {
 	super.setFont (font);
-	hFont = font != null ? SWTFontProvider.getFontHandle(font, getNativeZoom()) : 0;
+	hFont = font != null ? SWTFontProvider.getFontHandle(font, nativeZoom) : 0;
 	layoutItems (0, true);
 }
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TableItem.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TableItem.java
@@ -153,8 +153,8 @@ void destroyWidget () {
 }
 
 long fontHandle (int index) {
-	if (cellFont != null && cellFont [index] != null) return SWTFontProvider.getFontHandle(cellFont[index], getNativeZoom());
-	if (font != null) return SWTFontProvider.getFontHandle(font, getNativeZoom());
+	if (cellFont != null && cellFont [index] != null) return SWTFontProvider.getFontHandle(cellFont[index], nativeZoom);
+	if (font != null) return SWTFontProvider.getFontHandle(font, nativeZoom);
 	return -1;
 }
 
@@ -866,7 +866,7 @@ public void setFont (Font font){
 		error (SWT.ERROR_INVALID_ARGUMENT);
 	}
 	Font oldFont = this.font;
-	Font newFont = (font == null ? font : Font.win32_new(font, getNativeZoom()));
+	Font newFont = (font == null ? font : Font.win32_new(font, nativeZoom));
 	if (oldFont == newFont) return;
 	this.font = newFont;
 	if (oldFont != null && oldFont.equals (newFont)) return;
@@ -931,7 +931,7 @@ public void setFont (int index, Font font) {
 	}
 	Font oldFont = cellFont [index];
 	if (oldFont == font) return;
-	cellFont [index] = font == null ? font : Font.win32_new(font, getNativeZoom());
+	cellFont [index] = font == null ? font : Font.win32_new(font, nativeZoom);
 	if (oldFont != null && oldFont.equals (font)) return;
 	if (font != null) parent.setCustomDraw (true);
 	if ((parent.style & SWT.VIRTUAL) != 0) cached = true;
@@ -1277,7 +1277,7 @@ void handleDPIChange(Event event, float scalingFactor) {
 	if (cellFonts != null) {
 		for (int index = 0; index < cellFonts.length; index++) {
 			Font cellFont = cellFonts[index];
-			cellFonts[index] = cellFont == null ? null : Font.win32_new(cellFont, getNativeZoom());
+			cellFonts[index] = cellFont == null ? null : Font.win32_new(cellFont, nativeZoom);
 		}
 	}
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Tracker.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Tracker.java
@@ -823,7 +823,7 @@ public void setCursor(Cursor newCursor) {
 	checkWidget();
 	clientCursor = newCursor;
 	if (newCursor != null) {
-		if (inEvent) OS.SetCursor (Cursor.win32_getHandle(clientCursor, DPIUtil.getZoomForAutoscaleProperty(parent != null ? parent.getShellZoom() : getNativeZoom())));
+		if (inEvent) OS.SetCursor (Cursor.win32_getHandle(clientCursor, DPIUtil.getZoomForAutoscaleProperty(parent != null ? parent.getShellZoom() : nativeZoom)));
 	}
 }
 
@@ -896,7 +896,7 @@ long transparentProc (long hwnd, long msg, long wParam, long lParam) {
 			break;
 		case OS.WM_SETCURSOR:
 			if (clientCursor != null) {
-				OS.SetCursor (Cursor.win32_getHandle(clientCursor, DPIUtil.getZoomForAutoscaleProperty(parent != null ? parent.getShellZoom() : getNativeZoom())));
+				OS.SetCursor (Cursor.win32_getHandle(clientCursor, DPIUtil.getZoomForAutoscaleProperty(parent != null ? parent.getShellZoom() : nativeZoom)));
 				return 1;
 			}
 			if (resizeCursor != 0) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TreeItem.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TreeItem.java
@@ -312,8 +312,8 @@ void destroyWidget () {
 }
 
 long fontHandle (int index) {
-	if (cellFont != null && cellFont [index] != null) return SWTFontProvider.getFontHandle(cellFont[index], getNativeZoom());
-	if (font != null) return SWTFontProvider.getFontHandle(font, getNativeZoom());
+	if (cellFont != null && cellFont [index] != null) return SWTFontProvider.getFontHandle(cellFont[index], nativeZoom);
+	if (font != null) return SWTFontProvider.getFontHandle(font, nativeZoom);
 	return -1;
 }
 
@@ -1384,7 +1384,7 @@ public void setFont (Font font){
 		error (SWT.ERROR_INVALID_ARGUMENT);
 	}
 	Font oldFont = this.font;
-	Font newFont = (font == null ? font : Font.win32_new(font, getNativeZoom()));
+	Font newFont = (font == null ? font : Font.win32_new(font, nativeZoom));
 	if (oldFont == newFont) return;
 	this.font = newFont;
 	if (oldFont != null && oldFont.equals (font)) return;
@@ -1440,7 +1440,7 @@ public void setFont (int index, Font font) {
 	}
 	Font oldFont = cellFont [index];
 	if (oldFont == font) return;
-	cellFont [index] = font == null ? font : Font.win32_new(font, getNativeZoom());
+	cellFont [index] = font == null ? font : Font.win32_new(font, nativeZoom);
 	if (oldFont != null && oldFont.equals (font)) return;
 	if (font != null) parent.customDraw = true;
 	if ((parent.style & SWT.VIRTUAL) != 0) cached = true;
@@ -1822,7 +1822,7 @@ void handleDPIChange(Event event, float scalingFactor) {
 	if (cellFonts != null) {
 		for (int index = 0; index < cellFonts.length; index++) {
 			Font cellFont = cellFonts[index];
-			cellFonts[index] = cellFont == null ? null : Font.win32_new(cellFont, getNativeZoom());
+			cellFonts[index] = cellFont == null ? null : Font.win32_new(cellFont, nativeZoom);
 		}
 	}
 	for (TreeItem item : getItems()) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Widget.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Widget.java
@@ -2695,12 +2695,8 @@ void notifyDisposalTracker() {
 }
 
 GC createNewGC(long hDC, GCData data) {
-	data.nativeZoom = getNativeZoom();
+	data.nativeZoom = nativeZoom;
 	return GC.win32_new(hDC, data);
-}
-
-int getNativeZoom() {
-	return nativeZoom;
 }
 
 int getZoom() {

--- a/tests/org.eclipse.swt.tests.win32/ManualTests/org/eclipse/swt/widgets/PatternWin32ManualTest.java
+++ b/tests/org.eclipse.swt.tests.win32/ManualTests/org/eclipse/swt/widgets/PatternWin32ManualTest.java
@@ -33,7 +33,7 @@ public class PatternWin32ManualTest {
 
 	public static void main (String [] args) {
 		Shell shell = new Shell(display);
-		int zoom = shell.getNativeZoom();
+		int zoom = shell.nativeZoom;
 		int scalingFactor = 3;
 		int scaledZoom = zoom * scalingFactor;
 		int width = 400;


### PR DESCRIPTION
This PR inlines Widget#getNativeZoom as after some refactorings it is purely a getter for Wiget.nativeZoom now. Additionally, as the method was package protected mutliple places outside the widgets package uses the field directly anyway.

It was done with the Eclipse internal "inline" refactoring