### PR TITLE
[Win32] Fix NPE when setting autoscale disablement on top-level control

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Control.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Control.java
@@ -1313,9 +1313,10 @@ private void updateAutoScalingModeFromData() {
 	Object propagateAutoscaleDisabled = getData(PROPOGATE_AUTOSCALE_DISABLED);
 	boolean propagateAutoscaling = propagateAutoscaleDisabled == null || Boolean.parseBoolean(propagateAutoscaleDisabled.toString());
 	Object autoscaleDisabled = getData(DATA_AUTOSCALE_DISABLED);
-	boolean isAutoscaleDisabled = autoscaleDisabled != null && Boolean.parseBoolean(autoscaleDisabled.toString()) || parent.autoscalingMode == AutoscalingMode.DISABLED_INHERITED;
+	boolean isAutoscaleDisabledOnControl = autoscaleDisabled != null && Boolean.parseBoolean(autoscaleDisabled.toString());
+	boolean isAutoscaleDisabledInheritedFromParent = parent != null && parent.autoscalingMode == AutoscalingMode.DISABLED_INHERITED;
 	AutoscalingMode newAutoscalingMode = AutoscalingMode.ENABLED;
-	if (isAutoscaleDisabled) {
+	if (isAutoscaleDisabledOnControl || isAutoscaleDisabledInheritedFromParent) {
 		newAutoscalingMode = propagateAutoscaling ? AutoscalingMode.DISABLED_INHERITED : AutoscalingMode.DISABLED;
 	}
 	setAutoscalingMode(newAutoscalingMode);


### PR DESCRIPTION
With a recent change, a check for autoscale disablement inheritance from parent was added without a check if there is a parent at all. This can lead to an NPE. This change fixes that.

Fixes https://github.com/eclipse-platform/eclipse.platform.swt/issues/3028