### PR TITLE
[Win32] Update images of tree columns upon DPI change

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TreeItem.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TreeItem.java
@@ -1815,6 +1815,11 @@ String getNameText () {
 @Override
 void handleDPIChange(Event event, float scalingFactor) {
 	super.handleDPIChange(event, scalingFactor);
+	if (images != null) {
+		for (int i = 1; i < images.length; i++) {
+			setImage(i, images[i]);
+		}
+	}
 	if (font != null) {
 		setFont(font);
 	}


### PR DESCRIPTION
When moving a shell with a tree that uses images in any other than the first column to another monitor, those images will be lost in case the other monitor has a different zoom such that the UI is rescaled. The reason is that the DPI change handling for TreeItem does not consider the other images of the tree item at all.

This change explicitly resets all images of a tree item upon DPI change.

Contributes to https://github.com/eclipse-platform/eclipse.platform.swt/issues/3075

### Remaining limitation
One limitation is that if an item does not have an image set for the first column, there will be blank space where the image could be after rescaling. This will be fixed independently via:
- https://github.com/eclipse-platform/eclipse.platform.swt/pull/3077

Before rescaling:
<img width="586" height="143" alt="image" src="https://github.com/user-attachments/assets/eb22af1b-d7da-41aa-9ce9-42a5ebaeac94" />

After rescaling:
<img width="882" height="216" alt="image" src="https://github.com/user-attachments/assets/7cdf8de1-82fa-4b75-a9c3-ce95f8a2d395" />

This is, however, an issue that already happens now (without any rescaling) in case the item has a subitems that uses an image in the first column:
<img width="586" height="143" alt="image" src="https://github.com/user-attachments/assets/15546557-57af-4ffd-af84-9d13f454cf7c" />
And it also happens if you set and then remove an image, like this:
```java
item.setImage(imageColumn1);
item.setImage((Image) null);
```
<img width="586" height="143" alt="image" src="https://github.com/user-attachments/assets/d35d7554-7a48-4e4a-9d44-37e26b155f47" />
