### PR TITLE
Remove 2px chamfer from simple CTabFolder tab corners

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CTabFolderRenderer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CTabFolderRenderer.java
@@ -70,10 +70,10 @@ public class CTabFolderRenderer {
 	static final int[] BOTTOM_LEFT_CORNER = new int[] {0,-6, 1,-5, 1,-4, 4,-1, 5,-1, 6,0};
 	static final int[] BOTTOM_RIGHT_CORNER = new int[] {-6,0, -5,-1, -4,-1, -1,-4, -1,-5, 0,-6};
 
-	static final int[] SIMPLE_TOP_LEFT_CORNER = new int[] {0,2, 1,1, 2,0};
-	static final int[] SIMPLE_TOP_RIGHT_CORNER = new int[] {-2,0, -1,1, 0,2};
-	static final int[] SIMPLE_BOTTOM_LEFT_CORNER = new int[] {0,-2, 1,-1, 2,0};
-	static final int[] SIMPLE_BOTTOM_RIGHT_CORNER = new int[] {-2,0, -1,-1, 0,-2};
+	static final int[] SIMPLE_TOP_LEFT_CORNER = new int[] {0,0};
+	static final int[] SIMPLE_TOP_RIGHT_CORNER = new int[] {0,0};
+	static final int[] SIMPLE_BOTTOM_LEFT_CORNER = new int[] {0,0};
+	static final int[] SIMPLE_BOTTOM_RIGHT_CORNER = new int[] {0,0};
 	static final int[] SIMPLE_UNSELECTED_INNER_CORNER = new int[] {0,0};
 
 	static final int[] TOP_LEFT_CORNER_BORDERLESS = new int[] {0,6, 1,5, 1,4, 4,1, 5,1, 6,0};
@@ -81,10 +81,10 @@ public class CTabFolderRenderer {
 	static final int[] BOTTOM_LEFT_CORNER_BORDERLESS = new int[] {0,-6, 1,-6, 1,-5, 2,-4, 4,-2, 5,-1, 6,-1, 6,0};
 	static final int[] BOTTOM_RIGHT_CORNER_BORDERLESS = new int[] {-7,0, -7,-1, -6,-1, -5,-2, -3,-4, -2,-5, -2,-6, -1,-6};
 
-	static final int[] SIMPLE_TOP_LEFT_CORNER_BORDERLESS = new int[] {0,2, 1,1, 2,0};
-	static final int[] SIMPLE_TOP_RIGHT_CORNER_BORDERLESS= new int[] {-3,0, -2,1, -1,2};
-	static final int[] SIMPLE_BOTTOM_LEFT_CORNER_BORDERLESS = new int[] {0,-3, 1,-2, 2,-1, 3,0};
-	static final int[] SIMPLE_BOTTOM_RIGHT_CORNER_BORDERLESS = new int[] {-4,0, -3,-1, -2,-2, -1,-3};
+	static final int[] SIMPLE_TOP_LEFT_CORNER_BORDERLESS = new int[] {0,0};
+	static final int[] SIMPLE_TOP_RIGHT_CORNER_BORDERLESS= new int[] {0,0};
+	static final int[] SIMPLE_BOTTOM_LEFT_CORNER_BORDERLESS = new int[] {0,0};
+	static final int[] SIMPLE_BOTTOM_RIGHT_CORNER_BORDERLESS = new int[] {0,0};
 
 	static final RGB CLOSE_FILL = new RGB(240, 64, 64);
 


### PR DESCRIPTION
## Summary

- Flattens the `SIMPLE_*` corner arrays in `CTabFolderRenderer` from 2–4px diagonal chamfers to `{0,0}` (fully square corners)
- Affects both bordered and borderless variants: `SIMPLE_TOP_LEFT_CORNER`, `SIMPLE_TOP_RIGHT_CORNER`, `SIMPLE_BOTTOM_LEFT_CORNER`, `SIMPLE_BOTTOM_RIGHT_CORNER` and their `_BORDERLESS` counterparts
- The `SIMPLE_UNSELECTED_INNER_CORNER` was already `{0,0}` and is unchanged
- No logic changes — purely the polygon offset data used to draw simple-mode tab corners

Relates to #3150

## Test plan

- [ ] Run `Snippet82` and verify tab corners are now fully square (no diagonal cut at corners)
- [ ] Run `Snippet165` (which uses `setSimple(false)`) to verify curved tabs are unaffected
- [ ] Run `Test_org_eclipse_swt_custom_CTabFolder` tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)