### PR TITLE
[Win32] Allow to customize DPI awareness

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/widgets/DisplayWin32Test.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/widgets/DisplayWin32Test.java
@@ -27,6 +27,41 @@ class DisplayWin32Test {
 	}
 
 	@Test
+	public void monitorSpecificScaling_withCustomDpiAwareness() {
+		System.setProperty(Win32DPIUtils.CUSTOM_DPI_AWARENESS_PROPERTY, "System");
+		try {
+			Win32DPIUtils.setMonitorSpecificScaling(true);
+			Display display = Display.getDefault();
+			assertTrue(display.isRescalingAtRuntime());
+			assertEquals(OS.DPI_AWARENESS_CONTEXT_SYSTEM_AWARE, OS.GetThreadDpiAwarenessContext());
+		} finally {
+			System.clearProperty(Win32DPIUtils.CUSTOM_DPI_AWARENESS_PROPERTY);
+		}
+	}
+
+	@Test
+	public void customDpiAwareness_System() {
+		System.setProperty(Win32DPIUtils.CUSTOM_DPI_AWARENESS_PROPERTY, "System");
+		try {
+			Display.getDefault();
+			assertEquals(OS.DPI_AWARENESS_CONTEXT_SYSTEM_AWARE, OS.GetThreadDpiAwarenessContext());
+		} finally {
+			System.clearProperty(Win32DPIUtils.CUSTOM_DPI_AWARENESS_PROPERTY);
+		}
+	}
+
+	@Test
+	public void customDpiAwareness_PerMonitorV2() {
+		System.setProperty(Win32DPIUtils.CUSTOM_DPI_AWARENESS_PROPERTY, "PerMonitorV2");
+		try {
+			Display.getDefault();
+			assertEquals(OS.DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2, OS.GetThreadDpiAwarenessContext());
+		} finally {
+			System.clearProperty(Win32DPIUtils.CUSTOM_DPI_AWARENESS_PROPERTY);
+		}
+	}
+
+	@Test
 	@SuppressWarnings("removal")
 	public void setRescaleAtRuntime_activate() {
 		Display display = Display.getDefault();

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Display.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Display.java
@@ -953,6 +953,7 @@ protected void create (DeviceData data) {
 		setMonitorSpecificScaling(true);
 		Win32DPIUtils.setAutoScaleForMonitorSpecificScaling();
 	}
+	Win32DPIUtils.initializeCustomDpiAwareness();
 	createDisplay (data);
 	register (this);
 	if (Default == null) Default = this;


### PR DESCRIPTION
This adds a system property that allows to customize the DPI awareness of the SWT application to be executed. This allows to adapt the application to the desired DPI awareness without adapting the application's executable manifest. For monitor-specific scaling, this already happens implicitly, as it requires PerMonitorV2 awareness. This change will, for example, allow to execute applications without monitor-specific scaling and reasonable System DPI awareness (via org.eclipse.swt.internal.win32.dpiAwareness=System) without adapting the application's manifest.