### PR TITLE
Add PageSize record and PDFDocument constructor accepting PageSize

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Printing/cocoa/org/eclipse/swt/printing/PDFDocument.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Printing/cocoa/org/eclipse/swt/printing/PDFDocument.java
@@ -74,6 +74,30 @@ public final class PDFDocument extends Device {
 	}
 
 	/**
+	 * Constructs a new PDFDocument with the specified filename and page size.
+	 * <p>
+	 * You must dispose the PDFDocument when it is no longer required.
+	 * </p>
+	 *
+	 * @param filename the path to the PDF file to create
+	 * @param pageSize the page size specifying width and height in points (1/72 inch)
+	 *
+	 * @exception IllegalArgumentException <ul>
+	 *    <li>ERROR_NULL_ARGUMENT - if filename or pageSize is null</li>
+	 *    <li>ERROR_INVALID_ARGUMENT - if width or height is not positive</li>
+	 * </ul>
+	 * @exception SWTError <ul>
+	 *    <li>ERROR_NO_HANDLES - if the PDF context could not be created</li>
+	 * </ul>
+	 *
+	 * @see PageSize
+	 * @see #dispose()
+	 */
+	public PDFDocument(String filename, PageSize pageSize) {
+		super(checkData(filename, pageSize));
+	}
+
+	/**
 	 * Constructs a new PDFDocument with the specified filename and page dimensions.
 	 * <p>
 	 * You must dispose the PDFDocument when it is no longer required.
@@ -94,7 +118,15 @@ public final class PDFDocument extends Device {
 	 * @see #dispose()
 	 */
 	public PDFDocument(String filename, double widthInPoints, double heightInPoints) {
-		super(checkData(filename, widthInPoints, heightInPoints));
+		this(filename, new PageSize(widthInPoints, heightInPoints));
+	}
+
+	/**
+	 * Validates and prepares the data for construction.
+	 */
+	static PDFDocumentData checkData(String filename, PageSize pageSize) {
+		if (pageSize == null) SWT.error(SWT.ERROR_NULL_ARGUMENT);
+		return checkData(filename, pageSize.width(), pageSize.height());
 	}
 
 	/**

--- a/bundles/org.eclipse.swt/Eclipse SWT Printing/common/org/eclipse/swt/printing/PageSize.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Printing/common/org/eclipse/swt/printing/PageSize.java
@@ -1,0 +1,65 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Eclipse Platform Contributors and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eclipse Platform Contributors - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.swt.printing;
+
+/**
+ * A {@code PageSize} represents the dimensions of a page in points
+ * (1 point = 1/72 inch), as used in PDF documents and printing.
+ * <p>
+ * This record provides predefined constants for common paper sizes
+ * that are supported across all platforms (Windows, GTK, macOS).
+ * Using these constants avoids confusion between points and pixels
+ * and ensures consistent page dimensions.
+ * </p>
+ * <p>
+ * Example usage:
+ * </p>
+ * <pre>
+ *    PDFDocument pdf = new PDFDocument("output.pdf", PageSize.A4);
+ *    GC gc = new GC(pdf);
+ *    gc.drawText("Hello, PDF!", 100, 100);
+ *    gc.dispose();
+ *    pdf.dispose();
+ * </pre>
+ *
+ * @param width the width of the page in points (1/72 inch)
+ * @param height the height of the page in points (1/72 inch)
+ *
+ * @since 3.133
+ *
+ * @noreference This class is provisional API and subject to change. It is being made available to gather early feedback. The API or behavior may change in future releases as the implementation evolves based on user feedback.
+ */
+public record PageSize(double width, double height) {
+
+	/** US Letter size: 8.5 x 11 inches (612 x 792 points) */
+	public static final PageSize LETTER = new PageSize(612, 792);
+
+	/** US Legal size: 8.5 x 14 inches (612 x 1008 points) */
+	public static final PageSize LEGAL = new PageSize(612, 1008);
+
+	/** ISO A3 size: 297 x 420 mm (842 x 1191 points) */
+	public static final PageSize A3 = new PageSize(842, 1191);
+
+	/** ISO A4 size: 210 x 297 mm (595 x 842 points) */
+	public static final PageSize A4 = new PageSize(595, 842);
+
+	/** ISO A5 size: 148 x 210 mm (420 x 595 points) */
+	public static final PageSize A5 = new PageSize(420, 595);
+
+	/** US Executive size: 7.25 x 10.5 inches (522 x 756 points) */
+	public static final PageSize EXECUTIVE = new PageSize(522, 756);
+
+	/** US Tabloid size: 11 x 17 inches (792 x 1224 points) */
+	public static final PageSize TABLOID = new PageSize(792, 1224);
+}

