### PR TITLE
[Win32] Correct DPI context awareness value retrieval

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT PI/win32/library/os.c
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/win32/library/os.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2025 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -157,6 +157,26 @@ JNIEXPORT jboolean JNICALL OS_NATIVE(Arc)
 	OS_NATIVE_ENTER(env, that, Arc_FUNC);
 	rc = (jboolean)Arc((HDC)arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8);
 	OS_NATIVE_EXIT(env, that, Arc_FUNC);
+	return rc;
+}
+#endif
+
+#ifndef NO_AreDpiAwarenessContextsEqual
+JNIEXPORT jboolean JNICALL OS_NATIVE(AreDpiAwarenessContextsEqual)
+	(JNIEnv *env, jclass that, jlong arg0, jlong arg1)
+{
+	jboolean rc = 0;
+	OS_NATIVE_ENTER(env, that, AreDpiAwarenessContextsEqual_FUNC);
+/*
+	rc = (jboolean)AreDpiAwarenessContextsEqual((DPI_AWARENESS_CONTEXT)arg0, (DPI_AWARENESS_CONTEXT)arg1);
+*/
+	{
+		OS_LOAD_FUNCTION(fp, AreDpiAwarenessContextsEqual)
+		if (fp) {
+			rc = (jboolean)((jboolean (CALLING_CONVENTION*)(DPI_AWARENESS_CONTEXT, DPI_AWARENESS_CONTEXT))fp)((DPI_AWARENESS_CONTEXT)arg0, (DPI_AWARENESS_CONTEXT)arg1);
+		}
+	}
+	OS_NATIVE_EXIT(env, that, AreDpiAwarenessContextsEqual_FUNC);
 	return rc;
 }
 #endif

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/win32/library/os_custom.c
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/win32/library/os_custom.c
@@ -343,3 +343,103 @@ JNIEXPORT jboolean JNICALL OS_NATIVE(IsDarkModeAvailable)
 	return isAvailable;
 }
 #endif
