### PR TITLE
[Gtk4] Remove decoration of Shell with parent and ON_TOP

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Shell.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Shell.java
@@ -749,7 +749,6 @@ void createHandle (int index) {
 			int type = GTK.GTK_WINDOW_TOPLEVEL;
 			if (isChildShell && (style & SWT.ON_TOP) != 0) type = GTK.GTK_WINDOW_POPUP;
 			if (GTK.GTK4) {
-				// TODO: GTK4 need to handle for GTK_WINDOW_POPUP type
 				shellHandle = GTK4.gtk_window_new();
 				if (OS.isWayland()) {
 					long headerbar = GTK4.gtk_window_get_titlebar(shellHandle);
@@ -759,6 +758,9 @@ void createHandle (int index) {
 					    long hb = GTK4.gtk_header_bar_new();
 					    GTK4.gtk_window_set_titlebar(shellHandle, hb);
 					}
+				}
+				if (type == GTK.GTK_WINDOW_POPUP) {
+					GTK.gtk_window_set_decorated(shellHandle, false);
 				}
 			} else {
 				shellHandle = GTK3.gtk_window_new(type);


### PR DESCRIPTION
On Gtk 3 such shells are created with GTK_WINDOW_POPUP - aka undecorated amongst other things like transient_for and destroy with parent which are set for for every child shell.