### PR TITLE
[Cocoa] Use NSBezelStyleFlexiblePush for buttons with custom font size

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Button.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Button.java
@@ -829,7 +829,10 @@ void setBounds (int x, int y, int width, int height, boolean move, boolean resiz
 		}
 
 		NSButton button = (NSButton)view;
-		if (height > heightThreshold) {
+		// Use NSBezelStyleFlexiblePush when a custom font is set or when the height
+		// exceeds the standard button height. NSBezelStylePush assumes the macOS
+		// default font size (13pt) and clips text at larger sizes.
+		if (height > heightThreshold || font != null) {
 			button.setBezelStyle(OS.NSBezelStyleFlexiblePush);
 		} else {
 			button.setBezelStyle(OS.NSBezelStylePush);
@@ -845,9 +848,14 @@ void setBounds (int x, int y, int width, int height, boolean move, boolean resiz
 }
 
 @Override
-void setFont (NSFont font) {
+void setFont (NSFont nsFont) {
 	if (text != null) {
 		((NSButton)view).setAttributedTitle(createString());
+	}
+	if ((style & (SWT.PUSH | SWT.TOGGLE)) != 0 && (style & (SWT.FLAT | SWT.WRAP)) == 0) {
+		// Use NSBezelStyleFlexiblePush when a custom font is set. NSBezelStylePush
+		// assumes the macOS default font size (13pt) and clips text at larger sizes.
+		((NSButton)view).setBezelStyle(font != null ? OS.NSBezelStyleFlexiblePush : OS.NSBezelStylePush);
 	}
 }
 

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Button.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Button.java
@@ -28,8 +28,11 @@ import org.eclipse.swt.events.FocusEvent;
 import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.events.SelectionListener;
 import org.eclipse.swt.graphics.Color;
+import org.eclipse.swt.graphics.Font;
+import org.eclipse.swt.graphics.FontData;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.graphics.ImageGcDrawer;
+import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.layout.FillLayout;
 import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Button;
@@ -582,6 +585,34 @@ public void test_consistency_DragDetect () {
 	tearDown();
 	setUp(SWT.ARROW);
 	consistencyEvent(5, 5, 15, 15, ConsistencyUtility.MOUSE_DRAG);
+}
+
+/**
+ * Test that a push button reports a greater preferred height after its font
+ * size is increased. A button whose font grows larger must compute a
+ * proportionally taller preferred size so that layout managers allocate
+ * sufficient space and the text is not clipped.
+ *
+ * @see <a href="https://github.com/eclipse-platform/eclipse.platform.swt/issues/3085">issue #3085</a>
+ */
+@Test
+public void test_computeSize_largerWithLargeCustomFont() {
+	button.setText("OK");
+	shell.open();
+
+	Point defaultSize = button.computeSize(SWT.DEFAULT, SWT.DEFAULT);
+
+	FontData[] fontData = button.getFont().getFontData();
+	Font largeFont = new Font(button.getDisplay(), fontData[0].getName(), 50, fontData[0].getStyle());
+	try {
+		button.setFont(largeFont);
+		SwtTestUtil.processEvents();
+		Point largeSize = button.computeSize(SWT.DEFAULT, SWT.DEFAULT);
+		assertTrue(largeSize.y > defaultSize.y,
+				"Button with 50 pt font should be taller than button with default font");
+	} finally {
+		largeFont.dispose();
+	}
 }
 
 /** Test for Bug 381668 - NPE when disposing radio buttons right before they should gain focus */


### PR DESCRIPTION
> 🤖 This PR was created with [Claude Code](https://claude.ai/code).

## Issue

When a custom font with a size larger than the macOS default of 13 pt is set on a push or toggle button, the button text is visually clipped. macOS internally assumes the default font size when drawing a button with `NSBezelStylePush` and does not expand the rendered pill shape to accommodate taller text. This is reported in issue #3085.

## Root cause

`NSBezelStylePush` (value 1) is the standard rounded push button bezel on macOS. Its rendered height is fixed and optimised for the 13 pt system font. When SWT sets a larger custom font on an `NSButton` that still uses `NSBezelStylePush`, the native rendering engine clips the text to the fixed bezel height.

## Solution

Apple explicitly provides [`NSBezelStyleFlexiblePush`](https://developer.apple.com/documentation/AppKit/NSButton/BezelStyle-swift.enum/flexiblePush?language=objc) for exactly this situation. According to the documentation, this style allows the button to adapt its height to the content, making it the correct choice whenever text larger than the default font size is displayed.

The constant is defined in `NSButtonCell.h` of the macOS 15.4 SDK as:

```c
NSBezelStyleFlexiblePush = 2,
NSBezelStyleRegularSquare
    API_DEPRECATED_WITH_REPLACEMENT("NSBezelStyleFlexiblePush", macos(10.0, API_TO_BE_DEPRECATED))
    = NSBezelStyleFlexiblePush,
```

The `NSBezelStyleFlexiblePush` constant was introduced into `OS.java` as part of PR #3215 (which also replaced all other deprecated bezel style and button type constants with their modern equivalents).

The fix has two parts in `Button.java`:

1. **`setFont()`** — when a custom font is set (`Control.font != null`), immediately switch the bezel style to `NSBezelStyleFlexiblePush`. When the custom font is cleared, restore `NSBezelStylePush`. This ensures the correct style is active before any layout pass queries `computeSize()`.

2. **`setBounds()`** — extend the existing height-threshold condition with `|| font != null` so that a subsequent layout pass never reverts the bezel style back to `NSBezelStylePush` for buttons that carry a custom font.

Both guards apply only to `PUSH` and `TOGGLE` buttons without `FLAT` or `WRAP`, matching the scope of the existing bezel-style selection logic.

## Test

A regression test `test_computeSize_largerWithLargeCustomFont` is added to `Test_org_eclipse_swt_widgets_Button`. It verifies that a push button reports a strictly greater preferred height after its font is changed to 50 pt, ensuring layout managers allocate sufficient space and the button text is not clipped.

## Visual validation

The following snippet can be used to visually verify the fix. It shows a reference button with the default font alongside a button whose font size can be changed interactively via a combo box:

```java
package org.eclipse.swt.snippets;

import org.eclipse.swt.*;
import org.eclipse.swt.graphics.*;
import org.eclipse.swt.layout.*;
import org.eclipse.swt.widgets.*;

public class Snippet394 {

	public static void main(String[] args) {
		Display display = new Display();
		Shell shell = new Shell(display);
		shell.setText("Button Font Size Test (macOS issue #3085)");
		shell.setLayout(new GridLayout(2, false));

		FontData defaultFontData = display.getSystemFont().getFontData()[0];
		Font[] customFont = { null };

		new Label(shell, SWT.NONE).setText("Font Size:");
		Combo fontSizeCombo = new Combo(shell, SWT.READ_ONLY);
		fontSizeCombo.setItems("8", "10", "12", "13", "14", "16", "18", "20", "21", "22", "23", "24", "25", "26", "28", "30", "36", "48", "72");
		fontSizeCombo.select(5); // 16pt default
		fontSizeCombo.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false));

		new Label(shell, SWT.NONE).setText("Default font:");
		Button defaultButton = new Button(shell, SWT.PUSH);
		defaultButton.setText("Default Font Button");

		new Label(shell, SWT.NONE).setText("Custom font:");
		Button customButton = new Button(shell, SWT.PUSH);
		customButton.setText("Custom Font Button");

		customFont[0] = new Font(display, defaultFontData.getName(), 16, defaultFontData.getStyle());
		customButton.setFont(customFont[0]);

		fontSizeCombo.addListener(SWT.Selection, e -> {
			int size = Integer.parseInt(fontSizeCombo.getText());
			Font old = customFont[0];
			customFont[0] = new Font(display, defaultFontData.getName(), size, defaultFontData.getStyle());
			customButton.setFont(customFont[0]);
			shell.layout(true, true);
			if (old != null) old.dispose();
		});

		shell.addListener(SWT.Dispose, e -> {
			if (customFont[0] != null) customFont[0].dispose();
		});

		shell.pack();
		shell.open();
		while (!shell.isDisposed()) {
			if (!display.readAndDispatch()) display.sleep();
		}
		display.dispose();
	}
}
```

## Alternative proposal

PR #3086 by @xpomul addresses the same issue with a different approach: it overrides `cellSizeForBounds()` to manually add a fixed pixel offset (`FONT_SIZE_HEIGHT_ADJUST = 8`) to the cell height when a custom font larger than 16 pt is detected.

This proposal is preferable for the following reasons:

- **Uses the official Apple API.** `NSBezelStyleFlexiblePush` is the mechanism Apple specifically designed and documents for buttons that need to accommodate non-default font sizes. Manual height arithmetic works around a symptom rather than using the intended solution.
- **No magic numbers.** PR #3086 introduces two arbitrary constants: a font-size threshold of 16 pt and a height adjustment of 8 px. These values are not derived from any documented specification and may break with future macOS releases or display scaling factors.
- **No arbitrary font-size threshold.** This fix activates for any explicitly set custom font, regardless of size, which is the correct semantic: if the developer chose to override the font, the button should adapt. PR #3086 silently does nothing for custom fonts between 13 pt and 16 pt.
- **Correct at layout time.** By switching the bezel style in `setFont()`, `computeSize()` immediately returns the right preferred size. PR #3086 patches `cellSizeForBounds()`, which is only called in certain layout paths and may not be reached in all scenarios.
- **Leverages the native rendering engine.** With `NSBezelStyleFlexiblePush`, macOS itself computes and renders the correct button dimensions. There is no risk of the manual offset drifting out of sync with what the native layer actually draws.