### PR TITLE
[Cocoa] Fix deprecated SEL cast in sel_registerName (issue #3186)

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT PI/cocoa/library/os.c
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/cocoa/library/os.c
@@ -7645,7 +7645,7 @@ JNIEXPORT jlong JNICALL OS_NATIVE(sel_1registerName)
 	jlong rc = 0;
 	OS_NATIVE_ENTER(env, that, sel_1registerName_FUNC);
 	if (arg0) if ((lparg0 = (*env)->GetStringUTFChars(env, arg0, NULL)) == NULL) goto fail;
-	rc = (jlong)sel_registerName(lparg0);
+	rc = (jlong)((jlong (*)(const char*))sel_registerName)((const char*)lparg0);
 fail:
 	if (arg0 && lparg0) (*env)->ReleaseStringUTFChars(env, arg0, lparg0);
 	OS_NATIVE_EXIT(env, that, sel_1registerName_FUNC);

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/cocoa/org/eclipse/swt/internal/cocoa/OS.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/cocoa/org/eclipse/swt/internal/cocoa/OS.java
@@ -547,6 +547,10 @@ public static final native long object_setInstanceVariable(long obj, byte[] name
  * @param clazz cast=(Class)
  */
 public static final native long object_setClass(long obj, long clazz);
+/**
+ * @method flags=cast
+ * @param selectorName cast=(const char*)
+ */
 public static final native long sel_registerName(String selectorName);
 public static final native int objc_super_sizeof();
 


### PR DESCRIPTION
## Issue

Clang emits a `-Wcast-of-sel-type` deprecation warning in the auto-generated `os.c` when `sel_registerName` returns a `SEL` that is directly cast to `jlong`:

```c
rc = (jlong)sel_registerName(lparg0);
// warning: cast of type 'SEL _Nonnull' to 'jlong' (aka 'long') is deprecated;
//          use sel_getName instead [-Wcast-of-sel-type]
```

This warning is part of a broader set of deprecation warnings in the macOS/Cocoa native implementation tracked in issue #3186. Eliminating all such warnings is a prerequisite for enabling `-Werror` in the native build.

## Solution options considered

Several approaches were investigated before arriving at the final solution.

### ❌ Direct intermediate cast: `(jlong)(uintptr_t)sel_registerName(...)`

Adding an intermediate `uintptr_t` cast does not help — the compiler treats any cast **from** a `SEL` value to any type (integer or pointer) as deprecated:

```
warning: cast of type 'SEL _Nonnull' to 'uintptr_t' (aka 'unsigned long') is deprecated;
         use sel_getName instead [-Wcast-of-sel-type]
```

Same result with `void*` or `const char*` as intermediate types — the `-Wcast-of-sel-type` warning fires for any explicit cast **from** a `SEL` value regardless of the target type.

### ❌ Using `sel_getName`: `(jlong)(uintptr_t)sel_getName(sel_registerName(...))`

The compiler's suggestion — routing through `sel_getName(SEL) → const char*` — eliminates the deprecated cast. This was implemented via `flags=no_gen` in `OS.java` and a hand-written function body in `os_custom.c`. It works correctly, but has two drawbacks: it calls an extra runtime function and moves the implementation out of the auto-generated `os.c` into `os_custom.c`, which is harder to maintain.

Note: the build in the aarch64 fragment folder regenerates `os.c` from `OS.java` annotations on each run, so any annotation-based approach must work with the _compiled_ JNI generator in the Maven toolchain — not just the source.

### ✅ Function-pointer cast: `((jlong (*)(const char*))sel_registerName)(lparg0)`

The fix applies the same pattern SWT already uses for all `objc_msgSend` variants. Instead of casting the **value** returned by `sel_registerName`, the **function pointer itself** is cast to declare a different return type:

```c
rc = (jlong)((jlong (*)(const char*))sel_registerName)((const char*)lparg0);
```

The compiler sees no cast of a `SEL` value at all — the function is declared (via its retyped pointer) as returning `jlong` directly. This is semantically safe on all 64-bit Apple platforms where `SEL` (an 8-byte opaque pointer) and `jlong` share the same size and representation.

This approach is driven entirely by two JNI generator annotations in `OS.java`, keeping the implementation inside the auto-generated `os.c`:

```java
/**
 * @method flags=cast
 * @param selectorName cast=(const char*)
 */
public static final native long sel_registerName(String selectorName);
```

- `flags=cast` — instructs the generator to emit a function-pointer cast rather than a direct call
- `cast=(const char*)` — matches the native C parameter type `const char*` in the cast signature

## Changes

- **`OS.java`**: adds `@method flags=cast` and `@param selectorName cast=(const char*)` annotations to `sel_registerName`
- **`os.c`**: updated generated function body (reflects what the generator produces from the new annotations)

## Test plan

- [x] Build natives from the `binaries/org.eclipse.swt.cocoa.macosx.aarch64` fragment using `mvn clean process-resources -Dnative=cocoa.macosx.aarch64` — confirms the `-Wcast-of-sel-type` warning is gone
- [x] Verify the 7 remaining warnings are only the other known deprecated APIs from issue #3186:
  - `os.c:1102`: `CFURLCreateFromFSRef` — deprecated macOS 10.9
  - `os.c:1920`: `GetCurrentProcess` — deprecated macOS 10.9
  - `os.c:2119`: `LSGetApplicationForInfo` — deprecated macOS 10.10
  - `os.c:4040`: `NSPrintSavePath` — deprecated macOS 10.6
  - `os.c:4678`: `SecPolicySearchCopyNext` — deprecated macOS 10.7
  - `os.c:4694`: `SecPolicySearchCreate` — deprecated macOS 10.7
  - `os.c:4883`: passing arguments to a function without a prototype `[-Wdeprecated-non-prototype]`
- [x] Run the SWT test suite on macOS to confirm selector dispatch still works correctly across the codebase

## Notes

This change was developed with the assistance of [Claude Code](https://claude.ai/claude-code) (claude-sonnet-4-6). Multiple solution approaches were explored interactively, including direct casts, `sel_getName` routing, `no_gen` + `os_custom.c`, and the final function-pointer cast pattern.

Contributes to #3186.