### PR TITLE
Deprecate old Color constructors that require a Device/Display parameter

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Accessibility/win32/org/eclipse/swt/accessibility/Accessible.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Accessibility/win32/org/eclipse/swt/accessibility/Accessible.java
@@ -5099,7 +5099,7 @@ public class Accessible {
 			int r = Integer.parseInt(rgbString.substring(open + 1, comma1));
 			int g = Integer.parseInt(rgbString.substring(comma1 + 1, comma2));
 			int b = Integer.parseInt(rgbString.substring(comma2 + 1, close));
-			return new Color(control.getDisplay(), r, g, b);
+			return new Color(r, g, b);
 		} catch (NumberFormatException ex) {}
 		return null;
 	}

--- a/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/ControlEditor.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/ControlEditor.java
@@ -31,7 +31,7 @@ import org.eclipse.swt.widgets.*;
 * <pre><code>
 * Canvas canvas = new Canvas(shell, SWT.BORDER);
 * canvas.setBounds(10, 10, 300, 300);
-* Color color = new Color(null, 255, 0, 0);
+* Color color = new Color(255, 0, 0);
 * canvas.setBackground(color);
 * ControlEditor editor = new ControlEditor (canvas);
 * // The editor will be a button in the bottom right corner of the canvas.
@@ -46,7 +46,7 @@ import org.eclipse.swt.widgets.*;
 * 		RGB rgb = dialog.getRGB();
 * 		if (rgb != null) {
 * 			if (color != null) color.dispose();
-* 			color = new Color(null, rgb);
+* 			color = new Color(rgb);
 * 			canvas.setBackground(color);
 * 		}
 *

