### PR TITLE
Delegating Image(Display, String) to ImageFileNameProvider to init Image

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/graphics/Image.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/graphics/Image.java
@@ -596,10 +596,9 @@ public Image(Device device, InputStream stream) {
 public Image(Device device, String filename) {
 	super(device);
 	if (filename == null) SWT.error(SWT.ERROR_NULL_ARGUMENT);
+	this.imageFileNameProvider = zoom -> zoom == 100 ? filename : null;
 	currentDeviceZoom = DPIUtil.getDeviceZoom();
-	ElementAtZoom<ImageData> image = ImageDataLoader.loadByZoom(filename, FileFormat.DEFAULT_ZOOM, currentDeviceZoom);
-	ImageData data = DPIUtil.scaleImageData(device, image, currentDeviceZoom);
-	init(data);
+	initFromFileNameProvider(currentDeviceZoom);
 	init();
 }
 


### PR DESCRIPTION
In **GTK** and **Cocoa**, an image based on an SVG passed as filename to Image(Device, String) will be drawn now sharply with this change.

Contributes to https://github.com/eclipse-platform/eclipse.platform.swt/issues/2917

### How to Test

Run this Snippet on Windows, Mac and Linux and compare the results:
```
import java.nio.file.Path;
import org.eclipse.swt.graphics.Color;
import org.eclipse.swt.graphics.Image;
import org.eclipse.swt.graphics.ImageFileNameProvider;
import org.eclipse.swt.layout.FillLayout;
import org.eclipse.swt.widgets.Display;
import org.eclipse.swt.widgets.Shell;

public class SVGImageTests {
    
    public static void main(String[] args) throws Exception {
        final Display display = new Display();

        final Shell shell = new Shell(display);
        shell.setText("SVG Image Test");
        shell.setLayout(new FillLayout());
        shell.setBounds(250, 50, 1000, 400);
        shell.setBackground(new Color(255, 255, 255));
        
        String imgPath = "image.svg";
        Path fullPath = Path.of(SVGImageTests.class.getResource(imgPath).toURI());

        // Image loaded in file path
        Image image2 = new Image(display, fullPath.toString());
        
        // Image loaded in ImageFileNameProvider
        Image image3 = new Image(display, (ImageFileNameProvider) zoom -> {
            return zoom == 100 ? fullPath.toString() : null;
        });
        
        shell.addPaintListener(e -> {            
            e.gc.drawImage(image2, 340, 10, 300, 300);
            e.gc.drawText("Image(Display, String)", 420, 300);
            
            e.gc.drawImage(image3, 660, 10, 300, 300);
            e.gc.drawText("Image(Display, ImageFileNameProvider)", 700, 300);
        });
        
        shell.open();

        while(!shell.isDisposed()) {
            if(!display.readAndDispatch()) {
                display.sleep();
            }
        }

        display.dispose();
    }
}
```
Use this SVG image for the Snippet:

<img width="36" height="36" alt="image" src="https://github.com/user-attachments/assets/4d4737a7-23c1-4b66-ac81-68a794b72b94" />

Here's the outputs...

On Windows all Image methods result in sharp output:

<img width="771" height="422" alt="image" src="https://github.com/user-attachments/assets/cc0a9c5a-18e2-40b0-b6f7-c3b437ba3604" />


On Mac only using ImageFileNameProvider is sharp:

<img width="784" height="477" alt="image" src="https://github.com/user-attachments/assets/805d742a-8300-4eaa-a7d8-fc1fe5a8ef97" />

On Linux only using ImageFileNameProvider is sharp:

<img width="703" height="468" alt="image" src="https://github.com/user-attachments/assets/bcd636a3-cf8a-44d6-b3a7-26dc91d72152" />

### After Fix

Image use for testing: 
![eclipse16](https://github.com/user-attachments/assets/9be604b6-3086-4e49-b7a4-b09705549cc4)

GTK: 

<img width="1782" height="781" alt="image" src="https://github.com/user-attachments/assets/ec0aff1d-3d72-4038-a941-4d5e8180c81b" />

Cocoa:

<img width="2004" height="806" alt="image" src="https://github.com/user-attachments/assets/2e150a74-733e-4d48-8dd7-7efa8bc1ac73" />
