### PR TITLE
[win32] Fix autoscaling DPI in Device#getDpi

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Device.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Device.java
@@ -535,9 +535,10 @@ public Point getDPI () {
 	checkDevice ();
 	long hDC = internal_new_GC (null);
 	int dpiX = OS.GetDeviceCaps (hDC, OS.LOGPIXELSX);
+	int primaryZoomAtStartup = DPIUtil.mapDPIToZoom(dpiX);
 	int dpiY = OS.GetDeviceCaps (hDC, OS.LOGPIXELSY);
 	internal_dispose_GC (hDC, null);
-	return Win32DPIUtils.pixelToPointAsLocation(new Point (dpiX, dpiY), DPIUtil.getZoomForAutoscaleProperty(getDeviceZoom()));
+	return Win32DPIUtils.pixelToPointAsLocation(new Point (dpiX, dpiY), DPIUtil.getZoomForAutoscaleProperty(primaryZoomAtStartup));
 }
 
 /**


### PR DESCRIPTION
This PR fixes an issue introduced with c66545b when the call to DPIUtil#autoScaleDown was replaced with an explicit scaleDown with the result of Device#getDeviceZoom. This method is overwritten in Display and changed therefor the behavior in this method. This fix directly uses the value of OS.LOGPIXELSX to calculate the zoom to use as this provides a consistent behavior when monitor specific scaling is active.