### PR TITLE
[Gtk4] Text with SWT.SEARCH fixes

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/gtk4.c
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/gtk4.c
@@ -1186,6 +1186,16 @@ JNIEXPORT jlong JNICALL GTK4_NATIVE(gtk_1editable_1get_1text)
 }
 #endif
 
+#ifndef NO_gtk_1editable_1set_1alignment
+JNIEXPORT void JNICALL GTK4_NATIVE(gtk_1editable_1set_1alignment)
+	(JNIEnv *env, jclass that, jlong arg0, jfloat arg1)
+{
+	GTK4_NATIVE_ENTER(env, that, gtk_1editable_1set_1alignment_FUNC);
+	gtk_editable_set_alignment((GtkEditable *)arg0, (float)arg1);
+	GTK4_NATIVE_EXIT(env, that, gtk_1editable_1set_1alignment_FUNC);
+}
+#endif
+
 #ifndef NO_gtk_1editable_1set_1max_1width_1chars
 JNIEXPORT void JNICALL GTK4_NATIVE(gtk_1editable_1set_1max_1width_1chars)
 	(JNIEnv *env, jclass that, jlong arg0, jint arg1)

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/gtk4_stats.h
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/gtk4_stats.h
@@ -111,6 +111,7 @@ typedef enum {
 	gtk_1editable_1get_1delegate_FUNC,
 	gtk_1editable_1get_1max_1width_1chars_FUNC,
 	gtk_1editable_1get_1text_FUNC,
+	gtk_1editable_1set_1alignment_FUNC,
 	gtk_1editable_1set_1max_1width_1chars_FUNC,
 	gtk_1editable_1set_1text_FUNC,
 	gtk_1entry_1buffer_1get_1text_FUNC,

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/org/eclipse/swt/internal/gtk4/GTK4.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/org/eclipse/swt/internal/gtk4/GTK4.java
@@ -135,6 +135,11 @@ public class GTK4 {
 	public static final native int gtk_editable_get_max_width_chars(long editable);
 	/**
 	 * @param editable cast=(GtkEditable *)
+	 * @param alignment cast=(float)
+	 */
+	public static final native void gtk_editable_set_alignment(long editable, float alignment);
+	/**
+	 * @param editable cast=(GtkEditable *)
 	 * @param chars cast=(int)
 	 */
 	public static final native void gtk_editable_set_max_width_chars(long editable, int chars);

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Text.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Text.java
@@ -254,7 +254,7 @@ void createHandle (int index) {
 		 * We need to handle borders differently in GTK3.20+. GtkEntry without frame will have a blank background color.
 		 * So let's set border via css and override the background in this case to be COLOR_LIST_BACKGROUND.
 		 */
-		if ((style & SWT.BORDER) == 0) {
+		if ((style & SWT.BORDER) == 0 && !(GTK.GTK4 && (style & SWT.SEARCH) != 0) ) {
 			GTK.gtk_entry_set_has_frame(handle, false);
 			long context = GTK.gtk_widget_get_style_context(handle);
 			String background = display.gtk_rgba_to_css_string(display.COLOR_LIST_BACKGROUND_RGBA);
@@ -265,11 +265,17 @@ void createHandle (int index) {
 		if ((style & SWT.CENTER) != 0) alignment = 0.5f;
 		if ((style & SWT.RIGHT) != 0) alignment = 1.0f;
 		if (alignment > 0.0f) {
-			GTK.gtk_entry_set_alignment(handle, alignment);
+			if (!(GTK.GTK4 && (style & SWT.SEARCH) != 0)) {
+				GTK.gtk_entry_set_alignment(handle, alignment);
+			} else {
+				GTK4.gtk_editable_set_alignment(handle, alignment);
+			}
 		}
 
 		if (DISABLE_EMOJI && GTK.GTK_VERSION >= OS.VERSION(3, 22, 20)) {
-		    GTK.gtk_entry_set_input_hints(handle, GTK.GTK_INPUT_HINT_NO_EMOJI);
+			if (!(GTK.GTK4 && (style & SWT.SEARCH) != 0)) {
+				GTK.gtk_entry_set_input_hints(handle, GTK.GTK_INPUT_HINT_NO_EMOJI);
+			}
 		}
 	} else {
 		if (GTK.GTK4) {
@@ -699,7 +705,7 @@ Rectangle computeTrimInPixels (int x, int y, int width, int height) {
 			trim.width += tmp.left + tmp.right;
 			trim.height += tmp.top + tmp.bottom;
 		}
-		if (!GTK.GTK4 ||  ((style & SWT.SEARCH) == 0) ) {
+		if (!GTK.GTK4 || ((style & SWT.SEARCH) == 0) ) {
 			GdkRectangle icon_area = new GdkRectangle();
 			GTK.gtk_entry_get_icon_area(handle, GTK.GTK_ENTRY_ICON_PRIMARY, icon_area);
 			trim.x -= icon_area.width;


### PR DESCRIPTION
GtkSearchEntry on Gtk 4 is no longer a GtkEntry thus:
* BORDER can not be set anymore using gtk_entry_set_border
* alignment should be set using gtk_editable_set_alignment
* DISABLE_EMOJI via gtk_entry_set_input_hints has no effects. This prevents errors like:
(SWT:1297545): Gtk-CRITICAL **: 10:19:51.235: gtk_entry_FUNCTION_NAME: assertion 'GTK_IS_ENTRY (entry)' failed