### PR TITLE
Wrong SWT Error in Image(Device, InputStream) for IOException

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/graphics/Image.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/graphics/Image.java
@@ -696,7 +696,7 @@ public Image(Device device, InputStream stream) {
 				zoom -> ImageDataLoader.loadByZoom(new ByteArrayInputStream(input), FileFormat.DEFAULT_ZOOM, zoom).element());
 		init();
 	} catch (IOException e) {
-		SWT.error(SWT.ERROR_INVALID_ARGUMENT, e);
+		SWT.error(SWT.ERROR_IO, e);
 	} finally {
 		if (pool != null) pool.release();
 	}

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Image.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Image.java
@@ -2247,7 +2247,7 @@ private class ImageDataLoaderStreamProviderWrapper extends ImageFromImageDataPro
 			this.inputStreamData = inputStream.readAllBytes();
 			initImage();
 		} catch (IOException e) {
-			SWT.error(SWT.ERROR_INVALID_ARGUMENT, e);
+			SWT.error(SWT.ERROR_IO, e);
 		}
 	}
 

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_Image.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_Image.java
@@ -288,6 +288,15 @@ public void test_ConstructorLorg_eclipse_swt_graphics_DeviceLjava_io_InputStream
 	}
 	assertSWTProblem("Incorrect exception thrown for invalid InputStream", SWT.ERROR_UNSUPPORTED_FORMAT, e);
 
+	InputStream failingStream = new InputStream() {
+		@Override
+		public int read() throws IOException {
+			throw new IOException("bad input stream");
+		}
+	};
+	e = assertThrows(SWTException.class, () -> new Image(display, failingStream));
+	assertSWTProblem("Incorrect exception thrown for invalid InputStream", SWT.ERROR_IO, e);
+
 	String firstFile = SwtTestUtil.invalidImageFilenames[0];
 	Display[] displays = { display, null };
 	for (Display display : displays) {


### PR DESCRIPTION
As per contract of org.eclipse.swt.graphics.Image.Image(Device, InputStream), SWT Error - ERROR_IO should be thrown if IOException is caught while reading the inputStream.