### PR TITLE
Execute tests with non-default autoscaling settings in I-Build

### DIFF
--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/AllNonBrowserTests.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/AllNonBrowserTests.java
@@ -14,10 +14,15 @@
  *******************************************************************************/
 package org.eclipse.swt.tests.junit;
 
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 import java.util.ArrayList;
 import java.util.List;
 
 import org.eclipse.swt.graphics.Resource;
+import org.eclipse.swt.tests.junit.AllNonBrowserTests.NonBrowserTestSuite;
 import org.junit.platform.suite.api.AfterSuite;
 import org.junit.platform.suite.api.BeforeSuite;
 import org.junit.platform.suite.api.SelectClasses;
@@ -26,58 +31,68 @@ import org.junit.platform.suite.api.Suite;
 /**
  * Suite for running most SWT test cases (all except for browser tests).
  */
-@Suite(failIfNoTests = false)
-@SelectClasses({ //
-		// Basic tests
-		Test_org_eclipse_swt_SWT.class, //
-		Test_org_eclipse_swt_SWTException.class, //
-		Test_org_eclipse_swt_SWTError.class, //
-		Test_org_eclipse_swt_widgets_Display.class, //
-		// Groups of tests
-		AllGraphicsTests.class, //
-		AllWidgetTests.class, //
-		// Rest of tests alphabetically
-		DPIUtilTests.class, //
-		JSVGRasterizerTest.class, //
-		Test_org_eclipse_swt_accessibility_Accessible.class, //
-		Test_org_eclipse_swt_accessibility_AccessibleControlEvent.class, //
-		Test_org_eclipse_swt_accessibility_AccessibleEvent.class, //
-		Test_org_eclipse_swt_accessibility_AccessibleTextEvent.class, //
-		Test_org_eclipse_swt_dnd_ByteArrayTransfer.class, //
-		Test_org_eclipse_swt_dnd_Clipboard.class, //
-		Test_org_eclipse_swt_dnd_FileTransfer.class, //
-		Test_org_eclipse_swt_dnd_HTMLTransfer.class, //
-		Test_org_eclipse_swt_dnd_ImageTransfer.class, //
-		Test_org_eclipse_swt_dnd_RTFTransfer.class, //
-		Test_org_eclipse_swt_dnd_TextTransfer.class, //
-		Test_org_eclipse_swt_dnd_URLTransfer.class, //
-		Test_org_eclipse_swt_events_ArmEvent.class, //
-		Test_org_eclipse_swt_events_ControlEvent.class, //
-		Test_org_eclipse_swt_events_DisposeEvent.class, //
-		Test_org_eclipse_swt_events_FocusEvent.class, //
-		Test_org_eclipse_swt_events_HelpEvent.class, //
-		Test_org_eclipse_swt_events_KeyEvent.class, //
-		Test_org_eclipse_swt_events_MenuEvent.class, //
-		Test_org_eclipse_swt_events_ModifyEvent.class, //
-		Test_org_eclipse_swt_events_MouseEvent.class, //
-		Test_org_eclipse_swt_events_PaintEvent.class, //
-		Test_org_eclipse_swt_events_SelectionEvent.class, //
-		Test_org_eclipse_swt_events_ShellEvent.class, //
-		Test_org_eclipse_swt_events_TraverseEvent.class, //
-		Test_org_eclipse_swt_events_TreeEvent.class, //
-		Test_org_eclipse_swt_events_TypedEvent.class, //
-		Test_org_eclipse_swt_events_VerifyEvent.class, //
-		Test_org_eclipse_swt_internal_SVGRasterizer.class, //
-		Test_org_eclipse_swt_layout_BorderLayout.class, //
-		Test_org_eclipse_swt_layout_FormAttachment.class, //
-		Test_org_eclipse_swt_layout_GridData.class, //
-		Test_org_eclipse_swt_printing_PDFDocument.class, //
-		Test_org_eclipse_swt_printing_PrintDialog.class, //
-		Test_org_eclipse_swt_printing_Printer.class, //
-		Test_org_eclipse_swt_printing_PrinterData.class, //
-		Test_org_eclipse_swt_program_Program.class, //
-})
+@NonBrowserTestSuite
 public class AllNonBrowserTests {
+
+	// Combine the test annotations with the test classes in a wrapper annotation
+	// such that it can be reused for derived test suites
+	@Suite(failIfNoTests = false)
+	@SelectClasses({ //
+			// Basic tests
+			Test_org_eclipse_swt_SWT.class, //
+			Test_org_eclipse_swt_SWTException.class, //
+			Test_org_eclipse_swt_SWTError.class, //
+			Test_org_eclipse_swt_widgets_Display.class, //
+			// Groups of tests
+			AllGraphicsTests.class, //
+			AllWidgetTests.class, //
+			// Rest of tests alphabetically
+			DPIUtilTests.class, //
+			JSVGRasterizerTest.class, //
+			Test_org_eclipse_swt_accessibility_Accessible.class, //
+			Test_org_eclipse_swt_accessibility_AccessibleControlEvent.class, //
+			Test_org_eclipse_swt_accessibility_AccessibleEvent.class, //
+			Test_org_eclipse_swt_accessibility_AccessibleTextEvent.class, //
+			Test_org_eclipse_swt_dnd_ByteArrayTransfer.class, //
+			Test_org_eclipse_swt_dnd_Clipboard.class, //
+			Test_org_eclipse_swt_dnd_FileTransfer.class, //
+			Test_org_eclipse_swt_dnd_HTMLTransfer.class, //
+			Test_org_eclipse_swt_dnd_ImageTransfer.class, //
+			Test_org_eclipse_swt_dnd_RTFTransfer.class, //
+			Test_org_eclipse_swt_dnd_TextTransfer.class, //
+			Test_org_eclipse_swt_dnd_URLTransfer.class, //
+			Test_org_eclipse_swt_events_ArmEvent.class, //
+			Test_org_eclipse_swt_events_ControlEvent.class, //
+			Test_org_eclipse_swt_events_DisposeEvent.class, //
+			Test_org_eclipse_swt_events_FocusEvent.class, //
+			Test_org_eclipse_swt_events_HelpEvent.class, //
+			Test_org_eclipse_swt_events_KeyEvent.class, //
+			Test_org_eclipse_swt_events_MenuEvent.class, //
+			Test_org_eclipse_swt_events_ModifyEvent.class, //
+			Test_org_eclipse_swt_events_MouseEvent.class, //
+			Test_org_eclipse_swt_events_PaintEvent.class, //
+			Test_org_eclipse_swt_events_SelectionEvent.class, //
+			Test_org_eclipse_swt_events_ShellEvent.class, //
+			Test_org_eclipse_swt_events_TraverseEvent.class, //
+			Test_org_eclipse_swt_events_TreeEvent.class, //
+			Test_org_eclipse_swt_events_TypedEvent.class, //
+			Test_org_eclipse_swt_events_VerifyEvent.class, //
+			Test_org_eclipse_swt_internal_SVGRasterizer.class, //
+			Test_org_eclipse_swt_layout_BorderLayout.class, //
+			Test_org_eclipse_swt_layout_FormAttachment.class, //
+			Test_org_eclipse_swt_layout_GridData.class, //
+			Test_org_eclipse_swt_printing_PDFDocument.class, //
+			Test_org_eclipse_swt_printing_PrintDialog.class, //
+			Test_org_eclipse_swt_printing_Printer.class, //
+			Test_org_eclipse_swt_printing_PrinterData.class, //
+			Test_org_eclipse_swt_program_Program.class, //
+	})
+	@Retention(RetentionPolicy.RUNTIME)
+	@Target(ElementType.TYPE)
+	@interface NonBrowserTestSuite  {
+		//
+	}
+
 	private static List<Error> leakedResources;
 
 	@BeforeSuite

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/AllNonBrowserTests_AutoscaleOsNonDefaults.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/AllNonBrowserTests_AutoscaleOsNonDefaults.java
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Vector Informatik and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.swt.tests.junit;
+
+import org.eclipse.swt.tests.junit.AllNonBrowserTests.NonBrowserTestSuite;
+import org.junit.platform.suite.api.AfterSuite;
+import org.junit.platform.suite.api.BeforeSuite;
+
+/**
+ * Suite for running most SWT test cases (all except for browser tests) with non-default autoscaling settings.
+ * It is currently executed in I-Build tests (via test.xml) and may be executed for local testing.
+ */
+@NonBrowserTestSuite
+public class AllNonBrowserTests_AutoscaleOsNonDefaults extends AllNonBrowserTests {
+
+	@BeforeSuite
+	static void setNonDefaultAutoscale() {
+		System.setProperty("swt.autoScale", "quarter");
+		System.setProperty("swt.autoScale.updateOnRuntime", "true");
+	}
+
+	@AfterSuite
+	static void restoreDefaultAutoscale() {
+		System.clearProperty("swt.autoScale");
+		System.clearProperty("swt.autoScale.updateOnRuntime");
+	}
+
+
+}

--- a/tests/org.eclipse.swt.tests/pom.xml
+++ b/tests/org.eclipse.swt.tests/pom.xml
@@ -51,7 +51,6 @@
               <systemPropertyVariables>
                 <user.home>${project.build.directory}</user.home> <!-- used as cache directory for SWT native libraries -->
                 <org.eclipse.swt.internal.enableStrictChecks>true</org.eclipse.swt.internal.enableStrictChecks> <!-- see bug 532632 -->
-                <swt.autoScale>quarter</swt.autoScale>
               </systemPropertyVariables>
               <!-- Trim does not only remove the entries before entering the test method but
                    also every entry which is not part of the test class. See bug 558848 for example. -->

--- a/tests/org.eclipse.swt.tests/test.xml
+++ b/tests/org.eclipse.swt.tests/test.xml
@@ -24,7 +24,7 @@
   <!-- This target defines the tests that need to be run. -->
   <target name="suite" unless="performance">
     <property name="data" value="${eclipse-home}/swt_sniff_folder"/>
-    <delete dir="${location1}" quiet="true"/>
+    <delete dir="${data}" quiet="true"/>
     <ant target="core-test" antfile="${library-file}" dir="${eclipse-home}">
       <property name="data-dir" value="${data}"/>
       <property name="plugin-name" value="${plugin-name}"/>
@@ -34,9 +34,23 @@
     </ant>
   </target>
 	
+  <!-- This target defines the tests that need to be run. -->
+  <target name="suite-non-default-autoscale" unless="performance">
+    <property name="data" value="${eclipse-home}/swt_sniff_folder"/>
+    <delete dir="${data}" quiet="true"/>
+    <ant target="core-test" antfile="${library-file}" dir="${eclipse-home}">
+      <property name="data-dir" value="${data}"/>
+      <property name="plugin-name" value="${plugin-name}"/>
+      <property name="classname" value="org.eclipse.swt.tests.junit.AllNonBrowserTests_AutoscaleOsNonDefaults"/>
+      <!-- workaround for https://bugs.eclipse.org/502410 and checks for bug 532632 -->
+      <property name="vmargs" value="-Dorg.eclipse.swt.internal.gtk.disablePrinting -Dorg.eclipse.swt.internal.enableStrictChecks"/>
+    </ant>
+  </target>
+	
   <!-- This target defines the browser tests. -->
   <target name="browser-suite" unless="performance">
     <property name="data" value="${eclipse-home}/swt_sniff_folder"/>
+  	<delete dir="${data}" quiet="true"/>
     <ant target="core-test" antfile="${library-file}" dir="${eclipse-home}">
       <property name="timeout" value="900000"/>
       <property name="data-dir" value="${data}"/>
@@ -71,7 +85,7 @@
 
   <!-- This target runs the test suite. Any actions that need to happen after all -->
   <!-- the tests have been run should go here. -->
-  <target name="run" depends="init,suite,browser-suite,cleanup">
+  <target name="run" depends="init,suite,suite-non-default-autoscale,browser-suite,cleanup">
     <ant target="collect" antfile="${library-file}" dir="${eclipse-home}">
       <property name="includes" value="org*.xml"/>
       <property name="output-file" value="${plugin-name}.xml"/>


### PR DESCRIPTION
The SWT tests are currently executed with the default autoscaling settings during I-Builds. For Tycho test execution (e.g., in GitHub Actions runs), the configuration is modified to run in "quarter" autoscaling mode. Since multiple different autoscaling modes need to be supported (especially on Windows), the execution with just one configuration leads to a high risk of undetected regressions with other configurations.

This change extends the I-Build test execution to run the test suite with OS default settings and with one relevant non-default set of settings. For Windows, this will specifically cover the monitor-specific scaling with "quarter" autoscaling and non-monitor-specific scaling with "integer" autoscaling. For Linux and MacOS, which do not support monitor-specific scaling, this reduces to testing "integer" and "quarter" modes. This is achieved by an additional, accordingly configured test suite, which is added to the test.xml to be executed in I-Builds.
To keep the Tycho test execution times low (also used in GitHub Actions runs), that test suite is not added to Tycho test execution. The configuration is adapted to use the OS default settings for the Tycho runs (instead of using "quarter" mode, which is now covered by I-Build tests instead).

This becomes particularly useful when changing the Windows default for autoscaling in SWT to monitor-specific scaling, as it will ensure regression testing with the pre-existing default autoscaling settings:
- https://github.com/eclipse-platform/eclipse.platform.swt/pull/2955