### PR TITLE
Do not delete OS.SWP_NOSIZE bit for custom tooltips on Trees #3108

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Tree.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Tree.java
@@ -7404,7 +7404,11 @@ LRESULT wmNotify (NMHDR hdr, long wParam, long lParam) {
 	if (hdr.hwndFrom == itemToolTipHandle && itemToolTipHandle != 0) {
 		LRESULT result = wmNotifyToolTip (hdr, wParam, lParam);
 		if (result != null) return result;
+	} else if (hdr.hwndFrom == headerToolTipHandle && headerToolTipHandle != 0) {
+		// if it's the header, let Windows do its thing.
 	} else if (hdr.code == OS.TTN_SHOW) {
+		// Fallback: it's not about the item or about the header but it's still about a
+		// tooltip.
 		return positionTooltip(hdr, wParam, lParam, false);
 	}
 	if (hdr.hwndFrom == hwndHeader && hwndHeader != 0) {


### PR DESCRIPTION
Fixes https://github.com/eclipse-platform/eclipse.platform.swt/issues/3108

@HeikoKlare I noticed that commit 65a88c6402562c82ac88532c14412a5602e6bd24 not only moved these 2 lines up but it also added the additional check that I am removing in this PR.

https://github.com/eclipse-platform/eclipse.platform.swt/blob/1e86a0c6c8b35025557cccc4cc6120cfda9ac729/bundles/org.eclipse.swt/Eclipse%20SWT/win32/org/eclipse/swt/widgets/Tree.java#L8166-L8167

 Do you remember _why_ this check was necessary? I don't remember and honestly it seems like I simply missed this added logic back when I merged #2142 .

# How to test
- Hover over the columns headers in the _Problems_ view
- Edge case: position the workbench window in a way that the tooltip is supposed to span between 2 monitors with different scaling.

The edge case is just to be sure that nothing breaks, I remember that some of the stuff that was done around tooltips was to avoid UI hangs and infinite loops when working with monitors at different zooms.

I tested with this configuration but the zoom levels don't play a role, just the fact that the zoom levels are different:
- Primary monitor on the **right** at **125%**
- Secondary monitor on the **left** at **150%** (and also at **100%**)

No issues found. Here are some screenshots, I marked the division line between my 2 monitors with a yellow line (I added it manually to the screenshots).

<img width="188" height="106" alt="image" src="https://github.com/user-attachments/assets/7409fafa-0a09-4918-afd3-e3d6389ab654" />

---

<img width="170" height="124" alt="image" src="https://github.com/user-attachments/assets/055bd3c4-1f87-4a8e-b90a-1081f9865aff" />
