### PR TITLE
Use Rectangle.ofFloat for bounds in WM_PAINT to avoid rounding issues

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Composite.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Composite.java
@@ -1532,7 +1532,7 @@ LRESULT WM_PAINT (long wParam, long lParam) {
 
 					Event event = new Event ();
 					event.gc = gc;
-					event.setBounds(Win32DPIUtils.pixelToPoint(new Rectangle(ps.left, ps.top, width, height), getZoom()));
+					event.setBounds(Win32DPIUtils.pixelToPoint(new Rectangle.OfFloat(ps.left, ps.top, width, height), getZoom()));
 					sendEvent (SWT.Paint, event);
 					if (data.focusDrawn && !isDisposed ()) updateUIState ();
 					gc.dispose ();


### PR DESCRIPTION
When resizing or expanding scrollable with styled text (e.g. Git revision information), the width of the newly painted region can be small such that they are non-zero in pixels but rounded down to zero in points (after pixelToPoint call). This causes StyledText::handlePaint to skip drawing due to the below check , resulting in visible artifact lines.

`if (event.width == 0 || event.height == 0) return;` [link](https://github.com/eclipse-platform/eclipse.platform.swt/blob/master/bundles/org.eclipse.swt/Eclipse%20SWT%20Custom%20Widgets/common/org/eclipse/swt/custom/StyledText.java#L5981)


Using float-based bounds preserves these non-zero regions from being rounded to zero in points and prevents missed paint operations during resize.

### Steps to reproduce:  
(Originally posted by @HeikoKlare  in https://github.com/vi-eclipse/Eclipse-Platform/issues/560)
- Open a current IDE on a 150% monitor
- Open any Java file under Git version control and show the revision information in the ruler (right click -> "Team" -> "Show revision information")
- Hover over any of the markers with changes, such that the window with detail information appears
- Slowing increase the width of that window
- Artifact lines like the one mentioned in https://github.com/vi-eclipse/Eclipse-Platform/issues/560 appears without this change, 