### PR TITLE
[Gtk] Mark gtk_leave_notify as clearly gtk 3 method

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Control.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Control.java
@@ -4033,7 +4033,7 @@ void gtk4_leave_event(long controller, long event) {
 }
 
 @Override
-long gtk_leave_notify_event (long widget, long event) {
+long gtk3_leave_notify_event (long widget, long event) {
 	if (display.currentControl != this) return 0;
 	int [] state = new int [1];
 	GDK.gdk_event_get_state(event, state);

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Shell.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Shell.java
@@ -1656,29 +1656,21 @@ long gtk_focus_out_event (long widget, long event) {
 }
 
 @Override
-long gtk_leave_notify_event (long widget, long event) {
+long gtk3_leave_notify_event (long widget, long event) {
 	if (widget == shellHandle) {
 		if (isCustomResize ()) {
 			int [] state = new int [1];
-			if (GTK.GTK4) {
-				state[0] = GDK.gdk_event_get_modifier_state(event);
-			} else {
-				GDK.gdk_event_get_state(event, state);
-			}
+			GDK.gdk_event_get_state(event, state);
 
 			if ((state[0] & GDK.GDK_BUTTON1_MASK) == 0) {
-				if (GTK.GTK4) {
-					GTK4.gtk_widget_set_cursor (shellHandle, 0);
-				} else {
-					long window = gtk_widget_get_window (shellHandle);
-					GDK.gdk_window_set_cursor (window, 0);
-				}
+				long window = gtk_widget_get_window (shellHandle);
+				GDK.gdk_window_set_cursor (window, 0);
 				display.resizeMode = 0;
 			}
 		}
 		return 0;
 	}
-	return super.gtk_leave_notify_event (widget, event);
+	return super.gtk3_leave_notify_event (widget, event);
 }
 
 @Override

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/ToolItem.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/ToolItem.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2025 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -821,8 +821,8 @@ long gtk_focus_out_event (long widget, long event) {
 }
 
 @Override
-long gtk_leave_notify_event (long widget, long event) {
-	parent.gtk_leave_notify_event (widget, event);
+long gtk3_leave_notify_event (long widget, long event) {
+	parent.gtk3_leave_notify_event (widget, event);
 	if (drawHotImage) {
 		drawHotImage = false;
 		if (image != null) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Widget.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Widget.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2025 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -1004,7 +1004,7 @@ long gtk3_key_release_event (long widget, long event) {
 	return sendKeyEvent (SWT.KeyUp, event) ? 0 : 1;
 }
 
-long gtk_leave_notify_event (long widget, long event) {
+long gtk3_leave_notify_event (long widget, long event) {
 	return 0;
 }
 
@@ -2646,7 +2646,7 @@ long windowProc (long handle, long arg0, long user_data) {
 		case KEY_PRESS_EVENT: return gtk3_key_press_event (handle, arg0);
 		case KEY_RELEASE_EVENT: return gtk3_key_release_event (handle, arg0);
 		case INPUT: return gtk_input (handle, arg0);
-		case LEAVE_NOTIFY_EVENT: return gtk_leave_notify_event (handle, arg0);
+		case LEAVE_NOTIFY_EVENT: return gtk3_leave_notify_event (handle, arg0);
 		case MAP_EVENT: return gtk_map_event (handle, arg0);
 		case MNEMONIC_ACTIVATE: return gtk_mnemonic_activate (handle, arg0);
 		case MOTION_NOTIFY_EVENT: return gtk3_motion_notify_event (handle, arg0);


### PR DESCRIPTION
Simplify overrides to not try to handle gtk 4 in it as it can never happen.