### PR TITLE
[Gtk4] Fix CTabItem close button Gtk-CRITICAL

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Control.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Control.java
@@ -1787,7 +1787,8 @@ public Point toDisplay (Point point) {
  */
 Point getControlOrigin() {
 	double[] originX = new double[1], originY = new double[1];
-	boolean success = GTK4.gtk_widget_translate_coordinates(fixedHandle, getShell().shellHandle, 0, 0, originX, originY);
+	long widgetHandle = fixedHandle != 0 ? fixedHandle: eventHandle();
+	boolean success = GTK4.gtk_widget_translate_coordinates(widgetHandle, getShell().shellHandle, 0, 0, originX, originY);
 
 	return success ? new Point((int)originX[0], (int)originY[0]) : new Point(0, 0);
 }


### PR DESCRIPTION
Clicking on CTabItem close button causes:
```
(SWT:2017253): Gtk-CRITICAL **: 21:06:02.496: gtk_widget_compute_point:
assertion 'GTK_IS_WIDGET (widget)' failed
```
In this case fixedHandle is 0 and eventHandle has to be used like in https://github.com/eclipse-platform/eclipse.platform.swt/pull/2940