### PR TITLE
[Gtk4] Skip double draw in Canvas

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Canvas.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Canvas.java
@@ -546,4 +546,14 @@ void updateCaret () {
 	GTK.gtk_im_context_set_cursor_location (imHandle, rect);
 }
 
+@Override
+void snapshotToDraw(long handle, long snapshot) {
+	// Skip drawing if this is being called on fixedHandle to prevent double draws
+	// making carret not visible at all
+	if (fixedHandle != 0 && handle == fixedHandle) {
+		return;
+	}
+	super.snapshotToDraw(handle, snapshot);
+}
+
 }


### PR DESCRIPTION
Canvas does only custom draw thus fixedHandle receives unwanted snapshot calls leading to double redraws causing caret to become invisible. Fixes https://github.com/eclipse-platform/eclipse.platform.swt/issues/2812