### PR TITLE
[Win32] Ensure GC.textExtent/stringExtent returns large enough results

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/GC.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/GC.java
@@ -5877,7 +5877,7 @@ private class SetTransformOperation extends Operation {
  */
 public Point stringExtent (String string) {
 	if (string == null) SWT.error (SWT.ERROR_NULL_ARGUMENT);
-	return Win32DPIUtils.pixelToPointAsSize(drawable, stringExtentInPixels(string), getZoom());
+	return Win32DPIUtils.pixelToPointAsSufficientlyLargeSize(drawable, stringExtentInPixels(string), getZoom());
 }
 
 Point stringExtentInPixels (String string) {
@@ -5922,7 +5922,7 @@ Point stringExtentInPixels (String string) {
  * </ul>
  */
 public Point textExtent (String string) {
-	return Win32DPIUtils.pixelToPointAsSize(drawable, textExtentInPixels(string, SWT.DRAW_DELIMITER | SWT.DRAW_TAB), getZoom());
+	return textExtent(string, SWT.DRAW_DELIMITER | SWT.DRAW_TAB);
 }
 
 /**
@@ -5957,7 +5957,7 @@ public Point textExtent (String string) {
  * </ul>
  */
 public Point textExtent (String string, int flags) {
-	return Win32DPIUtils.pixelToPointAsSize(drawable, textExtentInPixels(string, flags), getZoom());
+	return Win32DPIUtils.pixelToPointAsSufficientlyLargeSize(textExtentInPixels(string, flags), getZoom());
 }
 
 Point textExtentInPixels(String string, int flags) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/Win32DPIUtils.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/Win32DPIUtils.java
@@ -137,6 +137,11 @@ public class Win32DPIUtils {
 		return pixelToPointAsSize (point, zoom);
 	}
 
+	public static Point pixelToPointAsSufficientlyLargeSize(Drawable drawable, Point point, int zoom) {
+		if (drawable != null && !drawable.isAutoScalable()) return point;
+		return pixelToPointAsSufficientlyLargeSize (point, zoom);
+	}
+
 	public static Point pixelToPointAsLocation(Drawable drawable, Point point, int zoom) {
 		if (drawable != null && !drawable.isAutoScalable()) return point;
 		return pixelToPointAsLocation (point, zoom);


### PR DESCRIPTION
The GC.textExtent()/stringExtent() operations return values in logical SWT points. On Windows, this involves a conversion from the actual pixel values according to the current zoom factor. This conversion includes a rounding to integer values which can lead to a value that is slightly smaller than the actual pixel value. The expectation of consumers is, however, that the result effectively represents the size of a bounding box, i.e., that the whole string fully fits into a rectangle of the returned size.

To ensure that the results of GC.textExtent()/stringExtent() are always large enough so that the text fits into an accordingly sized rectangle on every zoom, this change adapts the performed rounding operations to always round up the values. This makes the behavior consistent to rounding behavior of the Control.computeSize() methods with a similar semantics.

Contributes to https://github.com/eclipse-platform/eclipse.platform/issues/2295

### Example

The effects of the wrong rounding can be seen in Platform's Terminal implementation. Each character is drawn on its own in a grid according to the individual character size. And the calculated size for each character and thus the grid cells can become slightly too low on zooms != 100%, resulting in cut-off characters:
<img width="97" height="98" alt="image" src="https://github.com/user-attachments/assets/3b2c7670-a8eb-4f6a-a4ae-bbe9ae9cfa86" />

With this change, the resulting characters will have sufficient space:
<img width="112" height="103" alt="image" src="https://github.com/user-attachments/assets/e0b6e4d5-d71d-471b-87a1-564ce9f20a75" />
