### PR TITLE
Compute foreground and background colours for setEnabled and setEditable in StyledText

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/StyledText.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/StyledText.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -149,7 +149,7 @@ public class StyledText extends Canvas {
 	/** False iff the widget is disabled */
 	boolean enabled = true;
 	/** True iff the widget is in the midst of being enabled or disabled */
-	boolean insideSetEnableCall;
+	boolean insideUpdateColorsCall;
 	Clipboard clipboard;
 	int clickCount;
 	int autoScrollDirection = SWT.NULL;	// the direction of autoscrolling (up, down, right, left)
@@ -8278,7 +8278,7 @@ public void setBackground(Color color) {
 	boolean backgroundDisabled = false;
 	if (!this.enabled && color == null) {
 		if (background != null) {
-			Color disabledBg = getDisplay().getSystemColor(SWT.COLOR_TEXT_DISABLED_BACKGROUND);
+			Color disabledBg = getDisplay().getSystemColor(SWT.COLOR_WIDGET_DISABLED_FOREGROUND);
 			if (background.equals(disabledBg)) {
 				return;
 			} else {
@@ -8287,11 +8287,13 @@ public void setBackground(Color color) {
 			}
 		}
 	}
-	customBackground = color != null && !this.insideSetEnableCall && !backgroundDisabled;
+	customBackground = color != null && !this.insideUpdateColorsCall && !backgroundDisabled;
 	background = color;
 	super.setBackground(color);
-	resetCache(0, content.getLineCount());
-	setCaretLocations();
+	if (content != null) {
+		resetCache(0, content.getLineCount());
+		setCaretLocations();
+	}
 	super.redraw();
 }
 /**
@@ -8772,6 +8774,35 @@ public void setDragDetect (boolean dragDetect) {
 	checkWidget ();
 	this.dragDetect = dragDetect;
 }
+
+/**
+ * Applies foreground and background colors based on the control's state.
+ * Custom foreground and background settings are preserved and not overridden.
+ *
+ * @param enabled  {@code true} if the control is enabled; {@code false} otherwise
+ * @param editable {@code true} if the control is editable; {@code false} otherwise
+ *
+ */
+private void updateColors(boolean enabled, boolean editable) {
+	this.insideUpdateColorsCall = true;
+	Display display = getDisplay();
+	try {
+		if (enabled && editable) {
+			if (!customBackground) setBackground(display.getSystemColor(SWT.COLOR_LIST_BACKGROUND));
+			if (!customForeground) setForeground(display.getSystemColor(SWT.COLOR_LIST_FOREGROUND));
+		} else if(!enabled) {
+			if (!customBackground) setBackground(display.getSystemColor(SWT.COLOR_WIDGET_DISABLED_FOREGROUND));
+			if (!customForeground) setForeground(display.getSystemColor(SWT.COLOR_DARK_GRAY));
+		} else if(!editable) {
+			if (!customBackground) setBackground(display.getSystemColor(SWT.COLOR_WIDGET_DISABLED_FOREGROUND));
+			if (!customForeground) setForeground(display.getSystemColor(SWT.COLOR_LIST_FOREGROUND));
+		}
+	}
+	finally {
+		this.insideUpdateColorsCall = false;
+	}
+}
+
 /**
  * Sets whether the widget content can be edited.
  *
@@ -8785,28 +8816,13 @@ public void setDragDetect (boolean dragDetect) {
 public void setEditable(boolean editable) {
 	checkWidget();
 	this.editable = editable;
+	updateColors(this.enabled, this.editable);
 }
 @Override
 public void setEnabled(boolean enabled) {
 	super.setEnabled(enabled);
-	Display display = getDisplay();
 	this.enabled = enabled;
-	this.insideSetEnableCall = true;
-	try {
-		if (enabled && editable) {
-			if (!customBackground) setBackground(display.getSystemColor(SWT.COLOR_LIST_BACKGROUND));
-			if (!customForeground) setForeground(display.getSystemColor(SWT.COLOR_LIST_FOREGROUND));
-		} else if(!enabled) {
-			if (!customBackground) setBackground(display.getSystemColor(SWT.COLOR_TEXT_DISABLED_BACKGROUND));
-			if (!customForeground) setForeground(display.getSystemColor(SWT.COLOR_WIDGET_DISABLED_FOREGROUND));
-		} else if(!editable) {
-			if (!customBackground) setBackground(display.getSystemColor(SWT.COLOR_TEXT_DISABLED_BACKGROUND));
-			if (!customForeground) setForeground(display.getSystemColor(SWT.COLOR_LIST_FOREGROUND));
-		}
-	}
-	finally {
-		this.insideSetEnableCall = false;
-	}
+	updateColors(this.enabled, this.editable);
 }
 
 @Override
@@ -8873,7 +8889,7 @@ public void setForeground(Color color) {
 	boolean foregroundDisabled = false;
 	if (!this.enabled && color == null) {
 		if (foreground != null) {
-			Color disabledFg = getDisplay().getSystemColor(SWT.COLOR_WIDGET_DISABLED_FOREGROUND);
+			Color disabledFg = getDisplay().getSystemColor(SWT.COLOR_DARK_GRAY);
 			if (foreground.equals(disabledFg)) {
 				return;
 			} else {
@@ -8882,11 +8898,13 @@ public void setForeground(Color color) {
 			}
 		}
 	}
-	customForeground = color != null && !this.insideSetEnableCall && !foregroundDisabled;
+	customForeground = color != null && !this.insideUpdateColorsCall && !foregroundDisabled;
 	foreground = color;
 	super.setForeground(color);
-	resetCache(0, content.getLineCount());
-	setCaretLocations();
+	if (content != null) {
+		resetCache(0, content.getLineCount());
+		setCaretLocations();
+	}
 	super.redraw();
 }
 /**

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_custom_StyledText.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_custom_StyledText.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2025 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -3245,8 +3245,8 @@ public void test_setDoubleClickEnabledZ(){
 @Test
 public void test_setEnabled(){
 	// Get colors
-	Color disabledBg = text.getDisplay().getSystemColor(SWT.COLOR_TEXT_DISABLED_BACKGROUND);
-	Color disabledFg = text.getDisplay().getSystemColor(SWT.COLOR_WIDGET_DISABLED_FOREGROUND);
+	Color disabledBg = text.getDisplay().getSystemColor(SWT.COLOR_WIDGET_DISABLED_FOREGROUND);
+	Color disabledFg = text.getDisplay().getSystemColor(SWT.COLOR_DARK_GRAY);
 	Color enabledBg = text.getDisplay().getSystemColor(SWT.COLOR_LIST_BACKGROUND);
 	Color enabledFg = text.getDisplay().getSystemColor(SWT.COLOR_LIST_FOREGROUND);
 


### PR DESCRIPTION
This PR adds consistent handling of both foreground and background colors for both `setEnabled` and `setEditable` functions

The foreground and background colors were computed only for setEnabled. This has to be done for setEditable as
well to achieve consistency. Both the functions setEditable and setEnabled now recomputes foreground and background colour (earlier only applied in `setEnabled`)
This commit also adds a distinct foreground and background colour combination. Earlier the editable and non-editable state showed no difference. This now improves visual differentiation in StyledText. 

Test Snippet : [Test.txt](https://github.com/user-attachments/files/26307957/Test.txt)

The StyledText behaviour in non editable state is shown below :

Before :
<img width="500" height="198" alt="image" src="https://github.com/user-attachments/assets/83c4a595-2512-4861-8cb3-a263d7619c0e" />


After : 
<img width="500" height="197" alt="image" src="https://github.com/user-attachments/assets/7c067460-39a5-45bd-a55e-2327740f80a0" />



Fixes: https://github.com/eclipse-platform/eclipse.platform.swt/issues/3132, Fixes: https://github.com/eclipse-platform/eclipse.platform.swt/issues/230
