### PR TITLE
[Gtk] Remove Control.fixGdkEventTypeValues

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/org/eclipse/swt/internal/gtk/GDK.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/org/eclipse/swt/internal/gtk/GDK.java
@@ -222,20 +222,6 @@ public class GDK extends OS {
 	public static final int GDK_WINDOW_TYPE_HINT_UTILITY = 5;
 	public static final int GDK_WINDOW_TYPE_HINT_TOOLTIP = 10;
 
-	/** GdkEventType constants are different on GTK4 */
-	public static final int GDK4_EXPOSE = 3;
-	public static final int GDK4_MOTION_NOTIFY = 4;
-	public static final int GDK4_BUTTON_PRESS = 5;
-	public static final int GDK4_BUTTON_RELEASE = 6;
-	public static final int GDK4_KEY_PRESS = 7;
-	public static final int GDK4_KEY_RELEASE = 8;
-	public static final int GDK4_ENTER_NOTIFY = 9;
-	public static final int GDK4_LEAVE_NOTIFY = 10;
-	public static final int GDK4_FOCUS_CHANGE = 11;
-	public static final int GDK4_CONFIGURE = 12;
-	public static final int GDK4_MAP = 13;
-	public static final int GDK4_UNMAP = 14;
-
 	/** sizeof(TYPE) for 32/64 bit support */
 	public static final native int GdkKeymapKey_sizeof();
 	public static final native int GdkRGBA_sizeof();

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Combo.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Combo.java
@@ -1493,7 +1493,6 @@ long gtk_changed (long widget) {
 	long eventPtr = GTK.GTK4 ? 0 : GTK3.gtk_get_current_event ();
 	if (eventPtr != 0) {
 		int eventType = GDK.gdk_event_get_event_type(eventPtr);
-		eventType = fixGdkEventTypeValues(eventType);
 		switch (eventType) {
 			case GDK.GDK_KEY_PRESS:
 				keyPress = true;
@@ -1675,7 +1674,6 @@ long gtk3_event_after (long widget, long gdkEvent)  {
 	* field.
 	*/
 	int eventType = GDK.gdk_event_get_event_type(gdkEvent);
-	eventType = fixGdkEventTypeValues(eventType);
 	switch (eventType) {
 		case GDK.GDK_BUTTON_PRESS: {
 			int [] eventButton = new int [1];
@@ -2752,7 +2750,6 @@ String verifyText (String string, int start, int end) {
 	long eventPtr = GTK.GTK4 ? 0 : GTK3.gtk_get_current_event ();
 	if (eventPtr != 0) {
 		int type = GDK.gdk_event_get_event_type(eventPtr);
-		type = fixGdkEventTypeValues(type);
 		switch (type) {
 			case GDK.GDK_KEY_PRESS:
 				setKeyState (event, eventPtr);

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Control.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Control.java
@@ -286,30 +286,6 @@ long eventSurface () {
 	return gtk_widget_get_surface (eventHandle);
 }
 
-/**
- * GdkEventType constants different on GTK4 and GTK3.
- * This checks for GTK versions and return the correct constants defined in GDK.java
- * @return constant defined
- */
-static int fixGdkEventTypeValues(int eventType) {
-	if (GTK.GTK4) {
-		switch (eventType) {
-			case GDK.GDK4_EXPOSE: return GDK.GDK_EXPOSE;
-			case GDK.GDK4_MOTION_NOTIFY: return GDK.GDK_MOTION_NOTIFY;
-			case GDK.GDK4_BUTTON_PRESS: return GDK.GDK_BUTTON_PRESS;
-			case GDK.GDK4_BUTTON_RELEASE: return GDK.GDK_BUTTON_RELEASE;
-			case GDK.GDK4_KEY_PRESS: return GDK.GDK_KEY_PRESS;
-			case GDK.GDK4_ENTER_NOTIFY: return GDK.GDK_ENTER_NOTIFY;
-			case GDK.GDK4_LEAVE_NOTIFY: return GDK.GDK_LEAVE_NOTIFY;
-			case GDK.GDK4_FOCUS_CHANGE: return GDK.GDK_FOCUS_CHANGE;
-			case GDK.GDK4_CONFIGURE: return GDK.GDK_CONFIGURE;
-			case GDK.GDK4_MAP: return GDK.GDK_MAP;
-			case GDK.GDK4_UNMAP: return GDK.GDK_UNMAP;
-		}
-	}
-	return eventType;
-}
-
 void fixFocus (Control focusControl) {
 	Shell shell = getShell ();
 	Control control = this;
@@ -2714,7 +2690,6 @@ boolean dragDetect (int x, int y, boolean filter, boolean dragOnTimeout, boolean
 			if (dragging) return true;  //428852
 			if (eventPtr == 0) return dragOnTimeout;
 			int eventType = GDK.gdk_event_get_event_type(eventPtr);
-			eventType = fixGdkEventTypeValues(eventType);
 			switch (eventType) {
 				case GDK.GDK_MOTION_NOTIFY: {
 					long gdkResource = gdk_event_get_surface_or_window(eventPtr);
@@ -3718,7 +3693,6 @@ boolean checkSubwindow () {
 @Override
 long gtk3_event_after (long widget, long gdkEvent) {
 	int eventType = GDK.gdk_event_get_event_type(gdkEvent);
-	eventType = fixGdkEventTypeValues(eventType);
 	switch (eventType) {
 		case GDK.GDK_BUTTON_PRESS: {
 			if (widget != eventHandle ()) break;
@@ -4100,7 +4074,6 @@ long gtk_mnemonic_activate (long widget, long arg1) {
 	long eventPtr = GTK3.gtk_get_current_event ();
 	if (eventPtr != 0) {
 		int type = GDK.gdk_event_get_event_type(eventPtr);
-		type = fixGdkEventTypeValues(type);
 		if (type == GDK.GDK_KEY_PRESS) {
 			Control focusControl = display.getFocusControl ();
 			long focusHandle = focusControl != null ? focusControl.focusHandle () : 0;

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Link.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Link.java
@@ -341,7 +341,6 @@ long gtk_button_press_event (long widget, long event) {
 	if (result != 0) return result;
 
 	int eventType = GDK.gdk_event_get_event_type(event);
-	eventType = fixGdkEventTypeValues(eventType);
 
 	int [] eventButton = new int [1];
 	if (GTK.GTK4) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Menu.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Menu.java
@@ -366,9 +366,9 @@ void _setVisible (boolean visible) {
 					 */
 					eventPtr = GTK3.gtk_get_current_event();
 					if (eventPtr == 0) {
-						eventPtr = GDK.gdk_event_new(GTK.GTK4 ? GDK.GDK4_BUTTON_PRESS : GDK.GDK_BUTTON_PRESS);
+						eventPtr = GDK.gdk_event_new(GDK.GDK_BUTTON_PRESS);
 						GdkEventButton event = new GdkEventButton ();
-						event.type = GTK.GTK4 ? GDK.GDK4_BUTTON_PRESS : GDK.GDK_BUTTON_PRESS;
+						event.type = GDK.GDK_BUTTON_PRESS;
 						// Only assign a window on X11, as on Wayland the window is that of the mouse pointer
 						if (OS.isX11()) {
 							event.window = OS.g_object_ref(GTK3.gtk_widget_get_window (getShell().handle));
@@ -1415,7 +1415,6 @@ void adjustParentWindowWayland (long eventPtr) {
 		}
 		OS.g_object_ref(deviceResource);
 		int eventType = GDK.gdk_event_get_event_type(eventPtr);
-		eventType = Control.fixGdkEventTypeValues(eventType);
 		switch (eventType) {
 			case GDK.GDK_BUTTON_PRESS:
 				GdkEventButton eventButton = new GdkEventButton();

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/ScrollBar.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/ScrollBar.java
@@ -550,7 +550,6 @@ long gtk_value_changed (long range) {
 @Override
 long gtk3_event_after (long widget, long gdkEvent) {
 	int eventType = GDK.gdk_event_get_event_type(gdkEvent);
-	eventType = Control.fixGdkEventTypeValues(eventType);
 	switch (eventType) {
 		case GDK.GDK_BUTTON_RELEASE: {
 			int [] eventButton = new int [1];

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Slider.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Slider.java
@@ -232,7 +232,6 @@ long gtk_value_changed(long range) {
 @Override
 long gtk3_event_after (long widget, long gdkEvent) {
 	int eventType = GDK.gdk_event_get_event_type(gdkEvent);
-	eventType = Control.fixGdkEventTypeValues(eventType);
 	switch (eventType) {
 		case GDK.GDK_BUTTON_RELEASE: {
 			int [] eventButton = new int [1];

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Spinner.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Spinner.java
@@ -660,7 +660,6 @@ long gtk_changed (long widget) {
 	long eventPtr = GTK.GTK4 ? 0 : GTK3.gtk_get_current_event();
 	if (eventPtr != 0) {
 		int eventType = GDK.gdk_event_get_event_type(eventPtr);
-		eventType = fixGdkEventTypeValues(eventType);
 		switch (eventType) {
 			case GDK.GDK_KEY_PRESS:
 				keyPress = true;
@@ -1315,7 +1314,6 @@ String verifyText (String string, int start, int end) {
 	long eventPtr = GTK3.gtk_get_current_event ();
 	if (eventPtr != 0) {
 		int type = GDK.gdk_event_get_event_type(eventPtr);
-		type = fixGdkEventTypeValues(type);
 		switch (type) {
 			case GDK.GDK_KEY_PRESS:
 				setKeyState (event, eventPtr);

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/TableColumn.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/TableColumn.java
@@ -352,7 +352,6 @@ long gtk_clicked (long widget) {
 		}
 
 		int eventType = GDK.gdk_event_get_event_type(eventPtr);
-		eventType = Control.fixGdkEventTypeValues(eventType);
 		int eventTime = GDK.gdk_event_get_time(eventPtr);
 		switch (eventType) {
 			case GDK.GDK_BUTTON_RELEASE: {
@@ -374,7 +373,6 @@ long gtk_clicked (long widget) {
 @Override
 long gtk3_event_after (long widget, long gdkEvent) {
 	int eventType = GDK.gdk_event_get_event_type(gdkEvent);
-	eventType = Control.fixGdkEventTypeValues(eventType);
 	switch (eventType) {
 		case GDK.GDK_BUTTON_PRESS: {
 			int [] eventButton = new int [1];

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Text.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Text.java
@@ -1576,7 +1576,6 @@ long gtk_changed (long widget) {
 	long eventPtr = GTK.GTK4 ? 0 : GTK3.gtk_get_current_event ();
 	if (eventPtr != 0) {
 		int eventType = GDK.gdk_event_get_event_type(eventPtr);
-		eventType = fixGdkEventTypeValues(eventType);
 		switch (eventType) {
 			case GDK.GDK_KEY_PRESS:
 				keyPress = true;
@@ -1733,7 +1732,6 @@ long gtk3_event_after (long widget, long gdkEvent) {
 	*/
 	if ((style & SWT.SINGLE) != 0 && display.entrySelectOnFocus) {
 		int eventType = GDK.gdk_event_get_event_type(gdkEvent);
-		eventType = fixGdkEventTypeValues(eventType);
 		switch (eventType) {
 			case GDK.GDK_FOCUS_CHANGE:
 				boolean [] focusIn = new boolean [1];
@@ -2926,7 +2924,6 @@ String verifyText (String string, int start, int end) {
 	long eventPtr = GTK.GTK4 ? 0 : GTK3.gtk_get_current_event();
 	if (eventPtr != 0) {
 		int type = GDK.gdk_event_get_event_type(eventPtr);
-		type = fixGdkEventTypeValues(type);
 		switch (type) {
 			case GDK.GDK_KEY_PRESS:
 				setKeyState (event, eventPtr);

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/ToolItem.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/ToolItem.java
@@ -626,7 +626,6 @@ long gtk_clicked (long widget) {
 		long eventPtr = GTK3.gtk_get_current_event ();
 		if (eventPtr != 0) {
 			int eventType = GDK.gdk_event_get_event_type(eventPtr);
-			eventType = Control.fixGdkEventTypeValues(eventType);
 			long topHandle = topHandle();
 			switch (eventType) {
 				case GDK.GDK_KEY_RELEASE: //Fall Through..
@@ -789,7 +788,6 @@ void gtk4_enter_event(long controller, double x, double y, long event) {
 @Override
 long gtk3_event_after (long widget, long gdkEvent) {
 	int eventType = GDK.gdk_event_get_event_type(gdkEvent);
-	eventType = Control.fixGdkEventTypeValues(eventType);
 	switch (eventType) {
 		case GDK.GDK_BUTTON_PRESS: {
 			int [] eventButton = new int [1];

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Tracker.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Tracker.java
@@ -470,7 +470,7 @@ boolean grab () {
 @Override
 long gtk_button_release_event (long widget, long event) {
 	Control.mouseDown = false;
-	return gtk_mouse (GTK.GTK4 ? GDK.GDK4_BUTTON_RELEASE : GDK.GDK_BUTTON_RELEASE, widget, event);
+	return gtk_mouse (GDK.GDK_BUTTON_RELEASE, widget, event);
 }
 
 @Override
@@ -619,7 +619,7 @@ long gtk_motion_notify_event (long widget, long eventPtr) {
 		grabbed = grab ();
 		lastCursor = cursor;
 	}
-	return gtk_mouse (GTK.GTK4 ? GDK.GDK4_MOTION_NOTIFY : GDK.GDK_MOTION_NOTIFY, widget, eventPtr);
+	return gtk_mouse (GDK.GDK_MOTION_NOTIFY, widget, eventPtr);
 }
 
 long gtk_mouse (int eventType, long widget, long eventPtr) {
@@ -735,7 +735,6 @@ long gtk_mouse (int eventType, long widget, long eventPtr) {
 		oldX = newX [0];
 		oldY = newY [0];
 	}
-	eventType = Control.fixGdkEventTypeValues(eventType);
 	tracking = eventType != GDK.GDK_BUTTON_RELEASE;
 	return 0;
 }
@@ -912,7 +911,6 @@ private void setTrackerBackground(boolean opaque) {
 
 boolean processEvent (long eventPtr) {
 	int eventType = GDK.gdk_event_get_event_type(eventPtr);
-	eventType = Control.fixGdkEventTypeValues(eventType);
 	long widget = GTK3.gtk_get_event_widget (eventPtr);
 	switch (eventType) {
 		case GDK.GDK_MOTION_NOTIFY: gtk_motion_notify_event (widget, eventPtr); break;

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/TrayItem.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/TrayItem.java
@@ -258,8 +258,6 @@ long gtk_activate (long widget) {
 			gdk_event_free(currEvent);
 		}
 		gdk_event_free (nextEvent);
-		currEventType = Control.fixGdkEventTypeValues(currEventType);
-		nextEventType = Control.fixGdkEventTypeValues(nextEventType);
 		if (currEventType == GDK.GDK_BUTTON_PRESS && nextEventType == GDK.GDK_2BUTTON_PRESS) {
 			sendSelectionEvent (SWT.DefaultSelection);
 		}

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/TreeColumn.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/TreeColumn.java
@@ -371,7 +371,6 @@ int gtk_gesture_press_event(long gesture, int n_press, double x, double y, long 
 @Override
 long gtk3_event_after (long widget, long gdkEvent) {
 	int eventType = GDK.gdk_event_get_event_type(gdkEvent);
-	eventType = Control.fixGdkEventTypeValues(eventType);
 	switch (eventType) {
 		case GDK.GDK_BUTTON_PRESS: {
 			int [] eventButton = new int [1];

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Widget.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Widget.java
@@ -1727,7 +1727,6 @@ char [] sendIMKeyEvent (int type, long event, char [] chars) {
 		ptr = GTK.GTK4 ? GTK4.gtk_event_controller_get_current_event(controller):GTK3.gtk_get_current_event ();
 		if (ptr != 0) {
 			int eventType = GDK.gdk_event_get_event_type(ptr);
-			eventType = Control.fixGdkEventTypeValues(eventType);
 			switch (eventType) {
 				case GDK.GDK_KEY_PRESS:
 				case GDK.GDK_KEY_RELEASE:
@@ -1800,7 +1799,6 @@ void sendSelectionEvent (int eventType, Event event, boolean send) {
 	long ptr = GTK.GTK4 ? 0 : GTK3.gtk_get_current_event ();
 	if (ptr != 0) {
 		int currentEventType = GDK.gdk_event_get_event_type(ptr);
-		currentEventType = Control.fixGdkEventTypeValues(currentEventType);
 		switch (currentEventType) {
 			case GDK.GDK_BUTTON_PRESS:
 			case GDK.GDK_2BUTTON_PRESS:


### PR DESCRIPTION
This is a leftover from very first efforts to create Gtk 4 port when a mapping between event types in Gtk 3 and 4 was still smth supposed to work. With Gtk 4.0 deciding to go the event controlled path - this is all no-op now. What's worse - values of Gtk 4 GdkEventType constants are totally wrong when comparing with
https://docs.gtk.org/gdk4/enum.EventType.html thus best to drop entirely to prevent the chances that this breaks some corner case.