### PR TITLE
[Gtk4] Fix CTabFolder blank content after tab switch

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Composite.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Composite.java
@@ -523,6 +523,22 @@ void deregister () {
 }
 
 @Override
+void snapshotToDraw(long handle, long snapshot) {
+	/*
+	 * For Composites that have both a fixedHandle (outer SwtFixed) and an
+	 * inner handle (also SwtFixed), snapshotDrawProc fires for BOTH handles
+	 * because snapshotDrawProc is installed on the SwtFixed class.  Doing
+	 * custom painting on the outer fixedHandle places the result on top of
+	 * the children that were snapshotted via the inner handle, obscuring the
+	 * tab/page content after a visibility change (e.g. switching CTabFolder
+	 * tabs on GTK4).  Skip custom painting for the outer fixedHandle; the
+	 * inner handle will do it correctly.
+	 */
+	if (fixedHandle != 0 && handle == fixedHandle) return;
+	super.snapshotToDraw(handle, snapshot);
+}
+
+@Override
 void snapshotBackground (long handle, long snapshot) {
 	if ((state & OBSCURED) != 0) return;
 	/*


### PR DESCRIPTION
## Problem

On GTK4, switching away from a `CTabFolder` tab and back causes the tab content area to go blank.

## Root Cause

When a `Composite` has both a `fixedHandle` (outer SwtFixed) and an inner `handle` (also SwtFixed) — as is the case for `CTabFolder` with `SWT.BORDER` — `snapshotDrawProc` fires for **both** handles because it is installed on the SwtFixed **class**, not per instance.

The outer `fixedHandle` snapshot fires after children are already rendered, so calling `onPaint` (via `snapshotToDraw`) at that point draws the `CTabFolder` body on top of the tab content, obscuring it after a visibility change (tab switch and return).

## Fix

Override `snapshotToDraw` in `Composite` to skip painting when called for the outer `fixedHandle`. The inner `handle` will handle painting correctly.

This mirrors the identical guard already present in `Canvas.snapshotToDraw`.

## Test

Run `CTabFolder` with `SWT.BORDER`, switch to another tab and back — content remains visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)