### PR TITLE
PlainImageProviderWrapper:newImageHandle creates new ImageHandle

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Image.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Image.java
@@ -2294,13 +2294,11 @@ private class PlainImageProviderWrapper extends AbstractImageProviderWrapper {
 			return createBaseHandle(targetZoom);
 		}
 		if (memGC != null) {
-			if (memGC.getZoom() != targetZoom) {
-				GC currentGC = memGC;
-				memGC = null;
-				createHandle(targetZoom);
-				currentGC.refreshFor(new DrawableWrapper(Image.this, zoomContext));
-			}
-			return zoomLevelToImageHandle.get(targetZoom);
+			GC currentGC = memGC;
+			memGC = null;
+			ImageHandle imageHandle = createHandle(targetZoom);
+			currentGC.refreshFor(new DrawableWrapper(Image.this, zoomContext));
+			return imageHandle;
 		}
 		return super.newImageHandle(zoomContext);
 	}


### PR DESCRIPTION
This PR adjusts the implementation of
Image:PlainImageProviderWrapper:newImageHandle to always create a new handle instead of returning an existing one. If an ImageHandle exists, consumers are responsible for proactively checking that before calling this method.

With that said, the affected line is not even reached without the block being executed:

```
if (memGC.getZoom() != targetZoom) {
  GC currentGC = memGC;
  memGC = null;
  createHandle(targetZoom);
  currentGC.refreshFor(new DrawableWrapper(Image.this, zoomContext));
}
```
Hence it is safe to remove.