### PR TITLE
Stop using GDK_*_* macros

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/os.c
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/os.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2025 IBM Corporation and others. All rights reserved.
+ * Copyright (c) 2000, 2026 IBM Corporation and others. All rights reserved.
  * The contents of this file are made available under the terms
  * of the GNU Lesser General Public License (LGPL) Version 2.1 that
  * accompanies this distribution (lgpl-v21.txt).  The LGPL is also
@@ -27,30 +27,6 @@
 #ifdef _WIN32
   /* Many methods don't use their 'env' and 'that' arguments */
   #pragma warning (disable: 4100)
-#endif
-
-#ifndef NO_GDK_1EVENT_1TYPE
-JNIEXPORT jint JNICALL GDK_NATIVE(GDK_1EVENT_1TYPE)
-	(JNIEnv *env, jclass that, jlong arg0)
-{
-	jint rc = 0;
-	GDK_NATIVE_ENTER(env, that, GDK_1EVENT_1TYPE_FUNC);
-	rc = (jint)GDK_EVENT_TYPE((GdkEvent *)arg0);
-	GDK_NATIVE_EXIT(env, that, GDK_1EVENT_1TYPE_FUNC);
-	return rc;
-}
-#endif
-
-#ifndef NO_GDK_1EVENT_1WINDOW
-JNIEXPORT jlong JNICALL GDK_NATIVE(GDK_1EVENT_1WINDOW)
-	(JNIEnv *env, jclass that, jlong arg0)
-{
-	jlong rc = 0;
-	GDK_NATIVE_ENTER(env, that, GDK_1EVENT_1WINDOW_FUNC);
-	rc = (jlong)GDK_EVENT_WINDOW((GdkEventAny *)arg0);
-	GDK_NATIVE_EXIT(env, that, GDK_1EVENT_1WINDOW_FUNC);
-	return rc;
-}
 #endif
 
 #ifndef NO_GDK_1IS_1WAYLAND_1DISPLAY

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/os_stats.h
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/os_stats.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2025 IBM Corporation and others. All rights reserved.
+ * Copyright (c) 2000, 2026 IBM Corporation and others. All rights reserved.
  * The contents of this file are made available under the terms
  * of the GNU Lesser General Public License (LGPL) Version 2.1 that
  * accompanies this distribution (lgpl-v21.txt).  The LGPL is also
@@ -24,8 +24,6 @@
 #endif
 
 typedef enum {
-	GDK_1EVENT_1TYPE_FUNC,
-	GDK_1EVENT_1WINDOW_FUNC,
 	GDK_1IS_1WAYLAND_1DISPLAY_FUNC,
 	GDK_1IS_1X11_1DISPLAY_FUNC,
 	GDK_1TYPE_1PIXBUF_FUNC,

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/org/eclipse/swt/internal/gtk/GDK.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/org/eclipse/swt/internal/gtk/GDK.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2020 Red Hat Inc. and others. All rights reserved.
+ * Copyright (c) 2018, 2026 Red Hat Inc. and others. All rights reserved.
  * The contents of this file are made available under the terms
  * of the GNU Lesser General Public License (LGPL) Version 2.1 that
  * accompanies this distribution (lgpl-v21.txt).  The LGPL is also
@@ -242,10 +242,6 @@ public class GDK extends OS {
 	public static final native int GdkRectangle_sizeof();
 
 	/** Macros */
-	/** @param event cast=(GdkEvent *) */
-	public static final native int GDK_EVENT_TYPE(long event);
-	/** @param event cast=(GdkEventAny *) */
-	public static final native long GDK_EVENT_WINDOW(long event);
 	/** @param display cast=(GdkDisplay *) */
 	public static final native boolean GDK_IS_WAYLAND_DISPLAY(long display);
 	/** @param display cast=(GdkDisplay *) */

--- a/bundles/org.eclipse.swt/Eclipse SWT WebKit/gtk/org/eclipse/swt/browser/WebKit.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT WebKit/gtk/org/eclipse/swt/browser/WebKit.java
@@ -386,7 +386,7 @@ static long JSDOMEventProc (long arg0, long event, long user_data) {
 		final Browser browser = FindBrowser (arg0);
 		if (browser != null && user_data == WIDGET_EVENT){
 			/* this instance does need to use the GDK event to create an SWT event to send */
-			switch (GDK.GDK_EVENT_TYPE (event)) {
+			switch (GDK.gdk_event_get_event_type (event)) {
 				case GDK.GDK_KEY_PRESS: {
 					if (browser.isFocusControl ()) {
 						int [] key = new int [1];

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Control.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Control.java
@@ -3527,7 +3527,7 @@ long gtk_button_press_event (long widget, long event, boolean sendMouseDown) {
 		display.clickCount = 1;
 		long nextEvent = GDK.gdk_event_peek();
 		if (nextEvent != 0) {
-			int peekedEventType = GDK.GDK_EVENT_TYPE (nextEvent);
+			int peekedEventType = GDK.gdk_event_get_event_type (nextEvent);
 			if (peekedEventType == GDK.GDK_2BUTTON_PRESS) display.clickCount = 2;
 			if (peekedEventType == GDK.GDK_3BUTTON_PRESS) display.clickCount = 3;
 			gdk_event_free (nextEvent);

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Table.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Table.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2025 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -2332,7 +2332,7 @@ long gtk_motion_notify_event (long widget, long event) {
 		long surface = GDK.gdk_event_get_surface(event);
 		if (surface != gtk_widget_get_surface(handle)) return 0;
 	} else {
-		long window = GDK.GDK_EVENT_WINDOW (event);
+		long window = GDK.gdk_event_get_window (event);
 		if (window != GTK3.gtk_tree_view_get_bin_window (handle)) return 0;
 	}
 	return super.gtk_motion_notify_event (widget, event);

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/TrayItem.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/TrayItem.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -250,11 +250,11 @@ long gtk_activate (long widget) {
 	*/
 	long nextEvent = GDK.gdk_event_peek();
 	if (nextEvent != 0) {
-		int nextEventType = GDK.GDK_EVENT_TYPE (nextEvent);
+		int nextEventType = GDK.gdk_event_get_event_type (nextEvent);
 		long currEvent = GTK3.gtk_get_current_event ();
 		int currEventType = 0;
 		if (currEvent != 0) {
-			currEventType = GDK.GDK_EVENT_TYPE (currEvent);
+			currEventType = GDK.gdk_event_get_event_type (currEvent);
 			gdk_event_free(currEvent);
 		}
 		gdk_event_free (nextEvent);

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Tree.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Tree.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2025 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -2502,7 +2502,7 @@ long gtk_motion_notify_event (long widget, long event) {
 		long surface = GDK.gdk_event_get_surface(event);
 		if (surface != gtk_widget_get_surface(handle)) return 0;
 	} else {
-		long window = GDK.GDK_EVENT_WINDOW (event);
+		long window = GDK.gdk_event_get_window (event);
 		if (window != GTK3.gtk_tree_view_get_bin_window (handle)) return 0;
 	}
 	return super.gtk_motion_notify_event (widget, event);


### PR DESCRIPTION
There are functions for that available since long time so it's best to consistently use single and more reliable way.