### PR TITLE
[Win32] Check widget for disposal before zoom change notification

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CCombo.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CCombo.java
@@ -2039,17 +2039,16 @@ public boolean traverse(int event){
 }
 
 private void handleDPIChange(Event event) {
-	if (text != null) {
-		text.notifyListeners(SWT.ZoomChanged, event);
-	}
-	if (list != null) {
-		list.notifyListeners(SWT.ZoomChanged, event);
-	}
-	if (arrow != null) {
-		arrow.notifyListeners(SWT.ZoomChanged, event);
-	}
-	if (popup != null) {
-		popup.notifyListeners(SWT.ZoomChanged, event);
+	forwardDPIChange(event, text);
+	forwardDPIChange(event, list);
+	forwardDPIChange(event, arrow);
+	forwardDPIChange(event, popup);
+}
+
+private void forwardDPIChange(Event event, Widget widget) {
+	if (widget != null && !widget.isDisposed()) {
+		widget.notifyListeners(SWT.ZoomChanged, event);
 	}
 }
+
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/StyledText.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/StyledText.java
@@ -10932,9 +10932,11 @@ private void handleDPIChange(Event event) {
 			caretSet.add(caret);
 		}
 	}
-	caretSet.stream().filter(Objects::nonNull).forEach(caretToRefresh -> {
-		caretToRefresh.notifyListeners(SWT.ZoomChanged, event);
-	});
+	for (Caret caretToRefresh : caretSet) {
+		if (caretToRefresh != null && !caretToRefresh.isDisposed()) {
+			caretToRefresh.notifyListeners(SWT.ZoomChanged, event);
+		}
+	}
 }
 
 @Override

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/CoolBar.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/CoolBar.java
@@ -1222,7 +1222,7 @@ void handleDPIChange(Event event, float scalingFactor) {
 		CoolItem item = items[index];
 
 		Control control = item.control;
-		if (control != null) {
+		if (control != null && !control.isDisposed()) {
 			control.notifyListeners(SWT.ZoomChanged, event);
 			item.setControl(control);
 		}

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Decorations.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Decorations.java
@@ -1710,13 +1710,13 @@ void handleDPIChange(Event event, float scalingFactor) {
 	super.handleDPIChange(event, scalingFactor);
 
 	Menu menuBar = getMenuBar();
-	if (menuBar != null) {
+	if (menuBar != null && !menuBar.isDisposed()) {
 		menuBar.notifyListeners(SWT.ZoomChanged, event);
 	}
 
 	if (menus != null) {
 		for (Menu menu : menus) {
-			if (menu != null) {
+			if (menu != null && !menu.isDisposed()) {
 				menu.notifyListeners(SWT.ZoomChanged, event);
 			}
 		}

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ExpandBar.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ExpandBar.java
@@ -873,7 +873,9 @@ LRESULT wmScroll (ScrollBar bar, boolean update, long hwnd, int msg, long wParam
 void handleDPIChange(Event event, float scalingFactor) {
 	super.handleDPIChange(event, scalingFactor);
 	for (ExpandItem item : getItems()) {
-		item.notifyListeners(SWT.ZoomChanged, event);
+		if (item != null && !item.isDisposed()) {
+			item.notifyListeners(SWT.ZoomChanged, event);
+		}
 	}
 	layoutItems(0, true);
 	redraw();

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Menu.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Menu.java
@@ -1366,7 +1366,9 @@ LRESULT wmTimer (long wParam, long lParam) {
 void handleDPIChange(Event event, float scalingFactor) {
 	super.handleDPIChange(event, scalingFactor);
 	for (MenuItem item : getItems()) {
-		item.notifyListeners(SWT.ZoomChanged, event);
+		if (item != null && !item.isDisposed()) {
+			item.notifyListeners(SWT.ZoomChanged, event);
+		}
 	}
 }
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/MenuItem.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/MenuItem.java
@@ -1465,7 +1465,7 @@ void handleDPIChange(Event event, float scalingFactor) {
 	}
 	// Refresh the sub menu
 	Menu subMenu = getMenu();
-	if (subMenu != null) {
+	if (subMenu != null && !subMenu.isDisposed()) {
 		subMenu.notifyListeners(SWT.ZoomChanged, event);
 	}
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TabFolder.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TabFolder.java
@@ -1136,7 +1136,9 @@ void handleDPIChange(Event event, float scalingFactor) {
 		imageList = null;
 	}
 	for (int i = 0; i < getItemCount(); i++) {
-		items[i].notifyListeners(SWT.ZoomChanged, event);
+		if (items[i] != null && !items[i].isDisposed()) {
+			items[i].notifyListeners(SWT.ZoomChanged, event);
+		}
 	}
 }
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Table.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Table.java
@@ -7384,10 +7384,14 @@ void handleDPIChange(Event event, float scalingFactor) {
 	setItemHeight(-1);
 
 	for (TableItem item : getItems()) {
-		item.notifyListeners(SWT.ZoomChanged, event);
+		if (item != null && !item.isDisposed()) {
+			item.notifyListeners(SWT.ZoomChanged, event);
+		}
 	}
 	for (TableColumn tableColumn : getColumns()) {
-		tableColumn.notifyListeners(SWT.ZoomChanged, event);
+		if (tableColumn != null && !tableColumn.isDisposed()) {
+			tableColumn.notifyListeners(SWT.ZoomChanged, event);
+		}
 	}
 
 	if (getColumns().length == 0 && scrollWidth != 0) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Tree.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Tree.java
@@ -8317,10 +8317,14 @@ void handleDPIChange(Event event, float scalingFactor) {
 	setItemHeight(-1);
 
 	for (TreeColumn treeColumn : getColumns()) {
-		treeColumn.notifyListeners(SWT.ZoomChanged, event);
+		if (treeColumn != null && !treeColumn.isDisposed()) {
+			treeColumn.notifyListeners(SWT.ZoomChanged, event);
+		}
 	}
 	for (TreeItem item : getItems()) {
-		item.notifyListeners(SWT.ZoomChanged, event);
+		if (item != null && !item.isDisposed()) {
+			item.notifyListeners(SWT.ZoomChanged, event);
+		}
 	}
 
 	calculateAndApplyIndentSize();

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TreeItem.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TreeItem.java
@@ -1826,7 +1826,9 @@ void handleDPIChange(Event event, float scalingFactor) {
 		}
 	}
 	for (TreeItem item : getItems()) {
-		item.notifyListeners(SWT.ZoomChanged, event);
+		if (item != null && !item.isDisposed()) {
+			item.notifyListeners(SWT.ZoomChanged, event);
+		}
 	}
 }
 }


### PR DESCRIPTION
In most scenarios, zoom change processing happens asynchronously. In consequence, widgets may evolve and even already be disposed until a notification for a zoom change event on them actually is processed. This can lead to disposed widget exceptions in case such a notification is sent on an already disposed widget.

This change adapts all places that send zoom change notification on DPI change to check for disposal of the widget to send the notification to first.

Fixes https://github.com/eclipse-platform/eclipse.platform.swt/issues/3043