### PR TITLE
[GTK] Fix NPE in GC if already disposed

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/graphics/GC.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/graphics/GC.java
@@ -3786,6 +3786,7 @@ public void setXORMode(boolean xor) {
  * </ul>
  */
 public Point stringExtent(String string) {
+	if (handle == 0) SWT.error(SWT.ERROR_GRAPHIC_DISPOSED);
 	return textExtentInPixels(string, 0);
 }
 Point stringExtentInPixels(String string) {
@@ -3812,6 +3813,7 @@ Point stringExtentInPixels(String string) {
  * </ul>
  */
 public Point textExtent(String string) {
+	if (handle == 0) SWT.error(SWT.ERROR_GRAPHIC_DISPOSED);
 	return textExtentInPixels(string, SWT.DRAW_DELIMITER | SWT.DRAW_TAB);
 }
 

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_GC.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_GC.java
@@ -35,6 +35,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.SWTException;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.Font;
 import org.eclipse.swt.graphics.FontMetrics;
@@ -917,6 +918,9 @@ public void test_stringExtentLjava_lang_String() {
 	Point pt = gc.stringExtent("abc");
 	assertTrue(pt.x > 0);
 	assertTrue(pt.y > 0);
+	gc.dispose();
+	SWTException e = assertThrows(SWTException.class, () -> gc.stringExtent("abc"));
+	assertEquals(SWT.ERROR_GRAPHIC_DISPOSED, e.code);
 }
 
 @Test
@@ -924,6 +928,9 @@ public void test_textExtentLjava_lang_String() {
 	Point pt = gc.textExtent("abc");
 	assertTrue(pt.x > 0);
 	assertTrue(pt.y > 0);
+	gc.dispose();
+	SWTException e = assertThrows(SWTException.class, () -> gc.textExtent("abc"));
+	assertEquals(SWT.ERROR_GRAPHIC_DISPOSED, e.code);
 }
 
 @Test
@@ -931,6 +938,9 @@ public void test_textExtentLjava_lang_StringI() {
 	Point pt = gc.textExtent("abc", 0);
 	assertTrue(pt.x > 0);
 	assertTrue(pt.y > 0);
+	gc.dispose();
+	SWTException e = assertThrows(SWTException.class, () -> gc.textExtent("abc", 0));
+	assertEquals(SWT.ERROR_GRAPHIC_DISPOSED, e.code);
 }
 
 @Test


### PR DESCRIPTION
Calling `stringExtent(...)` or `textExtent(...)` may throw a NullPointerException, rather than an SWTException if the GC object has already been disposed. This is unexpected and inconsistent with how GC behaves on other platforms.