### PR TITLE
[Win32] Update shell icons on DPI change asynchronously

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Decorations.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Decorations.java
@@ -1708,15 +1708,6 @@ LRESULT WM_WINDOWPOSCHANGING (long wParam, long lParam) {
 @Override
 void handleDPIChange(Event event, float scalingFactor) {
 	super.handleDPIChange(event, scalingFactor);
-	Image image = getImage();
-	if (image != null) {
-		setImage(image);
-	}
-
-	Image[] images = getImages();
-	if (images != null && images.length > 0) {
-		setImages(images);
-	}
 
 	Menu menuBar = getMenuBar();
 	if (menuBar != null) {
@@ -1730,5 +1721,21 @@ void handleDPIChange(Event event, float scalingFactor) {
 			}
 		}
 	}
+
+	display.asyncExec(() -> {
+		if (isDisposed()) {
+			return;
+		}
+
+		Image image = getImage();
+		if (image != null) {
+			setImage(image);
+		}
+
+		Image[] images = getImages();
+		if (images != null && images.length > 0) {
+			setImages(images);
+		}
+	});
 }
 }


### PR DESCRIPTION
When changing the zoom of the current monitor, the taskbar icon for an SWT application is not updated properly but is replaced with a generic executable icon and will only be replaced with the actual application after quite some time/interaction (if at all). This seems to be caused by some caching effects of the Windows explorer.

This change defers the refresh of the icons to be executed after all DPI change processing has been handled. This results in reliable updates of the application icon once the DPI change processing has finished.