### PR TITLE
[GTK4] Browser crash when started from inside Eclipse

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT WebKit/gtk/library/webkitgtk.c
+++ b/bundles/org.eclipse.swt/Eclipse SWT WebKit/gtk/library/webkitgtk.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2025 IBM Corporation and others. All rights reserved.
+ * Copyright (c) 2009, 2026 IBM Corporation and others. All rights reserved.
  * The contents of this file are made available under the terms
  * of the GNU Lesser General Public License (LGPL) Version 2.1 that
  * accompanies this distribution (lgpl-v21.txt).  The LGPL is also
@@ -1950,6 +1950,28 @@ JNIEXPORT void JNICALL WebKitGTK_NATIVE(webkit_1user_1script_1unref)
 		}
 	}
 	WebKitGTK_NATIVE_EXIT(env, that, webkit_1user_1script_1unref_FUNC);
+}
+#endif
+
+#ifndef NO_webkit_1web_1context_1add_1path_1to_1sandbox
+JNIEXPORT void JNICALL WebKitGTK_NATIVE(webkit_1web_1context_1add_1path_1to_1sandbox)
+	(JNIEnv *env, jclass that, jlong arg0, jbyteArray arg1, jboolean arg2)
+{
+	jbyte *lparg1=NULL;
+	WebKitGTK_NATIVE_ENTER(env, that, webkit_1web_1context_1add_1path_1to_1sandbox_FUNC);
+	if (arg1) if ((lparg1 = (*env)->GetByteArrayElements(env, arg1, NULL)) == NULL) goto fail;
+/*
+	webkit_web_context_add_path_to_sandbox(arg0, lparg1, arg2);
+*/
+	{
+		WebKitGTK_LOAD_FUNCTION(fp, webkit_web_context_add_path_to_sandbox)
+		if (fp) {
+			((void (CALLING_CONVENTION*)(jlong, jbyte *, jboolean))fp)(arg0, lparg1, arg2);
+		}
+	}
+fail:
+	if (arg1 && lparg1) (*env)->ReleaseByteArrayElements(env, arg1, lparg1, 0);
+	WebKitGTK_NATIVE_EXIT(env, that, webkit_1web_1context_1add_1path_1to_1sandbox_FUNC);
 }
 #endif
 

--- a/bundles/org.eclipse.swt/Eclipse SWT WebKit/gtk/library/webkitgtk_stats.h
+++ b/bundles/org.eclipse.swt/Eclipse SWT WebKit/gtk/library/webkitgtk_stats.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2025 IBM Corporation and others. All rights reserved.
+ * Copyright (c) 2009, 2026 IBM Corporation and others. All rights reserved.
  * The contents of this file are made available under the terms
  * of the GNU Lesser General Public License (LGPL) Version 2.1 that
  * accompanies this distribution (lgpl-v21.txt).  The LGPL is also
@@ -118,6 +118,7 @@ typedef enum {
 	webkit_1user_1content_1manager_1remove_1all_1scripts_FUNC,
 	webkit_1user_1script_1new_FUNC,
 	webkit_1user_1script_1unref_FUNC,
+	webkit_1web_1context_1add_1path_1to_1sandbox_FUNC,
 	webkit_1web_1context_1allow_1tls_1certificate_1for_1host_FUNC,
 	webkit_1web_1context_1get_1cookie_1manager_FUNC,
 	webkit_1web_1context_1get_1default_FUNC,

--- a/bundles/org.eclipse.swt/Eclipse SWT WebKit/gtk/org/eclipse/swt/browser/WebKit.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT WebKit/gtk/org/eclipse/swt/browser/WebKit.java
@@ -661,8 +661,19 @@ public void create (Composite parent, int style) {
 
 	if (FirstCreate) {
 		FirstCreate = false;
+
 		// Register the swt:// custom protocol for BrowserFunction calls via XMLHttpRequest
 		long context = WebKitGTK.webkit_web_context_get_default();
+		if (GTK.GTK4) {
+			String xdgRuntimeDir = System.getenv("XDG_RUNTIME_DIR");
+			if (xdgRuntimeDir != null && !xdgRuntimeDir.isEmpty()) {
+				byte[] path = Converter.wcsToMbcs(xdgRuntimeDir, true);
+				WebKitGTK.webkit_web_context_add_path_to_sandbox(context, path, false);
+			}
+			// Add /tmp to sandbox for temporary files
+			byte[] tmpPath = Converter.wcsToMbcs("/tmp", true);
+			WebKitGTK.webkit_web_context_add_path_to_sandbox(context, tmpPath, false);
+		}
 		WebKitGTK.webkit_web_context_register_uri_scheme(context, SWT_PROTOCOL, RequestProc.getAddress(), 0, 0);
 		long security = WebKitGTK.webkit_web_context_get_security_manager(context);
 		WebKitGTK.webkit_security_manager_register_uri_scheme_as_secure(security, SWT_PROTOCOL);

--- a/bundles/org.eclipse.swt/Eclipse SWT WebKit/gtk/org/eclipse/swt/internal/webkit/WebKitGTK.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT WebKit/gtk/org/eclipse/swt/internal/webkit/WebKitGTK.java
@@ -395,6 +395,9 @@ public static final native void webkit_web_context_set_tls_errors_policy(long co
 public static final native void webkit_web_context_register_uri_scheme(long context, byte[] scheme, long callback, long user_data, long user_data_destroy_func);
 
 /** @method flags=dynamic */
+public static final native void webkit_web_context_add_path_to_sandbox(long context, byte[] path, boolean read_only);
+
+/** @method flags=dynamic */
 public static final native int webkit_web_view_can_go_back(long web_view);
 
 /** @method flags=dynamic */


### PR DESCRIPTION
WebKitGtk 6 enforces sandbox web process but for it to work properly one has to configure the sandbox to have access to
XDG_RUNTIME_DIR (contains Wayland/X11 display sockets) and /tmp (temporary files).

Fixes a crash when opening Welcome/Internal Web Browser views or Help system with
```
(process:2): Gtk-WARNING **: 14:56:39.676: Failed to open display

** (Eclipse:1773443): ERROR **: 14:56:39.750: readPIDFromPeer:
Unexpected short read from PID socket. (This usually means the auxiliary
process crashed immediately. Investigate that instead!)
```