### PR TITLE
[Win32] Deactivate monitor-specific scaling if PerMonitorV2 unsupported

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/widgets/DisplayWin32Test.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/widgets/DisplayWin32Test.java
@@ -42,7 +42,7 @@ class DisplayWin32Test {
 		try {
 			setMonitorSpecificScaling(true);
 			Display display = Display.getDefault();
-			assertTrue(display.isRescalingAtRuntime());
+			assertFalse(display.isRescalingAtRuntime());
 			assertExpectedDpiAwareness(OS.DPI_AWARENESS_CONTEXT_SYSTEM_AWARE);
 		} finally {
 			System.clearProperty(Win32DPIUtils.CUSTOM_DPI_AWARENESS_PROPERTY);

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/Win32DPIUtils.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/Win32DPIUtils.java
@@ -85,6 +85,10 @@ public class Win32DPIUtils {
 		return true;
 	}
 
+	public static boolean hasProperDpiAwarenessForMonitorSpecificScaling() {
+		return OS.AreDpiAwarenessContextsEqual(OS.DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2, OS.GetThreadDpiAwarenessContext());
+	}
+
 	public static <T> T runWithProperDPIAwareness(Display display, Supplier<T> operation) {
 		if (customDpiAwareness == -1) {
 			return operation.get();

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Display.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Display.java
@@ -5408,9 +5408,9 @@ private boolean initializeAutoscaling(boolean useMonitorSpecificScaling) {
 	if (!Win32DPIUtils.initializeCustomDpiAwareness() && !DPIUtil.isCustomAutoScale()) {
 		successfullySetDpiAwareness = setDpiAwareness(useMonitorSpecificScaling);
 	}
-	DPIUtil.setMonitorSpecificScaling(useMonitorSpecificScaling);
-	rescalingAtRuntime = useMonitorSpecificScaling;
-	coordinateSystemMapper = useMonitorSpecificScaling ? new MultiZoomCoordinateSystemMapper(this, this::getMonitors) : new SingleZoomCoordinateSystemMapper(this);
+	rescalingAtRuntime = useMonitorSpecificScaling && Win32DPIUtils.hasProperDpiAwarenessForMonitorSpecificScaling();
+	DPIUtil.setMonitorSpecificScaling(rescalingAtRuntime);
+	coordinateSystemMapper = rescalingAtRuntime ? new MultiZoomCoordinateSystemMapper(this, this::getMonitors) : new SingleZoomCoordinateSystemMapper(this);
 	// dispose an existing font registry for the default display
 	SWTFontProvider.disposeFontRegistry(this);
 	return successfullySetDpiAwareness;


### PR DESCRIPTION
For monitor-specific scaling, PerMonitorV2 is set (and required) as DPI awareness do work properly. By now, even if the DPI awareness was not successfully set to PerMonitorV2 (which can actually only happen on Windows Server 2016), monitor-specific scaling will still be enabled.

With this change, if the required DPI awareness for monitor-specific scaling could not be set, monitor-specific scaling will automatically be disabled.