### PR TITLE
[Gtk] Remove Control.toDisplayInPixel

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Control.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Control.java
@@ -1735,26 +1735,6 @@ public Point toDisplay(int x, int y) {
 	return new Point(x, y);
 }
 
-Point toDisplayInPixels(int x, int y) {
-	checkWidget();
-
-	int[] origin_x = new int[1], origin_y = new int[1];
-	if (GTK.GTK4) {
-		Point origin = getControlOrigin();
-		origin_x[0] = origin.x;
-		origin_y[0] = origin.y;
-	} else {
-		long window = eventWindow();
-		GDK.gdk_window_get_origin(window, origin_x, origin_y);
-	}
-
-	if ((style & SWT.MIRRORED) != 0) x = getClientWidth() - x;
-	x += origin_x[0];
-	y += origin_y[0];
-
-	return new Point(x, y);
-}
-
 /**
  * Returns a point which is the result of converting the
  * argument, which is specified in coordinates relative to

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Sash.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Sash.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2025 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -522,7 +522,7 @@ long gtk3_key_press_event(long widget, long eventPtr) {
 				} else {
 					cursorX += width / 2;
 				}
-				display.setCursorLocation(parent.toDisplayInPixels(cursorX, cursorY));
+				display.setCursorLocation(parent.toDisplay(cursorX, cursorY));
 			}
 			break;
 	}


### PR DESCRIPTION
It's package private and a duplicate of the public toDisplay.