### PR TITLE
Use device-free Color constructors instead of Device-based ones

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Accessibility/win32/org/eclipse/swt/accessibility/Accessible.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Accessibility/win32/org/eclipse/swt/accessibility/Accessible.java
@@ -5099,7 +5099,7 @@ public class Accessible {
 			int r = Integer.parseInt(rgbString.substring(open + 1, comma1));
 			int g = Integer.parseInt(rgbString.substring(comma1 + 1, comma2));
 			int b = Integer.parseInt(rgbString.substring(comma2 + 1, close));
-			return new Color(control.getDisplay(), r, g, b);
+			return new Color(r, g, b);
 		} catch (NumberFormatException ex) {}
 		return null;
 	}

--- a/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/ControlEditor.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/ControlEditor.java
@@ -31,7 +31,7 @@ import org.eclipse.swt.widgets.*;
 * <pre><code>
 * Canvas canvas = new Canvas(shell, SWT.BORDER);
 * canvas.setBounds(10, 10, 300, 300);
-* Color color = new Color(null, 255, 0, 0);
+* Color color = new Color(255, 0, 0);
 * canvas.setBackground(color);
 * ControlEditor editor = new ControlEditor (canvas);
 * // The editor will be a button in the bottom right corner of the canvas.
@@ -46,7 +46,7 @@ import org.eclipse.swt.widgets.*;
 * 		RGB rgb = dialog.getRGB();
 * 		if (rgb != null) {
 * 			if (color != null) color.dispose();
-* 			color = new Color(null, rgb);
+* 			color = new Color(rgb);
 * 			canvas.setBackground(color);
 * 		}
 *

