### PR TITLE
Ensuring AdjustWindowRectExForDpi uses consistent zoom

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Control.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Control.java
@@ -6161,9 +6161,7 @@ int getSystemMetrics(int nIndex) {
 }
 
 boolean adjustWindowRectEx(RECT lpRect, int dwStyle, boolean bMenu, int dwExStyle) {
-	Shell shell = getShell();
-	int zoom = shell != null ? shell.getZoom() : nativeZoom;
-	return OS.AdjustWindowRectExForDpi (lpRect, dwStyle, bMenu, dwExStyle, DPIUtil.mapZoomToDPI(zoom));
+	return OS.AdjustWindowRectExForDpi (lpRect, dwStyle, bMenu, dwExStyle, DPIUtil.mapZoomToDPI(getShellZoom()));
 }
 
 private static void resizeFont(Control control, int newZoom) {


### PR DESCRIPTION
Changed Control.adjustWindowRectEx to use getShellZoom() instead of shell.getZoom(). This ensures consistency with nativeZoom which is used by computeTrim and other layout logic, preventing the possibility of incorrect
border sizing when shell.getZoom() and nativeZoom are out of sync