### PR TITLE
[Win32] Initialize proper DPI awareness for non-monitor-specific scaling

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/widgets/DisplayWin32Test.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/widgets/DisplayWin32Test.java
@@ -33,6 +33,7 @@ class DisplayWin32Test {
 		setMonitorSpecificScaling(false);
 		Display display = Display.getDefault();
 		assertFalse(display.isRescalingAtRuntime());
+		assertExpectedDpiAwareness(OS.DPI_AWARENESS_CONTEXT_SYSTEM_AWARE);
 	}
 
 	@Test

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/DPIUtil.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/DPIUtil.java
@@ -121,6 +121,10 @@ private static void updateAutoScaleValue() {
 	}
 }
 
+public static boolean isCustomAutoScale() {
+	return System.getProperty (SWT_AUTOSCALE) != null;
+}
+
 /**
  * Returns {@code true} only if the current setup is compatible
  * with monitor-specific scaling. Returns {@code false} if:

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/Win32DPIUtils.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/Win32DPIUtils.java
@@ -44,23 +44,24 @@ public class Win32DPIUtils {
 
 	private static long customDpiAwareness = -1;
 
-	public static void initializeCustomDpiAwareness() {
+	public static boolean initializeCustomDpiAwareness() {
 		String customDpiAwareness = System.getProperty(CUSTOM_DPI_AWARENESS_PROPERTY);
 		if (customDpiAwareness != null) {
 			switch (customDpiAwareness.toLowerCase()) {
 			case "permonitorv2":
 				setDPIAwareness(OS.DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2);
-				break;
+				return true;
 			case "permonitor":
 				setDPIAwareness(OS.DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE);
-				break;
+				return true;
 			case "system":
 				setDPIAwareness(OS.DPI_AWARENESS_CONTEXT_SYSTEM_AWARE);
-				break;
+				return true;
 			default:
 				System.err.println("Invalid DPI awareness specified: " + customDpiAwareness);
 			}
 		}
+		return false;
 	}
 
 	public static boolean setDPIAwareness(long desiredDpiAwareness) {


### PR DESCRIPTION
When instantiating a display, the DPI awareness for its UI thread was set to PerMonitorV2 in case monitor-specific scaling is enabled. This allowed to keep the default process DPI awareness at "system" (or whatever the application used) with compatibility to non-monitor-specific scaling.
With the future enablement of monitor-specific scaling by default and the default DPI awareness becoming PerMonitorV2, it will be necessary to restore the previous default (most reasonable) DPI awareness "System" for the case that monitor-specific scaling is disabled.

This change implements the proper setting of DPI awareness in the following way:
- By default, the UI thread of a display uses DPI awareness "system" when monitor-specific scaling is disabled and "PerMonitorV2" when monitor-specific scaling is enabled.
- If the user specifies a custom DPI awareness or a custom autoscale mode via system property, the application's default DPI awareness will be kept (specified by the application of JVM manifest).

This will result in reasonable default behavior (DPI awareness fitting to the scaling mode) and still keeps the ability of customizing the autoscaling and DPI awareness behavior.

This change depends on and should thus be merged after:
- #2985

A good way to test this change is by starting any Eclipse product with `-Dswt.autoScale.updateOnRuntime=false` with a default JRE (which mean it has no customized manifest but uses "PerMonitorV2" as DPI awareness by default). This disables monitor-specific scaling such that the preexisting single-scale HiDPI support is used. What used to happen (since forever) is that the product is started with the JVMs default DPI awareness of "PerMonitorV2" even though deployed products (using the Equinox launcher) used "System", such that no rescaling happened when the application was moved to another monitor. With this change, the application with rescale in a blurry way, such that the runtime product behaves in the same way as when starting with the Equinox launcher.