### PR TITLE
[Gtk] Stop using deprecated gtk_calendar_select_day

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/gtk4.c
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/gtk4.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2025 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -751,12 +751,32 @@ JNIEXPORT jlong JNICALL GTK4_NATIVE(gtk_1calendar_1get_1date)
 #endif
 
 #ifndef NO_gtk_1calendar_1select_1day
+G_GNUC_BEGIN_IGNORE_DEPRECATIONS
 JNIEXPORT void JNICALL GTK4_NATIVE(gtk_1calendar_1select_1day)
 	(JNIEnv *env, jclass that, jlong arg0, jlong arg1)
 {
 	GTK4_NATIVE_ENTER(env, that, gtk_1calendar_1select_1day_FUNC);
 	gtk_calendar_select_day((GtkCalendar *)arg0, (GDateTime *)arg1);
 	GTK4_NATIVE_EXIT(env, that, gtk_1calendar_1select_1day_FUNC);
+}
+G_GNUC_END_IGNORE_DEPRECATIONS
+#endif
+
+#ifndef NO_gtk_1calendar_1set_1date
+JNIEXPORT void JNICALL GTK4_NATIVE(gtk_1calendar_1set_1date)
+	(JNIEnv *env, jclass that, jlong arg0, jlong arg1)
+{
+	GTK4_NATIVE_ENTER(env, that, gtk_1calendar_1set_1date_FUNC);
+/*
+	gtk_calendar_set_date((GtkCalendar *)arg0, (GDateTime *)arg1);
+*/
+	{
+		GTK4_LOAD_FUNCTION(fp, gtk_calendar_set_date)
+		if (fp) {
+			((void (CALLING_CONVENTION*)(GtkCalendar *, GDateTime *))fp)((GtkCalendar *)arg0, (GDateTime *)arg1);
+		}
+	}
+	GTK4_NATIVE_EXIT(env, that, gtk_1calendar_1set_1date_FUNC);
 }
 #endif
 

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/gtk4_stats.h
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/gtk4_stats.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2025 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -80,6 +80,7 @@ typedef enum {
 	gtk_1button_1set_1child_FUNC,
 	gtk_1calendar_1get_1date_FUNC,
 	gtk_1calendar_1select_1day_FUNC,
+	gtk_1calendar_1set_1date_FUNC,
 	gtk_1calendar_1set_1show_1day_1names_FUNC,
 	gtk_1calendar_1set_1show_1heading_FUNC,
 	gtk_1calendar_1set_1show_1week_1numbers_FUNC,

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/org/eclipse/swt/internal/gtk4/GTK4.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/org/eclipse/swt/internal/gtk4/GTK4.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2025 Syntevo and others.
+ * Copyright (c) 2021, 2026 Syntevo and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -81,10 +81,17 @@ public class GTK4 {
 	/** @param calendar cast=(GtkCalendar *) */
 	public static final native long gtk_calendar_get_date(long calendar);
 	/**
+	 * @method flags=ignore_deprecations
 	 * @param calendar cast=(GtkCalendar *)
 	 * @param date cast=(GDateTime *)
 	 */
 	public static final native void gtk_calendar_select_day(long calendar, long date);
+	/**
+	 * @method flags=dynamic
+	 * @param calendar cast=(GtkCalendar *)
+	 * @param date cast=(GDateTime *)
+	 */
+	public static final native void gtk_calendar_set_date(long calendar, long date);
 	/**
 	 * @param calendar cast=(GtkCalendar *)
 	 * @param value cast=(gboolean)

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/DateTime.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/DateTime.java
@@ -1499,7 +1499,11 @@ public void setDate (int year, int month, int day) {
 
 		if (GTK.GTK4) {
 			long dateTime = OS.g_date_time_new_local(year, month + 1, day, 0, 0, 0);
-			GTK4.gtk_calendar_select_day(calendarHandle, dateTime);
+			if (GTK.GTK_VERSION >= OS.VERSION(4, 20, 0)) {
+				GTK4.gtk_calendar_set_date(calendarHandle, dateTime);
+			} else {
+				GTK4.gtk_calendar_select_day(calendarHandle, dateTime);
+			}
 			OS.g_date_time_unref(dateTime);
 		} else {
 			GTK3.gtk_calendar_select_month (calendarHandle, month, year);


### PR DESCRIPTION
Gtk 4.10 added gtk_calendar_set_date as a replacement