### PR TITLE
[RelEng] Add JavaDoc-Basher Pull-Request check

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -19,3 +19,23 @@ jobs:
     with:
       botName: Eclipse Platform Bot
       botMail: platform-bot@eclipse.org
+
+  check-javadoc-consistency:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493 # v5.0.0
+    - uses: actions/setup-java@de5a937a1dc73fbc1a67d7d1aa4bebc1082f3190 # v5.0.0
+      with:
+        java-version: 25
+        distribution: 'temurin'
+        cache: maven
+    - name: Run JavaDoc basher
+      run: >
+        mvn --non-recursive --batch-mode --no-transfer-progress
+        -Pjavadoc-basher exec:exec@run-javadoc-basher
+    - name: Verify no changes
+      run: |
+        if ! git diff --exit-code ; then
+          echo "::error title=Inconsistent JavaDoc::JavaDoc-Basher discovered JavaDoc inconsistencies between implementations, which must be resolved."
+          exit 1
+        fi

--- a/pom.xml
+++ b/pom.xml
@@ -179,6 +179,50 @@
         </plugins>
       </build>
     </profile>
+    <profile>
+      <id>javadoc-basher</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>exec-maven-plugin</artifactId>
+            <version>3.6.3</version>
+            <executions>
+              <execution>
+                <id>run-javadoc-basher</id>
+                <goals>
+                  <goal>exec</goal>
+                </goals>
+                <phase>validate</phase>
+                <configuration>
+                  <forceJava>true</forceJava>
+                  <workingDirectory>bundles/org.eclipse.swt.tools</workingDirectory>
+                  <executable>java</executable>
+                  <arguments>
+                    <argument>-classpath</argument>
+                    <classpath/>
+                    <argument>JavadocBasher/org/eclipse/swt/tools/internal/JavadocBasher.java</argument>
+                  </arguments>
+                  <includePluginDependencies>true</includePluginDependencies>
+                </configuration>
+              </execution>
+            </executions>
+            <dependencies>
+              <dependency>
+                  <groupId>org.eclipse.jdt</groupId>
+                  <artifactId>org.eclipse.jdt.core</artifactId>
+                  <version>[3.44.0,)</version>
+              </dependency>
+              <dependency>
+                  <groupId>org.eclipse.platform</groupId>
+                  <artifactId>org.eclipse.jface</artifactId>
+                  <version>[3.38.0,)</version>
+              </dependency>
+            </dependencies>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
   </profiles>
 
 


### PR DESCRIPTION
The added check runs the javadoc-basher on each PR and ensures the JavaDoc of all public API elements is synchronized for all platforms. In case that run leads to changes in the git worktree, the check fails.

This ensures the JavaDoc is always properly in sync und thus avoids the need to verify JavaDoc consistency before the release as separate RelEng task, like it was done for example in
- https://github.com/eclipse-platform/eclipse.platform.swt/issues/3092

