### PR TITLE
Remove unused drawBorder() method in CTabFolderRenderer

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CTabFolderRenderer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CTabFolderRenderer.java
@@ -594,15 +594,6 @@ public class CTabFolderRenderer {
 		}
 	}
 
-	/*
-	 * Draw the border of the tab
-	 */
-	void drawBorder(GC gc, int[] shape) {
-
-		gc.setForeground(parent.getDisplay().getSystemColor(BORDER1_COLOR));
-		gc.drawPolyline(shape);
-	}
-
 	void drawBody(GC gc, Rectangle bounds, int state) {
 		Point size = new Point(bounds.width, bounds.height);
 		int selectedIndex = parent.selectedIndex;


### PR DESCRIPTION
The drawBorder(GC, int[]) method that drew polyline-based tab borders is no longer called anywhere. Remove it as dead code.