### PR TITLE
[Win32] Properly reinitialize image of items on DPI changes

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/Item.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/Item.java
@@ -230,6 +230,7 @@ private void handleDPIChange(Event event) {
 	// Refresh the image
 	Image image = getImage();
 	if (image != null) {
+		setImage(null);
 		setImage(image);
 	}
 }


### PR DESCRIPTION
The current logic for reinitializing the image of an item on DPI changes is insufficient as the default implementation of the called setImage() method and many of the overwrites of that method do an early return in case the image equals to the one that has already been set.

In order to force a reinitialization of the image, this change ensures that the image is first removed and then reset.

Fixes https://github.com/eclipse-platform/eclipse.platform.swt/issues/3073