### PR TITLE
[Win32] Improve parameterization of monitor-specific scaling enablement

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Display.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Display.java
@@ -951,8 +951,8 @@ protected void create (DeviceData data) {
 	checkDisplay (thread = Thread.currentThread (), true);
 	if (DPIUtil.isMonitorSpecificScalingActive()) {
 		setMonitorSpecificScaling(true);
-		DPIUtil.setMonitorSpecificScaling(true);
 	}
+	DPIUtil.setMonitorSpecificScaling(DPIUtil.isMonitorSpecificScalingActive());
 	Win32DPIUtils.initializeCustomDpiAwareness();
 	createDisplay (data);
 	register (this);

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/AllNonBrowserTests_AutoscaleOsNonDefaults.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/AllNonBrowserTests_AutoscaleOsNonDefaults.java
@@ -22,20 +22,21 @@ import org.junit.platform.suite.api.BeforeSuite;
 @NonBrowserTestSuite
 public class AllNonBrowserTests_AutoscaleOsNonDefaults extends AllNonBrowserTests {
 
+	private static final String AUTO_SCALE_PROPERTY = "swt.autoScale";
 	private static boolean originalMonitorSpecificScalingActive;
 
 	@SuppressWarnings("restriction")
 	@BeforeSuite
 	static void setNonDefaultAutoscale() {
 		originalMonitorSpecificScalingActive = DPIUtil.isMonitorSpecificScalingActive();
-		System.setProperty("swt.autoScale", "quarter");
-		DPIUtil.setMonitorSpecificScaling(true);
+		System.setProperty(AUTO_SCALE_PROPERTY, originalMonitorSpecificScalingActive ? "integer" : "quarter");
+		DPIUtil.setMonitorSpecificScaling(!originalMonitorSpecificScalingActive);
 	}
 
 	@SuppressWarnings("restriction")
 	@AfterSuite
 	static void restoreDefaultAutoscale() {
-		System.clearProperty("swt.autoScale");
+		System.clearProperty(AUTO_SCALE_PROPERTY);
 		DPIUtil.setMonitorSpecificScaling(originalMonitorSpecificScalingActive);
 	}
 


### PR DESCRIPTION
Some parts of the implementation currently assume monitor-specific scaling to be disabled by default and autoscaling mode to default to "integer". With monitor-specific scaling becoming the default in the future (see #2955), these assumptions will not hold anymore. In order to prepare for that, this change adapts some code to properly deal with monitor-specific scaling and autoscaling mode having arbitrary default values.