### PR TITLE
[win32] Remove overwritten Control#isAutoScalable

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Control.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Control.java
@@ -1901,11 +1901,6 @@ boolean isActive () {
 	return shell.getEnabled ();
 }
 
-@Override
-public boolean isAutoScalable() {
-	return autoscalingMode == AutoscalingMode.ENABLED;
-}
-
 /**
  * Returns <code>true</code> if the receiver is enabled and all
  * ancestors up to and including the receiver's nearest ancestor


### PR DESCRIPTION
This commit removes the overwritten implementation of Control#isAutoScalable. This overwritten behavior can cause issues when double buffering with images is used to rendere onto an autoscaled control. This might be reintroduced when the inconsistency that leads to this issue is solved beforehand.

Fixes https://github.com/eclipse-gef/gef-classic/issues/993