### PR TITLE
Correct initialization of image smooth scaling capability

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/DPIUtil.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/DPIUtil.java
@@ -446,7 +446,7 @@ public static void setDeviceZoom (int nativeDeviceZoom) {
 	// in GTK, preserve the current method when switching to a 100% monitor
 	boolean preserveScalingMethod = SWT.getPlatform().equals("gtk") && deviceZoom == 100;
 	if (!preserveScalingMethod && AUTO_SCALE_METHOD_SETTING == AutoScaleMethod.AUTO) {
-		if (useSmoothScalingByDefaultProvider.shouldUseSmoothScaling()) {
+		if (shouldUseSmoothScaling()) {
 			autoScaleMethod = AutoScaleMethod.SMOOTH;
 		} else {
 			autoScaleMethod = AutoScaleMethod.NEAREST;
@@ -454,15 +454,11 @@ public static void setDeviceZoom (int nativeDeviceZoom) {
 	}
 }
 
-@FunctionalInterface
-interface UseSmoothScalingProvider {
-    boolean shouldUseSmoothScaling();
-}
-
-private static UseSmoothScalingProvider useSmoothScalingByDefaultProvider = () -> false;
-
-static void setUseSmoothScalingByDefaultProvider(UseSmoothScalingProvider provider) {
-    useSmoothScalingByDefaultProvider = provider;
+private static boolean shouldUseSmoothScaling() {
+	if ("gtk".equals(SWT.getPlatform())) {
+		return DPIUtil.getDeviceZoom() / 100 * 100 != DPIUtil.getDeviceZoom();
+	}
+	return isMonitorSpecificScalingActive();
 }
 
 public static int getZoomForAutoscaleProperty (int nativeDeviceZoom) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/internal/GtkDPIUtil.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/internal/GtkDPIUtil.java
@@ -16,11 +16,6 @@ package org.eclipse.swt.internal;
 import org.eclipse.swt.graphics.*;
 
 public class GtkDPIUtil {
-	static {
-	    DPIUtil.setUseSmoothScalingByDefaultProvider(() -> {
-	        return DPIUtil.getDeviceZoom() / 100 * 100 != DPIUtil.getDeviceZoom();
-	    });
-	}
 
 	/**
 	 * Auto-scale up ImageData to device zoom that is at 100%.

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/Win32DPIUtils.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/Win32DPIUtils.java
@@ -42,10 +42,6 @@ public class Win32DPIUtils {
 	 */
 	public static final String CUSTOM_DPI_AWARENESS_PROPERTY = "org.eclipse.swt.internal.win32.dpiAwareness";
 
-	static {
-		DPIUtil.setUseSmoothScalingByDefaultProvider(() -> DPIUtil.isMonitorSpecificScalingActive());
-	}
-
 	private static int customDpiAwareness = -1;
 
 	public static void initializeCustomDpiAwareness() {


### PR DESCRIPTION
Smooth scaling of images is currently enabled in an OS-dependent way. An according provider is registered in DPIUtil by the OS-specific DPI utility classes. This is overly complex and, more severely, not correct. The provider is registered via the static initializers of the OS-specific DPI utility classes, but they may never be used or at least not before images are scaled for the first time. In such cases, the provider may not be registered as the class loader has never initialized the class.

This change moves the smooth-scaling initialization to the DPIUtil class, simplifying the code and reducing the risk of faulty behavior because of missing class loading of OS-dependent utility classes.