--- a/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/cocoa/org/eclipse/swt/dnd/DragSource.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/cocoa/org/eclipse/swt/dnd/DragSource.java
@@ -361,7 +361,7 @@ void drag(Event dragDetectEvent) {
 			int width = 20, height = 20;
 			Image newDragImage = new Image(Display.getCurrent(), width, height);
 			GC imageGC = new GC(newDragImage);
-			Color grayColor = new Color(Display.getCurrent(), 50, 50, 50);
+			Color grayColor = new Color(50, 50, 50);
 			imageGC.setForeground(grayColor);
 			imageGC.drawRectangle(0, 0, 19, 19);
 			imageGC.dispose();

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/win32/org/eclipse/swt/internal/win32/OS.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/win32/org/eclipse/swt/internal/win32/OS.java
@@ -2266,16 +2266,16 @@ public static final void setTheme(boolean isDarkTheme) {
 
 	display.setData("org.eclipse.swt.internal.win32.useDarkModeExplorerTheme", isDarkTheme);
 	display.setData("org.eclipse.swt.internal.win32.useShellTitleColoring",    isDarkTheme);
-	display.setData("org.eclipse.swt.internal.win32.menuBarForegroundColor",   isDarkTheme ? new Color(display, 0xD0, 0xD0, 0xD0) : null);
-	display.setData("org.eclipse.swt.internal.win32.menuBarBackgroundColor",   isDarkTheme ? new Color(display, 0x30, 0x30, 0x30) : null);
-	display.setData("org.eclipse.swt.internal.win32.menuBarBorderColor",       isDarkTheme ? new Color(display, 0x50, 0x50, 0x50) : null);
+	display.setData("org.eclipse.swt.internal.win32.menuBarForegroundColor",   isDarkTheme ? new Color(0xD0, 0xD0, 0xD0) : null);
+	display.setData("org.eclipse.swt.internal.win32.menuBarBackgroundColor",   isDarkTheme ? new Color(0x30, 0x30, 0x30) : null);
+	display.setData("org.eclipse.swt.internal.win32.menuBarBorderColor",       isDarkTheme ? new Color(0x50, 0x50, 0x50) : null);
 	display.setData("org.eclipse.swt.internal.win32.Canvas.use_WS_BORDER",     isDarkTheme);
 	display.setData("org.eclipse.swt.internal.win32.List.use_WS_BORDER",       isDarkTheme);
 	display.setData("org.eclipse.swt.internal.win32.Table.use_WS_BORDER",      isDarkTheme);
 	display.setData("org.eclipse.swt.internal.win32.Text.use_WS_BORDER",       isDarkTheme);
 	display.setData("org.eclipse.swt.internal.win32.Tree.use_WS_BORDER",       isDarkTheme);
-	display.setData("org.eclipse.swt.internal.win32.Table.headerLineColor",    isDarkTheme ? new Color(display, 0x50, 0x50, 0x50) : null);
-	display.setData("org.eclipse.swt.internal.win32.Label.disabledForegroundColor", isDarkTheme ? new Color(display, 0x80, 0x80, 0x80) : null);
+	display.setData("org.eclipse.swt.internal.win32.Table.headerLineColor",    isDarkTheme ? new Color(0x50, 0x50, 0x50) : null);
+	display.setData("org.eclipse.swt.internal.win32.Label.disabledForegroundColor", isDarkTheme ? new Color(0x80, 0x80, 0x80) : null);
 	display.setData("org.eclipse.swt.internal.win32.Combo.useDarkTheme",       isDarkTheme);
 	display.setData("org.eclipse.swt.internal.win32.ProgressBar.useColors",    isDarkTheme);
 	display.setData("org.eclipse.swt.internal.win32.Text.useDarkThemeIcons",   isDarkTheme);

--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/graphics/Color.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/graphics/Color.java
@@ -68,7 +68,9 @@ Color(Device device) {
  * </ul>
  *
  * @see #Color(int, int, int) The equivalent constructor not requiring a Device
+ * @deprecated Use {@link #Color(int, int, int)}
  */
+@Deprecated(since="2026-06")
 public Color(Device device, int red, int green, int blue) {
 	super(device);
 	init(red, green, blue, 255);
@@ -113,7 +115,9 @@ public Color(int red, int green, int blue) {
  * @see #Color(int, int, int, int) The equivalent constructor not requiring a Device
  *
  * @since 3.104
+ * @deprecated Use {@link #Color(int, int, int, int)}
  */
+@Deprecated(since="2026-06")
 public Color(Device device, int red, int green, int blue, int alpha) {
 	super(device);
 	init(red, green, blue, alpha);
@@ -155,7 +159,9 @@ public Color(int red, int green, int blue, int alpha) {
  * </ul>
  *
  * @see #Color(RGB) The equivalent constructor not requiring a Device
+ * @deprecated Use {@link #Color(RGB)}
  */
+@Deprecated(since="2026-06")
 public Color(Device device, RGB rgb) {
 	super(device);
 	if (rgb == null) SWT.error(SWT.ERROR_NULL_ARGUMENT);
@@ -197,7 +203,9 @@ public Color(RGB rgb) {
  * @see #Color(RGBA) The equivalent constructor not requiring a Device
  *
  * @since 3.104
+ * @deprecated Use {@link #Color(RGBA)}
  */
+@Deprecated(since="2026-06")
 public Color(Device device, RGBA rgba) {
 	super(device);
 	if (rgba == null) SWT.error(SWT.ERROR_NULL_ARGUMENT);
@@ -242,7 +250,9 @@ public Color(RGBA rgba) {
  * @see #Color(RGB, int) The equivalent constructor not requiring a Device
  *
  * @since 3.104
+ * @deprecated Use {@link #Color(RGB, int)}
  */
+@Deprecated(since="2026-06")
 public Color(Device device, RGB rgb, int alpha) {
 	super(device);
 	if (rgb == null) SWT.error(SWT.ERROR_NULL_ARGUMENT);

--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/graphics/Device.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/graphics/Device.java
@@ -594,23 +594,23 @@ public boolean getWarnings () {
  */
 protected void init () {
 	/* Create the standard colors */
-	COLOR_TRANSPARENT = new Color (this, 0xFF,0xFF,0xFF,0);
-	COLOR_BLACK = new Color (this, 0,0,0);
-	COLOR_DARK_RED = new Color (this, 0x80,0,0);
-	COLOR_DARK_GREEN = new Color (this, 0,0x80,0);
-	COLOR_DARK_YELLOW = new Color (this, 0x80,0x80,0);
-	COLOR_DARK_BLUE = new Color (this, 0,0,0x80);
-	COLOR_DARK_MAGENTA = new Color (this, 0x80,0,0x80);
-	COLOR_DARK_CYAN = new Color (this, 0,0x80,0x80);
-	COLOR_GRAY = new Color (this, 0xC0,0xC0,0xC0);
-	COLOR_DARK_GRAY = new Color (this, 0x80,0x80,0x80);
-	COLOR_RED = new Color (this, 0xFF,0,0);
-	COLOR_GREEN = new Color (this, 0,0xFF,0);
-	COLOR_YELLOW = new Color (this, 0xFF,0xFF,0);
-	COLOR_BLUE = new Color (this, 0,0,0xFF);
-	COLOR_MAGENTA = new Color (this, 0xFF,0,0xFF);
-	COLOR_CYAN = new Color (this, 0,0xFF,0xFF);
-	COLOR_WHITE = new Color (this, 0xFF,0xFF,0xFF);
+	COLOR_TRANSPARENT = new Color (0xFF,0xFF,0xFF,0);
+	COLOR_BLACK = new Color (0,0,0);
+	COLOR_DARK_RED = new Color (0x80,0,0);
+	COLOR_DARK_GREEN = new Color (0,0x80,0);
+	COLOR_DARK_YELLOW = new Color (0x80,0x80,0);
+	COLOR_DARK_BLUE = new Color (0,0,0x80);
+	COLOR_DARK_MAGENTA = new Color (0x80,0,0x80);
+	COLOR_DARK_CYAN = new Color (0,0x80,0x80);
+	COLOR_GRAY = new Color (0xC0,0xC0,0xC0);
+	COLOR_DARK_GRAY = new Color (0x80,0x80,0x80);
+	COLOR_RED = new Color (0xFF,0,0);
+	COLOR_GREEN = new Color (0,0xFF,0);
+	COLOR_YELLOW = new Color (0xFF,0xFF,0);
+	COLOR_BLUE = new Color (0,0,0xFF);
+	COLOR_MAGENTA = new Color (0xFF,0,0xFF);
+	COLOR_CYAN = new Color (0,0xFF,0xFF);
+	COLOR_WHITE = new Color (0xFF,0xFF,0xFF);
 
 	paragraphStyle = (NSMutableParagraphStyle)new NSMutableParagraphStyle().alloc().init();
 	paragraphStyle.setAlignment(OS.NSTextAlignmentLeft);

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/graphics/Color.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/graphics/Color.java
@@ -70,7 +70,9 @@ Color(Device device) {
  * </ul>
  *
  * @see #Color(int, int, int) The equivalent constructor not requiring a Device
+ * @deprecated Use {@link #Color(int, int, int)}
  */
+@Deprecated(since="2026-06")
 public Color(Device device, int red, int green, int blue) {
 	super(device);
 	init(red, green, blue, 255);
@@ -115,7 +117,9 @@ public Color(int red, int green, int blue) {
  * @see #Color(int, int, int, int) The equivalent constructor not requiring a Device
  *
  * @since 3.104
+ * @deprecated Use {@link #Color(int, int, int, int)}
  */
+@Deprecated(since="2026-06")
 public Color(Device device, int red, int green, int blue, int alpha) {
 	super(device);
 	init(red, green, blue, alpha);
@@ -157,7 +161,9 @@ public Color(int red, int green, int blue, int alpha) {
  * </ul>
  *
  * @see #Color(RGB) The equivalent constructor not requiring a Device
+ * @deprecated Use {@link #Color(RGB)}
  */
+@Deprecated(since="2026-06")
 public Color(Device device, RGB rgb) {
 	super(device);
 	if (rgb == null) SWT.error(SWT.ERROR_NULL_ARGUMENT);
@@ -199,7 +205,9 @@ public Color(RGB rgb) {
  * @see #Color(RGBA) The equivalent constructor not requiring a Device
  *
  * @since 3.104
+ * @deprecated Use {@link #Color(RGBA)}
  */
+@Deprecated(since="2026-06")
 public Color(Device device, RGBA rgba) {
 	super(device);
 	if (rgba == null) SWT.error(SWT.ERROR_NULL_ARGUMENT);
@@ -244,7 +252,9 @@ public Color(RGBA rgba) {
  * @see #Color(RGB, int) The equivalent constructor not requiring a Device
  *
  * @since 3.104
+ * @deprecated Use {@link #Color(RGB, int)}
  */
+@Deprecated(since="2026-06")
 public Color(Device device, RGB rgb, int alpha) {
 	super(device);
 	if (rgb == null) SWT.error(SWT.ERROR_NULL_ARGUMENT);

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Color.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Color.java
@@ -73,7 +73,9 @@ Color(Device device) {
  * </ul>
  *
  * @see #Color(int, int, int) The equivalent constructor not requiring a Device
+ * @deprecated Use {@link #Color(int, int, int)}
  */
+@Deprecated(since="2026-06")
 public Color (Device device, int red, int green, int blue) {
 	super(device);
 	init(red, green, blue, 255);
@@ -118,7 +120,9 @@ public Color(int red, int green, int blue) {
  * @see #Color(int, int, int, int) The equivalent constructor not requiring a Device
  *
  * @since 3.104
+ * @deprecated Use {@link #Color(int, int, int, int)}
  */
+@Deprecated(since="2026-06")
 public Color (Device device, int red, int green, int blue, int alpha) {
 	super(device);
 	init(red, green, blue, alpha);
@@ -160,7 +164,9 @@ public Color(int red, int green, int blue, int alpha) {
  * </ul>
  *
  * @see #Color(RGB) The equivalent constructor not requiring a Device
+ * @deprecated Use {@link #Color(RGB)}
  */
+@Deprecated(since="2026-06")
 public Color (Device device, RGB rgb) {
 	super(device);
 	if (rgb == null) SWT.error(SWT.ERROR_NULL_ARGUMENT);
@@ -202,7 +208,9 @@ public Color(RGB rgb) {
  * @see #Color(RGBA) The equivalent constructor not requiring a Device
  *
  * @since 3.104
+ * @deprecated Use {@link #Color(RGBA)}
  */
+@Deprecated(since="2026-06")
 public Color(Device device, RGBA rgba) {
 	super(device);
 	if (rgba == null) SWT.error(SWT.ERROR_NULL_ARGUMENT);
@@ -247,7 +255,9 @@ public Color(RGBA rgba) {
  * @see #Color(RGB, int) The equivalent constructor not requiring a Device
  *
  * @since 3.104
+ * @deprecated Use {@link #Color(RGB, int)}
  */
+@Deprecated(since="2026-06")
 public Color(Device device, RGB rgb, int alpha) {
 	super(device);
 	if (rgb == null) SWT.error(SWT.ERROR_NULL_ARGUMENT);

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/GC.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/GC.java
@@ -4858,7 +4858,7 @@ private class SetBackgroundOperation extends ReplaceableOperation  {
 
 	SetBackgroundOperation(Color color) {
 		RGB rgb = color.getRGB();
-		this.color = new Color(color.getDevice(), rgb);
+		this.color = new Color(rgb);
 		registerForDisposal(this.color);
 	}
 
@@ -5207,7 +5207,7 @@ private class SetForegroundOperation extends ReplaceableOperation  {
 
 	SetForegroundOperation(Color color) {
 		RGB rgb = color.getRGB();
-		this.color = new Color(color.getDevice(), rgb);
+		this.color = new Color(rgb);
 		registerForDisposal(this.color);
 	}
 

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_Color.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_Color.java
@@ -96,7 +96,7 @@ public void test_ConstructorLorg_eclipse_swt_graphics_DeviceIII() {
 }
 
 @Test
-@SuppressWarnings("unused")
+@SuppressWarnings({"unused", "deprecation"})
 public void test_ConstructorLorg_eclipse_swt_graphics_DeviceIII_with_device() {
 	// Test new Color(Device device, int red, int green, int blue)
 	// IllegalArgumentException if the red, green or blue argument is not between 0 and 255
@@ -203,7 +203,7 @@ public void test_ConstructorLorg_eclipse_swt_graphics_DeviceLorg_eclipse_swt_gra
 }
 
 @Test
-@SuppressWarnings("unused")
+@SuppressWarnings({"unused", "deprecation"})
 public void test_ConstructorLorg_eclipse_swt_graphics_DeviceLorg_eclipse_swt_graphics_RGB_with_device() {
 	// Test new Color(Device device, RGB rgb)
 	// IllegalArgumentException if the red, green or blue argument is not between 0 and 255; or rgb is null
@@ -307,7 +307,7 @@ public void test_ConstructorLorg_eclipse_swt_graphics_DeviceLorg_eclipse_swt_gra
 }
 
 @Test
-@SuppressWarnings("unused")
+@SuppressWarnings({"unused", "deprecation"})
 public void test_ConstructorLorg_eclipse_swt_graphics_DeviceLorg_eclipse_swt_graphics_RGBA_with_device() {
 	// Test new Color(Device device, RGBA rgba)
 	// IllegalArgumentException if the red, green, blue or alpha argument is not between 0 and 255; or rgba is null
@@ -400,6 +400,7 @@ public void test_equalsLjava_lang_Object() {
 }
 
 @Test
+@SuppressWarnings("deprecation")
 public void test_equalsLjava_lang_Object_with_device() {
 	Color color = new Color(display, 1, 2, 3);
 	Color sameColor = new Color(display, 1, 2, 3);
@@ -432,6 +433,7 @@ public void test_equalsLjava_lang_Object_with_device() {
 }
 
 @Test
+@SuppressWarnings("deprecation")
 public void test_equalsLjava_lang_Object_mix() {
 	Color color = new Color(display, 1, 2, 3);
 	Color sameColorNoDevice = new Color(1, 2, 3);
@@ -461,6 +463,7 @@ public void test_getBlue() {
 }
 
 @Test
+@SuppressWarnings("deprecation")
 public void test_getBlue_with_device() {
 	// Test Color.getBlue()
 	Color color = new Color(display, 0, 0, 255);
@@ -475,6 +478,7 @@ public void test_getGreen() {
 }
 
 @Test
+@SuppressWarnings("deprecation")
 public void test_getGreen_with_device() {
 	// Test Color.getGreen()
 	Color color = new Color(display, 0, 255, 0);
@@ -489,6 +493,7 @@ public void test_getRGB() {
 }
 
 @Test
+@SuppressWarnings("deprecation")
 public void test_getRGB_with_device() {
 	Color color = new Color(display, 255, 255, 255);
 	assertNotNull(color.getRGB());
@@ -503,6 +508,7 @@ public void test_getRed() {
 }
 
 @Test
+@SuppressWarnings("deprecation")
 public void test_getRed_with_device() {
 	// Test Color.getRed()
 	Color color = new Color(display, 255, 0, 0);
@@ -517,6 +523,7 @@ public void test_getAlpha() {
 }
 
 @Test
+@SuppressWarnings("deprecation")
 public void test_getAlpha_with_device() {
 	// Test Color.getRed()
 	Color color = new Color(display, 255, 0, 0, 0);
@@ -533,6 +540,7 @@ public void test_hashCode() {
 }
 
 @Test
+@SuppressWarnings("deprecation")
 public void test_hashCode_with_device() {
 	Color color = new Color(display, 12, 34, 56, 0);
 	Color otherColor = new Color(display, 12, 34, 56, 0);
@@ -556,6 +564,7 @@ public void test_isDisposed() {
 }
 
 @Test
+@SuppressWarnings("deprecation")
 public void test_isDisposed_with_device() {
 	// Test Color.isDisposed() false
 	Color color = new Color(display, 34, 67, 98, 0);
@@ -574,6 +583,7 @@ public void test_toString() {
 }
 
 @Test
+@SuppressWarnings("deprecation")
 public void test_toString_with_device() {
 	Color color = new Color(display, 0, 0, 255, 255);
 	assertNotNull(color.toString());
@@ -598,6 +608,7 @@ public void test_getDevice() {
 }
 
 @Test
+@SuppressWarnings("deprecation")
 public void test_getDevice_with_device() {
 	Color color = new Color(display, 0, 0, 255, 255);
 	assertEquals(display, color.getDevice());


### PR DESCRIPTION
The constructors new Color(Device, int, int, int), new Color(Device, RGB), and new Color(Device, RGBA) (and variants with alpha) are now deprecated. Modern display-free equivalents should be used instead.

This reduces boilerplate, avoids NPE risks on non-UI threads, and simplifies resource management as these colors do not require manual disposal.

Fixes https://github.com/eclipse-platform/eclipse.platform.swt/issues/3232