### PR TITLE
[Win32] Convert dash offset for line attributes in GC into pixels

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/GC.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/GC.java
@@ -4199,6 +4199,7 @@ public LineAttributes getLineAttributes () {
 	if(attributes.dash != null) {
 		attributes.dash = Win32DPIUtils.pixelToPoint(drawable, attributes.dash, deviceZoom);
 	}
+	attributes.dashOffset = Win32DPIUtils.pixelToPoint(drawable, attributes.dashOffset, deviceZoom);
 	return attributes;
 }
 
@@ -5367,8 +5368,9 @@ private class SetLineAttributesOperation extends ReplaceableOperation  {
 	private LineAttributes convertToPixels(LineAttributes attributes) {
 		int zoom = getZoom();
 		float[] dashInPixels =  Win32DPIUtils.pointToPixel(drawable, attributes.dash, zoom);
+		float dashOffsetInPixels = Win32DPIUtils.pointToPixel(drawable, attributes.dashOffset, zoom);
 		float widthInPixels = Win32DPIUtils.pointToPixel(drawable, attributes.width, zoom);
-		LineAttributes lineAttributesInPixels = new LineAttributes(widthInPixels, attributes.cap, attributes.join, attributes.style, dashInPixels, attributes.dashOffset, attributes.miterLimit);
+		LineAttributes lineAttributesInPixels = new LineAttributes(widthInPixels, attributes.cap, attributes.join, attributes.style, dashInPixels, dashOffsetInPixels, attributes.miterLimit);
 		return lineAttributesInPixels;
 	}
 }


### PR DESCRIPTION
When setting line attributes in a GC, the properties containing zoom-specific values are transformed from point into pixel values when assigning them to the actual GC data. While this is properly done for line width and dash, it is currently not done for the dash offset. With this change, also the dash offset is properly transformed into a pixel value.

This has been found via review in a separate PR: https://github.com/eclipse-platform/eclipse.platform.swt/pull/3148#discussion_r2999768471

This PR currently contains and should thus be merged after:
- https://github.com/eclipse-platform/eclipse.platform.swt/pull/3148