### PR TITLE
[Win32] Add test case to check auto-scaling mode calculation

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/widgets/ControlWin32Tests.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/widgets/ControlWin32Tests.java
@@ -369,4 +369,45 @@ class ControlWin32Tests {
 		assertEquals(300, childShell.getSizeInPixels().x);
 	}
 
+	@Test
+	public void testAutoScaleDisabledProperty() {
+		Display display = Display.getDefault();
+		Shell shell = new Shell(display);
+		shell.setData("AUTOSCALE_DISABLED", true);
+		assertEquals(AutoscalingMode.DISABLED_INHERITED, shell.autoscalingMode);
+		Composite child = new Composite(shell, SWT.NONE);
+		assertEquals(AutoscalingMode.DISABLED_INHERITED, child.autoscalingMode);
+	}
+
+	@Test
+	public void testAutoScaleDisabled() {
+		Display display = Display.getDefault();
+		Shell shell = new Shell(display);
+		shell.setAutoscalingMode(AutoscalingMode.DISABLED);
+		assertEquals(AutoscalingMode.DISABLED, shell.autoscalingMode);
+		Composite child = new Composite(shell, SWT.NONE);
+		assertEquals(AutoscalingMode.ENABLED, child.autoscalingMode);
+	}
+
+	@Test
+	public void testPropagateAutoScaleDisabledProperty() {
+		Display display = Display.getDefault();
+		Shell shell = new Shell(display);
+		shell.setData("AUTOSCALE_DISABLED", true);
+		shell.setData("PROPOGATE_AUTOSCALE_DISABLED", false);
+		assertEquals(AutoscalingMode.DISABLED, shell.autoscalingMode);
+		Composite child = new Composite(shell, SWT.NONE);
+		assertEquals(AutoscalingMode.ENABLED, child.autoscalingMode);
+	}
+
+	@Test
+	public void testPropagateAutoScaleDisabled() {
+		Display display = Display.getDefault();
+		Shell shell = new Shell(display);
+		shell.setAutoscalingMode(AutoscalingMode.DISABLED_INHERITED);
+		assertEquals(AutoscalingMode.DISABLED_INHERITED, shell.autoscalingMode);
+		Composite child = new Composite(shell, SWT.NONE);
+		assertEquals(AutoscalingMode.DISABLED_INHERITED, child.autoscalingMode);
+	}
+
 }


### PR DESCRIPTION
This adds test cases to check that the auto-scaling mode is correctly read from the widget data and correctly propagated to child widgets.