### PR TITLE
[Win32] Consider SWT.DRAW_DELIMITER flag when drawing text with GDI+

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/GC.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/GC.java
@@ -3037,6 +3037,9 @@ private RectF drawText(long gdipGraphics, char[] buffer, int start, int length, 
 private void drawTextGDIP(long gdipGraphics, String string, int x, int y, int flags, boolean draw, Point size) {
 	boolean needsBounds = !draw || (flags & SWT.DRAW_TRANSPARENT) == 0;
 	char[] buffer;
+	if ((flags & SWT.DRAW_DELIMITER) == 0) {
+		string = string.replaceAll("[\\r\\n]+", "");
+	}
 	int length = string.length();
 	if (length != 0) {
 		buffer = string.toCharArray();

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_GC.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_GC.java
@@ -955,6 +955,18 @@ public void test_textExtentLjava_lang_StringI() {
 }
 
 @Test
+public void test_textExtentLjava_lang_StringI_disabledLineDelimiter() {
+	gc.setAdvanced(false);
+	Point ptWithoutAdvanced = gc.textExtent("abc\u4E2D" + System.lineSeparator() + "def", 0);
+	gc.setAdvanced(true);
+	Point ptWithAdvanced = gc.textExtent("abc\u4E2D" + System.lineSeparator() + "def", 0);
+	// Due to slightly different rendering, size must not be identical but similar in advanced/non-advanced mode
+	assertTrue(Math.abs(ptWithAdvanced.x - ptWithoutAdvanced.x) <= 2);
+	assertTrue(Math.abs(ptWithAdvanced.y - ptWithoutAdvanced.y) <= 2);
+	gc.dispose();
+}
+
+@Test
 public void test_toString() {
 	String s = gc.toString();
 	assertNotNull(s);


### PR DESCRIPTION
The GC.drawText() implementation falls back to using GDI instead of GDI+ (even if enabled) in many cases for historic reasons. There were issues with rendering tabs back then. One of the few cases where GDI+ is used is when glyphs that are non existing for GDI are used. In that case, however, the DRAW_DELIMITER flag is not properly considered. The behavior is always as if the flag was enabled, i.e., line delimiters is always drawn even if the flag is not set.

This change corrects the behavior of the GDI+ text drawing implementation to consider if the DRAW_DELIMITER flag is not set. In consequence, strings with glyphs that are not supported by GDI are now rendered without line breaks if undesired as per defined flags.

Contributes to https://github.com/eclipse-platform/eclipse.platform.swt/issues/3091

This is the extraction of a fix that was included in https://github.com/eclipse-platform/eclipse.platform.swt/pull/3100

### How to test
The following snippet demonstrates the currently unintended behavior:

```java
public static void main(String[] args) {
	Display display = new Display();
	Shell shell = new Shell(display);
	shell.setLayout(new FillLayout());
	shell.setSize(250, 150);

	shell.addPaintListener(e -> {
		GC gc = e.gc;
		gc.drawText("\u4E2D\u6587:\r\n Should render on single line", 10, 10, SWT.DRAW_TAB);
		gc.setAdvanced(true);
		gc.drawText("\u4E2D\u6587:\r\n Should render on single line", 10, 50, SWT.DRAW_TAB);
	});

	shell.open();

	while (!shell.isDisposed()) {
		if (!display.readAndDispatch()) {
			display.sleep();
		}
	}
}
```

#### Before
<img width="236" height="143" alt="image" src="https://github.com/user-attachments/assets/97ad5461-952f-4929-8117-0b09def77aad" />

#### After
<img width="236" height="143" alt="image" src="https://github.com/user-attachments/assets/c7b10d4f-6a53-46dc-a6b9-698c15bb888d" />