### PR TITLE
CTabFolderRenderer: Reuse Region objects in drawBackground()

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CTabFolderRenderer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CTabFolderRenderer.java
@@ -35,6 +35,8 @@ public class CTabFolderRenderer {
 	Color fillColor;
 
 	private Font chevronFont = null;
+	private Region clippingRegion = null;
+	private Region shapeRegion = null;
 
 	static final RGB CLOSE_FILL = new RGB(240, 64, 64);
 
@@ -398,6 +400,16 @@ public class CTabFolderRenderer {
 			chevronFont.dispose();
 			chevronFont = null;
 		}
+
+		if (clippingRegion != null) {
+			clippingRegion.dispose();
+			clippingRegion = null;
+		}
+
+		if (shapeRegion != null) {
+			shapeRegion.dispose();
+			shapeRegion = null;
+		}
 	}
 
 	/**
@@ -499,14 +511,16 @@ public class CTabFolderRenderer {
 	}
 
 	void drawBackground(GC gc, int[] shape, int x, int y, int width, int height, Color defaultBackground, Image image, Color[] colors, int[] percents, boolean vertical) {
-		Region clipping = null, region = null;
+		Region clipping = null;
 		if (shape != null) {
-			clipping = new Region();
+			if (clippingRegion == null) clippingRegion = new Region();
+			if (shapeRegion == null) shapeRegion = new Region();
+			clipping = clippingRegion;
 			gc.getClipping(clipping);
-			region = new Region();
-			region.add(shape);
-			region.intersect(clipping);
-			gc.setClipping(region);
+			shapeRegion.subtract(shapeRegion);
+			shapeRegion.add(shape);
+			shapeRegion.intersect(clipping);
+			gc.setClipping(shapeRegion);
 		}
 		if (image != null) {
 			// draw the background image in shape
@@ -589,8 +603,6 @@ public class CTabFolderRenderer {
 		}
 		if (shape != null) {
 			gc.setClipping(clipping);
-			clipping.dispose();
-			region.dispose();
 		}
 	}
 


### PR DESCRIPTION
This PR addresses a performance task in #3219 by reusing Region objects in CTabFolderRenderer.drawBackground().

### Changes:
- Added  and  private fields to .
- Lazily initialize these regions in .
- Reuse these regions for clipping and shape intersection to avoid frequent allocation and disposal of native OS resources.
- Updated  to properly clean up the reused regions.

Verified with  (119 tests passed).