### PR TITLE
[Gtk] Simplify Widget.gdk_event_get_state

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/List.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/List.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2025 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -965,7 +965,7 @@ long gtk3_button_release_event (long widget, long event) {
  * @param event the gtk key press event that was fired.
  */
 void keyPressDefaultSelectionHandler (long event, int key) {
-	int keymask = gdk_event_get_state (event);
+	int keymask = gdk3_event_get_state (event);
 	switch (key) {
 		case GDK.GDK_Return:
 			// Send DefaultSelectionEvent when:

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Shell.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Shell.java
@@ -1793,13 +1793,8 @@ long gtk3_key_press_event (long widget, long event) {
 					if (keyval [0] != 0) {
 						int [] key = new int [1];
 						int [] state = new int[1];
-						if (GTK.GTK4) {
-							key[0] = GDK.gdk_key_event_get_keyval(event);
-							state[0] = GDK.gdk_event_get_modifier_state(event);
-						} else {
-							GDK.gdk_event_get_keyval(event, key);
-							GDK.gdk_event_get_state(event, state);
-						}
+						GDK.gdk_event_get_keyval(event, key);
+						GDK.gdk_event_get_state(event, state);
 
 						int mask = GTK.gtk_accelerator_get_default_mod_mask ();
 						if (key[0] == keyval [0] && (state[0] & mask) == (mods [0] & mask)) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Table.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Table.java
@@ -2149,7 +2149,7 @@ long gtk3_key_press_event (long widget, long event) {
 			// when    : Enter, Shift+Enter, Ctrl+Enter are pressed.
 			// Not when: Alt+Enter, (Meta|Super|Hyper)+Enter, reason is stateMask is not provided on Gtk.
 			// Note: alt+Enter creates a selection on GTK, but we filter it out to be a bit more consitent Win32 (521387)
-			int keymask = gdk_event_get_state (event);
+			int keymask = gdk3_event_get_state (event);
 			if ((keymask & (GDK.GDK_SUPER_MASK | GDK.GDK_META_MASK | GDK.GDK_HYPER_MASK | GDK.GDK_MOD1_MASK)) == 0) {
 				sendTreeDefaultSelection ();
 			}

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Tree.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Tree.java
@@ -2329,7 +2329,7 @@ long gtk3_key_press_event (long widget, long event) {
 			// When    : Enter, Shift+Enter, Ctrl+Enter are pressed.
 			// Not when: Alt+Enter, (Meta|Super|Hyper)+Enter, reason is stateMask is not provided on Gtk.
 			// Note: alt+Enter creates a selection on GTK, but we filter it out to be a bit more consistent Win32 (521387)
-			int keymask = gdk_event_get_state (event);
+			int keymask = gdk3_event_get_state (event);
 			if ((keymask & (GDK.GDK_SUPER_MASK | GDK.GDK_META_MASK | GDK.GDK_HYPER_MASK | GDK.GDK_MOD1_MASK)) == 0) {
 				sendTreeDefaultSelection ();
 			}

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Widget.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Widget.java
@@ -2369,13 +2369,9 @@ long gdk_event_get_surface_or_window(long event) {
  * @return the keymask to be used with constants like
  *        OS.GDK_SHIFT_MASK / OS.GDK_CONTROL_MASK / OS.GDK_MOD1_MASK etc..
  */
-int gdk_event_get_state (long event) {
+int gdk3_event_get_state (long event) {
 	int [] state = new int[1];
-	if (GTK.GTK4) {
-		state[0] = GDK.gdk_event_get_modifier_state(event);
-	} else {
-		GDK.gdk_event_get_state(event, state);
-	}
+	GDK.gdk_event_get_state(event, state);
 
 	return state[0];
 }


### PR DESCRIPTION
It's used only in Gtk 3 implementation thus rename to indicate that and drop if/else covering non-reachable Gtk 4.