### PR TITLE
Extract cluttered autoscaling mode handling into dedicated classes

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/AutoScaleCalculation.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/AutoScaleCalculation.java
@@ -1,0 +1,174 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Vector Informatik GmbH and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.swt.internal;
+
+final class AutoScaleCalculation {
+	private AutoScaleCalculation() {
+	}
+
+	interface AutoScale {
+		int getAutoScaledZoom(int zoom);
+		boolean isCompatibleToMonitorSpecificScaling();
+	}
+
+	private static class AutoScaleInteger implements AutoScale {
+		private static final String AS_STRING = "integer";
+
+		@Override
+		public int getAutoScaledZoom(int zoom) {
+			return Math.max ((zoom + 25) / 100 * 100, 100);
+		}
+
+		@Override
+		public boolean isCompatibleToMonitorSpecificScaling() {
+			return false;
+		}
+
+		@Override
+		public String toString() {
+			return AS_STRING;
+		}
+
+	}
+
+	private static class AutoScaleQuarter implements AutoScale {
+		private static final String AS_STRING = "quarter";
+
+		@Override
+		public int getAutoScaledZoom(int zoom) {
+			return  Math.round(zoom / 25f) * 25;
+		}
+
+		@Override
+		public boolean isCompatibleToMonitorSpecificScaling() {
+			return true;
+		}
+
+		@Override
+		public String toString() {
+			return AS_STRING;
+		}
+	}
+
+	private static class AutoScaleHalf implements AutoScale {
+		private static final String AS_STRING = "half";
+
+		@Override
+		public int getAutoScaledZoom(int zoom) {
+			// Math.round rounds 125->150 and 175->200,
+			// Math.rint rounds 125->100 and 175->200 matching
+			// "integer"
+			return (int) Math.rint(zoom / 50d) * 50;
+		}
+
+		@Override
+		public boolean isCompatibleToMonitorSpecificScaling() {
+			return false;
+		}
+
+		@Override
+		public String toString() {
+			return AS_STRING;
+		}
+	}
+
+	private static class AutoScaleExact implements AutoScale {
+		private static final String AS_STRING = "exact";
+
+		@Override
+		public int getAutoScaledZoom(int zoom) {
+			return zoom;
+		}
+
+		@Override
+		public boolean isCompatibleToMonitorSpecificScaling() {
+			return true;
+		}
+
+		@Override
+		public String toString() {
+			return AS_STRING;
+		}
+	}
+
+
+	private static class AutoScaleNone implements AutoScale {
+		private static final String AS_STRING = "false";
+
+		@Override
+		public int getAutoScaledZoom(int zoom) {
+			return 100;
+		}
+
+		@Override
+		public boolean isCompatibleToMonitorSpecificScaling() {
+			return false;
+		}
+
+		@Override
+		public String toString() {
+			return AS_STRING;
+		}
+	}
+
+	private static class AutoScaleValue implements AutoScale {
+
+		private final int fixedZoom;
+
+		AutoScaleValue(int zoom) {
+			this.fixedZoom = zoom;
+		}
+
+		@Override
+		public int getAutoScaledZoom(int zoom) {
+			return fixedZoom;
+		}
+
+		@Override
+		public boolean isCompatibleToMonitorSpecificScaling() {
+			return false;
+		}
+
+		@Override
+		public String toString() {
+			return fixedZoom + "";
+		}
+	}
+
+	static AutoScale parseFrom(String value) {
+		if (value != null) {
+			if (AutoScaleNone.AS_STRING.equalsIgnoreCase (value)) {
+				return new AutoScaleNone();
+			} else if (AutoScaleHalf.AS_STRING.equalsIgnoreCase (value)) {
+				return new AutoScaleHalf();
+			} else if (AutoScaleQuarter.AS_STRING.equalsIgnoreCase (value)) {
+				return new AutoScaleQuarter();
+			} else if (AutoScaleExact.AS_STRING.equalsIgnoreCase (value)) {
+				return new AutoScaleExact();
+			} else if (AutoScaleInteger.AS_STRING.equalsIgnoreCase(value)) {
+				return new AutoScaleInteger();
+			} else {
+				try {
+					int zoomValue = Integer.parseInt (value);
+					return new AutoScaleValue(zoomValue);
+				} catch (NumberFormatException e) {
+					// unsupported value, use default
+				}
+			}
+		}
+		return getDefaultAutoScale();
+	}
+
+	private static AutoScale getDefaultAutoScale() {
+		return DPIUtil.isMonitorSpecificScalingActive() ? new AutoScaleQuarter() : new AutoScaleInteger();
+	}
+
+}

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/AllNonBrowserTests_AutoscaleOsNonDefaults.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/AllNonBrowserTests_AutoscaleOsNonDefaults.java
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package org.eclipse.swt.tests.junit;
 
+import org.eclipse.swt.internal.DPIUtil;
 import org.eclipse.swt.tests.junit.AllNonBrowserTests.NonBrowserTestSuite;
 import org.junit.platform.suite.api.AfterSuite;
 import org.junit.platform.suite.api.BeforeSuite;
@@ -21,16 +22,21 @@ import org.junit.platform.suite.api.BeforeSuite;
 @NonBrowserTestSuite
 public class AllNonBrowserTests_AutoscaleOsNonDefaults extends AllNonBrowserTests {
 
+	private static boolean originalMonitorSpecificScalingActive;
+
+	@SuppressWarnings("restriction")
 	@BeforeSuite
 	static void setNonDefaultAutoscale() {
+		originalMonitorSpecificScalingActive = DPIUtil.isMonitorSpecificScalingActive();
 		System.setProperty("swt.autoScale", "quarter");
-		System.setProperty("swt.autoScale.updateOnRuntime", "true");
+		DPIUtil.setMonitorSpecificScaling(true);
 	}
 
+	@SuppressWarnings("restriction")
 	@AfterSuite
 	static void restoreDefaultAutoscale() {
 		System.clearProperty("swt.autoScale");
-		System.clearProperty("swt.autoScale.updateOnRuntime");
+		DPIUtil.setMonitorSpecificScaling(originalMonitorSpecificScalingActive);
 	}
 
 


### PR DESCRIPTION
The handling of different autoscaling modes is currently spread across the DPIUtil class, based on String matching and system property retrieval.
This change extracts and AutoScale class that encapsulates functionality and information related to a specific autoscaling mode (string representation, conversion, compatibility to monitor-specific scaling) into a dedicated class.

This is particularly a preparation for changing the default mode on Windows to quarter/monitor-specific scaling, as adapting the String matching logic for that would become incomprehensive.