### PR TITLE
Replace polyline/Region drawing with direct line and rect calls in CT…

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CTabFolderRenderer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CTabFolderRenderer.java
@@ -473,10 +473,10 @@ public class CTabFolderRenderer {
 		int[] percents = selected ? parent.selectionGradientPercents : parent.gradientPercents;
 		boolean vertical = selected ? parent.selectionGradientVertical : parent.gradientVertical;
 
-		drawBackground(gc, null, bounds.x, bounds.y, bounds.width, bounds.height, defaultBackground, image, colors, percents, vertical);
+		drawBackground(gc, bounds.x, bounds.y, bounds.width, bounds.height, defaultBackground, image, colors, percents, vertical);
 	}
 
-	void drawBackground(GC gc, int[] shape, boolean selected) {
+	void drawBackground(GC gc, boolean selected) {
 		Color defaultBackground = selected && parent.shouldHighlight() ? parent.selectionBackground : parent.getBackground();
 		Image image = selected ? parent.selectionBgImage : null;
 		Color[] colors = selected && parent.shouldHighlight() ? parent.selectionGradientColors : parent.gradientColors;
@@ -495,19 +495,10 @@ public class CTabFolderRenderer {
 			x += 1; width -= 2;
 		}
 		int y = parent.onBottom ? size.y - borderBottom - height : borderTop;
-		drawBackground(gc, shape, x, y, width, height, defaultBackground, image, colors, percents, vertical);
+		drawBackground(gc, x, y, width, height, defaultBackground, image, colors, percents, vertical);
 	}
 
-	void drawBackground(GC gc, int[] shape, int x, int y, int width, int height, Color defaultBackground, Image image, Color[] colors, int[] percents, boolean vertical) {
-		Region clipping = null, region = null;
-		if (shape != null) {
-			clipping = new Region();
-			gc.getClipping(clipping);
-			region = new Region();
-			region.add(shape);
-			region.intersect(clipping);
-			gc.setClipping(region);
-		}
+	void drawBackground(GC gc, int x, int y, int width, int height, Color defaultBackground, Image image, Color[] colors, int[] percents, boolean vertical) {
 		if (image != null) {
 			// draw the background image in shape
 			gc.setBackground(defaultBackground);
@@ -581,26 +572,12 @@ public class CTabFolderRenderer {
 				}
 			}
 		} else {
-			// draw a solid background using default background in shape
+			// draw a solid background
 			if ((parent.getStyle() & SWT.NO_BACKGROUND) != 0 || !defaultBackground.equals(parent.getBackground())) {
 				gc.setBackground(defaultBackground);
 				gc.fillRectangle(x, y, width, height);
 			}
 		}
-		if (shape != null) {
-			gc.setClipping(clipping);
-			clipping.dispose();
-			region.dispose();
-		}
-	}
-
-	/*
-	 * Draw the border of the tab
-	 */
-	void drawBorder(GC gc, int[] shape) {
-
-		gc.setForeground(parent.getDisplay().getSystemColor(BORDER1_COLOR));
-		gc.drawPolyline(shape);
 	}
 
 	void drawBody(GC gc, Rectangle bounds, int state) {
@@ -641,15 +618,8 @@ public class CTabFolderRenderer {
 									   x2-highlight_margin,y2-highlight_margin, x2-highlight_margin,y1,
 									   x2,y1, x2,y2, x1,y2};
 				}
-				// If horizontal gradient, show gradient across the whole area
-				if (selectedIndex != -1 && parent.selectionGradientColors != null && parent.selectionGradientColors.length > 1 && !parent.selectionGradientVertical) {
-					drawBackground(gc, shape, true);
-				} else if (selectedIndex == -1 && parent.gradientColors != null && parent.gradientColors.length > 1 && !parent.gradientVertical) {
-					drawBackground(gc, shape, false);
-				} else {
-					gc.setBackground(selectedIndex != -1 && parent.shouldHighlight() ? parent.selectionBackground : parent.getBackground());
-					gc.fillPolygon(shape);
-				}
+				gc.setBackground(selectedIndex != -1 && parent.shouldHighlight() ? parent.selectionBackground : parent.getBackground());
+				gc.fillPolygon(shape);
 			}
 			//Draw client area
 			if ((parent.getStyle() & SWT.NO_BACKGROUND) != 0) {
@@ -715,8 +685,7 @@ public class CTabFolderRenderer {
 				break;
 			}
 			case SWT.BACKGROUND: {
-				int[] shape = new int[] {x,y, x+10,y, x+10,y+10, x,y+10};
-				drawBackground(gc, shape, false);
+				drawBackground(gc, x, y, 10, 10, parent.getBackground(), null, null, null, false);
 				break;
 			}
 		}
