### PR TITLE
[Win32] Refresh image created by GC when drawn onto another drawable

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/GC.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/GC.java
@@ -1215,6 +1215,10 @@ private class DrawScalingImageToImageOperation extends ImageOperation {
 		Rectangle fullImageBounds = image.getBounds();
 		Rectangle requestedFullImageBoundsPixels = Win32DPIUtils.pointToPixel(drawable, fullImageBounds, scaledImageZoomWithTransform);
 
+		// In case there is a memGC for the image, a handle at proper zoom can be created by reapplying the GC operation
+		if (image.memGC != null) {
+			image.getHandle(getZoom(), data.nativeZoom);
+		}
 		image.executeOnImageHandleAtBestFittingSize((tempHandle) -> {
 			Rectangle srcPixels = computeSourceRectangle(tempHandle, fullImageBounds, src);
 			drawImage(image, srcPixels.x, srcPixels.y, srcPixels.width, srcPixels.height, destPixels.x, destPixels.y, destPixels.width,
@@ -1291,6 +1295,10 @@ private class DrawScaledImageOperation extends ImageOperation {
 		Rectangle destPixelsScaledWithTransform = Win32DPIUtils.pointToPixel(drawable, new Rectangle(destX , destY, destWidth , destHeight),
 				scaledImageZoomWithTransform);
 
+		// In case there is a memGC for the image, a handle at proper zoom can be created by reapplying the GC operation
+		if (image.memGC != null) {
+			image.getHandle(getZoom(), data.nativeZoom);
+		}
 		image.executeOnImageHandleAtBestFittingSize(tempHandle -> {
 			drawImage(image, 0, 0, tempHandle.width(), tempHandle.height(), destPixels.x, destPixels.y,
 					destPixels.width, destPixels.height, false, tempHandle);


### PR DESCRIPTION
With the improvements to use/generate the best-fitting handle when drawing an image on some other drawable, the previous refresh of the image when being drawn by a GC was implicitly removed. In consequence, the image-to-be-drawn is not refreshed anymore for a zoom for which no handle exists yet, even though there is a GC that could recreate the image for that zoom.

With this change, in case a GC for the image-to-be-drawn is still active, the image will be requested for the zoom to be drawn at, such that the GC recreates a proper handle for that zoom.