### PR TITLE
Resize Current Caret While Autoscaling

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Caret.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Caret.java
@@ -665,7 +665,9 @@ void handleDPIChange(Event event, float scalingFactor) {
 	if (font != null) {
 		setFont(font);
 	}
-	if (isVisible && hasFocus ()) resize();
+	if (isFocusCaret()) {
+		setFocus();
+	}
 }
 }
 


### PR DESCRIPTION
This PR contributes to autoscaling of the Caret which was last managed by the OS (hence the current caret) while autoscaling since there can only be one Caret visibile at a time. Also, the changes make sure that we do not change the visibility state of the Caret while autoscaling.

### How to reproduce the bug
- Create a long text in the editor so that text is wider than the editor and doesn't fit in it (should overflow).
- Place the Caret very close to the right side of the editor.
- Move the editor from 250% to 175 or 150%, you'll see the Caret stays big.

### Reason
When `StyledText#updateCaretVisibiltiy` is called, sometimes the composite is still not scaled and hence, one of the checks consider the caret to be not visible because it goes ahead of the right bound of the editor. However, the caret is set back to visible once the shell resizes at the end of autoscaling via the resize event. Hence, it is not wise to decide scaling of the caret based on its visibility during an intermediate state. A more stable way would be to strictly identify the current caret which should be scaled (the one in focus) and resize it.

### Proposal

While we autoscale a Caret, the following is valid:
- We use `OS#DestroyCaret` to destroy the only caret and create a new one - hence, there is always one globally active cursor on the OS level.
- While auoscaling, earlier we used to check for if a caret is visible then only we autoscale it. However, this might not always be true. After autoscaling, the editor might be laid out in such a way that the caret goes missing (also in ideal cases), hence, when it is moved, it is repainted with the right size. But the user can also make the editor bigger and then the caret will be visible but not resized.

The PR proposes the following solution:
- We only autoscale when there's a zoom change on the monitor or the window is moved to a different monitor.
- In both the case, the current caret is the one which needs to adapt and scale. Since a caret is globally singular inside the SWT implementation, this makes it easy to identify the currently active caret.
- Additionally, earlier using `Caret#resize` changed the visibility of the caret (although it was guarded by `isVisible` check), but with the new proposed check `Caret#isCurrentCaret`, if we call `Caret#resize`, it might change the visibility of the Caret. Hence, we should use `Caret#setFocus` which ensures the original state of Caret visibility and since its the current caret, it is semantically correct to call this method.