### PR TITLE
[Win32] Use proper zoom for computing size of CoolBar on DPI change

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/CoolBar.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/CoolBar.java
@@ -1227,7 +1227,7 @@ void handleDPIChange(Event event, float scalingFactor) {
 			item.setControl(control);
 		}
 
-		Point preferredControlSize =  item.getControl().computeSizeInPixels(new Point(SWT.DEFAULT, SWT.DEFAULT), getAutoscalingZoom(), true);
+		Point preferredControlSize =  item.getControl().computeSizeInPixels(new Point(SWT.DEFAULT, SWT.DEFAULT), computeBoundsZoom(), true);
 		int controlWidth = preferredControlSize.x;
 		int controlHeight = preferredControlSize.y;
 		if (((style & SWT.VERTICAL) != 0)) {


### PR DESCRIPTION
CoolBar's handleDPIChange() implementation calls computeSizeInPixels(), which is supposed be called with the zoom calculated by computeBoundsZoom() in order to properly reflect the zoom in an autoscale-disabled context. The same is done for the call in computeSize().
Even though the usage of a CoolBar inside an autoscale-disabled composite is unlikely, this unifies the used zoom for the sake of correctness and consistency.