### PR TITLE
[Cocoa] Replace deprecated OSAtomicIncrement32/OSAtomicDecrement32 in callback.c

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/common/library/callback.c
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/library/callback.c
@@ -29,7 +29,12 @@
 
 static CALLBACK_DATA callbackData[MAX_CALLBACKS];
 static int callbackEnabled = 1;
+#ifdef ATOMIC
+#include <stdatomic.h>
+static _Atomic int callbackEntryCount = 0;
+#else
 static int callbackEntryCount = 0;
+#endif
 static int initialized = 0;
 static jmethodID mid_Throwable_addSuppressed = NULL;
 
@@ -45,9 +50,8 @@ static jmethodID mid_Throwable_addSuppressed = NULL;
 #endif
 
 #ifdef ATOMIC
-#include <libkern/OSAtomic.h>
-#define ATOMIC_INC(value) OSAtomicIncrement32(&value);
-#define ATOMIC_DEC(value) OSAtomicDecrement32(&value);
+#define ATOMIC_INC(value) atomic_fetch_add_explicit(&value, 1, memory_order_relaxed);
+#define ATOMIC_DEC(value) atomic_fetch_sub_explicit(&value, 1, memory_order_relaxed);
 #else
 #define ATOMIC_INC(value) value++;
 #define ATOMIC_DEC(value) value--;


### PR DESCRIPTION
Instead use the methods from stdatomic.h introduced in the C11 standard:
- https://en.cppreference.com/w/c/atomic/atomic_fetch_add
- https://en.cppreference.com/w/c/atomic/atomic_fetch_sub
- https://en.cppreference.com/w/c/language/atomic.html
- https://en.cppreference.com/w/c/atomic/memory_order

To fix the current warning during compilation of the macOS native SWT binaries:
```
callback.c:1968:2: warning: 'OSAtomicIncrement32' is deprecated: first deprecated in macOS 10.12
- Use atomic_fetch_add_explicit(memory_order_relaxed) from <stdatomic.h> instead [-Wdeprecated-declarations]
```

Contributes to
- https://github.com/eclipse-platform/eclipse.platform.swt/issues/3186

The Copilot agent initially suggested to use the 'Clang/GCC built-ins `__sync_fetch_and_add` and `__sync_fetch_and_sub`' instead since they don't require any import and the declaration of `callbackEntryCount` as `_Atomic int`.
But I believe it's better to stick to the recommendation from the deprecation warning. Unfortunately I didn't find any official documentation from Apple online regarding that deprecation.

Instead of `memory_order_relaxed` we could also use another [memory_order](https://en.cppreference.com/w/c/atomic/memory_order) if suitable. But I'm not sure what's exactly required here.