### PR TITLE
[Win32] Move all monitor-specific scaling functionality to DPIUtil

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/internal/ResetMonitorSpecificScalingExtension.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/internal/ResetMonitorSpecificScalingExtension.java
@@ -31,7 +31,7 @@ public sealed class ResetMonitorSpecificScalingExtension implements BeforeEachCa
 
 	@Override
 	public void afterEach(ExtensionContext context) throws Exception {
-		Win32DPIUtils.setMonitorSpecificScaling(wasMonitorSpecificScalingActive);
+		DPIUtil.setMonitorSpecificScaling(wasMonitorSpecificScalingActive);
 		Display.getDefault().dispose();
 		DPIUtil.setDeviceZoom(100);
 	}

--- a/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/internal/WithMonitorSpecificScalingExtension.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/internal/WithMonitorSpecificScalingExtension.java
@@ -24,7 +24,7 @@ public final class WithMonitorSpecificScalingExtension extends ResetMonitorSpeci
 	@Override
 	public void beforeEach(ExtensionContext context) throws Exception {
 		super.beforeEach(context);
-		Win32DPIUtils.setMonitorSpecificScaling(true);
+		DPIUtil.setMonitorSpecificScaling(true);
 	}
 
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/widgets/ControlWin32Tests.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/widgets/ControlWin32Tests.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.swt.widgets;
 
