### PR TITLE
[Gtk4] Fix Composite background not propagating

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Composite.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Composite.java
@@ -522,6 +522,43 @@ void deregister () {
 	if (socketHandle != 0) display.removeWidget (socketHandle);
 }
 
+@Override
+void snapshotBackground (long handle, long snapshot) {
+	if ((state & OBSCURED) != 0) return;
+	/*
+	 * Draw the effective background before children are snapshotted.
+	 *
+	 * SWTFixed widget has no CSS background rule, thus obtain a Cairo
+	 * context from the snapshot and delegate to drawBackground(), which
+	 * paints the background image or color directly via Cairo.
+	 *
+	 * Skip when an explicit background color has been set (state & BACKGROUND):
+	 * GTK4 renders the CSS provider background automatically before calling
+	 * the snapshot vfunc.
+	 */
+	Control control = findBackgroundControl ();
+	boolean draw = control != null && control.backgroundImage != null;
+	if (!draw && (state & CANVAS) != 0) {
+		draw = (state & BACKGROUND) == 0;
+	}
+	if (!draw) return;
+
+	if (control == null) control = this;
+	GtkAllocation allocation = new GtkAllocation();
+	GTK.gtk_widget_get_allocation(handle, allocation);
+	int width = (state & ZERO_WIDTH) != 0 ? 0 : allocation.width;
+	int height = (state & ZERO_HEIGHT) != 0 ? 0 : allocation.height;
+	long rect = Graphene.graphene_rect_alloc();
+	Graphene.graphene_rect_init(rect, 0, 0, width, height);
+	long cairo = GTK4.gtk_snapshot_append_cairo(snapshot, rect);
+	if (cairo != 0) {
+		drawBackground(control, 0, cairo, 0, 0, width, height);
+		Cairo.cairo_destroy(cairo);
+	}
+	Graphene.graphene_rect_free(rect);
+}
+
+
 /**
  * Fills the interior of the rectangle specified by the arguments,
  * with the receiver's background.

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Display.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Display.java
@@ -1716,6 +1716,10 @@ static long rendererClassInitProc (long g_class, long class_data) {
 
 void snapshotDrawProc(long handle, long snapshot) {
 	Display display = getCurrent ();
+	Widget widget = display.getWidget (handle);
+	// Draw background before children so it appears behind them
+	if (widget != null) widget.snapshotBackground(handle, snapshot);
+
 	long child = GTK4.gtk_widget_get_first_child(handle);
 	// Propagate the snapshot down the widget tree first
 	while (child != 0) {
@@ -1723,7 +1727,6 @@ void snapshotDrawProc(long handle, long snapshot) {
 		child = GTK4.gtk_widget_get_next_sibling(child);
 	}
 	// Draw custom paint on top of children
-	Widget widget = display.getWidget (handle);
 	if (widget != null) widget.snapshotToDraw(handle, snapshot);
 }
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Widget.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Widget.java
@@ -2282,6 +2282,17 @@ long sizeRequestProc (long handle, long arg0, long user_data) {
 }
 
 /**
+ * Renders the widget background during a GTK4 snapshot. Called before
+ * children are snapshotted so the background appears behind them.
+ * Subclasses can override to perform background rendering.
+ *
+ * @param handle the widget receiving the snapshot
+ * @param snapshot the actual GtkSnapshot
+ */
+void snapshotBackground (long handle, long snapshot) {
+}
+
+/**
  * Converts an incoming snapshot into a gtk_draw() call, complete with
  * a Cairo context.
  *


### PR DESCRIPTION
Snapshot background before snapshoting children to actually propagate the background if not overriden.
Fixes one of the most notable problems on Gtk 4 - backgrounds being all white making components look out of place, not distinguish text fields from the rest and so on.