### PR TITLE
Avoid attempt to draw images with target width/height of 0

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/graphics/Image.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/graphics/Image.java
@@ -1878,7 +1878,7 @@ public static void drawAtSize(GC gc, ImageData imageData, int width, int height)
 }
 
 void executeOnImageAtSizeBestFittingSize(Consumer<Image> imageAtBestFittingSizeConsumer, int destWidth, int destHeight) {
-	Optional<Image> imageAtSize = cachedImageAtSize.refresh(destWidth, destHeight);
+	Optional<Image> imageAtSize = cachedImageAtSize.refresh(Math.max(1, destWidth), Math.max(1, destHeight));
 	imageAtBestFittingSizeConsumer.accept(imageAtSize.orElse(this));
 }
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/graphics/Image.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/graphics/Image.java
@@ -1025,7 +1025,7 @@ private class CachedImageAtSize {
 }
 
 void executeOnImageAtSize(Consumer<Image> imageAtBestFittingSizeConsumer, int destWidth, int destHeight) {
-	Optional<Image> imageAtSize = cachedImageAtSize.refresh(destWidth, destHeight);
+	Optional<Image> imageAtSize = cachedImageAtSize.refresh(Math.max(1, destWidth), Math.max(1, destHeight));
 	imageAtBestFittingSizeConsumer.accept(imageAtSize.orElse(this));
 }
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Image.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Image.java
@@ -941,8 +941,8 @@ ImageHandle getHandle (int targetZoom, int nativeZoom) {
 	return imageHandleManager.getOrCreate(targetZoom, () -> imageProvider.newImageHandle(zoomContext));
 }
 
-void executeOnImageHandleAtBestFittingSize(Consumer<ImageHandle> handleAtSizeConsumer, int widthHint, int heightHint) {
-	ImageHandle imageHandle = lastRequestedHandle.refresh(widthHint, heightHint);
+void executeOnImageHandleAtBestFittingSize(Consumer<ImageHandle> handleAtSizeConsumer, int destWidth, int destHeight) {
+	ImageHandle imageHandle = lastRequestedHandle.refresh(Math.max(1, destWidth), Math.max(1, destHeight));
 	handleAtSizeConsumer.accept(imageHandle);
 }
 


### PR DESCRIPTION
Recently, the ability to scale images for the desired target size of a drawImage operation executed on a GC and the incorporation of a Transform potentially applied to that GC have been implemented. With this, the target size for an image to be drawn can become 0 and the request of a handle of that size can fail, in particular when trying to rasterize an SVG at that size.

This change adapts the implementation of the handle retrieval for a desired size in the Image implementation so that the minimum size of the provided handle is 1 in both of the dimensions. The draw operation in the GC will then take care of potentially not drawing anything at all when the actual intended size is really 0.
It also adds a test case for the specific case of requesting a handle at size 0 and also adds a test for the general correctness of image handle retrieval when a transform is applied to the GC.

Fixes https://github.com/eclipse-platform/eclipse.platform.swt/issues/3078