### PR TITLE
[Win32] Update JavaDoc in GC.setXORMode() regarding limitation with GDI+

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/graphics/GC.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/graphics/GC.java
@@ -4035,14 +4035,22 @@ void setPatternPhase(Pattern pattern) {
 }
 
 /**
- * If the argument is <code>true</code>, puts the receiver
- * in a drawing mode where the resulting color in the destination
- * is the <em>exclusive or</em> of the color values in the source
- * and the destination, and if the argument is <code>false</code>,
- * puts the receiver in a drawing mode where the destination color
- * is replaced with the source color value.
+ * If the argument is <code>true</code>, puts the receiver in a drawing mode
+ * where the resulting color in the destination is the <em>exclusive or</em> of
+ * the color values in the source and the destination, and if the argument is
+ * <code>false</code>, puts the receiver in a drawing mode where the destination
+ * color is replaced with the source color value.
+ * <p>
+ * <b>IMPORTANT:</b> This operation may not work on every platform or with every
+ * configuration. Especially on Windows, GDI+ has no direct support for raster
+ * operations (ROPs). This means that advanced graphics must be <b>disabled</b>
+ * when using XOR mode. More specifically, this means that all operations that
+ * require advanced mode (e.g. {@link Transform}) can't be used in combination
+ * with XOR mode.
+ * </p>
  *
- * @param xor if <code>true</code>, then <em>xor</em> mode is used, otherwise <em>source copy</em> mode is used
+ * @param xor if <code>true</code>, then <em>xor</em> mode is used, otherwise
+ *            <em>source copy</em> mode is used
  *
  * @exception SWTException <ul>
  *    <li>ERROR_GRAPHIC_DISPOSED - if the receiver has been disposed</li>

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/graphics/GC.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/graphics/GC.java
@@ -3768,14 +3768,22 @@ public void setTransform(Transform transform) {
 }
 
 /**
- * If the argument is <code>true</code>, puts the receiver
- * in a drawing mode where the resulting color in the destination
- * is the <em>exclusive or</em> of the color values in the source
- * and the destination, and if the argument is <code>false</code>,
- * puts the receiver in a drawing mode where the destination color
- * is replaced with the source color value.
+ * If the argument is <code>true</code>, puts the receiver in a drawing mode
+ * where the resulting color in the destination is the <em>exclusive or</em> of
+ * the color values in the source and the destination, and if the argument is
+ * <code>false</code>, puts the receiver in a drawing mode where the destination
+ * color is replaced with the source color value.
+ * <p>
+ * <b>IMPORTANT:</b> This operation may not work on every platform or with every
+ * configuration. Especially on Windows, GDI+ has no direct support for raster
+ * operations (ROPs). This means that advanced graphics must be <b>disabled</b>
+ * when using XOR mode. More specifically, this means that all operations that
+ * require advanced mode (e.g. {@link Transform}) can't be used in combination
+ * with XOR mode.
+ * </p>
  *
- * @param xor if <code>true</code>, then <em>xor</em> mode is used, otherwise <em>source copy</em> mode is used
+ * @param xor if <code>true</code>, then <em>xor</em> mode is used, otherwise
+ *            <em>source copy</em> mode is used
  *
  * @exception SWTException <ul>
  *    <li>ERROR_GRAPHIC_DISPOSED - if the receiver has been disposed</li>

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/GC.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/GC.java
@@ -5707,14 +5707,22 @@ private void setLineWidthInPixels(int lineWidth) {
 }
 
 /**
- * If the argument is <code>true</code>, puts the receiver
- * in a drawing mode where the resulting color in the destination
- * is the <em>exclusive or</em> of the color values in the source
- * and the destination, and if the argument is <code>false</code>,
- * puts the receiver in a drawing mode where the destination color
- * is replaced with the source color value.
+ * If the argument is <code>true</code>, puts the receiver in a drawing mode
+ * where the resulting color in the destination is the <em>exclusive or</em> of
+ * the color values in the source and the destination, and if the argument is
+ * <code>false</code>, puts the receiver in a drawing mode where the destination
+ * color is replaced with the source color value.
+ * <p>
+ * <b>IMPORTANT:</b> This operation may not work on every platform or with every
+ * configuration. Especially on Windows, GDI+ has no direct support for raster
+ * operations (ROPs). This means that advanced graphics must be <b>disabled</b>
+ * when using XOR mode. More specifically, this means that all operations that
+ * require advanced mode (e.g. {@link Transform}) can't be used in combination
+ * with XOR mode.
+ * </p>
  *
- * @param xor if <code>true</code>, then <em>xor</em> mode is used, otherwise <em>source copy</em> mode is used
+ * @param xor if <code>true</code>, then <em>xor</em> mode is used, otherwise
+ *            <em>source copy</em> mode is used
  *
  * @exception SWTException <ul>
  *    <li>ERROR_GRAPHIC_DISPOSED - if the receiver has been disposed</li>


### PR DESCRIPTION
Enabling advanced mode causes SWT to switch from GDI to the GDI+. With GDI+, certain features, such as XOR, are not supported. This limitation should be documented.

Closes https://github.com/eclipse-platform/eclipse.platform.swt/issues/2984