### PR TITLE
Reduce useless Point creation

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CTabFolder.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CTabFolder.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -3911,8 +3911,7 @@ boolean updateItems (int showIndex) {
 	setButtonBounds();
 	changed |= chevronChanged;
 	if (changed && getToolTipText() != null) {
-		Point pt = getDisplay().getCursorLocation();
-		pt = toControl(pt);
+		Point pt = toControl(getDisplay().getCursorLocation());
 		_setToolTipText(pt.x, pt.y);
 	}
 	gc.dispose();

--- a/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/common/org/eclipse/swt/dnd/DropTargetEffect.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/common/org/eclipse/swt/dnd/DropTargetEffect.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2007, 2008 IBM Corporation and others.
+ * Copyright (c) 2007, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -97,8 +97,7 @@ public class DropTargetEffect extends DropTargetAdapter {
 	}
 
 	Widget getItem(Table table, int x, int y) {
-		Point coordinates = new Point(x, y);
-		coordinates = table.toControl(coordinates);
+		Point coordinates = table.toControl(x, y);
 		TableItem item = table.getItem(coordinates);
 		if (item != null) return item;
 		Rectangle area = table.getClientArea();
@@ -116,8 +115,7 @@ public class DropTargetEffect extends DropTargetAdapter {
 	}
 
 	Widget getItem(Tree tree, int x, int y) {
-		Point point = new Point(x, y);
-		point = tree.toControl(point);
+		Point point = tree.toControl(x, y);
 		TreeItem item = tree.getItem(point);
 		if (item == null) {
 			Rectangle area = tree.getClientArea();

--- a/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/gtk/org/eclipse/swt/dnd/TableDropTargetEffect.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/gtk/org/eclipse/swt/dnd/TableDropTargetEffect.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2025 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -135,8 +135,7 @@ public class TableDropTargetEffect extends DropTargetEffect {
 		Table table = (Table) control;
 		long handle = table.handle;
 		int effect = checkEffect(event.feedback);
-		Point coordinates = new Point(event.x, event.y);
-		coordinates = table.toControl(coordinates);
+		Point coordinates = table.toControl(event.x, event.y);
 		long [] path = new long [1];
 		GTK.gtk_tree_view_get_path_at_pos (handle, coordinates.x, coordinates.y, path, null, null, null);
 		int index = -1;

--- a/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/gtk/org/eclipse/swt/dnd/TreeDropTargetEffect.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/gtk/org/eclipse/swt/dnd/TreeDropTargetEffect.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2025 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -149,8 +149,7 @@ public class TreeDropTargetEffect extends DropTargetEffect {
 		int effect = checkEffect(event.feedback);
 
 		long handle = tree.handle;
-		Point coordinates = new Point(event.x, event.y);
-		coordinates = tree.toControl(coordinates);
+		Point coordinates = tree.toControl(event.x, event.y);
 		long [] path = new long [1];
 		GTK.gtk_tree_view_get_path_at_pos (handle, coordinates.x, coordinates.y, path, null, null, null);
 		int index = -1;

--- a/bundles/org.eclipse.swt/Eclipse SWT/emulated/coolbar/org/eclipse/swt/widgets/CoolBar.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/emulated/coolbar/org/eclipse/swt/widgets/CoolBar.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -330,7 +330,7 @@ boolean insertItemIntoRow(CoolItem item, int rowIndex, int x_root) {
 	Rectangle bounds = items[rowIndex][0].internalGetBounds();
 	int rowY = bounds.y;
 	int oldRowHeight = bounds.height;
-	int x = Math.max(0, Math.abs(x_root - toDisplay(new Point(0, 0)).x));
+	int x = Math.max(0, Math.abs(x_root - toDisplay(0, 0).x));
 
 	/* Find the insertion index and add the item. */
 	int index;
@@ -604,7 +604,7 @@ void onMouseMove(Event event) {
 	fixEvent(event);
 	CoolItem grabbed = getGrabbedItem(event.x, event.y);
 	if (dragging != null) {
-		int left_root = toDisplay(new Point(event.x - itemXOffset, event.y)).x;
+		int left_root = toDisplay(event.x - itemXOffset, event.y).x;
 		Rectangle bounds = dragging.internalGetBounds();
 		if (event.y < bounds.y) {
 			moveUp(dragging, left_root);

--- a/examples/org.eclipse.swt.examples/src/org/eclipse/swt/examples/controlexample/CoolBarTab.java
+++ b/examples/org.eclipse.swt.examples/src/org/eclipse/swt/examples/controlexample/CoolBarTab.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2025 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -383,7 +383,7 @@ class CoolBarTab extends Tab {
 					final ToolBar  toolBar = toolItem.getParent();
 
 					Rectangle toolItemBounds = toolItem.getBounds();
-					Point point = toolBar.toDisplay(new Point(toolItemBounds.x, toolItemBounds.y));
+					Point point = toolBar.toDisplay(toolItemBounds.x, toolItemBounds.y);
 					menu.setLocation(point.x, point.y + toolItemBounds.height);
 					setMenuVisible(true);
 				}
@@ -429,7 +429,7 @@ class CoolBarTab extends Tab {
 				CoolItem coolItem = (CoolItem) event.widget;
 				Rectangle itemBounds = coolItem.getBounds ();
 				itemBounds.width = event.x - itemBounds.x;
-				Point pt = coolBar.toDisplay(new Point (itemBounds.x, itemBounds.y));
+				Point pt = coolBar.toDisplay(itemBounds.x, itemBounds.y);
 				itemBounds.x = pt.x;
 				itemBounds.y = pt.y;
 
@@ -444,7 +444,7 @@ class CoolBarTab extends Tab {
 				int i = 0;
 				while (i < toolCount) {
 					Rectangle toolBounds = tools[i].getBounds ();
-					pt = toolBar.toDisplay(new Point(toolBounds.x, toolBounds.y));
+					pt = toolBar.toDisplay(toolBounds.x, toolBounds.y);
 					toolBounds.x = pt.x;
 					toolBounds.y = pt.y;
 					Rectangle intersection = itemBounds.intersection (toolBounds);
@@ -490,7 +490,7 @@ class CoolBarTab extends Tab {
 				/* Display the pop-up menu at the lower left corner of the arrow button.
 				 * Dispose the menu when the user is done with it.
 				 */
-				pt = coolBar.toDisplay(new Point(event.x, event.y));
+				pt = coolBar.toDisplay(event.x, event.y);
 				menu.setLocation (pt.x, pt.y);
 				menu.setVisible (true);
 				while (menu != null && !menu.isDisposed() && menu.isVisible ()) {

--- a/examples/org.eclipse.swt.examples/src/org/eclipse/swt/examples/controlexample/TableTab.java
+++ b/examples/org.eclipse.swt.examples/src/org/eclipse/swt/examples/controlexample/TableTab.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -784,7 +784,7 @@ class TableTab extends ScrollableTab {
 	protected void specialPopupMenuItems(Menu menu, Event event) {
 		MenuItem item = new MenuItem(menu, SWT.PUSH);
 		item.setText("getItem(Point) on mouse coordinates");
-		menuMouseCoords = table1.toControl(new Point(event.x, event.y));
+		menuMouseCoords = table1.toControl(event.x, event.y);
 		item.addSelectionListener(widgetSelectedAdapter(e -> {
 			eventConsole.append ("getItem(Point(" + menuMouseCoords + ")) returned: " + table1.getItem(menuMouseCoords));
 			eventConsole.append ("\n");

--- a/examples/org.eclipse.swt.examples/src/org/eclipse/swt/examples/controlexample/ToolBarTab.java
+++ b/examples/org.eclipse.swt.examples/src/org/eclipse/swt/examples/controlexample/ToolBarTab.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2015 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -378,8 +378,8 @@ class ToolBarTab extends Tab {
 				final ToolItem toolItem = (ToolItem) event.widget;
 				final ToolBar  toolBar = toolItem.getParent();
 
-				Point point = toolBar.toDisplay(new Point(event.x, event.y));
-				menu.setLocation(point.x, point.y);
+				Point point = toolBar.toDisplay(event.x, event.y);
+				menu.setLocation(point);
 				menu.setVisible(true);
 			}
 		}

--- a/examples/org.eclipse.swt.examples/src/org/eclipse/swt/examples/controlexample/TreeTab.java
+++ b/examples/org.eclipse.swt.examples/src/org/eclipse/swt/examples/controlexample/TreeTab.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -869,7 +869,7 @@ class TreeTab extends ScrollableTab {
 		MenuItem item = new MenuItem(menu, SWT.PUSH);
 		item.setText("getItem(Point) on mouse coordinates");
 		final Tree t = (Tree) event.widget;
-		menuMouseCoords = t.toControl(new Point(event.x, event.y));
+		menuMouseCoords = t.toControl(event.x, event.y);
 		item.addSelectionListener(widgetSelectedAdapter(e -> {
 			eventConsole.append ("getItem(Point(" + menuMouseCoords + ")) returned: " + t.getItem(menuMouseCoords));
 			eventConsole.append ("\n");

--- a/examples/org.eclipse.swt.examples/src/org/eclipse/swt/examples/fileviewer/FileViewer.java
+++ b/examples/org.eclipse.swt.examples/src/org/eclipse/swt/examples/fileviewer/FileViewer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2025 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -45,7 +45,6 @@ import org.eclipse.swt.events.ShellListener;
 import org.eclipse.swt.events.TreeAdapter;
 import org.eclipse.swt.events.TreeEvent;
 import org.eclipse.swt.graphics.Image;
-import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.graphics.Rectangle;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
@@ -536,7 +535,7 @@ public class FileViewer {
 			}
 			private File getTargetFile(DropTargetEvent event) {
 				// Determine the target File for the drop
-				TreeItem item = tree.getItem(tree.toControl(new Point(event.x, event.y)));
+				TreeItem item = tree.getItem(tree.toControl(event.x, event.y));
 				File targetFile = null;
 				if (item != null) {
 					// We are over a particular item in the tree, use the item's file
@@ -845,7 +844,7 @@ public class FileViewer {
 			}
 			private File getTargetFile(DropTargetEvent event) {
 				// Determine the target File for the drop
-				TableItem item = table.getItem(table.toControl(new Point(event.x, event.y)));
+				TableItem item = table.getItem(table.toControl(event.x, event.y));
 				File targetFile = null;
 				if (item == null) {
 					// We are over an unoccupied area of the table.

--- a/examples/org.eclipse.swt.examples/src/org/eclipse/swt/examples/graphics/CustomAlphaTab.java
+++ b/examples/org.eclipse.swt.examples/src/org/eclipse/swt/examples/graphics/CustomAlphaTab.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2006, 2016 IBM Corporation and others.
+ * Copyright (c) 2006, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -113,7 +113,7 @@ public void createControlPanel(Composite parent) {
 		final Button button = (Button) event.widget;
 		final Composite parent1 = button.getParent();
 		Rectangle bounds = button.getBounds();
-		Point point = parent1.toDisplay(new Point(bounds.x, bounds.y));
+		Point point = parent1.toDisplay(bounds.x, bounds.y);
 		menu.setLocation(point.x, point.y + bounds.height);
 		menu.setVisible(true);
 	});

--- a/examples/org.eclipse.swt.examples/src/org/eclipse/swt/examples/graphics/CustomFontTab.java
+++ b/examples/org.eclipse.swt.examples/src/org/eclipse/swt/examples/graphics/CustomFontTab.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2006, 2016 IBM Corporation and others.
+ * Copyright (c) 2006, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -164,7 +164,7 @@ public void createControlPanel(Composite parent) {
 		final Button button = (Button) event.widget;
 		final Composite parent1 = button.getParent();
 		Rectangle bounds = button.getBounds();
-		Point point = parent1.toDisplay(new Point(bounds.x, bounds.y));
+		Point point = parent1.toDisplay(bounds.x, bounds.y);
 		menu.setLocation(point.x, point.y + bounds.height);
 		menu.setVisible(true);
 	});

--- a/examples/org.eclipse.swt.examples/src/org/eclipse/swt/examples/graphics/GradientDialog.java
+++ b/examples/org.eclipse.swt.examples/src/org/eclipse/swt/examples/graphics/GradientDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2006, 2020 IBM Corporation and others.
+ * Copyright (c) 2006, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -185,7 +185,7 @@ public class GradientDialog extends Dialog {
 			final Button button = (Button) event.widget;
 			final Composite parent1 = button.getParent();
 			Rectangle bounds = button.getBounds();
-			Point point = parent1.toDisplay(new Point(bounds.x, bounds.y));
+			Point point = parent1.toDisplay(bounds.x, bounds.y);
 			menu1.setLocation(point.x, point.y + bounds.height);
 			menu1.setVisible(true);
 		});
@@ -206,7 +206,7 @@ public class GradientDialog extends Dialog {
 			final Button button = (Button) event.widget;
 			final Composite parent1 = button.getParent();
 			Rectangle bounds = button.getBounds();
-			Point point = parent1.toDisplay(new Point(bounds.x, bounds.y));
+			Point point = parent1.toDisplay(bounds.x, bounds.y);
 			menu2.setLocation(point.x, point.y + bounds.height);
 			menu2.setVisible(true);
 		});

--- a/examples/org.eclipse.swt.examples/src/org/eclipse/swt/examples/graphics/GradientTab.java
+++ b/examples/org.eclipse.swt.examples/src/org/eclipse/swt/examples/graphics/GradientTab.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2006, 2016 IBM Corporation and others.
+ * Copyright (c) 2006, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -101,7 +101,7 @@ public void createControlPanel(final Composite parent) {
 		final ToolItem toolItem = (ToolItem) event.widget;
 		final ToolBar  toolBar = toolItem.getParent();
 		Rectangle toolItemBounds = toolItem.getBounds();
-		Point point = toolBar.toDisplay(new Point(toolItemBounds.x, toolItemBounds.y));
+		Point point = toolBar.toDisplay(toolItemBounds.x, toolItemBounds.y);
 		menu1.setLocation(point.x, point.y + toolItemBounds.height);
 		menu1.setVisible(true);
 	});
@@ -124,7 +124,7 @@ public void createControlPanel(final Composite parent) {
 		final ToolItem toolItem = (ToolItem) event.widget;
 		final ToolBar  toolBar = toolItem.getParent();
 		Rectangle toolItemBounds = toolItem.getBounds();
-		Point point = toolBar.toDisplay(new Point(toolItemBounds.x, toolItemBounds.y));
+		Point point = toolBar.toDisplay(toolItemBounds.x, toolItemBounds.y);
 		menu2.setLocation(point.x, point.y + toolItemBounds.height);
 		menu2.setVisible(true);
 	});

--- a/examples/org.eclipse.swt.examples/src/org/eclipse/swt/examples/graphics/GraphicAntialiasTab.java
+++ b/examples/org.eclipse.swt.examples/src/org/eclipse/swt/examples/graphics/GraphicAntialiasTab.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2006, 2016 IBM Corporation and others.
+ * Copyright (c) 2006, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -109,7 +109,7 @@ public void createControlPanel(Composite parent) {
 		final Button button = (Button) event.widget;
 		final Composite parent1 = button.getParent();
 		Rectangle bounds = button.getBounds();
-		Point point = parent1.toDisplay(new Point(bounds.x, bounds.y));
+		Point point = parent1.toDisplay(bounds.x, bounds.y);
 		menu.setLocation(point.x, point.y + bounds.height);
 		menu.setVisible(true);
 	});

--- a/examples/org.eclipse.swt.examples/src/org/eclipse/swt/examples/graphics/GraphicsExample.java
+++ b/examples/org.eclipse.swt.examples/src/org/eclipse/swt/examples/graphics/GraphicsExample.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2025 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -301,7 +301,7 @@ void createToolBar(final Composite parent) {
 			final ToolItem toolItem = (ToolItem) event.widget;
 			final ToolBar  toolBar = toolItem.getParent();
 			Rectangle toolItemBounds = toolItem.getBounds();
-			Point point = toolBar.toDisplay(new Point(toolItemBounds.x, toolItemBounds.y));
+			Point point = toolBar.toDisplay(toolItemBounds.x, toolItemBounds.y);
 			backMenu.setLocation(point.x, point.y + toolItemBounds.height);
 			backMenu.setVisible(true);
 		}

--- a/examples/org.eclipse.swt.examples/src/org/eclipse/swt/examples/graphics/LineCapTab.java
+++ b/examples/org.eclipse.swt.examples/src/org/eclipse/swt/examples/graphics/LineCapTab.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2006, 2016 IBM Corporation and others.
+ * Copyright (c) 2006, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -91,7 +91,7 @@ public void createControlPanel(Composite parent) {
 		final Button button = (Button) event.widget;
 		final Composite parent1 = button.getParent();
 		Rectangle bounds = button.getBounds();
-		Point point = parent1.toDisplay(new Point(bounds.x, bounds.y));
+		Point point = parent1.toDisplay(bounds.x, bounds.y);
 		menu.setLocation(point.x, point.y + bounds.height);
 		menu.setVisible(true);
 	});

--- a/examples/org.eclipse.swt.examples/src/org/eclipse/swt/examples/graphics/LineJoinTab.java
+++ b/examples/org.eclipse.swt.examples/src/org/eclipse/swt/examples/graphics/LineJoinTab.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2006, 2016 IBM Corporation and others.
+ * Copyright (c) 2006, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -110,7 +110,7 @@ public void createControlPanel(Composite parent) {
 		final Button button = (Button) event.widget;
 		final Composite parent1 = button.getParent();
 		Rectangle bounds = button.getBounds();
-		Point point = parent1.toDisplay(new Point(bounds.x, bounds.y));
+		Point point = parent1.toDisplay(bounds.x, bounds.y);
 		menu.setLocation(point.x, point.y + bounds.height);
 		menu.setVisible(true);
 	});

--- a/examples/org.eclipse.swt.examples/src/org/eclipse/swt/examples/graphics/LineStyleTab.java
+++ b/examples/org.eclipse.swt.examples/src/org/eclipse/swt/examples/graphics/LineStyleTab.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2006, 2016 IBM Corporation and others.
+ * Copyright (c) 2006, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -106,7 +106,7 @@ public void createControlPanel(Composite parent) {
 		final Button button = (Button) event.widget;
 		final Composite parent1 = button.getParent();
 		Rectangle bounds = button.getBounds();
-		Point point = parent1.toDisplay(new Point(bounds.x, bounds.y));
+		Point point = parent1.toDisplay(bounds.x, bounds.y);
 		menu.setLocation(point.x, point.y + bounds.height);
 		menu.setVisible(true);
 	});

--- a/examples/org.eclipse.swt.examples/src/org/eclipse/swt/examples/graphics/PathClippingAnimTab.java
+++ b/examples/org.eclipse.swt.examples/src/org/eclipse/swt/examples/graphics/PathClippingAnimTab.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2006, 2016 IBM Corporation and others.
+ * Copyright (c) 2006, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -98,7 +98,7 @@ public class PathClippingAnimTab extends AnimatedGraphicsTab {
 			final Button button = (Button) event.widget;
 			final Composite parent1 = button.getParent();
 			Rectangle bounds = button.getBounds();
-			Point point = parent1.toDisplay(new Point(bounds.x, bounds.y));
+			Point point = parent1.toDisplay(bounds.x, bounds.y);
 			menu.setLocation(point.x, point.y + bounds.height);
 			menu.setVisible(true);
 		});

--- a/examples/org.eclipse.swt.examples/src/org/eclipse/swt/examples/graphics/PathClippingTab.java
+++ b/examples/org.eclipse.swt.examples/src/org/eclipse/swt/examples/graphics/PathClippingTab.java
@@ -114,7 +114,7 @@ public void createControlPanel(Composite parent) {
 		final Button button = (Button) event.widget;
 		final Composite parent1 = button.getParent();
 		Rectangle bounds = button.getBounds();
-		Point point = parent1.toDisplay(new Point(bounds.x, bounds.y));
+		Point point = parent1.toDisplay(bounds.x, bounds.y);
 		menu.setLocation(point.x, point.y + bounds.height);
 		menu.setVisible(true);
 	});

--- a/examples/org.eclipse.swt.examples/src/org/eclipse/swt/examples/graphics/PathTab.java
+++ b/examples/org.eclipse.swt.examples/src/org/eclipse/swt/examples/graphics/PathTab.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2006, 2016 IBM Corporation and others.
+ * Copyright (c) 2006, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -117,7 +117,7 @@ public void createControlPanel(Composite parent) {
 		final Button button = (Button) event.widget;
 		final Composite parent1 = button.getParent();
 		Rectangle bounds = button.getBounds();
-		Point point = parent1.toDisplay(new Point(bounds.x, bounds.y));
+		Point point = parent1.toDisplay(bounds.x, bounds.y);
 		menu.setLocation(point.x, point.y + bounds.height);
 		menu.setVisible(true);
 	});

--- a/examples/org.eclipse.swt.examples/src/org/eclipse/swt/examples/graphics/RegionClippingTab.java
+++ b/examples/org.eclipse.swt.examples/src/org/eclipse/swt/examples/graphics/RegionClippingTab.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2006, 2016 IBM Corporation and others.
+ * Copyright (c) 2006, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -119,7 +119,7 @@ public void createControlPanel(Composite parent) {
 		final Button button = (Button) event.widget;
 		final Composite parent1 = button.getParent();
 		Rectangle bounds = button.getBounds();
-		Point point = parent1.toDisplay(new Point(bounds.x, bounds.y));
+		Point point = parent1.toDisplay(bounds.x, bounds.y);
 		menu1.setLocation(point.x, point.y + bounds.height);
 		menu1.setVisible(true);
 	});
@@ -136,7 +136,7 @@ public void createControlPanel(Composite parent) {
 		final Button button = (Button) event.widget;
 		final Composite parent1 = button.getParent();
 		Rectangle bounds = button.getBounds();
-		Point point = parent1.toDisplay(new Point(bounds.x, bounds.y));
+		Point point = parent1.toDisplay(bounds.x, bounds.y);
 		menu2.setLocation(point.x, point.y + bounds.height);
 		menu2.setVisible(true);
 	});

--- a/examples/org.eclipse.swt.examples/src/org/eclipse/swt/examples/graphics/SpiralTab.java
+++ b/examples/org.eclipse.swt.examples/src/org/eclipse/swt/examples/graphics/SpiralTab.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2006, 2016 IBM Corporation and others.
+ * Copyright (c) 2006, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -98,7 +98,7 @@ public void createControlPanel(Composite parent) {
 		final Button button = (Button) event.widget;
 		final Composite parent1 = button.getParent();
 		Rectangle bounds = button.getBounds();
-		Point point = parent1.toDisplay(new Point(bounds.x, bounds.y));
+		Point point = parent1.toDisplay(bounds.x, bounds.y);
 		menu.setLocation(point.x, point.y + bounds.height);
 		menu.setVisible(true);
 	});

--- a/examples/org.eclipse.swt.examples/src/org/eclipse/swt/examples/graphics/TextAntialiasTab.java
+++ b/examples/org.eclipse.swt.examples/src/org/eclipse/swt/examples/graphics/TextAntialiasTab.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2006, 2016 IBM Corporation and others.
+ * Copyright (c) 2006, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -110,7 +110,7 @@ public void createControlPanel(Composite parent) {
 		final Button button = (Button) event.widget;
 		final Composite parent1 = button.getParent();
 		Rectangle bounds = button.getBounds();
-		Point point = parent1.toDisplay(new Point(bounds.x, bounds.y));
+		Point point = parent1.toDisplay(bounds.x, bounds.y);
 		menu.setLocation(point.x, point.y + bounds.height);
 		menu.setVisible(true);
 	});

--- a/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet140.java
+++ b/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet140.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -63,7 +63,7 @@ public static void main (String [] args) {
 			if (event.detail == SWT.ARROW) {
 				CoolItem item = (CoolItem) event.widget;
 				Rectangle itemBounds = item.getBounds();
-				Point pt = coolBar.toDisplay(new Point(itemBounds.x, itemBounds.y));
+				Point pt = coolBar.toDisplay(itemBounds.x, itemBounds.y);
 				itemBounds.x = pt.x;
 				itemBounds.y = pt.y;
 				ToolBar bar = (ToolBar) item.getControl();
@@ -72,7 +72,7 @@ public static void main (String [] args) {
 				int i = 0;
 				while (i < tools.length) {
 					Rectangle toolBounds = tools[i].getBounds();
-					pt = bar.toDisplay(new Point(toolBounds.x, toolBounds.y));
+					pt = bar.toDisplay(toolBounds.x, toolBounds.y);
 					toolBounds.x = pt.x;
 					toolBounds.y = pt.y;
 
@@ -109,8 +109,8 @@ public static void main (String [] args) {
 				 * Drop down the menu below the chevron, with the left edges
 				 * aligned.
 				 */
-				pt = coolBar.toDisplay(new Point(event.x, event.y));
-				chevronMenu.setLocation(pt.x, pt.y);
+				pt = coolBar.toDisplay(event.x, event.y);
+				chevronMenu.setLocation(pt);
 				chevronMenu.setVisible(true);
 			}
 		}));

--- a/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet67.java
+++ b/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet67.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -41,9 +41,8 @@ public static void main (String [] args) {
 	item.addListener (SWT.Selection, event -> {
 		if (event.detail == SWT.ARROW) {
 			Rectangle rect = item.getBounds ();
-			Point pt = new Point (rect.x, rect.y + rect.height);
-			pt = toolBar.toDisplay (pt);
-			menu.setLocation (pt.x, pt.y);
+			Point pt = toolBar.toDisplay (rect.x, rect.y + rect.height);
+			menu.setLocation (pt);
 			menu.setVisible (true);
 		}
 	});

--- a/tests/org.eclipse.swt.tests.cocoa/ManualTests/org/eclipse/swt/tests/cocoa/snippets/Bug577767_macOS_TableScrollsPastContent.java
+++ b/tests/org.eclipse.swt.tests.cocoa/ManualTests/org/eclipse/swt/tests/cocoa/snippets/Bug577767_macOS_TableScrollsPastContent.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Syntevo and others.
+ * Copyright (c) 2021, 2026 Syntevo and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -14,11 +14,18 @@
 
 package org.eclipse.swt.tests.cocoa.snippets;
 
-import org.eclipse.swt.*;
-import org.eclipse.swt.graphics.Point;
+import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Rectangle;
-import org.eclipse.swt.layout.*;
-import org.eclipse.swt.widgets.*;
+import org.eclipse.swt.layout.FillLayout;
+import org.eclipse.swt.layout.GridLayout;
+import org.eclipse.swt.widgets.Button;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Label;
+import org.eclipse.swt.widgets.Shell;
+import org.eclipse.swt.widgets.Table;
+import org.eclipse.swt.widgets.TableItem;
+import org.eclipse.swt.widgets.Tree;
+import org.eclipse.swt.widgets.TreeItem;
 
 public final class Bug577767_macOS_TableScrollsPastContent {
 	public static void testTable(Button button, boolean isVirtual) {
@@ -53,7 +60,7 @@ public final class Bug577767_macOS_TableScrollsPastContent {
 		// A way to get rid of popup for convenience of testing
 		table.addListener (SWT.MouseDown, e -> popup.dispose ());
 
-		popup.setLocation (button.toDisplay (new Point (20, 20)));
+		popup.setLocation (button.toDisplay (20, 20));
 		popup.setSize (200, 200);
 		popup.open ();
 	}
@@ -90,7 +97,7 @@ public final class Bug577767_macOS_TableScrollsPastContent {
 		// A way to get rid of popup for convenience of testing
 		tree.addListener (SWT.MouseDown, e -> popup.dispose ());
 
-		popup.setLocation (button.toDisplay (new Point (20, 20)));
+		popup.setLocation (button.toDisplay (20, 20));
 		popup.setSize (200, 200);
 		popup.open ();
 	}

--- a/tests/org.eclipse.swt.tests.gtk/ManualTests/org/eclipse/swt/tests/gtk/snippets/Bug186038_DNDActivateEvent.java
+++ b/tests/org.eclipse.swt.tests.gtk/ManualTests/org/eclipse/swt/tests/gtk/snippets/Bug186038_DNDActivateEvent.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Red Hat and others. All rights reserved.
+ * Copyright (c) 2018, 2026 Red Hat and others. All rights reserved.
  * The contents of this file are made available under the terms
  * of the GNU Lesser General Public License (LGPL) Version 2.1 that
  * accompanies this distribution (lgpl-v21.txt).  The LGPL is also
@@ -167,8 +167,8 @@ public class Bug186038_DNDActivateEvent {
 			dropDownShell.setText("This is a drop down widget.shell");
 			dropDownShell.setSize(100, 200);
 			Rectangle buttonRect = button1.getBounds();
-			Point p = button1.getParent().toDisplay(new Point(buttonRect.x, buttonRect.y + buttonRect.height));
-			dropDownShell.setLocation(p.x, p.y);
+			Point p = button1.getParent().toDisplay(buttonRect.x, buttonRect.y + buttonRect.height);
+			dropDownShell.setLocation(p);
 			dropDownShell.setVisible(true);
 			dropDownShell.setFocus();
 		}

--- a/tests/org.eclipse.swt.tests.gtk/ManualTests/org/eclipse/swt/tests/gtk/snippets/Bug306067_DesktopEffectShellEvent.java
+++ b/tests/org.eclipse.swt.tests.gtk/ManualTests/org/eclipse/swt/tests/gtk/snippets/Bug306067_DesktopEffectShellEvent.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Red Hat and others. All rights reserved.
+ * Copyright (c) 2018, 2026 Red Hat and others. All rights reserved.
  * The contents of this file are made available under the terms
  * of the GNU Lesser General Public License (LGPL) Version 2.1 that
  * accompanies this distribution (lgpl-v21.txt).  The LGPL is also
@@ -104,8 +104,8 @@ public class Bug306067_DesktopEffectShellEvent {
 			dropDownShell.setText("This is a drop down shell");
 			dropDownShell.setSize(100, 200);
 			Rectangle buttonRect = button.getBounds();
-			Point p = button.getParent().toDisplay(new Point(buttonRect.x, buttonRect.y + buttonRect.height));
-			dropDownShell.setLocation(p.x, p.y);
+			Point p = button.getParent().toDisplay(buttonRect.x, buttonRect.y + buttonRect.height);
+			dropDownShell.setLocation(p);
 			dropDownShell.setVisible(true);
 			dropDownShell.setFocus();
 		}

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_CoolBar.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_CoolBar.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -166,7 +166,7 @@ class CoolItemSelectionListener extends SelectionAdapter {
 			CoolItem coolItem = (CoolItem) event.widget;
 			Rectangle itemBounds = coolItem.getBounds ();
 			itemBounds.width = event.x - itemBounds.x;
-			Point pt = coolBar.toDisplay(new Point (itemBounds.x, itemBounds.y));
+			Point pt = coolBar.toDisplay(itemBounds.x, itemBounds.y);
 			itemBounds.x = pt.x;
 			itemBounds.y = pt.y;
 
@@ -181,7 +181,7 @@ class CoolItemSelectionListener extends SelectionAdapter {
 			int i = 0;
 			while (i < toolCount) {
 				Rectangle toolBounds = tools[i].getBounds ();
-				pt = toolBar.toDisplay(new Point(toolBounds.x, toolBounds.y));
+				pt = toolBar.toDisplay(toolBounds.x, toolBounds.y);
 				toolBounds.x = pt.x;
 				toolBounds.y = pt.y;
 				Rectangle intersection = itemBounds.intersection (toolBounds);
@@ -201,8 +201,8 @@ class CoolItemSelectionListener extends SelectionAdapter {
 			/* Display the pop-up menu at the lower left corner of the arrow button.
 			 * Dispose the menu when the user is done with it.
 			 */
-			pt = coolBar.toDisplay(new Point(event.x, event.y));
-			menu.setLocation (pt.x, pt.y);
+			pt = coolBar.toDisplay(event.x, event.y);
+			menu.setLocation (pt);
 			menu.setVisible (true);
 			Display display = coolBar.getDisplay ();
 			while (menu != null && !menu.isDisposed() && menu.isVisible ()) {


### PR DESCRIPTION
Calling methods with method(new Point(x,y)) when there is an override method(x,y) that is simply called by the former one just generates noise.