--- a/bundles/org.eclipse.swt/Eclipse SWT Printing/gtk/org/eclipse/swt/printing/PDFDocument.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Printing/gtk/org/eclipse/swt/printing/PDFDocument.java
@@ -74,6 +74,30 @@ public final class PDFDocument extends Device {
 	}
 
 	/**
+	 * Constructs a new PDFDocument with the specified filename and page size.
+	 * <p>
+	 * You must dispose the PDFDocument when it is no longer required.
+	 * </p>
+	 *
+	 * @param filename the path to the PDF file to create
+	 * @param pageSize the page size specifying width and height in points (1/72 inch)
+	 *
+	 * @exception IllegalArgumentException <ul>
+	 *    <li>ERROR_NULL_ARGUMENT - if filename or pageSize is null</li>
+	 *    <li>ERROR_INVALID_ARGUMENT - if width or height is not positive</li>
+	 * </ul>
+	 * @exception SWTError <ul>
+	 *    <li>ERROR_NO_HANDLES - if the PDF surface could not be created</li>
+	 * </ul>
+	 *
+	 * @see PageSize
+	 * @see #dispose()
+	 */
+	public PDFDocument(String filename, PageSize pageSize) {
+		super(checkData(filename, pageSize));
+	}
+
+	/**
 	 * Constructs a new PDFDocument with the specified filename and page dimensions.
 	 * <p>
 	 * You must dispose the PDFDocument when it is no longer required.
@@ -94,7 +118,15 @@ public final class PDFDocument extends Device {
 	 * @see #dispose()
 	 */
 	public PDFDocument(String filename, double widthInPoints, double heightInPoints) {
-		super(checkData(filename, widthInPoints, heightInPoints));
+		this(filename, new PageSize(widthInPoints, heightInPoints));
+	}
+
+	/**
+	 * Validates and prepares the data for construction.
+	 */
+	static PDFDocumentData checkData(String filename, PageSize pageSize) {
+		if (pageSize == null) SWT.error(SWT.ERROR_NULL_ARGUMENT);
+		return checkData(filename, pageSize.width(), pageSize.height());
 	}
 
 	/**

--- a/bundles/org.eclipse.swt/Eclipse SWT Printing/win32/org/eclipse/swt/printing/PDFDocument.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Printing/win32/org/eclipse/swt/printing/PDFDocument.java
@@ -162,6 +162,37 @@ public final class PDFDocument extends Device {
 	}
 
 	/**
+	 * Constructs a new PDFDocument with the specified filename and page size.
+	 * <p>
+	 * The page size specifies the preferred dimensions in points (1/72 inch). On Windows,
+	 * the Microsoft Print to PDF driver only supports standard paper sizes, so the actual
+	 * page size may be larger than requested. Use {@link #getBounds()} to query the actual
+	 * page dimensions after construction.
+	 * </p>
+	 * <p>
+	 * You must dispose the PDFDocument when it is no longer required.
+	 * </p>
+	 *
+	 * @param filename the path to the PDF file to create
+	 * @param pageSize the page size specifying width and height in points (1/72 inch)
+	 *
+	 * @exception IllegalArgumentException <ul>
+	 *    <li>ERROR_NULL_ARGUMENT - if filename or pageSize is null</li>
+	 *    <li>ERROR_INVALID_ARGUMENT - if width or height is not positive</li>
+	 * </ul>
+	 * @exception SWTError <ul>
+	 *    <li>ERROR_NO_HANDLES - if the PDF printer is not available</li>
+	 * </ul>
+	 *
+	 * @see PageSize
+	 * @see #dispose()
+	 * @see #getBounds()
+	 */
+	public PDFDocument(String filename, PageSize pageSize) {
+		super(checkData(filename, pageSize));
+	}
+
+	/**
 	 * Constructs a new PDFDocument with the specified filename and preferred page dimensions.
 	 * <p>
 	 * The dimensions specify the preferred page size in points (1/72 inch). On Windows,
@@ -189,7 +220,15 @@ public final class PDFDocument extends Device {
 	 * @see #getBounds()
 	 */
 	public PDFDocument(String filename, double widthInPoints, double heightInPoints) {
-		super(checkData(filename, widthInPoints, heightInPoints));
+		this(filename, new PageSize(widthInPoints, heightInPoints));
+	}
+
+	/**
+	 * Validates and prepares the data for construction.
+	 */
+	static PDFDocumentData checkData(String filename, PageSize pageSize) {
+		if (pageSize == null) SWT.error(SWT.ERROR_NULL_ARGUMENT);
+		return checkData(filename, pageSize.width(), pageSize.height());
 	}
 
 	/**

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_printing_PDFDocument.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_printing_PDFDocument.java
@@ -13,7 +13,9 @@
  *******************************************************************************/
 package org.eclipse.swt.tests.junit;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
