### PR TITLE
Ignore undefined all-zero alpha data for 32-bit icons without mask

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Image.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Image.java
@@ -3142,12 +3142,14 @@ private class DestroyableImageHandle implements InternalImageHandle {
 					if (!hasMaskData && depth == 32) {
 						alphaData = new byte[width * height];
 						boolean hasAlphaData = false;
+						boolean isAllZeroAlpha = true;
 						for (int pixelIndex = 0; pixelIndex < alphaData.length; pixelIndex++) {
 							alphaData[pixelIndex] = data[pixelIndex * 4 + 3];
 							hasAlphaData |= alphaData[pixelIndex] != -1;
+							isAllZeroAlpha &= alphaData[pixelIndex] == 0;
 						}
 						// In case there is alpha data, replace the empty mask data with proper alpha data
-						if (hasAlphaData) {
+						if (hasAlphaData && !isAllZeroAlpha) {
 							maskData = null;
 						} else {
 							alphaData = null;


### PR DESCRIPTION
I have a png image (icon), which has no maskData and no alpha pixels (that means it is fully opaque):
<img width="48" height="48" alt="image" src="https://github.com/user-attachments/assets/aba7541b-e0bb-4eea-abff-3035863d5593" />

On Windows, GetDIBits() may return undefined alpha bytes for 32-bit BI_RGB bitmaps, commonly resulting in all-zero alpha even for fully opaque images.

When icon mask data is missing, this caused opaque icons to be incorrectly treated as fully transparent.

Reject all-zero alpha data and only replace empty mask data when the alpha channel contains meaningful (non-opaque, non-zero) values.

### How to test

- Run the following snippet on 100% (only reproducible on 100%, otherwise image will be scaled, image semantics will change and we will never run into this issue):

**Note:** Add the attached image on the same folder as snippet

```
import org.eclipse.swt.*;
import org.eclipse.swt.graphics.*;
import org.eclipse.swt.layout.*;
import org.eclipse.swt.widgets.*;

public class ImageTransparencyFix {
    public static void main(String[] args) {
    	System.setProperty("swt.autoScale.updateOnRuntime", "true");
        Display display = new Display();
        Shell shell = new Shell(display);
        shell.setText("Image Transparency Toolbar Demo");
        shell.setSize(300, 200);
        shell.setLayout(new FillLayout());

        Image original = new Image(display, ImageTransparencyFix.class.getResourceAsStream("png-image.png"));

        ImageData data = original.getImageData();
        Image transparentImage = new Image(display, data, data.getTransparencyMask());

        ToolBar imageToolBar = new ToolBar(shell, SWT.FLAT);
        for (int i = 0; i < 3; i++) {
            ToolItem item = new ToolItem(imageToolBar, SWT.PUSH);
            item.setImage(transparentImage);
            item.setToolTipText("Image ToolItem ToolTip " + i);
        }

        // 4) Open UI
        shell.open();
        while (!shell.isDisposed()) {
            if (!display.readAndDispatch()) display.sleep();
        }

        // 5) Dispose resources
        transparentImage.dispose();
        original.dispose();
        display.dispose();
    }
}
```

- You will see the images on toolbar will be completely transparent.
<img width="286" height="193" alt="image" src="https://github.com/user-attachments/assets/0ee2bad9-21db-4f52-a5dd-194328199faa" />

### After fix 
<img width="286" height="193" alt="image" src="https://github.com/user-attachments/assets/e4f0e479-0fe1-4be0-a8f9-5d42e9a7f4d6" />
