### PR TITLE
Move null-check to called method.

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/GC.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/GC.java
@@ -5876,11 +5876,11 @@ private class SetTransformOperation extends Operation {
  * </ul>
  */
 public Point stringExtent (String string) {
-	if (string == null) SWT.error (SWT.ERROR_NULL_ARGUMENT);
 	return Win32DPIUtils.pixelToPointAsSufficientlyLargeSize(drawable, stringExtentInPixels(string), getZoom());
 }
 
 Point stringExtentInPixels (String string) {
+	if (string == null) SWT.error (SWT.ERROR_NULL_ARGUMENT);
 	checkNonDisposed();
 	checkGC(FONT);
 	int length = string.length();
@@ -5892,7 +5892,6 @@ Point stringExtentInPixels (String string) {
 	}
 	SIZE size = new SIZE();
 	if (length == 0) {
-//		OS.GetTextExtentPoint32(handle, SPACE, SPACE.length(), size);
 		OS.GetTextExtentPoint32(handle, new char[]{' '}, 1, size);
 		return new Point(0, size.cy);
 	} else {


### PR DESCRIPTION
Same as with the "textExtent" methods, the "stringExtent" method in GC could verify that the parameter is not null further down in the call-stack.

Also get rid of commented code.