+
+#ifndef NO_DPI_1AWARENESS_1CONTEXT_1PER_1MONITOR_1AWARE
+JNIEXPORT jlong JNICALL OS_NATIVE(DPI_1AWARENESS_1CONTEXT_1PER_1MONITOR_1AWARE)
+	(JNIEnv *env, jclass that)
+{
+	/* Suppress warnings about unreferenced parameters */
+	(void)env;
+	(void)that;
+		
+	jlong rc = 0;
+	OS_NATIVE_ENTER(env, that, DPI_1AWARENESS_1CONTEXT_1PER_1MONITOR_1AWARE_FUNC);
+	#ifdef DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE
+			rc = (jlong)(LONG_PTR)DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE;
+		#else
+			rc = 0;
+		#endif
+	OS_NATIVE_EXIT(env, that, DPI_1AWARENESS_1CONTEXT_1PER_1MONITOR_1AWARE_FUNC);
+	return rc;
+}
+#endif
+
+#ifndef NO_DPI_1AWARENESS_1CONTEXT_1PER_1MONITOR_1AWARE_1V2
+JNIEXPORT jlong JNICALL OS_NATIVE(DPI_1AWARENESS_1CONTEXT_1PER_1MONITOR_1AWARE_1V2)
+	(JNIEnv *env, jclass that)
+{
+	/* Suppress warnings about unreferenced parameters */
+	(void)env;
+	(void)that;
+	
+	jlong rc = 0;
+	OS_NATIVE_ENTER(env, that, DPI_1AWARENESS_1CONTEXT_1PER_1MONITOR_1AWARE_1V2_FUNC);
+	#ifdef DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2
+		rc = (jlong)(LONG_PTR)DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2;
+	#else
+		rc = 0;
+	#endif
+	OS_NATIVE_EXIT(env, that, DPI_1AWARENESS_1CONTEXT_1PER_1MONITOR_1AWARE_1V2_FUNC);
+	return rc;
+}
+#endif
+
+#ifndef NO_DPI_1AWARENESS_1CONTEXT_1SYSTEM_1AWARE
+JNIEXPORT jlong JNICALL OS_NATIVE(DPI_1AWARENESS_1CONTEXT_1SYSTEM_1AWARE)
+	(JNIEnv *env, jclass that)
+{
+	/* Suppress warnings about unreferenced parameters */
+	(void)env;
+	(void)that;
+	
+	jlong rc = 0;
+	OS_NATIVE_ENTER(env, that, DPI_1AWARENESS_1CONTEXT_1SYSTEM_1AWARE_FUNC);
+	#ifdef DPI_AWARENESS_CONTEXT_SYSTEM_AWARE
+		rc = (jlong)(LONG_PTR)DPI_AWARENESS_CONTEXT_SYSTEM_AWARE;
+	#else
+		rc = 0;
+	#endif
+	OS_NATIVE_EXIT(env, that, DPI_1AWARENESS_1CONTEXT_1SYSTEM_1AWARE_FUNC);
+	return rc;
+}
+#endif
+
+#ifndef NO_DPI_1AWARENESS_1CONTEXT_1UNAWARE
+JNIEXPORT jlong JNICALL OS_NATIVE(DPI_1AWARENESS_1CONTEXT_1UNAWARE)
+	(JNIEnv *env, jclass that)
+{
+	/* Suppress warnings about unreferenced parameters */
+	(void)env;
+	(void)that;
+	
+	jlong rc = 0;
+	OS_NATIVE_ENTER(env, that, DPI_1AWARENESS_1CONTEXT_1UNAWARE_FUNC);
+	#ifdef DPI_AWARENESS_CONTEXT_UNAWARE
+		rc = (jlong)(LONG_PTR)DPI_AWARENESS_CONTEXT_UNAWARE;
+	#else
+		rc = 0;
+	#endif
+	OS_NATIVE_EXIT(env, that, DPI_1AWARENESS_1CONTEXT_1UNAWARE_FUNC);
+	return rc;
+}
+#endif
+
+#ifndef NO_DPI_1AWARENESS_1CONTEXT_1UNAWARE_1GDISCALED
+JNIEXPORT jlong JNICALL OS_NATIVE(DPI_1AWARENESS_1CONTEXT_1UNAWARE_1GDISCALED)
+	(JNIEnv *env, jclass that)
+{
+	/* Suppress warnings about unreferenced parameters */
+	(void)env;
+	(void)that;
+	
+	jlong rc = 0;
+	OS_NATIVE_ENTER(env, that, DPI_1AWARENESS_1CONTEXT_1UNAWARE_1GDISCALED_FUNC);
+	#ifdef DPI_AWARENESS_CONTEXT_UNAWARE_GDISCALED
+		rc = (jlong)(LONG_PTR)DPI_AWARENESS_CONTEXT_UNAWARE_GDISCALED;
+	#else
+		rc = 0;
+	#endif
+	OS_NATIVE_EXIT(env, that, DPI_1AWARENESS_1CONTEXT_1UNAWARE_1GDISCALED_FUNC);
+	return rc;
+}
+#endif

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/win32/library/os_custom.h
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/win32/library/os_custom.h
@@ -24,3 +24,4 @@
 #define OpenThemeDataForDpi_LIB "uxtheme.dll"
 #define GetThreadDpiAwarenessContext_LIB "user32.dll"
 #define SetThreadDpiAwarenessContext_LIB "user32.dll"
