### PR TITLE
[Gtk4] Align Display.mapInPixels implementations

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Display.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Display.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2025 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -4184,20 +4184,17 @@ Rectangle mapInPixels (Control from, Control to, int x, int y, int width, int he
 	if (from != null && from.isDisposed()) error (SWT.ERROR_INVALID_ARGUMENT);
 	if (to != null && to.isDisposed()) error (SWT.ERROR_INVALID_ARGUMENT);
 
-	// TODO: GTK4 no longer able to retrieve surface/window origin
-	if (GTK.GTK4) return new Rectangle(x, y, 0, 0);
-
 	Rectangle rect = new Rectangle (x, y, width, height);
 	if (from == to) return rect;
 	boolean fromRTL = false, toRTL = false;
 	if (from != null) {
-		Point origin = from.getWindowOrigin ();
+		Point origin = GTK.GTK4 ? from.getSurfaceOrigin() : from.getWindowOrigin ();
 		if (fromRTL = (from.style & SWT.MIRRORED) != 0) rect.x = from.getClientWidth () - rect.x;
 		rect.x += origin.x;
 		rect.y += origin.y;
 	}
 	if (to != null) {
-		Point origin = to.getWindowOrigin ();
+		Point origin = GTK.GTK4 ? from.getSurfaceOrigin() : from.getWindowOrigin ();
 		rect.x -= origin.x;
 		rect.y -= origin.y;
 		if (toRTL = (to.style & SWT.MIRRORED) != 0) rect.x = to.getClientWidth () - rect.x;


### PR DESCRIPTION
2 out of the 3 impl used getSurfaceOrigin on Gtk 4.x, the 3rd one simply returned new Rectangle(x, y, 0, 0);. Adjust it to use getSurfaceOrigin too.