### PR TITLE
[Win32] Make ImageList retrieval from Display consider zoom

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/ImageList.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/ImageList.java
@@ -331,10 +331,6 @@ public Image get (int index) {
 	return images [index];
 }
 
-public int getStyle () {
-	return style;
-}
-
 public long getHandle(int targetZoom) {
 	if (!zoomToHandle.containsKey(targetZoom)) {
 		int scaledWidth = DPIUtil.pointToPixel(DPIUtil.pixelToPoint(width, this.zoom), targetZoom);
@@ -372,6 +368,11 @@ public Point getImageSize() {
 	int [] cx = new int [1], cy = new int [1];
 	OS.ImageList_GetIconSize (handle, cx, cy);
 	return Win32DPIUtils.pixelToPointAsSize(new Point (cx [0], cy [0]), zoom);
+}
+
+public boolean isFittingFor(int style, int width, int height, int zoom) {
+	Point imageSize = getImageSize();
+	return this.style == style && imageSize.x == width && imageSize.y == height && this.zoom == zoom;
 }
 
 public int indexOf (Image image) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Display.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Display.java
@@ -2045,12 +2045,9 @@ ImageList getImageList (int style, int width, int height, int zoom) {
 	while (i < length) {
 		ImageList list = imageList [i];
 		if (list == null) break;
-		Point size = list.getImageSize();
-		if (size.x == width && size.y == height) {
-			if (list.getStyle () == style) {
-				list.addRef();
-				return list;
-			}
+		if (list.isFittingFor(style, width, height, zoom)) {
+			list.addRef();
+			return list;
 		}
 		i++;
 	}
@@ -2075,12 +2072,9 @@ ImageList getImageListToolBar (int style, int width, int height, int zoom) {
 	while (i < length) {
 		ImageList list = toolImageList [i];
 		if (list == null) break;
-		Point size = list.getImageSize();
-		if (size.x == width && size.y == height) {
-			if (list.getStyle () == style) {
-				list.addRef();
-				return list;
-			}
+		if (list.isFittingFor(style, width, height, zoom)) {
+			list.addRef();
+			return list;
 		}
 		i++;
 	}
@@ -2105,12 +2099,9 @@ ImageList getImageListToolBarDisabled (int style, int width, int height, int zoo
 	while (i < length) {
 		ImageList list = toolDisabledImageList [i];
 		if (list == null) break;
-		Point size = list.getImageSize();
-		if (size.x == width && size.y == height) {
-			if (list.getStyle () == style) {
-				list.addRef();
-				return list;
-			}
+		if (list.isFittingFor(style, width, height, zoom)) {
+			list.addRef();
+			return list;
 		}
 		i++;
 	}
@@ -2135,12 +2126,9 @@ ImageList getImageListToolBarHot (int style, int width, int height, int zoom) {
 	while (i < length) {
 		ImageList list = toolHotImageList [i];
 		if (list == null) break;
-		Point size = list.getImageSize();
-		if (size.x == width && size.y == height) {
-			if (list.getStyle () == style) {
-				list.addRef();
-				return list;
-			}
+		if (list.isFittingFor(style, width, height, zoom)) {
+			list.addRef();
+			return list;
 		}
 		i++;
 	}


### PR DESCRIPTION
When requesting an ImageList from a Display, the zoom is currently not considered when scanning through the existing image lists for a matching one. This can lead to an image list with a wrong zoom being used, such that the contained image handles are not properly fitting in size and thus need to be scaled.

This changes includes the zoom into the identification of whether one of a Display's image lists fits to the requested properties or not. To this end, the whole validation logic is moved to the ImageList class itself, such that it's style and zoom do not need to be exposed unnecessarily.