@@ -793,11 +762,10 @@ public class CTabFolderRenderer {
 	 * Draw the unselected border for the receiver on the left.
 	 */
 	void drawLeftUnselectedBorder(GC gc, Rectangle bounds, int state) {
+		gc.setForeground(parent.getDisplay().getSystemColor(BORDER1_COLOR));
 		int x = bounds.x;
 		int y = bounds.y;
 		int height = bounds.height;
-
-		gc.setForeground(parent.getDisplay().getSystemColor(BORDER1_COLOR));
 		if (parent.onBottom) {
 			gc.drawLine(x, y - 1, x, y + height - 1);
 		} else {
@@ -908,11 +876,10 @@ public class CTabFolderRenderer {
 	 * Draw the unselected border for the receiver on the right.
 	 */
 	void drawRightUnselectedBorder(GC gc, Rectangle bounds, int state) {
+		gc.setForeground(parent.getDisplay().getSystemColor(BORDER1_COLOR));
 		int x = bounds.x + bounds.width - 1;
 		int y = bounds.y;
 		int height = bounds.height;
-
-		gc.setForeground(parent.getDisplay().getSystemColor(BORDER1_COLOR));
 		if (parent.onBottom) {
 			gc.drawLine(x, y + height - 1, x, y - 1);
 		} else {
@@ -942,9 +909,8 @@ public class CTabFolderRenderer {
 			int yy = parent.onBottom ? size.y - borderBottom - parent.tabHeight - highlight_header : borderTop + parent.tabHeight + 1;
 			int ww = size.x - borderLeft - borderRight;
 			int hh = highlight_header - 1;
-			int[] shape = new int[] {xx,yy, xx+ww,yy, xx+ww,yy+hh, xx,yy+hh};
 			if (parent.selectionGradientColors != null && !parent.selectionGradientVertical) {
-				drawBackground(gc, shape, parent.shouldHighlight());
+				drawBackground(gc, parent.shouldHighlight());
 			} else {
 				gc.setBackground(parent.shouldHighlight() ? parent.selectionBackground : parent.getBackground());
 				gc.fillRectangle(xx, yy, ww, hh);
@@ -965,43 +931,19 @@ public class CTabFolderRenderer {
 				}
 
 				// draw selected tab background and outline
-				shape = new int[12];
+				int[] shape = null;
 				if (parent.onBottom) {
-					int index = 0;
-					shape[index++] = x; // first point repeated here because below we reuse shape to draw outline
-					shape[index++] = y - 1;
-					shape[index++] = x;
-					shape[index++] = y - 1;
-					shape[index++] = x;
-					shape[index++] = y + height;
 					if (borderLeft == 0 && itemIndex == parent.firstIndex) {
-						shape[index - 2] += x;
-						shape[index - 1] += y + height;
+						shape = new int[] {x, y-1, x, y+height, x, y+height, rightEdge-1, y+height-1, rightEdge-1, y-1, rightEdge-1, y-1};
+					} else {
+						shape = new int[] {x, y-1, x, y-1, x, y+height-1, rightEdge-1, y+height-1, rightEdge-1, y-1, rightEdge-1, y-1};
 					}
-					shape[index++] = rightEdge - 1;
-					shape[index++] = y + height - 1;
-					shape[index++] = rightEdge - 1;
-					shape[index++] = y - 1;
-					shape[index++] = rightEdge - 1;
-					shape[index++] = y - 1;
 				} else {
-					int index = 0;
-					shape[index++] = x; // first point repeated here because below we reuse shape to draw outline
-					shape[index++] = y + height + 1;
-					shape[index++] = x;
-					shape[index++] = y + height + 1;
-					shape[index++] = x;
-					shape[index++] = y;
 					if (borderLeft == 0 && itemIndex == parent.firstIndex) {
-						shape[index - 2] += x;
-						shape[index - 1] += y;
+						shape = new int[] {x, y+height+1, x, y, x, y, rightEdge-1, y, rightEdge-1, y+height+1, rightEdge-1, y+height+1};
+					} else {
+						shape = new int[] {x, y+height+1, x, y+height+1, x, y, rightEdge-1, y, rightEdge-1, y+height+1, rightEdge-1, y+height+1};
 					}
-					shape[index++] = rightEdge - 1;
-					shape[index++] = y;
-					shape[index++] = rightEdge - 1;
-					shape[index++] = y + height + 1;
-					shape[index++] = rightEdge - 1;
-					shape[index++] = y + height + 1;
 				}
 
 				Rectangle clipping = gc.getClipping();
@@ -1013,7 +955,7 @@ public class CTabFolderRenderer {
 				if (tabInPaint) {
 					// fill in tab background
 					if (parent.selectionGradientColors != null && !parent.selectionGradientVertical) {
-						drawBackground(gc, shape, true);
+						drawBackground(gc, true);
 					} else {
 						Color defaultBackground = parent.shouldHighlight() ? parent.selectionBackground : parent.getBackground();
 						Image image = parent.selectionBgImage;
@@ -1021,10 +963,10 @@ public class CTabFolderRenderer {
 						int[] percents = parent.selectionGradientPercents;
 						boolean vertical = parent.selectionGradientVertical;
 						xx = x;
-						yy = parent.onBottom ? y -1 : y + 1;
+						yy = parent.onBottom ? y - 1 : y + 1;
 						ww = width;
 						hh = height;
-						drawBackground(gc, shape, xx, yy, ww, hh, defaultBackground, image, colors, percents, vertical);
+						drawBackground(gc, xx, yy, ww, hh, defaultBackground, image, colors, percents, vertical);
 					}
 				}
 
@@ -1158,9 +1100,9 @@ public class CTabFolderRenderer {
 
 			// If horizontal gradient, show gradient across the whole area
 			if (selectedIndex != -1 && parent.selectionGradientColors != null && parent.selectionGradientColors.length > 1 && !parent.selectionGradientVertical) {
-				drawBackground(gc, shape, true);
+				drawBackground(gc, true);
 			} else if (selectedIndex == -1 && parent.gradientColors != null && parent.gradientColors.length > 1 && !parent.gradientVertical) {
-				drawBackground(gc, shape, false);
+				drawBackground(gc, false);
 			} else {
 				gc.setBackground(selectedIndex != -1 && parent.shouldHighlight() ? parent.selectionBackground : parent.getBackground());
 				gc.fillPolygon(shape);
@@ -1178,44 +1120,18 @@ public class CTabFolderRenderer {
 		int y = parent.onBottom ? size.y - borderBottom - tabHeight : borderTop;
 		int width = size.x - borderLeft - borderRight + 1;
 		int height = tabHeight - 1;
-		int[] shape = new int[8];
+		int[] shape;
 		// Draw Tab Header
 		if (parent.onBottom) {
-			int index = 0;
-			shape[index++] = x;
-			shape[index++] = y - highlight_header;
-			shape[index++] = x;
-			shape[index++] = y + height;
-			if (borderLeft == 0)
-				shape[index - 1] += 1;
-			shape[index++] = x + width;
-			shape[index++] = y + height;
-			if (borderLeft == 0)
-				shape[index - 1] += 1;
-			shape[index++] = x + width;
-			shape[index++] = y - highlight_header;
+			int bottomY = y + height + (borderLeft == 0 ? 1 : 0);
+			shape = new int[] {x, y-highlight_header, x, bottomY, x+width, bottomY, x+width, y-highlight_header};
 		} else {
-			int index = 0;
-			shape[index++] = x;
-			shape[index++] = y + height + highlight_header + 1;
-			shape[index++] = x;
-			shape[index++] = y;
-			shape[index++] = x + width;
-			shape[index++] = y;
-			shape[index++] = x + width;
-			shape[index++] = y + height + highlight_header + 1;
+			shape = new int[] {x, y+height+highlight_header+1, x, y, x+width, y, x+width, y+height+highlight_header+1};
 		}
 		// Fill in background
 		boolean single = parent.single;
 		boolean bkSelected = single && selectedIndex != -1;
-		drawBackground(gc, shape, bkSelected);
-		// Fill in parent background for non-rectangular shape
-		Region r = new Region();
-		r.add(new Rectangle(x, y, width + 1, height + 1));
-		r.subtract(shape);
-		gc.setBackground(parent.getParent().getBackground());
-		fillRegion(gc, r);
-		r.dispose();
+		drawBackground(gc, bkSelected);
 
 		// Draw selected tab
 		if (selectedIndex == -1) {
@@ -1302,16 +1218,6 @@ public class CTabFolderRenderer {
 		}
 	}
 
-	void fillRegion(GC gc, Region region) {
-		// NOTE: region passed in to this function will be modified
-		Region clipping = new Region();
-		gc.getClipping(clipping);
-		region.intersect(clipping);
-		gc.setClipping(region);
-		gc.fillRectangle(region.getBounds());
-		gc.setClipping(clipping);
-		clipping.dispose();
-	}
 
 	Color getFillColor() {
 		if (fillColor == null) {


### PR DESCRIPTION
…abFolderRenderer

Now that all tab corners are square, the polyline-based shape approach is unnecessary. Replace with direct gc.drawLine() / gc.drawRectangle() calls:

- Remove EMPTY_CORNER constant (was {0,0}, i.e. no corner offset)
- Remove drawBorder(GC, int[] shape) — callers now draw lines directly
- Simplify drawLeftUnselectedBorder / drawRightUnselectedBorder to a single gc.drawLine() each
- Remove Region-based polygon clipping from drawBackground(); since all shapes are rectangular the clipping was a no-op — remove the shape parameter from the signature entirely
- Remove fillRegion() — no longer called
- Simplify shape arrays in drawSelected and drawTabArea from loop-built polylines (that iterated over EMPTY_CORNER) to inline int[] literals
- Remove the Region.subtract(shape) / fillRegion block in drawTabArea that painted parent background into curved-corner cutouts (corners are now square so this region was always empty)