### PR TITLE
[GTK] Scale external program icons to 16x16

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/gtk3.c
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/gtk3.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2025 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -1093,6 +1093,18 @@ JNIEXPORT jlong JNICALL GTK3_NATIVE(gtk_1icon_1theme_1lookup_1by_1gicon)
 	GTK3_NATIVE_ENTER(env, that, gtk_1icon_1theme_1lookup_1by_1gicon_FUNC);
 	rc = (jlong)gtk_icon_theme_lookup_by_gicon((GtkIconTheme *)arg0, (GIcon *)arg1, (gint)arg2, (GtkIconLookupFlags)arg3);
 	GTK3_NATIVE_EXIT(env, that, gtk_1icon_1theme_1lookup_1by_1gicon_FUNC);
+	return rc;
+}
+#endif
+
+#ifndef NO_gtk_1icon_1theme_1lookup_1by_1gicon_1for_1scale
+JNIEXPORT jlong JNICALL GTK3_NATIVE(gtk_1icon_1theme_1lookup_1by_1gicon_1for_1scale)
+	(JNIEnv *env, jclass that, jlong arg0, jlong arg1, jint arg2, jint arg3, jint arg4)
+{
+	jlong rc = 0;
+	GTK3_NATIVE_ENTER(env, that, gtk_1icon_1theme_1lookup_1by_1gicon_1for_1scale_FUNC);
+	rc = (jlong)gtk_icon_theme_lookup_by_gicon_for_scale((GtkIconTheme *)arg0, (GIcon *)arg1, (gint)arg2, (gint)arg3, (GtkIconLookupFlags)arg4);
+	GTK3_NATIVE_EXIT(env, that, gtk_1icon_1theme_1lookup_1by_1gicon_1for_1scale_FUNC);
 	return rc;
 }
 #endif

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/gtk3_stats.h
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/gtk3_stats.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2025 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -111,6 +111,7 @@ typedef enum {
 	gtk_1icon_1theme_1get_1default_FUNC,
 	gtk_1icon_1theme_1load_1icon_FUNC,
 	gtk_1icon_1theme_1lookup_1by_1gicon_FUNC,
+	gtk_1icon_1theme_1lookup_1by_1gicon_1for_1scale_FUNC,
 	gtk_1im_1context_1filter_1keypress_FUNC,
 	gtk_1image_1new_1from_1icon_1name_FUNC,
 	gtk_1image_1new_1from_1surface_FUNC,

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/org/eclipse/swt/internal/gtk3/GTK3.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/org/eclipse/swt/internal/gtk3/GTK3.java
@@ -795,6 +795,15 @@ public class GTK3 {
 	 * @param flags cast=(GtkIconLookupFlags)
 	 */
 	public static final native long gtk_icon_theme_lookup_by_gicon(long icon_theme, long icon, int size, int flags);
+	/* GtkIconTheme */
+	/**
+	 * @param icon_theme cast=(GtkIconTheme *)
+	 * @param icon cast=(GIcon *)
+	 * @param size cast=(gint)
+	 * @param scale cast=(gint)
+	 * @param flags cast=(GtkIconLookupFlags)
+	 */
+	public static final native long gtk_icon_theme_lookup_by_gicon_for_scale(long icon_theme, long icon, int size, int scale, int flags);
 	/**
 	 * @param icon_theme cast=(GtkIconTheme *)
 	 * @param icon_name cast=(const gchar *)

--- a/bundles/org.eclipse.swt/Eclipse SWT Program/gtk/org/eclipse/swt/program/Program.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Program/gtk/org/eclipse/swt/program/Program.java
@@ -168,7 +168,7 @@ public ImageData getImageData(int zoom) {
 			OS.g_object_unref(paintable);
 		} else {
 			long icon_theme = GTK3.gtk_icon_theme_get_default();
-			long gicon_info = GTK3.gtk_icon_theme_lookup_by_gicon(icon_theme, gicon, 16/*size*/, 0);
+			long gicon_info = GTK3.gtk_icon_theme_lookup_by_gicon_for_scale(icon_theme, gicon, 16/*size*/, 1/*scale*/, 0);
 			if (gicon_info != 0) {
 				pixbuf = GTK3.gtk_icon_info_load_icon(gicon_info, null);
 				OS.g_object_unref(gicon_info);
@@ -204,6 +204,10 @@ public ImageData getImageData(int zoom) {
 					}
 				}
 				data.alphaData = alphaData;
+				if (height > 16 && width > 16) {
+					ImageData scaled = data.scaledTo(16, 16);
+					data = scaled;
+				}
 			} else {
 				PaletteData palette = new PaletteData(0xFF0000, 0xFF00, 0xFF);
 				data = new ImageData(width, height, 24, palette, 4, srcData);


### PR DESCRIPTION
GTK3 API gtk_icon_theme_lookup_by_gicon() returns 48x48 icons, despite specifying size 16x16 in the arguments.

This change scales the retrieved icon to 16x16,
to avoid unexpected program icon sizes.

Fixes: #3003