### PR TITLE
Avoid unnecessary Point creation in ImageDataAtSizeProvider

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/ImageDataAtSizeProvider.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/ImageDataAtSizeProvider.java
@@ -45,7 +45,7 @@ public interface ImageDataAtSizeProvider extends ImageDataProvider {
 	@Override
 	default ImageData getImageData(int zoom) {
 		Point defaultSize = getDefaultSize();
-		if (new Point(-1, -1).equals(defaultSize)) {
+		if (defaultSize.x == -1 && defaultSize.y == -1) {
 			if (zoom == 100) {
 				return new ImageData(1, 1, 32, new PaletteData(0xFF0000, 0xFF00, 0xFF));
 			}


### PR DESCRIPTION
We can directly check the x and y coordinates of the default size, which avoids any additional noise for the JVM GC.