### PR TITLE
Fix improper ImageData size when loading SVG from InputStream #3011

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/graphics/Image.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/graphics/Image.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2025 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -1520,8 +1520,19 @@ private void initUsingImageDataProvider(ImageDataProvider imageDataProvider) {
 private static ImageDataProvider createImageDataProvider(InputStream stream) throws IOException {
 	byte[] streamData = stream.readAllBytes();
 	if (ImageDataLoader.isDynamicallySizable(new ByteArrayInputStream(streamData))) {
-		ImageDataAtSizeProvider imageDataAtSizeProvider = (width, height) -> ImageDataLoader
-				.loadBySize(new ByteArrayInputStream(streamData), width, height);
+		ImageDataAtSizeProvider imageDataAtSizeProvider = new ImageDataAtSizeProvider() {
+			@Override
+			public ImageData getImageData(int zoom) {
+				return ImageDataLoader
+						.loadByZoom(new ByteArrayInputStream(streamData), FileFormat.DEFAULT_ZOOM, zoom)
+						.element();
+			}
+
+			@Override
+			public ImageData getImageData(int width, int height) {
+				return ImageDataLoader.loadBySize(new ByteArrayInputStream(streamData), width, height);
+			}
+		};
 		return imageDataAtSizeProvider;
 	}
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/graphics/Image.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/graphics/Image.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2025 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -811,8 +811,19 @@ private void initFromImageDataProvider(int zoom) {
 private static ImageDataProvider createImageDataProvider(InputStream stream) throws IOException {
 	byte[] streamData = stream.readAllBytes();
 	if (ImageDataLoader.isDynamicallySizable(new ByteArrayInputStream(streamData))) {
-		ImageDataAtSizeProvider imageDataAtSizeProvider = (width, height) -> ImageDataLoader
-				.loadBySize(new ByteArrayInputStream(streamData), width, height);
+		ImageDataAtSizeProvider imageDataAtSizeProvider = new ImageDataAtSizeProvider() {
+			@Override
+			public ImageData getImageData(int zoom) {
+				return ImageDataLoader
+						.loadByZoom(new ByteArrayInputStream(streamData), FileFormat.DEFAULT_ZOOM, zoom)
+						.element();
+			}
+
+			@Override
+			public ImageData getImageData(int width, int height) {
+				return ImageDataLoader.loadBySize(new ByteArrayInputStream(streamData), width, height);
+			}
+		};
 		return imageDataAtSizeProvider;
 	}
 


### PR DESCRIPTION
On Linux, loading an `Image` from an `InputStream` is internally handled via an `ImageDataAtSizeProvider`.

When loading `ImageData` by zoom, this interface requires a proper implementation of the `getDefaultSize()` method, which in return requires the `ImageData` be loaded at 100% zoom, even when the source data is dynamically sizable. To avoid loading the same resource twice, this data is then used when requesting the `ImageData` with default size.

The tests have been updated to test the loading of an `Image` from an `InputStream` and to also check the size of the `ImageData` at 100% zoom.

Closes https://github.com/eclipse-platform/eclipse.platform.swt/issues/3011