+#define AreDpiAwarenessContextsEqual_LIB "user32.dll"

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/win32/library/os_stats.h
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/win32/library/os_stats.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2025 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -31,6 +31,7 @@ typedef enum {
 	AllowSetForegroundWindow_FUNC,
 	AlphaBlend_FUNC,
 	Arc_FUNC,
+	AreDpiAwarenessContextsEqual_FUNC,
 	AssocQueryString_FUNC,
 	BITMAPINFOHEADER_1sizeof_FUNC,
 	BITMAP_1sizeof_FUNC,
@@ -100,6 +101,11 @@ typedef enum {
 	DIBSECTION_1sizeof_FUNC,
 	DOCHOSTUIINFO_1sizeof_FUNC,
 	DOCINFO_1sizeof_FUNC,
+	DPI_1AWARENESS_1CONTEXT_1PER_1MONITOR_1AWARE_FUNC,
+	DPI_1AWARENESS_1CONTEXT_1PER_1MONITOR_1AWARE_1V2_FUNC,
+	DPI_1AWARENESS_1CONTEXT_1SYSTEM_1AWARE_FUNC,
+	DPI_1AWARENESS_1CONTEXT_1UNAWARE_FUNC,
+	DPI_1AWARENESS_1CONTEXT_1UNAWARE_1GDISCALED_FUNC,
 	DRAWITEMSTRUCT_1sizeof_FUNC,
 	DROPFILES_1sizeof_FUNC,
 	DefFrameProc_FUNC,

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/win32/org/eclipse/swt/internal/win32/OS.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/win32/org/eclipse/swt/internal/win32/OS.java
@@ -354,11 +354,11 @@ public class OS extends C {
 	public static final short DMDUP_SIMPLEX = 1;
 	public static final short DMDUP_VERTICAL = 2;
 	public static final short DMDUP_HORIZONTAL = 3;
-	public static final int DPI_AWARENESS_CONTEXT_UNAWARE = 24592;
-	public static final int DPI_AWARENESS_CONTEXT_UNAWARE_GDISCALED = 1073766416;
-	public static final int DPI_AWARENESS_CONTEXT_SYSTEM_AWARE = 24593;
-	public static final int DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE = 18;
-	public static final int DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2 = 34;
+	public static final long DPI_AWARENESS_CONTEXT_UNAWARE = DPI_AWARENESS_CONTEXT_UNAWARE();
+	public static final long DPI_AWARENESS_CONTEXT_UNAWARE_GDISCALED = DPI_AWARENESS_CONTEXT_UNAWARE_GDISCALED();
+	public static final long DPI_AWARENESS_CONTEXT_SYSTEM_AWARE = DPI_AWARENESS_CONTEXT_SYSTEM_AWARE();
+	public static final long DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE = DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE();
+	public static final long DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2 = DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2();
 	public static final int DSTINVERT = 0x550009;
 	public static final int DT_BOTTOM = 0x8;
 	public static final int DT_CALCRECT = 0x400;
@@ -2350,6 +2350,12 @@ public static final native boolean AlphaBlend(long hdcDest, int nXOriginDest, in
 /** @param hdc cast=(HDC) */
 public static final native boolean Arc (long hdc, int nLeftRect, int nTopRect, int nRightRect, int nBottomRect, int nXStartArc, int nYStartArc, int nXEndArc, int nYEndArc);
 /**
+ * @method flags=dynamic
+ * @param dpiContextA cast=(DPI_AWARENESS_CONTEXT)
+ * @param dpiContextB cast=(DPI_AWARENESS_CONTEXT)
+ */
+public static final native boolean AreDpiAwarenessContextsEqual (long dpiContextA, long dpiContextB);
+/**
  * @param pszAssoc flags=no_out
  * @param pszExtra flags=no_out
  * @param pcchOut cast=(DWORD *)
@@ -2573,6 +2579,16 @@ public static final native long DispatchMessage (MSG lpmsg);
  * @param pDevModeInput cast=(PDEVMODEW)
  */
 public static final native int DocumentProperties (long hWnd, long hPrinter, char[] pDeviceName, long pDevModeOutput, long pDevModeInput, int fMode);
+/** @method flags=no_gen */
+public static final native long DPI_AWARENESS_CONTEXT_UNAWARE();
+/** @method flags=no_gen */
+public static final native long DPI_AWARENESS_CONTEXT_UNAWARE_GDISCALED();
+/** @method flags=no_gen */
+public static final native long DPI_AWARENESS_CONTEXT_SYSTEM_AWARE();
+/** @method flags=no_gen */
+public static final native long DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE();
+/** @method flags=no_gen */
+public static final native long DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2();
 /**
  * @param hwnd cast=(HWND)
  * @param pt flags=struct

--- a/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/widgets/DisplayWin32Test.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/widgets/DisplayWin32Test.java
@@ -1,7 +1,8 @@
 package org.eclipse.swt.widgets;
 
 import static org.eclipse.swt.internal.DPIUtil.setMonitorSpecificScaling;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.swt.internal.*;
 import org.eclipse.swt.internal.win32.*;
@@ -17,7 +18,14 @@ class DisplayWin32Test {
 		setMonitorSpecificScaling(true);
 		Display display = Display.getDefault();
 		assertTrue(display.isRescalingAtRuntime());
-		assertEquals(OS.DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2, OS.GetThreadDpiAwarenessContext());
+
+		assertExpectedDpiAwareness(OS.DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2);
+	}
+
+	private static void assertExpectedDpiAwareness(long expected) {
+		long currentDpiAwareness = OS.GetThreadDpiAwarenessContext();
+		boolean hasExpectedDpiAwareness = OS.AreDpiAwarenessContextsEqual(expected,currentDpiAwareness);
+		assertTrue(hasExpectedDpiAwareness, "unexpected DPI awareness: " + currentDpiAwareness);
 	}
 
 	@Test
@@ -34,7 +42,7 @@ class DisplayWin32Test {
 			setMonitorSpecificScaling(true);
 			Display display = Display.getDefault();
 			assertTrue(display.isRescalingAtRuntime());
-			assertEquals(OS.DPI_AWARENESS_CONTEXT_SYSTEM_AWARE, OS.GetThreadDpiAwarenessContext());
+			assertExpectedDpiAwareness(OS.DPI_AWARENESS_CONTEXT_SYSTEM_AWARE);
 		} finally {
 			System.clearProperty(Win32DPIUtils.CUSTOM_DPI_AWARENESS_PROPERTY);
 		}
@@ -45,7 +53,7 @@ class DisplayWin32Test {
 		System.setProperty(Win32DPIUtils.CUSTOM_DPI_AWARENESS_PROPERTY, "System");
 		try {
 			Display.getDefault();
-			assertEquals(OS.DPI_AWARENESS_CONTEXT_SYSTEM_AWARE, OS.GetThreadDpiAwarenessContext());
+			assertExpectedDpiAwareness(OS.DPI_AWARENESS_CONTEXT_SYSTEM_AWARE);
 		} finally {
 			System.clearProperty(Win32DPIUtils.CUSTOM_DPI_AWARENESS_PROPERTY);
 		}
@@ -56,7 +64,7 @@ class DisplayWin32Test {
 		System.setProperty(Win32DPIUtils.CUSTOM_DPI_AWARENESS_PROPERTY, "PerMonitorV2");
 		try {
 			Display.getDefault();
-			assertEquals(OS.DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2, OS.GetThreadDpiAwarenessContext());
+			assertExpectedDpiAwareness(OS.DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2);
 		} finally {
 			System.clearProperty(Win32DPIUtils.CUSTOM_DPI_AWARENESS_PROPERTY);
 		}
@@ -68,7 +76,7 @@ class DisplayWin32Test {
 		Display display = Display.getDefault();
 		display.setRescalingAtRuntime(true);
 		assertTrue(display.isRescalingAtRuntime());
-		assertEquals(OS.DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2, OS.GetThreadDpiAwarenessContext());
+		assertExpectedDpiAwareness(OS.DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2);
 	}
 
 	@Test
@@ -77,7 +85,7 @@ class DisplayWin32Test {
 		Display display = Display.getDefault();
 		display.setRescalingAtRuntime(false);
 		assertFalse(display.isRescalingAtRuntime());
-		assertEquals(OS.DPI_AWARENESS_CONTEXT_SYSTEM_AWARE, OS.GetThreadDpiAwarenessContext());
+		assertExpectedDpiAwareness(OS.DPI_AWARENESS_CONTEXT_SYSTEM_AWARE);
 	}
 
 	@Test
@@ -86,13 +94,13 @@ class DisplayWin32Test {
 		Display display = Display.getDefault();
 		display.setRescalingAtRuntime(false);
 		assertFalse(display.isRescalingAtRuntime());
-		assertEquals(OS.DPI_AWARENESS_CONTEXT_SYSTEM_AWARE, OS.GetThreadDpiAwarenessContext());
+		assertExpectedDpiAwareness(OS.DPI_AWARENESS_CONTEXT_SYSTEM_AWARE);
 		display.setRescalingAtRuntime(true);
 		assertTrue(display.isRescalingAtRuntime());
-		assertEquals(OS.DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2, OS.GetThreadDpiAwarenessContext());
+		assertExpectedDpiAwareness(OS.DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2);
 		display.setRescalingAtRuntime(false);
 		assertFalse(display.isRescalingAtRuntime());
-		assertEquals(OS.DPI_AWARENESS_CONTEXT_SYSTEM_AWARE, OS.GetThreadDpiAwarenessContext());
+		assertExpectedDpiAwareness(OS.DPI_AWARENESS_CONTEXT_SYSTEM_AWARE);
 	}
 
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/Win32DPIUtils.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/Win32DPIUtils.java
@@ -42,7 +42,7 @@ public class Win32DPIUtils {
 	 */
 	public static final String CUSTOM_DPI_AWARENESS_PROPERTY = "org.eclipse.swt.internal.win32.dpiAwareness";
 
-	private static int customDpiAwareness = -1;
+	private static long customDpiAwareness = -1;
 
 	public static void initializeCustomDpiAwareness() {
 		String customDpiAwareness = System.getProperty(CUSTOM_DPI_AWARENESS_PROPERTY);
@@ -63,7 +63,7 @@ public class Win32DPIUtils {
 		}
 	}
 
-	public static boolean setDPIAwareness(int desiredDpiAwareness) {
+	public static boolean setDPIAwareness(long desiredDpiAwareness) {
 		if (desiredDpiAwareness == OS.GetThreadDpiAwarenessContext()) {
 			return true;
 		}

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Display.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Display.java
@@ -5408,7 +5408,7 @@ public boolean setRescalingAtRuntime(boolean activate) {
 }
 
 private boolean setMonitorSpecificScaling(boolean activate) {
-	int desiredApiAwareness = activate ? OS.DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2 : OS.DPI_AWARENESS_CONTEXT_SYSTEM_AWARE;
+	long desiredApiAwareness = activate ? OS.DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2 : OS.DPI_AWARENESS_CONTEXT_SYSTEM_AWARE;
 	if (Win32DPIUtils.setDPIAwareness(desiredApiAwareness)) {
 		rescalingAtRuntime = activate;
 		coordinateSystemMapper = activate ? new MultiZoomCoordinateSystemMapper(this, this::getMonitors) : new SingleZoomCoordinateSystemMapper(this);


### PR DESCRIPTION
The DPI_AWARENESS_CONTEXT values are currently defined as constants, but they are actually defined as typedefed handles instead of compile time constants in Windows' windef.h. So the constants defined in SWT may not fit the actual values as used by the OS. This currently seems to be the case for the System awareness value, which does not fit the OS value.

This change adapts the definition of the values to retrieve the actual current values from the OS instead of hardcoding them in constants.

Can, e.g., be tested with different values passed to `-Dorg.eclipse.swt.internal.win32.dpiAwareness`, such as "system" or "permonitorv2". For me "system" did not work before this change.