+import static org.eclipse.swt.internal.DPIUtil.setMonitorSpecificScaling;
 import static org.junit.Assert.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -36,7 +37,7 @@ class ControlWin32Tests {
 
 	@Test
 	public void testScaleFontCorrectlyInAutoScaleScenario() {
-		Win32DPIUtils.setMonitorSpecificScaling(true);
+		setMonitorSpecificScaling(true);
 		Display display = Display.getDefault();
 
 		assertTrue("Autoscale property is not set to true", display.isRescalingAtRuntime());
@@ -48,7 +49,7 @@ class ControlWin32Tests {
 
 	@Test
 	public void testSetFontWithMonitorSpecificScalingEnabled() {
-		Win32DPIUtils.setMonitorSpecificScaling(true);
+		setMonitorSpecificScaling(true);
 		Display display = Display.getDefault();
 		Image colorImage = new Image(display, 10, 10);
 		GC gc = new GC(colorImage);
@@ -59,7 +60,7 @@ class ControlWin32Tests {
 
 	@Test
 	public void testDoNotScaleFontInNoAutoScaleScenario() {
-		Win32DPIUtils.setMonitorSpecificScaling(false);
+		setMonitorSpecificScaling(false);
 		Display display = Display.getDefault();
 
 		assertFalse("Autoscale property is not set to false", display.isRescalingAtRuntime());
@@ -71,7 +72,7 @@ class ControlWin32Tests {
 
 	@Test
 	public void testDoNotScaleFontInNoAutoScaleScenarioWithLegacyFontRegistry() {
-		Win32DPIUtils.setMonitorSpecificScaling(false);
+		setMonitorSpecificScaling(false);
 		String originalValue = System.getProperty("swt.fontRegistry");
 		System.setProperty("swt.fontRegistry", "legacy");
 		try {
@@ -93,7 +94,7 @@ class ControlWin32Tests {
 
 	@Test
 	public void testCorrectScaleUpUsingDifferentSetBoundsMethod() {
-		Win32DPIUtils.setMonitorSpecificScaling(true);
+		setMonitorSpecificScaling(true);
 		Display display = Display.getDefault();
 		Shell shell = new Shell(display);
 		Button button = new Button(shell, SWT.PUSH);
@@ -114,7 +115,7 @@ class ControlWin32Tests {
 	@CsvSource({ "2.0, quarter, true", "0.5, 100, false",
 			"1.0, 200, false", "2.0, 200, false", "2.0, quarter, false", })
 	public void testAutoScaleImageData(float scaleFactor, String autoScale, boolean monitorSpecificScaling) {
-		Win32DPIUtils.setMonitorSpecificScaling(monitorSpecificScaling);
+		setMonitorSpecificScaling(monitorSpecificScaling);
 		DPIUtil.runWithAutoScaleValue(autoScale, () -> {
 			Display display = new Display();
 			try {
@@ -167,7 +168,7 @@ class ControlWin32Tests {
 	 */
 	@Test
 	void testChildFillsCompositeWithOffset() {
-		Win32DPIUtils.setMonitorSpecificScaling(true);
+		setMonitorSpecificScaling(true);
 		// pixel values at 125%: (2.5, 2.5, 2.5, 2.5) --> when rounding bottom right
 		// corner (pixel value (5, 5)) instead of width/height independently, will be
 		// rounded to (3, 3, 2, 2) --> too small for child
@@ -205,7 +206,7 @@ class ControlWin32Tests {
 	 */
 	@Test
 	void testChildWithOffsetFillsComposite() {
-		Win32DPIUtils.setMonitorSpecificScaling(true);
+		setMonitorSpecificScaling(true);
 		// pixel values at 125%: (0, 0, 5, 5)
 		Rectangle parentBounds = new Rectangle(0, 0, 4, 4);
 		// pixel values at 125%: (2.5, 2.5, 2.5, 2.5) --> when rounding width/height
@@ -252,7 +253,7 @@ class ControlWin32Tests {
 	 */
 	@Test
 	void testFitChildIntoParent() {
-		Win32DPIUtils.setMonitorSpecificScaling(true);
+		setMonitorSpecificScaling(true);
 		// pixel values at 125%: (0, 0, 5, 5)
 		Rectangle parentBounds = new Rectangle(0, 0, 4, 4);
 		// pixel values at 125%: (2.5, 2.5, 3.75, 3.75) --> rounded to (3, 3, 3, 3)
@@ -276,7 +277,7 @@ class ControlWin32Tests {
 	// and not for fitting actually larger childs into parts
 	@Test
 	void testFitChildIntoParent_limitedSizeDifference() {
-		Win32DPIUtils.setMonitorSpecificScaling(true);
+		setMonitorSpecificScaling(true);
 		// pixel values at 125%: (0, 0, 5, 5)
 		Rectangle parentBounds = new Rectangle(0, 0, 4, 4);
 		// pixel values at 125%: (2.5, 2.5, 5, 5) --> rounded to (3, 3, 5, 5)
@@ -315,7 +316,7 @@ class ControlWin32Tests {
 	 */
 	@Test
 	void testChildFillsScrollableWithBadlyRoundedClientArea() {
-		Win32DPIUtils.setMonitorSpecificScaling(true);
+		setMonitorSpecificScaling(true);
 		Display display = Display.getDefault();
 		Shell shell = new Shell(display);
 		Composite parent = new Composite(shell, SWT.H_SCROLL|SWT.V_SCROLL);
@@ -358,7 +359,7 @@ class ControlWin32Tests {
 
 	@Test
 	void testChildShellGetSize() {
-		Win32DPIUtils.setMonitorSpecificScaling(true);
+		setMonitorSpecificScaling(true);
 		Display display = Display.getDefault();
 		Shell shell = new Shell(display);
 		shell.nativeZoom = 150;

--- a/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/widgets/DisplayWin32Test.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/widgets/DisplayWin32Test.java
@@ -1,5 +1,6 @@
 package org.eclipse.swt.widgets;
 
+import static org.eclipse.swt.internal.DPIUtil.setMonitorSpecificScaling;
 import static org.junit.jupiter.api.Assertions.*;
 
 import org.eclipse.swt.internal.*;
@@ -13,7 +14,7 @@ class DisplayWin32Test {
 
 	@Test
 	public void monitorSpecificScaling_activate() {
-		Win32DPIUtils.setMonitorSpecificScaling(true);
+		setMonitorSpecificScaling(true);
 		Display display = Display.getDefault();
 		assertTrue(display.isRescalingAtRuntime());
 		assertEquals(OS.DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2, OS.GetThreadDpiAwarenessContext());
@@ -21,7 +22,7 @@ class DisplayWin32Test {
 
 	@Test
 	public void monitorSpecificScaling_deactivate() {
-		Win32DPIUtils.setMonitorSpecificScaling(false);
+		setMonitorSpecificScaling(false);
 		Display display = Display.getDefault();
 		assertFalse(display.isRescalingAtRuntime());
 	}
@@ -30,7 +31,7 @@ class DisplayWin32Test {
 	public void monitorSpecificScaling_withCustomDpiAwareness() {
 		System.setProperty(Win32DPIUtils.CUSTOM_DPI_AWARENESS_PROPERTY, "System");
 		try {
-			Win32DPIUtils.setMonitorSpecificScaling(true);
+			setMonitorSpecificScaling(true);
 			Display display = Display.getDefault();
 			assertTrue(display.isRescalingAtRuntime());
 			assertEquals(OS.DPI_AWARENESS_CONTEXT_SYSTEM_AWARE, OS.GetThreadDpiAwarenessContext());

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/DPIUtil.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/DPIUtil.java
@@ -312,6 +312,18 @@ public static int pointToPixel(int size, int zoom) {
 	return Math.round (size * scaleFactor);
 }
 
+public static void setMonitorSpecificScaling(boolean activate) {
+	System.setProperty(SWT_AUTOSCALE_UPDATE_ON_RUNTIME, Boolean.toString(activate));
+	boolean isDefaultAutoScale = DPIUtil.getAutoScaleValue() == null;
+	if (isDefaultAutoScale) {
+		DPIUtil.setAutoScaleValue("quarter");
+	} else if (!DPIUtil.isSetupCompatibleToMonitorSpecificScaling()) {
+		throw new SWTError(SWT.ERROR_NOT_IMPLEMENTED,
+				"monitor-specific scaling is only implemented for auto-scale values \"quarter\", \"exact\", but \""
+						+ DPIUtil.getAutoScaleValue() + "\" has been specified");
+	}
+}
+
 /**
  * Represents an element, such as some image data, at a specific zoom level.
  *

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/Win32DPIUtils.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/Win32DPIUtils.java
@@ -325,21 +325,6 @@ public class Win32DPIUtils {
 		return pointToPixel (rect, zoom);
 	}
 
-	public static void setMonitorSpecificScaling(boolean activate) {
-		System.setProperty(DPIUtil.SWT_AUTOSCALE_UPDATE_ON_RUNTIME, Boolean.toString(activate));
-	}
-
-	public static void setAutoScaleForMonitorSpecificScaling() {
-		boolean isDefaultAutoScale = DPIUtil.getAutoScaleValue() == null;
-		if (isDefaultAutoScale) {
-			DPIUtil.setAutoScaleValue("quarter");
-		} else if (!DPIUtil.isSetupCompatibleToMonitorSpecificScaling()) {
-			throw new SWTError(SWT.ERROR_NOT_IMPLEMENTED,
-					"monitor-specific scaling is only implemented for auto-scale values \"quarter\", \"exact\", \"false\" or a concrete zoom value, but \""
-							+ DPIUtil.getAutoScaleValue() + "\" has been specified");
-		}
-	}
-
 	public static int getPrimaryMonitorZoomAtStartup() {
 		long hDC = OS.GetDC(0);
 		int dpi = OS.GetDeviceCaps(hDC, OS.LOGPIXELSX);

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Display.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Display.java
@@ -951,7 +951,7 @@ protected void create (DeviceData data) {
 	checkDisplay (thread = Thread.currentThread (), true);
 	if (DPIUtil.isMonitorSpecificScalingActive()) {
 		setMonitorSpecificScaling(true);
-		Win32DPIUtils.setAutoScaleForMonitorSpecificScaling();
+		DPIUtil.setMonitorSpecificScaling(true);
 	}
 	Win32DPIUtils.initializeCustomDpiAwareness();
 	createDisplay (data);


### PR DESCRIPTION
DPIUtil already contains all monitor-specific-scaling-related functionality for retrieving the state and identifying compatibility. Only the (internal) possibility to set the mode is placed in Win32DPIUtils, which just scatters the according logic.

This change moves the monitor-specific-scaling-related utility functions completely to DPIUtil. On Linux and MacOS they will currently not have an effect.