### PR TITLE
[Gtk4] Prevent rare crash in Shell.setVisible

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Shell.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Shell.java
@@ -2909,7 +2909,14 @@ public void setVisible (boolean visible) {
 		 * up in front of the full-screen window.
 		 */
 		if (parent!=null && parent.getShell().getFullScreen()) {
-			GTK3.gtk_window_set_type_hint(shellHandle, GDK.GDK_WINDOW_TYPE_HINT_DIALOG);
+			if (GTK.GTK4) {
+				GTK.gtk_window_set_modal(shellHandle, true);
+				GTK.gtk_window_set_transient_for(shellHandle, parent.getShell().shellHandle);
+				GTK.gtk_window_set_destroy_with_parent(shellHandle, true);
+			} else {
+				GTK3.gtk_window_set_type_hint(shellHandle, GDK.GDK_WINDOW_TYPE_HINT_DIALOG);
+
+			}
 		}
 	} else {
 		updateModal ();


### PR DESCRIPTION
A *_MODAL shells with fullscreen parent was calling removed Gtk 3 function causing a crash with Exception in thread "main" java.lang.UnsatisfiedLinkError: 'void
org.eclipse.swt.internal.gtk3.GTK3.gtk_window_set_type_hint(long, int)' .

Simplified snippet to reproduce:
```java
Shell shell = new Shell(display);
	shell.setText("Snippet 1");
	shell.setFullScreen(true);
	shell.open ();
	Shell shell2 = new Shell(shell, SWT.PRIMARY_MODAL);
	shell2.setText("Child");
	shell2.open();
```