@@ -23,6 +25,7 @@ import java.nio.file.Path;
 
 import org.eclipse.swt.graphics.GC;
 import org.eclipse.swt.printing.PDFDocument;
+import org.eclipse.swt.printing.PageSize;
 import org.eclipse.swt.widgets.Display;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -97,6 +100,87 @@ public class Test_org_eclipse_swt_printing_PDFDocument {
 		String headerString = new String(fileContent, 0, Math.min(5, fileContent.length));
 		assertTrue(headerString.startsWith("%PDF-"),
 			"PDF file should start with %PDF- magic bytes, but got: " + headerString);
+	}
+
+	@Test
+	public void test_createPDFDocumentWithPageSize() throws IOException {
+		// Create a temporary file for the PDF
+		tempFile = Files.createTempFile(tempDir, "test_pagesize", ".pdf").toFile();
+		String filename = tempFile.getAbsolutePath();
+
+		// Create PDF document using PageSize constant
+		pdfDocument = new PDFDocument(filename, PageSize.A4);
+		assertNotNull(pdfDocument, "PDFDocument should be created with PageSize");
+
+		// Create a GC on the PDF document
+		gc = new GC(pdfDocument);
+		assertNotNull(gc, "GC should be created on PDFDocument");
+
+		// Draw text
+		gc.drawText("Hello from PageSize.A4!", 100, 100);
+
+		// Dispose of resources to finalize the PDF
+		gc.dispose();
+		gc = null;
+		pdfDocument.dispose();
+		pdfDocument = null;
+
+		// Verify the PDF file was created and is not empty
+		assertTrue(tempFile.exists(), "PDF file should exist");
+		assertTrue(tempFile.length() > 0, "PDF file should not be empty");
+
+		// Verify PDF magic bytes
+		byte[] fileContent = Files.readAllBytes(tempFile.toPath());
+		String headerString = new String(fileContent, 0, Math.min(5, fileContent.length));
+		assertTrue(headerString.startsWith("%PDF-"),
+			"PDF file should start with %PDF- magic bytes, but got: " + headerString);
+	}
+
+	@Test
+	public void test_pageSizePredefinedConstants() {
+		// Verify predefined paper sizes have correct dimensions
+		assertEquals(612, PageSize.LETTER.width());
+		assertEquals(792, PageSize.LETTER.height());
+
+		assertEquals(612, PageSize.LEGAL.width());
+		assertEquals(1008, PageSize.LEGAL.height());
+
+		assertEquals(595, PageSize.A4.width());
+		assertEquals(842, PageSize.A4.height());
+
+		assertEquals(842, PageSize.A3.width());
+		assertEquals(1191, PageSize.A3.height());
+
+		assertEquals(420, PageSize.A5.width());
+		assertEquals(595, PageSize.A5.height());
+
+		assertEquals(522, PageSize.EXECUTIVE.width());
+		assertEquals(756, PageSize.EXECUTIVE.height());
+
+		assertEquals(792, PageSize.TABLOID.width());
+		assertEquals(1224, PageSize.TABLOID.height());
+	}
+
+	@Test
+	public void test_pageSizeCustom() {
+		// Verify custom page sizes can be created
+		PageSize custom = new PageSize(300, 400);
+		assertEquals(300, custom.width());
+		assertEquals(400, custom.height());
+	}
+
+	@Test
+	public void test_createPDFDocumentWithNullPageSize() {
+		assertThrows(IllegalArgumentException.class, () -> {
+			new PDFDocument("test.pdf", (PageSize) null);
+		});
+	}
+
+	@Test
+	public void test_pageSizeEquality() {
+		// Records should have value-based equality
+		PageSize a4Copy = new PageSize(595, 842);
+		assertEquals(PageSize.A4, a4Copy);
 	}
 
 }


### PR DESCRIPTION
Introduce a new PageSize record in the common printing package that holds page dimensions (width and height) in points (1/72 inch). The record includes predefined constants for common paper sizes: LETTER, LEGAL, A3, A4, A5, EXECUTIVE, and TABLOID supported across platforms.