### PR TITLE
[Gtk] Remove Control.setLocationInPixels methods

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Canvas.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Canvas.java
@@ -452,7 +452,7 @@ public void scroll (int destX, int destY, int x, int y, int width, int height, b
 			Rectangle rect = child.getBoundsInPixels ();
 			if (Math.min(x + width, rect.x + rect.width) >= Math.max (x, rect.x) &&
 				Math.min(y + height, rect.y + rect.height) >= Math.max (y, rect.y)) {
-					child.setLocationInPixels (rect.x + deltaX, rect.y + deltaY);
+					child.setLocation (rect.x + deltaX, rect.y + deltaY);
 			}
 		}
 	}

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Control.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Control.java
@@ -1267,12 +1267,6 @@ public void setLocation (Point location) {
 	setBounds (location.x, location.y, 0, 0, true, false);
 }
 
-void setLocationInPixels (Point location) {
-	checkWidget ();
-	if (location == null) error (SWT.ERROR_NULL_ARGUMENT);
-	setBounds (location.x, location.y, 0, 0, true, false);
-}
-
 /**
  * Sets the receiver's location to the point specified by the arguments which
  * are relative to the receiver's parent (or its display if its parent is null),
@@ -1292,12 +1286,6 @@ void setLocationInPixels (Point location) {
  * </ul>
  */
 public void setLocation(int x, int y) {
-	checkWidget();
-	Point loc = new Point (x, y);
-	setBounds (loc.x, loc.y, 0, 0, true, false);
-}
-
-void setLocationInPixels(int x, int y) {
 	checkWidget();
 	setBounds (x, y, 0, 0, true, false);
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Shell.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Shell.java
@@ -669,7 +669,7 @@ void center () {
 	} else {
 		y = Math.max (y, monitorRect.y);
 	}
-	setLocationInPixels (x, y);
+	setLocation (x, y);
 }
 
 @Override
@@ -1275,7 +1275,7 @@ Point getLocationInPixels () {
 	// Bug in GTK: when shell is moved and then hidden, its location does not get updated.
 	// Move it before getting its location.
 	if (!getVisible() && moved) {
-		setLocationInPixels(oldX, oldY);
+		setLocation(oldX, oldY);
 	}
 	int [] x = new int [1], y = new int [1];
 	if (GTK.GTK4) {
@@ -2924,7 +2924,7 @@ public void setVisible (boolean visible) {
 	checkWidget();
 
 	if (moved) { //fix shell location if it was moved.
-		setLocationInPixels(oldX, oldY);
+		setLocation(oldX, oldY);
 	}
 	int mask = SWT.PRIMARY_MODAL | SWT.APPLICATION_MODAL | SWT.SYSTEM_MODAL;
 	if ((style & mask) != 0) {


### PR DESCRIPTION
Useless methods that simply duplicate the public ones and create noise in the implementation.