### PR TITLE
[Win32] Fix faulty point to pixel conversion in Display#postEvent()

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Display.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Display.java
@@ -3643,7 +3643,7 @@ public boolean post (Event event) {
 					int y = OS.GetSystemMetrics (OS.SM_YVIRTUALSCREEN);
 					int width = OS.GetSystemMetrics (OS.SM_CXVIRTUALSCREEN);
 					int height = OS.GetSystemMetrics (OS.SM_CYVIRTUALSCREEN);
-					Point loc = Win32DPIUtils.pointToPixelAsLocation(event.getLocation(), getDeviceZoom());
+					Point loc = translateToDisplayCoordinates(event.getLocation());
 					inputs.dx = ((loc.x - x) * 65535 + width - 2) / (width - 1);
 					inputs.dy = ((loc.y - y) * 65535 + height - 2) / (height - 1);
 				} else {


### PR DESCRIPTION
For mouse events executed via Display#postEvent() the mouse position in points is transformed into pixel coordinates. This is erroneously done via a call to pointToPixel, but the coordinates are in the global display coordinate system which is fragmented (based on different zooms) in case of monitor-specific scaling, such that the CoordinateSystemMapper has to be used just like at all other places in the Display class.

This change fixes the coordinate transformation in Display#postEvent().