### PR TITLE
[Gtk4] Condense Menu sizes

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/org/eclipse/swt/internal/gtk/swt_theming_fixes_gtk_4_0_0.css
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/org/eclipse/swt/internal/gtk/swt_theming_fixes_gtk_4_0_0.css
@@ -5,3 +5,8 @@ button {
 	min-height: 0px;
 	min-width: 0px;
 }
+modelbutton {
+    padding-top: 2px;
+    padding-bottom: 2px;
+    min-height: 0;
+}


### PR DESCRIPTION
Gtk 4.x by default uses far more space than on Gtk 3.x thus make it smaller to be closer to how menu looks on Gtk 3.