### PR TITLE
Avoid compatibility check failure for Uber JARs and Universal Binaries

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT PI/cocoa/org/eclipse/swt/internal/Platform.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/cocoa/org/eclipse/swt/internal/Platform.java
@@ -21,7 +21,7 @@ public static boolean isLoadable () {
 }
 
 public static void exitIfNotLoadable() {
-	if (!Library.isLoadable ()) {
+	if (!Library.isLoadable (true)) {
 		System.err.println("Libraries for platform " + Platform.PLATFORM + " cannot be loaded because of incompatible environment");
 		System.exit(1);
 	}

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/common/org/eclipse/swt/internal/Library.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/common/org/eclipse/swt/internal/Library.java
@@ -13,15 +13,10 @@
  *******************************************************************************/
 package org.eclipse.swt.internal;
 
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.JarURLConnection;
-import java.net.URL;
-import java.net.URLConnection;
-import java.nio.file.Files;
-import java.nio.file.StandardCopyOption;
-import java.util.jar.Attributes;
+import java.io.*;
+import java.net.*;
+import java.nio.file.*;
+import java.util.jar.*;
 
 public class Library {
 
@@ -192,6 +187,10 @@ static boolean extract (String extractToFilePath, String mappedName) {
 }
 
 static boolean isLoadable () {
+	return isLoadable(false);
+}
+
+static boolean isLoadable (boolean ignoreMissingManifest) {
 	URL url = Platform.class.getClassLoader ().getResource ("org/eclipse/swt/internal/Library.class"); //$NON-NLS-1$
 	if (!url.getProtocol ().equals ("jar")) { //$NON-NLS-1$
 		/* SWT is presumably running in a development environment */
@@ -216,6 +215,9 @@ static boolean isLoadable () {
 	String manifestOS = attributes.getValue ("SWT-OS"); //$NON-NLS-1$
 	String manifestArch = attributes.getValue ("SWT-Arch"); //$NON-NLS-1$
 	if (arch.equals (manifestArch) && os.equals (manifestOS)) {
+		return true;
+	}
+	if (manifestArch == null && manifestOS == null && ignoreMissingManifest) {
 		return true;
 	}
 

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/org/eclipse/swt/internal/Platform.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/org/eclipse/swt/internal/Platform.java
@@ -22,7 +22,7 @@ public static boolean isLoadable () {
 }
 
 public static void exitIfNotLoadable() {
-	if (!Library.isLoadable ()) {
+	if (!Library.isLoadable (true)) {
 		System.err.println("Libraries for platform " + Platform.PLATFORM + " cannot be loaded because of incompatible environment");
 		System.exit(1);
 	}

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/win32/org/eclipse/swt/internal/Platform.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/win32/org/eclipse/swt/internal/Platform.java
@@ -23,7 +23,7 @@ public static boolean isLoadable () {
 }
 
 public static void exitIfNotLoadable() {
-	if (!Library.isLoadable ()) {
+	if (!Library.isLoadable (true)) {
 		System.err.println("Libraries for platform " + Platform.PLATFORM + " cannot be loaded because of incompatible environment");
 		System.exit(1);
 	}


### PR DESCRIPTION
When packaging SWT into an Uber Jar or using universal binaries (for multiple architectures), the Jar manifest cannot reference a single OS and/or architecture. As a result, the compatibility check implemented in Library.isLaodable() can never succeed for such a packaging. With those compatibility checks always being executed upon initialization of SWT with a recent change, using such packaging of SWT became difficult or impossible.

This change makes the initialization of SWT not fail in case the JAR manifest is completely lacking the according entries for OS and architecture. This will still make the initialization fail if an OS and/or architecture is specified in the manifest that is incompatible to the current environment, but in case the manifest does not contain such entries, the library will just (try to) boot. The behavior of Platform.isLoadable() is preserved. That method will still return false in case the Manifest does not contain according entries, as this is the long-standing behavior of that method.

Fixes https://github.com/eclipse-platform/eclipse.platform.swt/issues/2928