### PR TITLE
[Win32][Edge] Fix BrowserFunction race condition using AddScriptToExecuteOnDocumentCreated

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Browser/win32/org/eclipse/swt/browser/Edge.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Browser/win32/org/eclipse/swt/browser/Edge.java
@@ -85,6 +85,8 @@ class Edge extends WebBrowser {
 	boolean inNewWindow;
 	private boolean inEvaluate;
 	HashMap<Long, LocationEvent> navigations = new HashMap<>();
+	/** Maps BrowserFunction index to the script ID from AddScriptToExecuteOnDocumentCreated. */
+	private final Map<Integer, String> functionScriptIds = new HashMap<>();
 	private boolean ignoreGotFocus;
 	private boolean ignoreFocusIn;
 	private String lastCustomText;
@@ -1146,14 +1148,6 @@ int handleNavigationStarting(long pView, long pArgs, boolean top) {
 	navigations.put(pNavId[0], event);
 	if (event.doit) {
 		settings.put_IsScriptEnabled(jsEnabledOnNextPage);
-		// Register browser functions in the new document.
-		if (!functions.isEmpty()) {
-			StringBuilder sb = new StringBuilder();
-			for (BrowserFunction function : functions.values()) {
-				sb.append(function.functionString);
-			}
-			execute(sb.toString());
-		}
 	} else {
 		args.put_Cancel(true);
 	}
@@ -1834,6 +1828,51 @@ private boolean setWebpageData(String url, String postData, String[] headers, St
 @Override
 public boolean setUrl(String url, String postData, String[] headers) {
 	return setWebpageData(url, postData, headers, null);
+}
+
+/**
+ * Registers the function script persistently via AddScriptToExecuteOnDocumentCreated so it is
+ * injected on every future document creation before any page scripts run, avoiding the race
+ * condition between async function injection and navigation completion.
+ * If called while inside a WebView2 callback, the persistent registration is deferred via
+ * {@link Display#asyncExec(Runnable)} so it completes once the callback returns.
+ * See <a href="https://github.com/eclipse-platform/eclipse.platform.swt/issues/20">issue #20</a>.
+ */
+@Override
+public void createFunction(BrowserFunction function) {
+	super.createFunction(function);
+	int functionIndex = function.index;
+	String functionString = function.functionString;
+	if (inCallback > 0) {
+		// Cannot wait for a callback result while already inside a WebView2 callback;
+		// defer the persistent registration to after the callback completes.
+		browser.getDisplay().asyncExec(() -> {
+			if (browser.isDisposed() || !functions.containsKey(functionIndex)) return;
+			registerFunctionScript(functionIndex, functionString);
+		});
+		return;
+	}
+	registerFunctionScript(functionIndex, functionString);
+}
+
+private void registerFunctionScript(int functionIndex, String functionString) {
+	String[] scriptId = new String[1];
+	callAndWait(scriptId, completion ->
+		webViewProvider.getWebView(true).AddScriptToExecuteOnDocumentCreated(
+			stringToWstr(functionString), completion.getAddress()));
+	if (scriptId[0] != null) {
+		functionScriptIds.put(functionIndex, scriptId[0]);
+	}
+}
+
+@Override
+void deregisterFunction(BrowserFunction function) {
+	super.deregisterFunction(function);
+	String scriptId = functionScriptIds.remove(function.index);
+	if (scriptId != null) {
+		webViewProvider.getWebView(true).RemoveScriptToExecuteOnDocumentCreated(
+			stringToWstr(scriptId));
+	}
 }
 
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/win32/org/eclipse/swt/internal/ole/win32/ICoreWebView2.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/win32/org/eclipse/swt/internal/ole/win32/ICoreWebView2.java
@@ -67,6 +67,10 @@ public int AddScriptToExecuteOnDocumentCreated(char[] javaScript, long handler) 
 	return COM.VtblCall(27, address, javaScript, handler);
 }
 
+public int RemoveScriptToExecuteOnDocumentCreated(char[] id) {
+	return COM.VtblCall(28, address, id);
+}
+
 public int ExecuteScript(char[] javaScript, IUnknown handler) {
 	return COM.VtblCall(29, address, javaScript, handler.address);
 }

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_browser_Browser.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_browser_Browser.java
@@ -2943,6 +2943,95 @@ public void test_BrowserFunction_multiprocess() {
 	browser2.dispose();
 }
 
+/**
+ * Regression test for https://github.com/eclipse-platform/eclipse.platform.swt/issues/20
+ *
+ * <p>A BrowserFunction registered before a navigation must be available when the new page's
+ * inline scripts execute (not just after the page finishes loading). In Edge/WebView2,
+ * function injection via {@code execute()} is asynchronous and can race with navigation
+ * completion. The fix uses {@code AddScriptToExecuteOnDocumentCreated} which guarantees
+ * injection before any page script runs.
+ */
+@Test
+public void test_BrowserFunction_availableBeforePageScripts_issue20() {
+	assumeTrue(isEdge, "Race condition is specific to async Edge/WebView2 implementation");
+	AtomicBoolean functionCalled = new AtomicBoolean(false);
+	AtomicBoolean pageLoadCompleted = new AtomicBoolean(false);
+
+	new BrowserFunction(browser, "options") {
+		@Override
+		public Object function(Object[] arguments) {
+			functionCalled.set(true);
+			return null;
+		}
+	};
+
+	// Navigate to a page whose inline <script> calls options() immediately.
+	// With the fix, options() is injected before any page scripts via
+	// AddScriptToExecuteOnDocumentCreated and is therefore guaranteed to be defined.
+	browser.addProgressListener(completedAdapter(e -> pageLoadCompleted.set(true)));
+	browser.setText("<html><body><script>options();</script></body></html>");
+
+	shell.open();
+	assertTrue(waitForPassCondition(pageLoadCompleted::get), "Page did not finish loading");
+	assertTrue(functionCalled.get(),
+		"BrowserFunction 'options' was not called by the page script — it was not available "
+		+ "before page scripts ran (regression of https://github.com/eclipse-platform/eclipse.platform.swt/issues/20)");
+}
+
+/**
+ * Regression test for https://github.com/eclipse-platform/eclipse.platform.swt/issues/20
+ *
+ * <p>BrowserFunctions must survive page navigations. When a second Browser instance is being
+ * initialized concurrently, event-loop processing for the first browser can cause its async
+ * function-injection script to race with navigation completion, making the function undefined
+ * on the newly loaded page.
+ */
+@Test
+public void test_BrowserFunction_availableOnLoad_concurrentInstances_issue20() {
+	assumeTrue(isEdge, "Race condition is specific to async Edge/WebView2 implementation");
+	AtomicBoolean browser1FuncAvailable = new AtomicBoolean(false);
+	AtomicBoolean browser2FuncAvailable = new AtomicBoolean(false);
+
+	// Use new Browser() directly (not the createBrowser() helper that waits for
+	// initialization) so that both browsers are initializing concurrently, replicating
+	// the timing described in the bug report.
+	Browser b1 = new Browser(shell, SWT.NONE);
+	b1.setUrl("about:blank");
+	new BrowserFunction(b1, "options") {
+		@Override
+		public Object function(Object[] arguments) { return null; }
+	};
+	b1.addProgressListener(completedAdapter(e -> {
+		try {
+			b1.evaluate("options();");
+			browser1FuncAvailable.set(true);
+		} catch (SWTException ignored) {}
+	}));
+	createdBroswers.add(b1);
+
+	// Creating a second browser forces event-loop processing that can reveal the race.
+	Browser b2 = new Browser(shell, SWT.NONE);
+	b2.setUrl("about:blank");
+	new BrowserFunction(b2, "options") {
+		@Override
+		public Object function(Object[] arguments) { return null; }
+	};
+	b2.addProgressListener(completedAdapter(e -> {
+		try {
+			b2.evaluate("options();");
+			browser2FuncAvailable.set(true);
+		} catch (SWTException ignored) {}
+	}));
+	createdBroswers.add(b2);
+
+	shell.open();
+	assertTrue(
+		waitForPassCondition(() -> browser1FuncAvailable.get() && browser2FuncAvailable.get()),
+		"BrowserFunction must be available when page load completes on both browsers "
+		+ "(regression of https://github.com/eclipse-platform/eclipse.platform.swt/issues/20)");
+}
+
 @Test
 @Disabled("Too fragile on CI, Display.getDefault().post(event) does not work reliably")
 public void test_TabTraversalOutOfBrowser() {


### PR DESCRIPTION
## Summary

Fixes #20 (see also #2449 for a reproduction snippet).

In Edge/WebView2, `execute()` is asynchronous. When `new BrowserFunction()` is called, the injection script is queued via `ExecuteScript()`, but if a page navigation completes before WebView2 processes that queued script, the function is unavailable in the new document. This race is most easily triggered when two `Browser` instances are created in quick succession, as the second browser's initialization forces event-loop processing that can advance the first browser's navigation past the injection window.

**Fix:** Override `createFunction()` in `Edge` to register every function script via `AddScriptToExecuteOnDocumentCreated`. This WebView2 API guarantees the script runs on **every** future document creation, before any page scripts — eliminating the race condition. The script ID returned by the async registration is stored so it can be cleaned up via `RemoveScriptToExecuteOnDocumentCreated` when the `BrowserFunction` is disposed.

When `createFunction()` is called from within a WebView2 callback (`inCallback > 0`), blocking on the registration would deadlock, so the persistent registration is deferred via `Display.asyncExec()` to complete once the callback returns. This ensures **every** function is always persistently registered, removing the need for any `NavigationStarting` fallback re-injection.

## Changes

- `ICoreWebView2.java`: Add missing `RemoveScriptToExecuteOnDocumentCreated` vtbl binding (index 28, between `AddScriptToExecuteOnDocumentCreated` at 27 and `ExecuteScript` at 29)
- `Edge.java`: Override `createFunction()` to persistently register every function via `AddScriptToExecuteOnDocumentCreated` (deferred via `asyncExec` when inside a callback); override `deregisterFunction()` to call `RemoveScriptToExecuteOnDocumentCreated` on disposal; remove the `NavigationStarting` fallback re-injection since all functions are now always persistently registered
- `Test_org_eclipse_swt_browser_Browser.java`: Two regression tests (`isEdge`-only):
  - `test_BrowserFunction_availableBeforePageScripts_issue20`: registers a function, navigates to a page whose inline `<script>` immediately calls it, asserts the function was invoked (tests the `AddScriptToExecuteOnDocumentCreated` guarantee directly)
  - `test_BrowserFunction_availableOnLoad_concurrentInstances_issue20`: creates two browsers concurrently without waiting for initialization, verifies both functions are callable when their pages complete loading (replicates the original bug report timing)

## Test plan

- [x] Run `test_BrowserFunction_availableBeforePageScripts_issue20` on Windows with Edge
- [x] Run `test_BrowserFunction_availableOnLoad_concurrentInstances_issue20` on Windows with Edge
- [x] Run existing `test_BrowserFunction_*` tests to verify no regressions
- [x] Manually verify with the reproduction snippet from [#2449 comment](https://github.com/eclipse-platform/eclipse.platform.swt/issues/2449#issuecomment-3233601556)
