### PR TITLE
[Win32] Avoid unnecessary handle creation for image of ImageGcDrawer

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Image.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Image.java
@@ -2789,11 +2789,10 @@ private class ImageGcDrawerWrapper extends DynamicImageProviderWrapper {
 
 	@Override
 	protected ElementAtZoom<ImageData> loadImageData(int zoom) {
-		return new ElementAtZoom<>(getImageMetadata(new ZoomContext(zoom)).getImageData(), zoom);
+		return new ElementAtZoom<>(loadImageData(new ZoomContext(zoom)), zoom);
 	}
 
-	@Override
-	protected DestroyableImageHandle newImageHandle(ZoomContext zoomContext) {
+	private ImageData loadImageData(ZoomContext zoomContext) {
 		currentZoom = zoomContext;
 		int targetZoom = zoomContext.targetZoom();
 		int gcStyle = drawer.getGcStyle();
@@ -2813,12 +2812,16 @@ private class ImageGcDrawerWrapper extends DynamicImageProviderWrapper {
 			drawer.drawOn(gc, width, height);
 			ImageData imageData = image.getImageData(targetZoom);
 			drawer.postProcess(imageData);
-			ImageData newData = adaptImageDataIfDisabledOrGray(imageData);
-			return init(newData, targetZoom);
+			return adaptImageDataIfDisabledOrGray(imageData);
 		} finally {
 			gc.dispose();
 			image.dispose();
 		}
+	}
+
+	@Override
+	protected DestroyableImageHandle newImageHandle(ZoomContext zoomContext) {
+		return init(loadImageData(zoomContext), zoomContext.targetZoom);
 	}
 
 	@Override


### PR DESCRIPTION
With an Image based on an ImageGcDrawer, a call to #getImageData() will always create a handle for the requested zoom. For all other kinds of images, this will at most create a temporary handle and only cache the image data to avoid unnecessary handles for zooms you may never need.

This change adapts the ImageGcDrawerWrapper implementation to not create a handle when requesting image data for a zoom for which no handle exists yet.