--- a/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/cocoa/org/eclipse/swt/dnd/DragSource.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/cocoa/org/eclipse/swt/dnd/DragSource.java
@@ -361,7 +361,7 @@ void drag(Event dragDetectEvent) {
 			int width = 20, height = 20;
 			Image newDragImage = new Image(Display.getCurrent(), width, height);
 			GC imageGC = new GC(newDragImage);
-			Color grayColor = new Color(Display.getCurrent(), 50, 50, 50);
+			Color grayColor = new Color(50, 50, 50);
 			imageGC.setForeground(grayColor);
 			imageGC.drawRectangle(0, 0, 19, 19);
 			imageGC.dispose();

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/win32/org/eclipse/swt/internal/win32/OS.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/win32/org/eclipse/swt/internal/win32/OS.java
@@ -2266,16 +2266,16 @@ public static final void setTheme(boolean isDarkTheme) {
 
 	display.setData("org.eclipse.swt.internal.win32.useDarkModeExplorerTheme", isDarkTheme);
 	display.setData("org.eclipse.swt.internal.win32.useShellTitleColoring",    isDarkTheme);
-	display.setData("org.eclipse.swt.internal.win32.menuBarForegroundColor",   isDarkTheme ? new Color(display, 0xD0, 0xD0, 0xD0) : null);
-	display.setData("org.eclipse.swt.internal.win32.menuBarBackgroundColor",   isDarkTheme ? new Color(display, 0x30, 0x30, 0x30) : null);
-	display.setData("org.eclipse.swt.internal.win32.menuBarBorderColor",       isDarkTheme ? new Color(display, 0x50, 0x50, 0x50) : null);
+	display.setData("org.eclipse.swt.internal.win32.menuBarForegroundColor",   isDarkTheme ? new Color(0xD0, 0xD0, 0xD0) : null);
+	display.setData("org.eclipse.swt.internal.win32.menuBarBackgroundColor",   isDarkTheme ? new Color(0x30, 0x30, 0x30) : null);
+	display.setData("org.eclipse.swt.internal.win32.menuBarBorderColor",       isDarkTheme ? new Color(0x50, 0x50, 0x50) : null);
 	display.setData("org.eclipse.swt.internal.win32.Canvas.use_WS_BORDER",     isDarkTheme);
 	display.setData("org.eclipse.swt.internal.win32.List.use_WS_BORDER",       isDarkTheme);
 	display.setData("org.eclipse.swt.internal.win32.Table.use_WS_BORDER",      isDarkTheme);
 	display.setData("org.eclipse.swt.internal.win32.Text.use_WS_BORDER",       isDarkTheme);
 	display.setData("org.eclipse.swt.internal.win32.Tree.use_WS_BORDER",       isDarkTheme);
-	display.setData("org.eclipse.swt.internal.win32.Table.headerLineColor",    isDarkTheme ? new Color(display, 0x50, 0x50, 0x50) : null);
-	display.setData("org.eclipse.swt.internal.win32.Label.disabledForegroundColor", isDarkTheme ? new Color(display, 0x80, 0x80, 0x80) : null);
+	display.setData("org.eclipse.swt.internal.win32.Table.headerLineColor",    isDarkTheme ? new Color(0x50, 0x50, 0x50) : null);
+	display.setData("org.eclipse.swt.internal.win32.Label.disabledForegroundColor", isDarkTheme ? new Color(0x80, 0x80, 0x80) : null);
 	display.setData("org.eclipse.swt.internal.win32.Combo.useDarkTheme",       isDarkTheme);
 	display.setData("org.eclipse.swt.internal.win32.ProgressBar.useColors",    isDarkTheme);
 	display.setData("org.eclipse.swt.internal.win32.Text.useDarkThemeIcons",   isDarkTheme);

--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/graphics/Device.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/graphics/Device.java
@@ -594,23 +594,23 @@ public boolean getWarnings () {
  */
 protected void init () {
 	/* Create the standard colors */
-	COLOR_TRANSPARENT = new Color (this, 0xFF,0xFF,0xFF,0);
-	COLOR_BLACK = new Color (this, 0,0,0);
-	COLOR_DARK_RED = new Color (this, 0x80,0,0);
-	COLOR_DARK_GREEN = new Color (this, 0,0x80,0);
-	COLOR_DARK_YELLOW = new Color (this, 0x80,0x80,0);
-	COLOR_DARK_BLUE = new Color (this, 0,0,0x80);
-	COLOR_DARK_MAGENTA = new Color (this, 0x80,0,0x80);
-	COLOR_DARK_CYAN = new Color (this, 0,0x80,0x80);
-	COLOR_GRAY = new Color (this, 0xC0,0xC0,0xC0);
-	COLOR_DARK_GRAY = new Color (this, 0x80,0x80,0x80);
-	COLOR_RED = new Color (this, 0xFF,0,0);
-	COLOR_GREEN = new Color (this, 0,0xFF,0);
-	COLOR_YELLOW = new Color (this, 0xFF,0xFF,0);
-	COLOR_BLUE = new Color (this, 0,0,0xFF);
-	COLOR_MAGENTA = new Color (this, 0xFF,0,0xFF);
-	COLOR_CYAN = new Color (this, 0,0xFF,0xFF);
-	COLOR_WHITE = new Color (this, 0xFF,0xFF,0xFF);
+	COLOR_TRANSPARENT = new Color (0xFF,0xFF,0xFF,0);
+	COLOR_BLACK = new Color (0,0,0);
+	COLOR_DARK_RED = new Color (0x80,0,0);
+	COLOR_DARK_GREEN = new Color (0,0x80,0);
+	COLOR_DARK_YELLOW = new Color (0x80,0x80,0);
+	COLOR_DARK_BLUE = new Color (0,0,0x80);
+	COLOR_DARK_MAGENTA = new Color (0x80,0,0x80);
+	COLOR_DARK_CYAN = new Color (0,0x80,0x80);
+	COLOR_GRAY = new Color (0xC0,0xC0,0xC0);
+	COLOR_DARK_GRAY = new Color (0x80,0x80,0x80);
+	COLOR_RED = new Color (0xFF,0,0);
+	COLOR_GREEN = new Color (0,0xFF,0);
+	COLOR_YELLOW = new Color (0xFF,0xFF,0);
+	COLOR_BLUE = new Color (0,0,0xFF);
+	COLOR_MAGENTA = new Color (0xFF,0,0xFF);
+	COLOR_CYAN = new Color (0,0xFF,0xFF);
+	COLOR_WHITE = new Color (0xFF,0xFF,0xFF);
 
 	paragraphStyle = (NSMutableParagraphStyle)new NSMutableParagraphStyle().alloc().init();
 	paragraphStyle.setAlignment(OS.NSTextAlignmentLeft);

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/GC.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/GC.java
@@ -4854,7 +4854,7 @@ private class SetBackgroundOperation extends ReplaceableOperation  {
 
 	SetBackgroundOperation(Color color) {
 		RGB rgb = color.getRGB();
-		this.color = new Color(color.getDevice(), rgb);
+		this.color = new Color(rgb);
 		registerForDisposal(this.color);
 	}
 
@@ -5203,7 +5203,7 @@ private class SetForegroundOperation extends ReplaceableOperation  {
 
 	SetForegroundOperation(Color color) {
 		RGB rgb = color.getRGB();
-		this.color = new Color(color.getDevice(), rgb);
+		this.color = new Color(rgb);
 		registerForDisposal(this.color);
 	}
 


### PR DESCRIPTION
## Summary

- Replace all internal SWT usages of `new Color(device, r, g, b)`, `new Color(device, rgb)`, etc. with the modern display-free equivalents `new Color(r, g, b)`, `new Color(rgb)`, etc.
- Affected files: `Accessible.java` (win32), `ControlEditor.java`, `DragSource.java` (cocoa), `OS.java` (win32), `Device.java` (cocoa), `GC.java` (win32)
- No deprecation annotations are added in this PR; those are handled separately

## Test plan

- [ ] Existing tests pass (no behavioral change, pure constructor call migration)
- [ ] Linux GTK build passes
- [ ] Windows Win32 build passes
- [ ] macOS Cocoa build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)