### PR TITLE
[win32] Pass zoom to Scrollable#computeTrimInPixels

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Decorations.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Decorations.java
@@ -279,7 +279,7 @@ Control computeTabRoot () {
 	return this;
 }
 
-@Override Rectangle computeTrimInPixels (int x, int y, int width, int height) {
+@Override Rectangle computeTrimInPixels (int x, int y, int width, int height, int zoom) {
 	checkWidget ();
 
 	/* Get the size of the trimmings */

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ExpandBar.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ExpandBar.java
@@ -172,7 +172,7 @@ Point computeSizeInPixels (Point hintInPoints, int zoom, boolean changed) {
 	if (height == 0) height = DEFAULT_HEIGHT;
 	if (hintInPoints.x != SWT.DEFAULT) width = hintInPixels.x;
 	if (hintInPoints.y != SWT.DEFAULT) height = hintInPixels.y;
-	Rectangle trim = computeTrimInPixels (0, 0, width, height);
+	Rectangle trim = computeTrimInPixels (0, 0, width, height, zoom);
 	return new Point (trim.width, trim.height);
 }
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Group.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Group.java
@@ -166,9 +166,9 @@ Point computeSizeInPixels (Point hintInPoints, int zoom, boolean changed) {
 	return size;
 }
 
-@Override Rectangle computeTrimInPixels (int x, int y, int width, int height) {
+@Override Rectangle computeTrimInPixels (int x, int y, int width, int height, int zoom) {
 	checkWidget ();
-	Rectangle trim = super.computeTrimInPixels (x, y, width, height);
+	Rectangle trim = super.computeTrimInPixels (x, y, width, height, zoom);
 	long newFont, oldFont = 0;
 	long hDC = OS.GetDC (handle);
 	newFont = OS.SendMessage (handle, OS.WM_GETFONT, 0, 0);

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Scrollable.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Scrollable.java
@@ -120,12 +120,12 @@ long callWindowProc (long hwnd, int msg, long wParam, long lParam) {
  */
 public Rectangle computeTrim (int x, int y, int width, int height) {
 	checkWidget ();
-	int zoom = getZoom();
+	int zoom = computeBoundsZoom();
 	Rectangle rectangle = Win32DPIUtils.pointToPixelWithSufficientlyLargeSize(new Rectangle(x, y, width, height), zoom);
-	return Win32DPIUtils.pixelToPointWithSufficientlyLargeSize(computeTrimInPixels(rectangle.x, rectangle.y, rectangle.width, rectangle.height), zoom);
+	return Win32DPIUtils.pixelToPointWithSufficientlyLargeSize(computeTrimInPixels(rectangle.x, rectangle.y, rectangle.width, rectangle.height, zoom), zoom);
 }
 
-Rectangle computeTrimInPixels (int x, int y, int width, int height) {
+Rectangle computeTrimInPixels (int x, int y, int width, int height, int zoom) {
 	long scrolledHandle = scrolledHandle ();
 	RECT rect = new RECT ();
 	OS.SetRect (rect, x, y, x + width, y + height);

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Spinner.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Spinner.java
@@ -303,11 +303,11 @@ Point computeSizeInPixels (Point hintInPoints, int zoom, boolean changed) {
 		height = Math.max(height, upDownHeight + borderAdjustment);
 	}
 
-	Rectangle trim = computeTrimInPixels (0, 0, width, height);
+	Rectangle trim = computeTrimInPixels (0, 0, width, height, zoom);
 	return new Point (trim.width, trim.height);
 }
 
-@Override Rectangle computeTrimInPixels (int x, int y, int width, int height) {
+@Override Rectangle computeTrimInPixels (int x, int y, int width, int height, int zoom) {
 	checkWidget ();
 
 	/* Get the trim of the text control */

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TabFolder.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TabFolder.java
@@ -200,7 +200,7 @@ Point computeSizeInPixels (Point hintInPoints, int zoom, boolean changed) {
 	return size;
 }
 
-@Override Rectangle computeTrimInPixels (int x, int y, int width, int height) {
+@Override Rectangle computeTrimInPixels (int x, int y, int width, int height, int zoom) {
 	checkWidget ();
 	RECT rect = new RECT ();
 	OS.SetRect (rect, x, y, x + width, y + height);

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Text.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Text.java
@@ -748,13 +748,13 @@ Point computeSizeInPixels (Point hintInPoints, int zoom, boolean changed) {
 	if (height == 0) height = DEFAULT_HEIGHT;
 	if (hintInPoints.x != SWT.DEFAULT) width = hintInPixels.x;
 	if (hintInPoints.y != SWT.DEFAULT) height = hintInPixels.y;
-	Rectangle trim = computeTrimInPixels (0, 0, width, height);
+	Rectangle trim = computeTrimInPixels (0, 0, width, height, zoom);
 	return new Point (trim.width, trim.height);
 }
 
-@Override Rectangle computeTrimInPixels (int x, int y, int width, int height) {
+@Override Rectangle computeTrimInPixels (int x, int y, int width, int height, int zoom) {
 	checkWidget ();
-	Rectangle rect = super.computeTrimInPixels (x, y, width, height);
+	Rectangle rect = super.computeTrimInPixels (x, y, width, height, zoom);
 	/*
 	* The preferred height of a single-line text widget
 	* has been hand-crafted to be the same height as

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ToolBar.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ToolBar.java
@@ -272,7 +272,7 @@ Point computeSizeInPixels (Point hintInPoints, int zoom, boolean changed) {
 	if (height == 0) height = DEFAULT_HEIGHT;
 	if (hintInPoints.x != SWT.DEFAULT) width = hintInPixels.x;
 	if (hintInPoints.y != SWT.DEFAULT) height = hintInPixels.y;
-	Rectangle trim = computeTrimInPixels (0, 0, width, height);
+	Rectangle trim = computeTrimInPixels (0, 0, width, height, zoom);
 	width = trim.width;  height = trim.height;
 	/*
 	 * Cache this size information for possible re-use as this method gets called
@@ -283,8 +283,8 @@ Point computeSizeInPixels (Point hintInPoints, int zoom, boolean changed) {
 	return new Point (width, height);
 }
 
-@Override Rectangle computeTrimInPixels (int x, int y, int width, int height) {
-	Rectangle trim = super.computeTrimInPixels (x, y, width, height);
+@Override Rectangle computeTrimInPixels (int x, int y, int width, int height, int zoom) {
+	Rectangle trim = super.computeTrimInPixels (x, y, width, height, zoom);
 	int bits = OS.GetWindowLong (handle, OS.GWL_STYLE);
 	if ((bits & OS.CCS_NODIVIDER) == 0) trim.height += 2;
 	return trim;


### PR DESCRIPTION
The PR unifies the behavior of Scrollable#computeTrimInPixels to computeBoundsInPixels. As computeBoundsInPixels was extended to always require a zoom to calculate for, the same should apply to computeTrimInPixels as it is usually called from computeBoundsInPixels and must be calculate with the same zoom as context.