### PR TITLE
[Gtk] Motion notify signal is Gtk 3 only

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Control.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Control.java
@@ -4119,7 +4119,7 @@ void gtk4_motion_event(long controller, double x, double y, long event) {
 }
 
 @Override
-long gtk_motion_notify_event (long widget, long event) {
+long gtk3_motion_notify_event (long widget, long event) {
 	double[] eventX = new double[1];
 	double[] eventY = new double[1];
 	GDK.gdk_event_get_coords(event, eventX, eventY);
@@ -4147,13 +4147,8 @@ long gtk_motion_notify_event (long widget, long event) {
 
 			int [] eventButton = new int [1];
 			int [] eventState = new int [1];
-			if (GTK.GTK4) {
-				eventButton[0] = GDK.gdk_button_event_get_button(event);
-				eventState[0] = GDK.gdk_event_get_modifier_state(event);
-			} else {
-				GDK.gdk_event_get_button(event, eventButton);
-				GDK.gdk_event_get_state(event, eventState);
-			}
+			GDK.gdk_event_get_button(event, eventButton);
+			GDK.gdk_event_get_state(event, eventState);
 
 			if (sendDragEvent (eventButton[0], eventState[0], scaledEvent.x, scaledEvent.y, false)) {
 				return 1;
@@ -4170,30 +4165,24 @@ long gtk_motion_notify_event (long widget, long event) {
 	int [] state = new int [1];
 	boolean isHint = false;
 
-	if (GTK.GTK4) {
-		state[0] = GDK.gdk_event_get_modifier_state(event);
-		x = eventX[0];
-		y = eventY[0];
-	} else {
-		double [] eventRX = new double[1];
-		double [] eventRY = new double[1];
-		GDK.gdk_event_get_root_coords(event, eventRX, eventRY);
-		x = eventRX[0];
-		y = eventRY[0];
+	double [] eventRX = new double[1];
+	double [] eventRY = new double[1];
+	GDK.gdk_event_get_root_coords(event, eventRX, eventRY);
+	x = eventRX[0];
+	y = eventRY[0];
 
-		GdkEventMotion gdkEvent = new GdkEventMotion();
-		GTK3.memmove(gdkEvent, event, GdkEventMotion.sizeof);
-		state[0] = gdkEvent.state;
-		isHint = gdkEvent.is_hint != 0;
+	GdkEventMotion gdkEvent = new GdkEventMotion();
+	GTK3.memmove(gdkEvent, event, GdkEventMotion.sizeof);
+	state[0] = gdkEvent.state;
+	isHint = gdkEvent.is_hint != 0;
 
-		if (isHint) {
-			int [] pointer_x = new int [1], pointer_y = new int [1], mask = new int [1];
-			long window = eventWindow ();
-			display.getWindowPointerPosition (window, pointer_x, pointer_y, mask);
-			x = pointer_x [0];
-			y = pointer_y [0];
-			state[0] = mask [0];
-		}
+	if (isHint) {
+		int [] pointer_x = new int [1], pointer_y = new int [1], mask = new int [1];
+		long window = eventWindow ();
+		display.getWindowPointerPosition (window, pointer_x, pointer_y, mask);
+		x = pointer_x [0];
+		y = pointer_y [0];
+		state[0] = mask [0];
 	}
 
 	if (this != display.currentControl) {
@@ -4208,8 +4197,7 @@ long gtk_motion_notify_event (long widget, long event) {
 		}
 	}
 
-	return sendMouseEvent(SWT.MouseMove, 0, time, x, y, isHint, state[0])
-			? 0 : 1;
+	return sendMouseEvent(SWT.MouseMove, 0, time, x, y, isHint, state[0]) ? 0 : 1;
 }
 
 @Override

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Link.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Link.java
@@ -519,21 +519,16 @@ long gtk3_key_press_event (long widget, long eventPtr) {
 }
 
 @Override
-long gtk_motion_notify_event (long widget, long event) {
-	long result = super.gtk_motion_notify_event (widget, event);
+long gtk3_motion_notify_event (long widget, long event) {
+	long result = super.gtk3_motion_notify_event (widget, event);
 	if (result != 0) return result;
 
 	double [] eventX = new double [1];
 	double [] eventY = new double [1];
 
 	int [] state = new int [1];
-	if (GTK.GTK4) {
-		GDK.gdk_event_get_position(event, eventX, eventY);
-		state[0] = GDK.gdk_event_get_modifier_state(event);
-	} else {
-		GDK.gdk_event_get_coords(event, eventX, eventY);
-		GDK.gdk_event_get_state(event, state);
-	}
+	GDK.gdk_event_get_coords(event, eventX, eventY);
+	GDK.gdk_event_get_state(event, state);
 
 	int x = (int) eventX[0];
 	int y = (int) eventY[0];

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Sash.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Sash.java
@@ -531,8 +531,8 @@ long gtk3_key_press_event(long widget, long eventPtr) {
 }
 
 @Override
-long gtk_motion_notify_event(long widget, long eventPtr) {
-	long result = super.gtk_motion_notify_event(widget, eventPtr);
+long gtk3_motion_notify_event(long widget, long eventPtr) {
+	long result = super.gtk3_motion_notify_event(widget, eventPtr);
 	if (result != 0) return result;
 
 	if (!dragging) return 0;

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Shell.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Shell.java
@@ -1702,15 +1702,11 @@ long gtk_move_focus (long widget, long directionType) {
 }
 
 @Override
-long gtk_motion_notify_event (long widget, long event) {
+long gtk3_motion_notify_event (long widget, long event) {
 	if (widget == shellHandle) {
 		if (isCustomResize ()) {
 			int [] state = new int [1];
-			if (GTK.GTK4) {
-				state[0] = GDK.gdk_event_get_modifier_state(event);
-			} else {
-				GDK.gdk_event_get_state(event, state);
-			}
+			GDK.gdk_event_get_state(event, state);
 
 			double [] eventRX = new double [1];
 			double [] eventRY = new double [1];
@@ -1762,41 +1758,27 @@ long gtk_motion_notify_event (long widget, long event) {
 						break;
 				}
 				if (x != display.resizeBoundsX || y != display.resizeBoundsY) {
-					if (GTK.GTK4) {
-						/* TODO: GTK4 no longer exist, will probably need to us gdk_toplevel_begin_move &
-						 * gdk_toplevel_begin_resize to provide this functionality
-						 */
-					} else {
-						GDK.gdk_window_move_resize (gtk_widget_get_window (shellHandle), x, y, width, height);
-					}
+					GDK.gdk_window_move_resize (gtk_widget_get_window (shellHandle), x, y, width, height);
 				} else {
 					GTK3.gtk_window_resize (shellHandle, width, height);
 				}
 			} else {
 				double [] eventX = new double [1];
 				double [] eventY = new double [1];
-				if (GTK.GTK4) {
-					GDK.gdk_event_get_position(event, eventX, eventY);
-				} else {
-					GDK.gdk_event_get_coords(event, eventX, eventY);
-				}
+				GDK.gdk_event_get_coords(event, eventX, eventY);
 
 				int mode = getResizeMode (eventX[0], eventY[0]);
 				if (mode != display.resizeMode) {
 					long cursor = display.getSystemCursor(mode).handle;
-					if (GTK.GTK4) {
-						GTK4.gtk_widget_set_cursor (shellHandle, cursor);
-					} else {
-						long window = gtk_widget_get_window (shellHandle);
-						GDK.gdk_window_set_cursor (window, cursor);
-					}
+					long window = gtk_widget_get_window (shellHandle);
+					GDK.gdk_window_set_cursor (window, cursor);
 					display.resizeMode = mode;
 				}
 			}
 		}
 		return 0;
 	}
-	return super.gtk_motion_notify_event (widget, event);
+	return super.gtk3_motion_notify_event (widget, event);
 }
 
 @Override

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Table.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Table.java
@@ -2327,15 +2327,10 @@ long gtk_draw (long widget, long cairo) {
 }
 
 @Override
-long gtk_motion_notify_event (long widget, long event) {
-	if (GTK.GTK4) {
-		long surface = GDK.gdk_event_get_surface(event);
-		if (surface != gtk_widget_get_surface(handle)) return 0;
-	} else {
-		long window = GDK.gdk_event_get_window (event);
-		if (window != GTK3.gtk_tree_view_get_bin_window (handle)) return 0;
-	}
-	return super.gtk_motion_notify_event (widget, event);
+long gtk3_motion_notify_event (long widget, long event) {
+	long window = GDK.gdk_event_get_window (event);
+	if (window != GTK3.gtk_tree_view_get_bin_window (handle)) return 0;
+	return super.gtk3_motion_notify_event (widget, event);
 }
 
 @Override

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Tracker.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Tracker.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2025 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -470,7 +470,7 @@ boolean grab () {
 @Override
 long gtk_button_release_event (long widget, long event) {
 	Control.mouseDown = false;
-	return gtk_mouse (GDK.GDK_BUTTON_RELEASE, widget, event);
+	return gtk3_mouse (GDK.GDK_BUTTON_RELEASE, widget, event);
 }
 
 @Override
@@ -612,27 +612,19 @@ long gtk3_key_press_event (long widget, long eventPtr) {
 }
 
 @Override
-long gtk_motion_notify_event (long widget, long eventPtr) {
+long gtk3_motion_notify_event (long widget, long eventPtr) {
 	long cursor = this.cursor != null ? this.cursor.handle : 0;
 	if (cursor != lastCursor) {
 		ungrab ();
 		grabbed = grab ();
 		lastCursor = cursor;
 	}
-	return gtk_mouse (GDK.GDK_MOTION_NOTIFY, widget, eventPtr);
+	return gtk3_mouse (GDK.GDK_MOTION_NOTIFY, widget, eventPtr);
 }
 
-long gtk_mouse (int eventType, long widget, long eventPtr) {
+long gtk3_mouse (int eventType, long widget, long eventPtr) {
 	int [] newX = new int [1], newY = new int [1];
-	if (GTK.GTK4) {
-		double[] newXDouble = new double[1], newYDouble = new double[1];
-		display.getPointerPosition(newXDouble, newYDouble);
-
-		newX[0] = (int)newXDouble[0];
-		newY[0] = (int)newYDouble[0];
-	} else {
-		display.getWindowPointerPosition(window, newX, newY, null);
-	}
+	display.getWindowPointerPosition(window, newX, newY, null);
 
 	if (oldX != newX [0] || oldY != newY [0]) {
 		Rectangle [] oldRectangles = rectangles;
@@ -913,7 +905,7 @@ boolean processEvent (long eventPtr) {
 	int eventType = GDK.gdk_event_get_event_type(eventPtr);
 	long widget = GTK3.gtk_get_event_widget (eventPtr);
 	switch (eventType) {
-		case GDK.GDK_MOTION_NOTIFY: gtk_motion_notify_event (widget, eventPtr); break;
+		case GDK.GDK_MOTION_NOTIFY: gtk3_motion_notify_event (widget, eventPtr); break;
 		case GDK.GDK_BUTTON_RELEASE: gtk_button_release_event (widget, eventPtr); break;
 		case GDK.GDK_KEY_PRESS: gtk3_key_press_event (widget, eventPtr); break;
 		case GDK.GDK_KEY_RELEASE: gtk3_key_release_event (widget, eventPtr); break;

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Tree.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Tree.java
@@ -2497,15 +2497,10 @@ long gtk_draw (long widget, long cairo) {
 }
 
 @Override
-long gtk_motion_notify_event (long widget, long event) {
-	if (GTK.GTK4) {
-		long surface = GDK.gdk_event_get_surface(event);
-		if (surface != gtk_widget_get_surface(handle)) return 0;
-	} else {
-		long window = GDK.gdk_event_get_window (event);
-		if (window != GTK3.gtk_tree_view_get_bin_window (handle)) return 0;
-	}
-	return super.gtk_motion_notify_event (widget, event);
+long gtk3_motion_notify_event (long widget, long event) {
+	long window = GDK.gdk_event_get_window (event);
+	if (window != GTK3.gtk_tree_view_get_bin_window (handle)) return 0;
+	return super.gtk3_motion_notify_event (widget, event);
 }
 
 @Override

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Widget.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Widget.java
@@ -1045,7 +1045,7 @@ long gtk_month_changed (long widget) {
 	return 0;
 }
 
-long gtk_motion_notify_event (long widget, long event) {
+long gtk3_motion_notify_event (long widget, long event) {
 	return 0;
 }
 
@@ -2649,7 +2649,7 @@ long windowProc (long handle, long arg0, long user_data) {
 		case LEAVE_NOTIFY_EVENT: return gtk_leave_notify_event (handle, arg0);
 		case MAP_EVENT: return gtk_map_event (handle, arg0);
 		case MNEMONIC_ACTIVATE: return gtk_mnemonic_activate (handle, arg0);
-		case MOTION_NOTIFY_EVENT: return gtk_motion_notify_event (handle, arg0);
+		case MOTION_NOTIFY_EVENT: return gtk3_motion_notify_event (handle, arg0);
 		case MOVE_FOCUS: return gtk_move_focus (handle, arg0);
 		case POPULATE_POPUP: return gtk_populate_popup (handle, arg0);
 		case SCROLL_EVENT:	return gtk_scroll_event (handle, arg0);


### PR DESCRIPTION
Rename the handler to gtk3_motion_notify_event to make it obvious and simplify implementations to not try to handle Gtk 4 case as it will never end there.