### PR TITLE
[Gtk4] gdk_event_handler_set is gone

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/org/eclipse/swt/internal/gtk/GDK.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/org/eclipse/swt/internal/gtk/GDK.java
@@ -540,7 +540,7 @@ public class GDK extends OS {
 	/**
 	 * @method flags=dynamic
 	 */
-	// TODO GTK4 function removed
+	/* [GTK3 only, if-def'd in os.h] */
 	public static final native void gdk_event_handler_set(long func, long data, long notify);
 	/* [GTK3 only, if-def'd in os.h] */
 	public static final native long gdk_event_new(int type);

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Display.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Display.java
@@ -1305,9 +1305,11 @@ void createDisplay (DeviceData data) {
 	GTK.gtk_widget_realize (shellHandle);
 
 	/* Initialize the filter and event callback */
-	eventCallback = new Callback (this, "eventProc", 2); //$NON-NLS-1$
-	eventProc = eventCallback.getAddress ();
-	GDK.gdk_event_handler_set (eventProc, 0, 0);
+	if (!GTK.GTK4) {
+		eventCallback = new Callback (this, "eventProc", 2); //$NON-NLS-1$
+		eventProc = eventCallback.getAddress ();
+		GDK.gdk_event_handler_set (eventProc, 0, 0);
+	}
 
 	signalCallback = new Callback (this, "signalProc", 3); //$NON-NLS-1$
 	signalProc = signalCallback.getAddress ();
@@ -1577,6 +1579,7 @@ void error (int code) {
 	SWT.error (code);
 }
 
+// Used on GTK 3 only
 long eventProc (long event, long data) {
 	/*
 	* Use gdk_event_get_time() rather than event.time or
@@ -1589,8 +1592,7 @@ long eventProc (long event, long data) {
 	int time = GDK.gdk_event_get_time (event);
 	if (time != 0) lastEventTime = time;
 
-	int eventType = GTK.GTK4 ? GDK.gdk_event_get_event_type(event) : GDK.GDK_EVENT_TYPE (event);
-	Control.fixGdkEventTypeValues(eventType);
+	int eventType = GDK.gdk_event_get_event_type(event);
 	switch (eventType) {
 		case GDK.GDK_BUTTON_PRESS:
 		case GDK.GDK_KEY_PRESS:
@@ -1607,12 +1609,7 @@ long eventProc (long event, long data) {
 		}
 	}
 	if (!dispatch) {
-		long copiedEvent;
-		if (GTK.GTK4) {
-			copiedEvent = GDK.gdk_event_ref (event);
-		} else {
-			copiedEvent = GDK.gdk_event_copy (event);
-		}
+		long copiedEvent = GDK.gdk_event_copy (event);
 
 		addGdkEvent (copiedEvent);
 		return 0;
@@ -4772,8 +4769,10 @@ void releaseDisplay () {
 	COLOR_TOGGLE_BUTTON_FOREGROUND_RGBA = null;
 
 	/* Dispose the event callback */
-	GDK.gdk_event_handler_set (0, 0, 0);
-	eventCallback.dispose ();  eventCallback = null;
+	if (!GTK.GTK4) {
+		GDK.gdk_event_handler_set (0, 0, 0);
+		eventCallback.dispose ();  eventCallback = null;
+	}
 
 	/* Dispose the hidden shell */
 	if (shellHandle != 0) {


### PR DESCRIPTION
It was called in Gtk 4 codepaths luckily not causing crashes. Uncovers that eventProc is only used on Gtk 3 so there could be no efforts to make calls in it Gtk 4 safe.