### PR TITLE
[Win32] Initialize nativeZoom of TrayItem

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TrayItem.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TrayItem.java
@@ -79,6 +79,7 @@ public class TrayItem extends Item {
 public TrayItem (Tray parent, int style) {
 	super (parent, style);
 	this.parent = parent;
+	this.nativeZoom = display.getDeviceZoom();
 	parent.createItem (this, parent.getItemCount ());
 	createUpdateWidget (true);
 }


### PR DESCRIPTION
The Tray implementation uses the default constructor of the Widget class. When using that constructor, the nativeZoom of the widget is not initialized. In case of a Tray, contained TrayItems inherit that zoom and will fail to get an image set because the zoom is zero. With this change, TrayItem will initialize its native zoom based on the zoom of the context device.