### PR TITLE
[win32] Use correct zoom in Control#getSystemMetrics

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Control.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Control.java
@@ -6097,6 +6097,13 @@ void handleDPIChange(Event event, float scalingFactor) {
 	}
 }
 
+@Override
+int getSystemMetrics(int nIndex) {
+	Shell shell = getShell();
+	int zoom = shell != null ? shell.getZoom() : nativeZoom;
+	return OS.GetSystemMetricsForDpi(nIndex, DPIUtil.mapZoomToDPI(zoom));
+}
+
 boolean adjustWindowRectEx(RECT lpRect, int dwStyle, boolean bMenu, int dwExStyle) {
 	Shell shell = getShell();
 	int zoom = shell != null ? shell.getZoom() : nativeZoom;

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ScrollBar.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ScrollBar.java
@@ -999,4 +999,12 @@ LRESULT wmScrollChild (long wParam, long lParam) {
 	return null;
 }
 
+@Override
+int getSystemMetrics(int nIndex) {
+	// Control#getSystemMetrics should be used if possible,
+	// as it considers if autoscaling of a Control is
+	// disabled which would affect the ScrollBar as well,
+	// therefore the value is fetched via the parent
+	return parent.getSystemMetrics(nIndex);
+}
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TreeColumn.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TreeColumn.java
@@ -762,4 +762,13 @@ void handleDPIChange(Event event, float scalingFactor) {
 		setImage(image);
 	}
 }
+
+@Override
+int getSystemMetrics(int nIndex) {
+	// Control#getSystemMetrics should be used if possible,
+	// as it considers if autoscaling of a Control is
+	// disabled which would affect the TreeColumn as well,
+	// therefore the value is fetched via the parent
+	return parent.getSystemMetrics(nIndex);
+}
 }


### PR DESCRIPTION
This PR overrides Widget#getSystemMetrics for Control to utilize Shell#getZoom if possible to define the target zoom. This is necessary if the control has its autoscaling disabled.