### PR TITLE
[Win32] Fix wrong line width in GC upon recreation for different zoom

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/GC.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/GC.java
@@ -5361,8 +5361,15 @@ private class SetLineAttributesOperation extends ReplaceableOperation  {
 
 	@Override
 	void apply() {
-		attributes.width = Win32DPIUtils.pointToPixel(drawable, attributes.width, getZoom());
-		setLineAttributesInPixels(attributes);
+		setLineAttributesInPixels(convertToPixels(attributes));
+	}
+
+	private LineAttributes convertToPixels(LineAttributes attributes) {
+		int zoom = getZoom();
+		float[] dashInPixels =  Win32DPIUtils.pointToPixel(drawable, attributes.dash, zoom);
+		float widthInPixels = Win32DPIUtils.pointToPixel(drawable, attributes.width, zoom);
+		LineAttributes lineAttributesInPixels = new LineAttributes(widthInPixels, attributes.cap, attributes.join, attributes.style, dashInPixels, attributes.dashOffset, attributes.miterLimit);
+		return lineAttributesInPixels;
 	}
 }
 
@@ -5424,12 +5431,6 @@ private void setLineAttributesInPixels (LineAttributes attributes) {
 			if (!changed && lineDashes[i] != dash) changed = true;
 		}
 		if (changed) {
-			float[] newDashes = new float[dashes.length];
-			int deviceZoom = getZoom();
-			for (int i = 0; i < newDashes.length; i++) {
-				newDashes[i] = Win32DPIUtils.pointToPixel(drawable, dashes[i], deviceZoom);
-			}
-			dashes = newDashes;
 			mask |= LINE_STYLE;
 		} else {
 			dashes = lineDashes;

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/Win32DPIUtils.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/Win32DPIUtils.java
@@ -240,6 +240,21 @@ public class Win32DPIUtils {
 		return returnArray;
 	}
 
+	public static float[] pointToPixel(Drawable drawable, float values[], int zoom) {
+		if (drawable != null && !drawable.isAutoScalable()) {
+			return values;
+		}
+		if (zoom == 100 || values == null) {
+			return values;
+		}
+		float scaleFactor = DPIUtil.getScalingFactor (zoom);
+		float scaledValues[] = new float[values.length];
+		for (int i = 0; i < scaledValues.length; i++) {
+			scaledValues[i] = values[i] * scaleFactor;
+		}
+		return scaledValues;
+	}
+
 	public static int[] pointToPixel(Drawable drawable, int[] pointArray, int zoom) {
 		if (drawable != null && !drawable.isAutoScalable()) return pointArray;
 		return pointToPixel (pointArray, zoom);

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_GC.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_GC.java
@@ -854,6 +854,17 @@ public void test_setLineAttributes$I() {
 	assertEquals(new LineAttributes(width, cap, join, style, dashes, dashOffset, miterLimit), gc.getLineAttributes(), "actual line attributes differ from the ones that have been set");
 	assertEquals(width, passedLineAttributes.width, 0.0f, "setter call changed line width");
 
+	// Ensure that after recreating the image handle from the GC on Windows does not overwrite any values
+	int currentZoom = DPIUtil.getDeviceZoom();
+	int alternateZoom = currentZoom == 100 ? 200 : 100;
+	image.getImageData(alternateZoom);
+	assertEquals(width, gc.getLineWidth(), "unexpected line width");
+	assertEquals(cap, gc.getLineCap(), "unexpected line cap");
+	assertEquals(join, gc.getLineJoin(), "unexpected line join");
+	assertEquals(style, gc.getLineStyle(), "unexpected line style");
+	assertEquals(new LineAttributes(width, cap, join, style, dashes, dashOffset, miterLimit), gc.getLineAttributes(), "actual line attributes differ from the ones that have been set");
+	assertEquals(width, passedLineAttributes.width, 0.0f, "setter call changed line width");
+
 	gc.setLineAttributes(new LineAttributes(1));
 	assertEquals(new LineAttributes(1), gc.getLineAttributes());
 }


### PR DESCRIPTION
The Win32 implementation of the GC class stores executed operations to allow the recreation of the underlying drawable's handle for a different zoom if requested. The setLineAttributes() operation stores the passed line attributes including the line width. Once this operation is applied, the line width is transformed from point into pixel coordinates. Instead of just using the pixel value during operation execution, the actual attribute value (in points) of the operation is overwritten, such that subsequent applications of that operation will use a wrong value.

This change adapts the implementation of the SetLineAttributes operation to not overwrite the original line attributes. In addition, it extracts the point-to-pixel conversion for dashes that was erroneously placed inside the called setLineAttributesInPixels method so that a proper line attributes object transformed into pixel values is passed to that method.

Fixes https://github.com/eclipse-gef/gef-classic/issues/1075

This can be tested with the snippet in https://github.com/eclipse-gef/gef-classic/issues/1075.

I've also ensured and tested that this does not reintroduce https://github.com/eclipse-platform/eclipse.platform.swt/issues/687.