### PR TITLE
[win32] Calculate zoom for adjustWindowRectEx via Shell

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Control.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Control.java
@@ -6053,6 +6053,12 @@ void handleDPIChange(Event event, float scalingFactor) {
 	}
 }
 
+boolean adjustWindowRectEx(RECT lpRect, int dwStyle, boolean bMenu, int dwExStyle) {
+	Shell shell = getShell();
+	int zoom = shell != null ? shell.getZoom() : nativeZoom;
+	return OS.AdjustWindowRectExForDpi (lpRect, dwStyle, bMenu, dwExStyle, DPIUtil.mapZoomToDPI(zoom));
+}
+
 private static void resizeFont(Control control, int newZoom) {
 	Display display = control.getDisplay();
 	Font font = control.font;

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Widget.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Widget.java
@@ -2711,9 +2711,4 @@ int getSystemMetrics(int nIndex) {
 	return OS.GetSystemMetricsForDpi(nIndex, DPIUtil.mapZoomToDPI(nativeZoom));
 }
 
-boolean adjustWindowRectEx(RECT lpRect, int dwStyle, boolean bMenu, int dwExStyle) {
-	return OS.AdjustWindowRectExForDpi (lpRect, dwStyle, bMenu, dwExStyle, DPIUtil.mapZoomToDPI(nativeZoom));
-}
-
-
 }


### PR DESCRIPTION
This PR moves the internal utility method Widget#adjustWindowRectEx to Control to utilize Shell#getZoom if possible to define the target zoom. This is necessary if the control has its autoscaling disabled.

Note: Currently all calling places are passing nativeZoom. But subsequent PRs will pass the zoom based on other variables, which makes this change necessary