### PR TITLE
[GTK4] Fix CTabFolder chevron click GTK-Critical

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Control.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Control.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2025 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -6872,7 +6872,8 @@ Point getWindowOrigin () {
  */
 Point getSurfaceOrigin () {
 	double[] originX = new double[1], originY = new double[1];
-	boolean success = GTK4.gtk_widget_translate_coordinates(fixedHandle, getShell().shellHandle, 0, 0, originX, originY);
+	long widgetHandle = fixedHandle != 0 ? fixedHandle: eventHandle();
+	boolean success = GTK4.gtk_widget_translate_coordinates(widgetHandle, getShell().shellHandle, 0, 0, originX, originY);
 
 	return success ? new Point((int)originX[0], (int)originY[0]) : new Point(0, 0);
 }


### PR DESCRIPTION
Error is like:
```
(SWT:339274): Gtk-CRITICAL **: 17:08:42.533: gtk_widget_compute_point:
assertion 'GTK_IS_WIDGET (widget)' failed
```

The problem comes from Control.getSurfaceOrigin method relying on fixedHandle to translate coordinated but not every widget has such, use eventHandle() instead.

Tested with Snippet165.