### PR TITLE
Remove redundant GC.dispose() calls for Image

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Image.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Image.java
@@ -2831,7 +2831,6 @@ private class ImageGcDrawerWrapper extends DynamicImageProviderWrapper {
 			drawer.postProcess(imageData);
 			return adaptImageDataIfDisabledOrGray(imageData);
 		} finally {
-			gc.dispose();
 			image.dispose();
 		}
 	}

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Composite.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Composite.java
@@ -1635,7 +1635,6 @@ LRESULT WM_PAINT (long wParam, long lParam) {
 						GCData gcData = gc.getGCData ();
 						if (gcData.focusDrawn && !isDisposed ()) updateUIState ();
 					}
-					gc.dispose();
 					if (!isDisposed ()) {
 						paintGC.drawImage (image, DPIUtil.pixelToPoint(ps.left, zoom), DPIUtil.pixelToPoint(ps.top, zoom));
 					}


### PR DESCRIPTION
This minor refactoring eliminates unnecessary calls to GC.dispose() since disposing an Image automatically disposes its associated GC. There is no visual impact from this change.