### PR TITLE
Make PDFDocument extend Device instead of implementing Drawable

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Printing/cocoa/org/eclipse/swt/printing/PDFDocument.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Printing/cocoa/org/eclipse/swt/printing/PDFDocument.java
@@ -43,14 +43,15 @@ import org.eclipse.swt.internal.cocoa.*;
  *
  * @see GC
  * @since 3.133
+ *
+ * @noreference This class is provisional API and subject to change. It is being made available to gather early feedback. The API or behavior may change in future releases as the implementation evolves based on user feedback.
  */
-public class PDFDocument implements Drawable {
-	Device device;
+public final class PDFDocument extends Device {
 	long pdfContext;
 	NSGraphicsContext graphicsContext;
 	boolean isGCCreated = false;
-	boolean disposed = false;
 	boolean pageStarted = false;
+	String filename;
 
 	/**
 	 * Width of the page in points (1/72 inch)
@@ -61,6 +62,16 @@ public class PDFDocument implements Drawable {
 	 * Height of the page in points (1/72 inch)
 	 */
 	double heightInPoints;
+
+	/**
+	 * Internal data class to pass PDF document parameters through
+	 * the Device constructor.
+	 */
+	static class PDFDocumentData extends DeviceData {
+		String filename;
+		double widthInPoints;
+		double heightInPoints;
+	}
 
 	/**
 	 * Constructs a new PDFDocument with the specified filename and page dimensions.
@@ -83,52 +94,38 @@ public class PDFDocument implements Drawable {
 	 * @see #dispose()
 	 */
 	public PDFDocument(String filename, double widthInPoints, double heightInPoints) {
-		this(null, filename, widthInPoints, heightInPoints);
+		super(checkData(filename, widthInPoints, heightInPoints));
 	}
 
 	/**
-	 * Constructs a new PDFDocument with the specified filename and page dimensions,
-	 * associated with the given device.
-	 * <p>
-	 * You must dispose the PDFDocument when it is no longer required.
-	 * </p>
-	 *
-	 * @param device the device to associate with this PDFDocument
-	 * @param filename the path to the PDF file to create
-	 * @param widthInPoints the width of each page in points (1/72 inch)
-	 * @param heightInPoints the height of each page in points (1/72 inch)
-	 *
-	 * @exception IllegalArgumentException <ul>
-	 *    <li>ERROR_NULL_ARGUMENT - if filename is null</li>
-	 *    <li>ERROR_INVALID_ARGUMENT - if width or height is not positive</li>
-	 * </ul>
-	 * @exception SWTError <ul>
-	 *    <li>ERROR_NO_HANDLES - if the PDF context could not be created</li>
-	 * </ul>
-	 *
-	 * @see #dispose()
+	 * Validates and prepares the data for construction.
 	 */
-	public PDFDocument(Device device, String filename, double widthInPoints, double heightInPoints) {
+	static PDFDocumentData checkData(String filename, double widthInPoints, double heightInPoints) {
 		if (filename == null) SWT.error(SWT.ERROR_NULL_ARGUMENT);
 		if (widthInPoints <= 0 || heightInPoints <= 0) SWT.error(SWT.ERROR_INVALID_ARGUMENT);
+		PDFDocumentData data = new PDFDocumentData();
+		data.filename = filename;
+		data.widthInPoints = widthInPoints;
+		data.heightInPoints = heightInPoints;
+		return data;
+	}
+
+	/**
+	 * Creates the PDF device in the operating system.
+	 * This method is called before <code>init</code>.
+	 *
+	 * @param data the DeviceData which describes the receiver
+	 */
+	@Override
+	protected void create(DeviceData data) {
+		PDFDocumentData pdfData = (PDFDocumentData) data;
+		this.filename = pdfData.filename;
+		this.widthInPoints = pdfData.widthInPoints;
+		this.heightInPoints = pdfData.heightInPoints;
 
 		NSAutoreleasePool pool = null;
 		if (!NSThread.isMainThread()) pool = (NSAutoreleasePool) new NSAutoreleasePool().alloc().init();
 		try {
-			this.widthInPoints = widthInPoints;
-			this.heightInPoints = heightInPoints;
-
-			// Get device from the current display if not provided
-			if (device == null) {
-				try {
-					this.device = org.eclipse.swt.widgets.Display.getDefault();
-				} catch (Exception e) {
-					this.device = null;
-				}
-			} else {
-				this.device = device;
-			}
-
 			// Create CFURL from the filename
 			NSString path = NSString.stringWith(filename);
 			NSURL fileURL = NSURL.fileURLWithPath(path);
@@ -184,11 +181,11 @@ public class PDFDocument implements Drawable {
 	 * </p>
 	 *
 	 * @exception SWTException <ul>
-	 *    <li>ERROR_WIDGET_DISPOSED - if the receiver has been disposed</li>
+	 *    <li>ERROR_DEVICE_DISPOSED - if the receiver has been disposed</li>
 	 * </ul>
 	 */
 	public void newPage() {
-		if (disposed) SWT.error(SWT.ERROR_WIDGET_DISPOSED);
+		checkDevice();
 		NSAutoreleasePool pool = null;
 		if (!NSThread.isMainThread()) pool = (NSAutoreleasePool) new NSAutoreleasePool().alloc().init();
 		try {
@@ -216,11 +213,11 @@ public class PDFDocument implements Drawable {
 	 *    <li>ERROR_INVALID_ARGUMENT - if width or height is not positive</li>
 	 * </ul>
 	 * @exception SWTException <ul>
-	 *    <li>ERROR_WIDGET_DISPOSED - if the receiver has been disposed</li>
+	 *    <li>ERROR_DEVICE_DISPOSED - if the receiver has been disposed</li>
 	 * </ul>
 	 */
 	public void newPage(double widthInPoints, double heightInPoints) {
-		if (disposed) SWT.error(SWT.ERROR_WIDGET_DISPOSED);
+		checkDevice();
 		if (widthInPoints <= 0 || heightInPoints <= 0) SWT.error(SWT.ERROR_INVALID_ARGUMENT);
 
 		this.widthInPoints = widthInPoints;
@@ -234,11 +231,11 @@ public class PDFDocument implements Drawable {
 	 * @return the width in points (1/72 inch)
 	 *
 	 * @exception SWTException <ul>
-	 *    <li>ERROR_WIDGET_DISPOSED - if the receiver has been disposed</li>
+	 *    <li>ERROR_DEVICE_DISPOSED - if the receiver has been disposed</li>
 	 * </ul>
 	 */
 	public double getWidth() {
-		if (disposed) SWT.error(SWT.ERROR_WIDGET_DISPOSED);
+		checkDevice();
 		return widthInPoints;
 	}
 
@@ -248,12 +245,45 @@ public class PDFDocument implements Drawable {
 	 * @return the height in points (1/72 inch)
 	 *
 	 * @exception SWTException <ul>
-	 *    <li>ERROR_WIDGET_DISPOSED - if the receiver has been disposed</li>
+	 *    <li>ERROR_DEVICE_DISPOSED - if the receiver has been disposed</li>
 	 * </ul>
 	 */
 	public double getHeight() {
-		if (disposed) SWT.error(SWT.ERROR_WIDGET_DISPOSED);
+		checkDevice();
 		return heightInPoints;
+	}
+
+	/**
+	 * Returns the DPI (dots per inch) of the PDF document.
+	 * PDF documents work in points where 1 point = 1/72 inch,
+	 * so the DPI is always 72.
+	 *
+	 * @return a point whose x coordinate is the horizontal DPI and whose y coordinate is the vertical DPI
+	 *
+	 * @exception SWTException <ul>
+	 *    <li>ERROR_DEVICE_DISPOSED - if the receiver has been disposed</li>
+	 * </ul>
+	 */
+	@Override
+	public Point getDPI() {
+		checkDevice();
+		return new Point(72, 72);
+	}
+
+	/**
+	 * Returns a rectangle describing the receiver's size and location.
+	 * The rectangle dimensions are in points (1/72 inch).
+	 *
+	 * @return the bounding rectangle
+	 *
+	 * @exception SWTException <ul>
+	 *    <li>ERROR_DEVICE_DISPOSED - if the receiver has been disposed</li>
+	 * </ul>
+	 */
+	@Override
+	public Rectangle getBounds() {
+		checkDevice();
+		return new Rectangle(0, 0, (int) widthInPoints, (int) heightInPoints);
 	}
 
 	/**
@@ -273,7 +303,7 @@ public class PDFDocument implements Drawable {
 	 */
 	@Override
 	public long internal_new_GC(GCData data) {
-		if (disposed) SWT.error(SWT.ERROR_WIDGET_DISPOSED);
+		checkDevice();
 		if (isGCCreated) SWT.error(SWT.ERROR_INVALID_ARGUMENT);
 
 		NSAutoreleasePool pool = null;
@@ -290,18 +320,16 @@ public class PDFDocument implements Drawable {
 				if ((data.style & mask) == 0) {
 					data.style |= SWT.LEFT_TO_RIGHT;
 				}
-				data.device = device;
+				data.device = this;
 				data.flippedContext = graphicsContext;
 				data.restoreContext = true;
 				NSSize size = new NSSize();
 				size.width = widthInPoints;
 				size.height = heightInPoints;
 				data.size = size;
-				if (device != null) {
-					data.background = device.getSystemColor(SWT.COLOR_WHITE).handle;
-					data.foreground = device.getSystemColor(SWT.COLOR_BLACK).handle;
-					data.font = device.getSystemFont();
-				}
+				data.background = getSystemColor(SWT.COLOR_WHITE).handle;
+				data.foreground = getSystemColor(SWT.COLOR_BLACK).handle;
+				data.font = getSystemFont();
 			}
 			isGCCreated = true;
 			return graphicsContext.id;
@@ -350,27 +378,12 @@ public class PDFDocument implements Drawable {
 	}
 
 	/**
-	 * Returns <code>true</code> if the PDFDocument has been disposed,
-	 * and <code>false</code> otherwise.
-	 *
-	 * @return <code>true</code> when the PDFDocument is disposed and <code>false</code> otherwise
+	 * Destroys the PDF document handle.
+	 * This method is called internally by the dispose
+	 * mechanism of the <code>Device</code> class.
 	 */
-	public boolean isDisposed() {
-		return disposed;
-	}
-
-	/**
-	 * Disposes of the operating system resources associated with
-	 * the PDFDocument. Applications must dispose of all PDFDocuments
-	 * that they allocate.
-	 * <p>
-	 * This method finalizes the PDF file and writes it to disk.
-	 * </p>
-	 */
-	public void dispose() {
-		if (disposed) return;
-		disposed = true;
-
+	@Override
+	protected void destroy() {
 		NSAutoreleasePool pool = null;
 		if (!NSThread.isMainThread()) pool = (NSAutoreleasePool) new NSAutoreleasePool().alloc().init();
 		try {

--- a/bundles/org.eclipse.swt/Eclipse SWT Printing/gtk/org/eclipse/swt/printing/PDFDocument.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Printing/gtk/org/eclipse/swt/printing/PDFDocument.java
@@ -44,13 +44,14 @@ import org.eclipse.swt.internal.cairo.*;
  *
  * @see GC
  * @since 3.133
+ *
+ * @noreference This class is provisional API and subject to change. It is being made available to gather early feedback. The API or behavior may change in future releases as the implementation evolves based on user feedback.
  */
-public class PDFDocument implements Drawable {
-	Device device;
+public final class PDFDocument extends Device {
 	long surface;
 	long cairo;
 	boolean isGCCreated = false;
-	boolean disposed = false;
+	String filename;
 
 	/**
 	 * Width of the page in points (1/72 inch)
@@ -61,6 +62,16 @@ public class PDFDocument implements Drawable {
 	 * Height of the page in points (1/72 inch)
 	 */
 	double heightInPoints;
+
+	/**
+	 * Internal data class to pass PDF document parameters through
+	 * the Device constructor.
+	 */
+	static class PDFDocumentData extends DeviceData {
+		String filename;
+		double widthInPoints;
+		double heightInPoints;
+	}
 
 	/**
 	 * Constructs a new PDFDocument with the specified filename and page dimensions.
@@ -83,60 +94,34 @@ public class PDFDocument implements Drawable {
 	 * @see #dispose()
 	 */
 	public PDFDocument(String filename, double widthInPoints, double heightInPoints) {
-		if (filename == null) SWT.error(SWT.ERROR_NULL_ARGUMENT);
-		if (widthInPoints <= 0 || heightInPoints <= 0) SWT.error(SWT.ERROR_INVALID_ARGUMENT);
-
-		this.widthInPoints = widthInPoints;
-		this.heightInPoints = heightInPoints;
-
-		byte[] filenameBytes = Converter.wcsToMbcs(filename, true);
-		surface = Cairo.cairo_pdf_surface_create(filenameBytes, widthInPoints, heightInPoints);
-		if (surface == 0) SWT.error(SWT.ERROR_NO_HANDLES);
-
-		cairo = Cairo.cairo_create(surface);
-		if (cairo == 0) {
-			Cairo.cairo_surface_destroy(surface);
-			surface = 0;
-			SWT.error(SWT.ERROR_NO_HANDLES);
-		}
-
-		// Get device from the current display or create a temporary one
-		try {
-			device = org.eclipse.swt.widgets.Display.getDefault();
-		} catch (Exception e) {
-			device = null;
-		}
+		super(checkData(filename, widthInPoints, heightInPoints));
 	}
 
 	/**
-	 * Constructs a new PDFDocument with the specified filename and page dimensions,
-	 * associated with the given device.
-	 * <p>
-	 * You must dispose the PDFDocument when it is no longer required.
-	 * </p>
-	 *
-	 * @param device the device to associate with this PDFDocument
-	 * @param filename the path to the PDF file to create
-	 * @param widthInPoints the width of each page in points (1/72 inch)
-	 * @param heightInPoints the height of each page in points (1/72 inch)
-	 *
-	 * @exception IllegalArgumentException <ul>
-	 *    <li>ERROR_NULL_ARGUMENT - if filename is null</li>
-	 *    <li>ERROR_INVALID_ARGUMENT - if width or height is not positive</li>
-	 * </ul>
-	 * @exception SWTError <ul>
-	 *    <li>ERROR_NO_HANDLES - if the PDF surface could not be created</li>
-	 * </ul>
-	 *
-	 * @see #dispose()
+	 * Validates and prepares the data for construction.
 	 */
-	public PDFDocument(Device device, String filename, double widthInPoints, double heightInPoints) {
+	static PDFDocumentData checkData(String filename, double widthInPoints, double heightInPoints) {
 		if (filename == null) SWT.error(SWT.ERROR_NULL_ARGUMENT);
 		if (widthInPoints <= 0 || heightInPoints <= 0) SWT.error(SWT.ERROR_INVALID_ARGUMENT);
+		PDFDocumentData data = new PDFDocumentData();
+		data.filename = filename;
+		data.widthInPoints = widthInPoints;
+		data.heightInPoints = heightInPoints;
+		return data;
+	}
 
-		this.device = device;
-		this.widthInPoints = widthInPoints;
-		this.heightInPoints = heightInPoints;
+	/**
+	 * Creates the PDF device in the operating system.
+	 * This method is called before <code>init</code>.
+	 *
+	 * @param data the DeviceData which describes the receiver
+	 */
+	@Override
+	protected void create(DeviceData data) {
+		PDFDocumentData pdfData = (PDFDocumentData) data;
+		this.filename = pdfData.filename;
+		this.widthInPoints = pdfData.widthInPoints;
+		this.heightInPoints = pdfData.heightInPoints;
 
 		byte[] filenameBytes = Converter.wcsToMbcs(filename, true);
 		surface = Cairo.cairo_pdf_surface_create(filenameBytes, widthInPoints, heightInPoints);
@@ -159,11 +144,11 @@ public class PDFDocument implements Drawable {
 	 * </p>
 	 *
 	 * @exception SWTException <ul>
-	 *    <li>ERROR_WIDGET_DISPOSED - if the receiver has been disposed</li>
+	 *    <li>ERROR_DEVICE_DISPOSED - if the receiver has been disposed</li>
 	 * </ul>
 	 */
 	public void newPage() {
-		if (disposed) SWT.error(SWT.ERROR_WIDGET_DISPOSED);
+		checkDevice();
 		Cairo.cairo_show_page(cairo);
 	}
 
@@ -181,11 +166,11 @@ public class PDFDocument implements Drawable {
 	 *    <li>ERROR_INVALID_ARGUMENT - if width or height is not positive</li>
 	 * </ul>
 	 * @exception SWTException <ul>
-	 *    <li>ERROR_WIDGET_DISPOSED - if the receiver has been disposed</li>
+	 *    <li>ERROR_DEVICE_DISPOSED - if the receiver has been disposed</li>
 	 * </ul>
 	 */
 	public void newPage(double widthInPoints, double heightInPoints) {
-		if (disposed) SWT.error(SWT.ERROR_WIDGET_DISPOSED);
+		checkDevice();
 		if (widthInPoints <= 0 || heightInPoints <= 0) SWT.error(SWT.ERROR_INVALID_ARGUMENT);
 
 		Cairo.cairo_show_page(cairo);
@@ -200,11 +185,11 @@ public class PDFDocument implements Drawable {
 	 * @return the width in points (1/72 inch)
 	 *
 	 * @exception SWTException <ul>
-	 *    <li>ERROR_WIDGET_DISPOSED - if the receiver has been disposed</li>
+	 *    <li>ERROR_DEVICE_DISPOSED - if the receiver has been disposed</li>
 	 * </ul>
 	 */
 	public double getWidth() {
-		if (disposed) SWT.error(SWT.ERROR_WIDGET_DISPOSED);
+		checkDevice();
 		return widthInPoints;
 	}
 
@@ -214,12 +199,45 @@ public class PDFDocument implements Drawable {
 	 * @return the height in points (1/72 inch)
 	 *
 	 * @exception SWTException <ul>
-	 *    <li>ERROR_WIDGET_DISPOSED - if the receiver has been disposed</li>
+	 *    <li>ERROR_DEVICE_DISPOSED - if the receiver has been disposed</li>
 	 * </ul>
 	 */
 	public double getHeight() {
-		if (disposed) SWT.error(SWT.ERROR_WIDGET_DISPOSED);
+		checkDevice();
 		return heightInPoints;
+	}
+
+	/**
+	 * Returns the DPI (dots per inch) of the PDF document.
+	 * PDF documents work in points where 1 point = 1/72 inch,
+	 * so the DPI is always 72.
+	 *
+	 * @return a point whose x coordinate is the horizontal DPI and whose y coordinate is the vertical DPI
+	 *
+	 * @exception SWTException <ul>
+	 *    <li>ERROR_DEVICE_DISPOSED - if the receiver has been disposed</li>
+	 * </ul>
+	 */
+	@Override
+	public Point getDPI() {
+		checkDevice();
+		return new Point(72, 72);
+	}
+
+	/**
+	 * Returns a rectangle describing the receiver's size and location.
+	 * The rectangle dimensions are in points (1/72 inch).
+	 *
+	 * @return the bounding rectangle
+	 *
+	 * @exception SWTException <ul>
+	 *    <li>ERROR_DEVICE_DISPOSED - if the receiver has been disposed</li>
+	 * </ul>
+	 */
+	@Override
+	public Rectangle getBounds() {
+		checkDevice();
+		return new Rectangle(0, 0, (int) widthInPoints, (int) heightInPoints);
 	}
 
 	/**
@@ -239,7 +257,7 @@ public class PDFDocument implements Drawable {
 	 */
 	@Override
 	public long internal_new_GC(GCData data) {
-		if (disposed) SWT.error(SWT.ERROR_WIDGET_DISPOSED);
+		checkDevice();
 		if (isGCCreated) SWT.error(SWT.ERROR_INVALID_ARGUMENT);
 
 		if (data != null) {
@@ -247,27 +265,13 @@ public class PDFDocument implements Drawable {
 			if ((data.style & mask) == 0) {
 				data.style |= SWT.LEFT_TO_RIGHT;
 			}
-			data.device = device;
+			data.device = this;
 			data.cairo = cairo;
 			data.width = (int) widthInPoints;
 			data.height = (int) heightInPoints;
-			if (device != null) {
-				data.foregroundRGBA = device.getSystemColor(SWT.COLOR_BLACK).handle;
-				data.backgroundRGBA = device.getSystemColor(SWT.COLOR_WHITE).handle;
-				data.font = device.getSystemFont();
-			} else {
-				// Fallback: create default colors manually using GdkRGBA values
-				data.foregroundRGBA = new org.eclipse.swt.internal.gtk.GdkRGBA();
-				data.foregroundRGBA.red = 0;
-				data.foregroundRGBA.green = 0;
-				data.foregroundRGBA.blue = 0;
-				data.foregroundRGBA.alpha = 1;
-				data.backgroundRGBA = new org.eclipse.swt.internal.gtk.GdkRGBA();
-				data.backgroundRGBA.red = 1;
-				data.backgroundRGBA.green = 1;
-				data.backgroundRGBA.blue = 1;
-				data.backgroundRGBA.alpha = 1;
-			}
+			data.foregroundRGBA = getSystemColor(SWT.COLOR_BLACK).handle;
+			data.backgroundRGBA = getSystemColor(SWT.COLOR_WHITE).handle;
+			data.font = getSystemFont();
 		}
 		isGCCreated = true;
 		return cairo;
@@ -302,27 +306,12 @@ public class PDFDocument implements Drawable {
 	}
 
 	/**
-	 * Returns <code>true</code> if the PDFDocument has been disposed,
-	 * and <code>false</code> otherwise.
-	 *
-	 * @return <code>true</code> when the PDFDocument is disposed and <code>false</code> otherwise
+	 * Destroys the PDF document handle.
+	 * This method is called internally by the dispose
+	 * mechanism of the <code>Device</code> class.
 	 */
-	public boolean isDisposed() {
-		return disposed;
-	}
-
-	/**
-	 * Disposes of the operating system resources associated with
-	 * the PDFDocument. Applications must dispose of all PDFDocuments
-	 * that they allocate.
-	 * <p>
-	 * This method finalizes the PDF file and writes it to disk.
-	 * </p>
-	 */
-	public void dispose() {
-		if (disposed) return;
-		disposed = true;
-
+	@Override
+	protected void destroy() {
 		if (cairo != 0) {
 			Cairo.cairo_destroy(cairo);
 			cairo = 0;


### PR DESCRIPTION
Change `PDFDocument` to subclass `Device` rather than implement `Drawable` to centralize resource management, align with `Device` lifecycle, and simplify drawing logic.

This also fixes some complication with the windows implementation that possibly chooses bad defaults and confuses screen DPI with PDF defaults (72 DPI).

Further the classes are now made `final` to prevent complications in future enhancements as sub-classes are not useful here.