### PR TITLE
[Win32] Fix default value for autoscale disablement propagation

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Control.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Control.java
@@ -1311,7 +1311,7 @@ public void setData(String key, Object value) {
 @Deprecated(since = "2026-03", forRemoval = true)
 private void updateAutoScalingModeFromData() {
 	Object propagateAutoscaleDisabled = getData(PROPOGATE_AUTOSCALE_DISABLED);
-	boolean propagateAutoscaling = propagateAutoscaleDisabled != null && Boolean.parseBoolean(propagateAutoscaleDisabled.toString());
+	boolean propagateAutoscaling = propagateAutoscaleDisabled == null || Boolean.parseBoolean(propagateAutoscaleDisabled.toString());
 	Object autoscaleDisabled = getData(DATA_AUTOSCALE_DISABLED);
 	boolean isAutoscaleDisabled = autoscaleDisabled != null && Boolean.parseBoolean(autoscaleDisabled.toString());
 	if (isAutoscaleDisabled) {


### PR DESCRIPTION
Autoscale disablement at the level of individual controls was recently made public API. With that change, the previous activation of that feature via hidden data fields on the controls was wrapped into a proper object-oriented representation. Previously, when not having the data field for propagation of autoscale disablement to children set, it was assumed to be activated by default. With the recent change, the default was accidentally changed, so that propagation to children is deactivated by default.

To preserve backward compatibility, this change restores the original behavior of propagating autoscale disablement to children in case the according data value is not set.

Regression can, e.g., be seen in GEF Classic (see https://github.com/eclipse-gef/gef-classic/issues/986).

### Before
<img width="257" height="251" alt="image" src="https://github.com/user-attachments/assets/be9d0604-dd52-4f38-b0ee-4073b0e72540" />

### After
<img width="250" height="218" alt="image" src="https://github.com/user-attachments/assets/6f5b42e4-cf6a-45a9-972b-f579b27ba619" />
