### PR TITLE
[Win32] Enable monitor-specific scaling by default

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/DPIUtil.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/DPIUtil.java
@@ -125,6 +125,10 @@ public static boolean isCustomAutoScale() {
 	return System.getProperty (SWT_AUTOSCALE) != null;
 }
 
+public static String getEffectiveAutoScaleValue() {
+	return autoScaleValue.toString();
+}
+
 /**
  * Returns {@code true} only if the current setup is compatible
  * with monitor-specific scaling. Returns {@code false} if:
@@ -168,7 +172,7 @@ public static boolean isMonitorSpecificScalingActive() {
 		return false;
 	}
 	String updateOnRuntimeValue = System.getProperty(SWT_AUTOSCALE_UPDATE_ON_RUNTIME);
-	return "force".equalsIgnoreCase(updateOnRuntimeValue) || "true".equalsIgnoreCase(updateOnRuntimeValue);
+	return !"false".equalsIgnoreCase(updateOnRuntimeValue);
 }
 
 public static int pixelToPoint(int size, int zoom) {
@@ -465,10 +469,7 @@ public static int getZoomForAutoscaleProperty (int nativeDeviceZoom) {
 
 public static void runWithAutoScaleValue(String autoScaleValue, Runnable runnable) {
 	AutoScale initialAutoScaleValue = DPIUtil.autoScaleValue;
-	// This method is used to adapt to the autoscale value used by the Equinox launcher,
-	// which currently defaults to "integer". So we need to use explicit "integer" default here
-	// until the Equinox launcher is adapted.
-	DPIUtil.autoScaleValue = AutoScaleCalculation.parseFrom(autoScaleValue == null ? "integer" : autoScaleValue);
+	DPIUtil.autoScaleValue = AutoScaleCalculation.parseFrom(autoScaleValue);
 	DPIUtil.deviceZoom = getZoomForAutoscaleProperty(nativeDeviceZoom);
 	try {
 		runnable.run();


### PR DESCRIPTION
By now, SWT had monitor-specific scaling on Windows disabled by default and used the existing, single-zoom HiDPI support. There are good reasons to now change the default of SWT to have monitor-specific scaling enabled:
- Eclipse applications default to have monitor-specific scaling enabled for several months now, so SWT and Eclipse default behaviors are different
- With default JVM settings, pure SWT application have no proper scaling as the existing HiDPI support requires DPI awareness "System" to function properly whereas the JVM default is "PerMonitorV2" and requires the application to scale on its own. So by default, SWT applications currently have no scaling at all
- The feature has matured throughout the last year with it being the default for Eclipse application for several months now.

This change adapts the SWT default to enable monitor-specific scaling on Windows.

### How to test

Just run any SWT snippet and move it between monitors of different zooms. It will adapt it's scale while it did not do prior to this PR.

### Feedback welcome

I would appreciate feedback on whether we agree on changing this default. I propose to merge this before M2 so that people get aware it early enough. When merging, I will also create an according N&N.