### PR TITLE
[Gtk] Remove Display.mapInPixels methods

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Composite.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Composite.java
@@ -559,7 +559,7 @@ public void drawBackground (GC gc, int x, int y, int width, int height, int offs
 		long cairo = data.cairo;
 		Cairo.cairo_save (cairo);
 		if (control.backgroundImage != null) {
-			Point pt = display.mapInPixels (this, control, 0, 0);
+			Point pt = display.map (this, control, 0, 0);
 			Cairo.cairo_translate (cairo, -pt.x - offsetX, -pt.y - offsetY);
 			x += pt.x + offsetX;
 			y += pt.y + offsetY;
@@ -1438,7 +1438,7 @@ void printWidget (GC gc, long drawable, int depth, int x, int y) {
 	gc.setClipping (newClip);
 	super.printWidget (gc, drawable, depth, x, y);
 	Rectangle clientRect = getClientAreaInPixels ();
-	Point pt = display.mapInPixels (this, parent, clientRect.x, clientRect.y);
+	Point pt = display.map (this, parent, clientRect.x, clientRect.y);
 	clientRect.x = x + pt.x - rect.x;
 	clientRect.y = y + pt.y - rect.y;
 	newClip.intersect (clientRect);

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Control.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Control.java
@@ -217,7 +217,7 @@ void drawBackground (Control control, long gdkResource, long cr, int x, int y, i
 		Cairo.cairo_clip(cairo);
 	}
 	if (control.backgroundImage != null) {
-		Point pt = display.mapInPixels (this, control, 0, 0);
+		Point pt = display.map (this, control, 0, 0);
 		Cairo.cairo_translate (cairo, -pt.x, -pt.y);
 		x += pt.x;
 		y += pt.y;
@@ -4130,7 +4130,7 @@ void gtk4_motion_event(long controller, double x, double y, long event) {
 		if (display.currentControl != null && !display.currentControl.isDisposed()) {
 			display.removeMouseHoverTimeout(display.currentControl.handle);
 			/*
-			 *  Note: for GTK4, the call to display.mapInPixels function was removed due to the
+			 *  Note: for GTK4, the call to display.map function was removed due to the
 			 *  inability to get the origin of surfaces. Testing needs to be done to see if
 			 *  the x, y, coordinates suffice.
 			 */
@@ -4226,7 +4226,7 @@ long gtk_motion_notify_event (long widget, long event) {
 	if (this != display.currentControl) {
 		if (display.currentControl != null && !display.currentControl.isDisposed ()) {
 			display.removeMouseHoverTimeout(display.currentControl.handle);
-			Point pt = display.mapInPixels(this, display.currentControl, (int)x, (int)y);
+			Point pt = display.map(this, display.currentControl, (int)x, (int)y);
 			display.currentControl.sendMouseEvent(SWT.MouseExit,  0, time, pt.x, pt.y, isHint, state[0]);
 		}
 		if (!isDisposed ()) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/DateTime.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/DateTime.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2025 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -626,7 +626,7 @@ void dropDownCalendar (boolean drop) {
 	Display display = getDisplay ();
 
 	//To display popup calendar, we need to know where the parent is relative to the whole screen.
-	Rectangle coordsRelativeToScreen = display.mapInPixels (getParent (), null, getBoundsInPixels ());
+	Rectangle coordsRelativeToScreen = display.map (getParent (), null, getBoundsInPixels ());
 	Rectangle displayRect = getMonitor ().getClientArea ();
 
 	showPopupShell (containerBounds, calendarSize, coordsRelativeToScreen, displayRect);

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Display.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Display.java
@@ -4048,27 +4048,6 @@ public Point map (Control from, Control to, int x, int y) {
 	return point;
 }
 
-Point mapInPixels (Control from, Control to, int x, int y) {
-	checkDevice ();
-	if (from != null && from.isDisposed()) error (SWT.ERROR_INVALID_ARGUMENT);
-	if (to != null && to.isDisposed()) error (SWT.ERROR_INVALID_ARGUMENT);
-	Point point = new Point (x, y);
-	if (from == to) return point;
-	if (from != null) {
-		Point origin = GTK.GTK4 ? from.getSurfaceOrigin() : from.getWindowOrigin ();
-		if ((from.style & SWT.MIRRORED) != 0) point.x = from.getClientWidth () - point.x;
-		point.x += origin.x;
-		point.y += origin.y;
-	}
-	if (to != null) {
-		Point origin = GTK.GTK4 ? to.getSurfaceOrigin() : to.getWindowOrigin ();
-		point.x -= origin.x;
-		point.y -= origin.y;
-		if ((to.style & SWT.MIRRORED) != 0) point.x = to.getClientWidth () - point.x;
-	}
-	return point;
-}
-
 /**
  * Maps a point from one coordinate system to another.
  * When the control is null, coordinates are mapped to
@@ -4109,12 +4088,6 @@ public Rectangle map (Control from, Control to, Rectangle rectangle) {
 	checkDevice();
 	if (rectangle == null) error (SWT.ERROR_NULL_ARGUMENT);
 	return map (from, to, rectangle.x, rectangle.y, rectangle.width, rectangle.height);
-}
-
-Rectangle mapInPixels (Control from, Control to, Rectangle rectangle) {
-	checkDevice();
-	if (rectangle == null) error (SWT.ERROR_NULL_ARGUMENT);
-	return mapInPixels (from, to, rectangle.x, rectangle.y, rectangle.width, rectangle.height);
 }
 
 /**
@@ -4170,31 +4143,6 @@ public Rectangle map (Control from, Control to, int x, int y, int width, int hei
 	}
 	if (to != null) {
 		Point origin = GTK.GTK4 ? to.getSurfaceOrigin() : to.getWindowOrigin ();
-		rect.x -= origin.x;
-		rect.y -= origin.y;
-		if (toRTL = (to.style & SWT.MIRRORED) != 0) rect.x = to.getClientWidth () - rect.x;
-	}
-
-	if (fromRTL != toRTL) rect.x -= rect.width;
-	return rect;
-}
-
-Rectangle mapInPixels (Control from, Control to, int x, int y, int width, int height) {
-	checkDevice();
-	if (from != null && from.isDisposed()) error (SWT.ERROR_INVALID_ARGUMENT);
-	if (to != null && to.isDisposed()) error (SWT.ERROR_INVALID_ARGUMENT);
-
-	Rectangle rect = new Rectangle (x, y, width, height);
-	if (from == to) return rect;
-	boolean fromRTL = false, toRTL = false;
-	if (from != null) {
-		Point origin = GTK.GTK4 ? from.getSurfaceOrigin() : from.getWindowOrigin ();
-		if (fromRTL = (from.style & SWT.MIRRORED) != 0) rect.x = from.getClientWidth () - rect.x;
-		rect.x += origin.x;
-		rect.y += origin.y;
-	}
-	if (to != null) {
-		Point origin = GTK.GTK4 ? from.getSurfaceOrigin() : from.getWindowOrigin ();
 		rect.x -= origin.x;
 		rect.y -= origin.y;
 		if (toRTL = (to.style & SWT.MIRRORED) != 0) rect.x = to.getClientWidth () - rect.x;

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Shell.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Shell.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2025 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -655,7 +655,7 @@ void bringToTop (boolean force) {
 void center () {
 	if (parent == null) return;
 	Rectangle rect = getBoundsInPixels ();
-	Rectangle parentRect = display.mapInPixels (parent, null, parent.getClientAreaInPixels());
+	Rectangle parentRect = display.map(parent, null, parent.getClientAreaInPixels());
 	int x = Math.max (parentRect.x, parentRect.x + (parentRect.width - rect.width) / 2);
 	int y = Math.max (parentRect.y, parentRect.y + (parentRect.height - rect.height) / 2);
 	Rectangle monitorRect = parent.getMonitor ().getClientArea();

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Tracker.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Tracker.java
@@ -200,7 +200,7 @@ Point adjustMoveCursor () {
 	int newX = bounds.x + bounds.width / 2;
 	int newY = bounds.y;
 
-	Point point = display.mapInPixels(parent, null, newX, newY);
+	Point point = display.map(parent, null, newX, newY);
 	display.setCursorLocation(point);
 
 	int[] actualX = new int[1], actualY = new int[1], state = new int[1];
@@ -237,7 +237,7 @@ Point adjustResizeCursor () {
 		newY = bounds.y + bounds.height / 2;
 	}
 
-	Point point = display.mapInPixels (parent, null, newX, newY);
+	Point point = display.map (parent, null, newX, newY);
 	display.setCursorLocation (point);
 
 	/*
@@ -368,7 +368,7 @@ void drawRectangles (Rectangle [] rects) {
 
 		// Ensure we have absolute screen coordinates. (btw, there are no absolute coordinates on Wayland, so Tracker(Display) is probably broken).
 		if (parent != null) {  // if Tracker(Display) has absolute coords.  Tracker(Composite) has relative. For relative, we need to find absolute.
-			cachedUnion = display.mapInPixels(parent, null, cachedUnion) ;
+			cachedUnion = display.map(parent, null, cachedUnion) ;
 		}
 
 		if (!cachedCombinedDisplayResolution.intersects(cachedUnion)) {
@@ -382,7 +382,7 @@ void drawRectangles (Rectangle [] rects) {
 		// Combine Rects into a region. (region is not necessarily a rectangle, E.g it can be 'L' shaped etc..).
 		for (int i = 0; i < rects.length; i++) {
 			// Turn filled rectangles into just the outer lines by drawing one line at a time.
-			Rectangle r = parent != null ? display.mapInPixels(parent, null, rects[i]) : rects[i];
+			Rectangle r = parent != null ? display.map(parent, null, rects[i]) : rects[i];
 			rect.x = r.x;
 			rect.y = r.y;
 			rect.width = r.width + 1;
@@ -646,7 +646,7 @@ long gtk_mouse (int eventType, long widget, long eventPtr) {
 			Rectangle eventRect = new Rectangle (newX [0], newY [0], 0, 0);
 			event.setBounds (eventRect);
 		} else {
-			Point screenCoord = display.mapInPixels (parent, null, newX [0], newY [0]);
+			Point screenCoord = display.map (parent, null, newX [0], newY [0]);
 			Rectangle eventRect = new Rectangle (screenCoord.x, screenCoord.y, 0, 0);
 			event.setBounds (eventRect);
 		}


### PR DESCRIPTION
They had exactly the same implementation as Display.map methods (except for one copy/paste error).