### PR TITLE
Fix TLS error constants for WebKitGTK

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT WebKit/gtk/org/eclipse/swt/internal/webkit/WebKitGTK.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT WebKit/gtk/org/eclipse/swt/internal/webkit/WebKitGTK.java
@@ -76,14 +76,15 @@ public class WebKitGTK extends C {
 
 	public static final int WEBKIT_TLS_ERRORS_POLICY_IGNORE = 0;
 
-	public static final int G_TLS_CERTIFICATE_UNKNOWN_CA = 0;
-	public static final int G_TLS_CERTIFICATE_BAD_IDENTITY = 1;
-	public static final int G_TLS_CERTIFICATE_NOT_ACTIVATED = 2;
-	public static final int G_TLS_CERTIFICATE_EXPIRED = 3;
-	public static final int G_TLS_CERTIFICATE_REVOKED = 4;
-	public static final int G_TLS_CERTIFICATE_INSECURE = 5;
-	public static final int G_TLS_CERTIFICATE_GENERIC_ERROR = 6;
-	public static final int G_TLS_CERTIFICATE_VALIDATE_ALL = 7;
+	public static final int G_TLS_CERTIFICATE_NO_FLAGS = 0;
+	public static final int G_TLS_CERTIFICATE_UNKNOWN_CA = 1 << 0;
+	public static final int G_TLS_CERTIFICATE_BAD_IDENTITY = 1 << 1;
+	public static final int G_TLS_CERTIFICATE_NOT_ACTIVATED = 1 << 2;
+	public static final int G_TLS_CERTIFICATE_EXPIRED = 1 << 3;
+	public static final int G_TLS_CERTIFICATE_REVOKED = 1 << 4;
+	public static final int G_TLS_CERTIFICATE_INSECURE = 1 << 5;
+	public static final int G_TLS_CERTIFICATE_GENERIC_ERROR = 1 << 6;
+	public static final int G_TLS_CERTIFICATE_VALIDATE_ALL = 0x7f;
 
 	public static final int WEBKIT_WEBSITE_DATA_COOKIES = GTK.GTK4 ? 64 : 1 << 8;
 


### PR DESCRIPTION
With the wrong constants, the error messages displayed to users would show the incorrect reason for the bad certificate.

This can be manually tested by using https://badssl.com/, such as making sure the error messages match for URLs such as:

- https://expired.badssl.com/
- https://wrong.host.badssl.com/
- https://untrusted-root.badssl.com/

Fixes https://github.com/eclipse-platform/eclipse.platform.swt/issues/2697