### PR TITLE
[GTK3] Fix ToolBar.computeSize 60 Hz repaint loop with SWT.WRAP

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/gtk3.c
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/gtk3.c
@@ -1987,16 +1987,6 @@ JNIEXPORT void JNICALL GTK3_NATIVE(gtk_1toolbar_1set_1icon_1size)
 }
 #endif
 
-#ifndef NO_gtk_1toolbar_1set_1show_1arrow
-JNIEXPORT void JNICALL GTK3_NATIVE(gtk_1toolbar_1set_1show_1arrow)
-	(JNIEnv *env, jclass that, jlong arg0, jboolean arg1)
-{
-	GTK3_NATIVE_ENTER(env, that, gtk_1toolbar_1set_1show_1arrow_FUNC);
-	gtk_toolbar_set_show_arrow((GtkToolbar *)arg0, (gboolean)arg1);
-	GTK3_NATIVE_EXIT(env, that, gtk_1toolbar_1set_1show_1arrow_FUNC);
-}
-#endif
-
 #ifndef NO_gtk_1toolbar_1set_1style
 JNIEXPORT void JNICALL GTK3_NATIVE(gtk_1toolbar_1set_1style)
 	(JNIEnv *env, jclass that, jlong arg0, jint arg1)

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/gtk3_stats.h
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/library/gtk3_stats.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2025 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -184,7 +184,6 @@ typedef enum {
 	gtk_1toolbar_1insert_FUNC,
 	gtk_1toolbar_1new_FUNC,
 	gtk_1toolbar_1set_1icon_1size_FUNC,
-	gtk_1toolbar_1set_1show_1arrow_FUNC,
 	gtk_1toolbar_1set_1style_FUNC,
 	gtk_1tree_1view_1column_1cell_1get_1size_FUNC,
 	gtk_1tree_1view_1get_1bin_1window_FUNC,

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/org/eclipse/swt/internal/gtk3/GTK3.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/org/eclipse/swt/internal/gtk3/GTK3.java
@@ -704,11 +704,6 @@ public class GTK3 {
 	public static final native void gtk_toolbar_insert(long toolbar, long item, int pos);
 	/**
 	 * @param toolbar cast=(GtkToolbar *)
-	 * @param show_arrow cast=(gboolean)
-	 */
-	public static final native void gtk_toolbar_set_show_arrow(long toolbar, boolean show_arrow);
-	/**
-	 * @param toolbar cast=(GtkToolbar *)
 	 * @param style cast=(GtkToolbarStyle)
 	 */
 	public static final native void gtk_toolbar_set_style(long toolbar, int style);

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/ToolBar.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/ToolBar.java
@@ -177,23 +177,7 @@ Point computeSizeInPixels (int wHint, int hHint, boolean changed) {
 	if (wHint != SWT.DEFAULT && wHint < 0) wHint = 0;
 	if (hHint != SWT.DEFAULT && hHint < 0) hHint = 0;
 
-	Point size = null;
-
-	if (GTK.GTK4) {
-		size = computeNativeSize (handle, wHint, hHint, changed);
-	} else {
-		/*
-		 * Feature in GTK. Size of toolbar is calculated incorrectly
-		 * and appears as just the overflow arrow, if the arrow is enabled
-		 * to display. The fix is to disable it before the computation of
-		 * size and enable it if WRAP style is set.
-		 */
-		GTK3.gtk_toolbar_set_show_arrow (handle, false);
-		size = computeNativeSize (handle, wHint, hHint, changed);
-		if ((style & SWT.WRAP) != 0) GTK3.gtk_toolbar_set_show_arrow (handle, true);
-	}
-
-	return size;
+	return computeNativeSize (handle, wHint, hHint, changed);
 }
 
 @Override
@@ -609,18 +593,8 @@ void reskinChildren (int flags) {
 
 @Override
 int setBounds (int x, int y, int width, int height, boolean move, boolean resize) {
-	if (!GTK.GTK4) GTK3.gtk_toolbar_set_show_arrow (handle, false);
 	int result = super.setBounds (x, y, width, height, move, resize);
 	if ((result & RESIZED) != 0) relayout ();
-	if ((style & SWT.WRAP) != 0) {
-		if (GTK.GTK4) {
-			/* TODO: GTK4 will require us to implement our own
-			 * overflow menu. May require the use of the "toolbar" style class
-			 * applied to the widget.  */
-		} else {
-			GTK3.gtk_toolbar_set_show_arrow (handle, true);
-		}
-	}
 
 	return result;
 }


### PR DESCRIPTION
## Summary
- Remove the `gtk_toolbar_set_show_arrow` toggle workaround in `ToolBar.computeSizeInPixels` that caused two GTK invalidation cycles per measurement call
- This workaround was added in 2012 (Bug 46025) for GTK 3.4 and is no longer needed on modern GTK 3.24
- When a `SWT.WRAP` ToolBar sits inside a frequently-measured parent (e.g. `CTabFolder.setTopRight`), the toggle created a self-sustaining ~60 Hz repaint loop burning 10-25% CPU while idle
- Add Snippet394 to verify ToolBar sizing works correctly without the workaround

## Test plan
- [ ] Run Snippet394 on GTK3 to verify both WRAP and non-WRAP toolbars report similar widths
- [ ] Run the reproducer from #3236 with `SWT.WRAP` and confirm CPU stays at 0% on idle
- [ ] Verify `SWT.WRAP` toolbar overflow behavior still works correctly (items hidden behind chevron when toolbar is too narrow)
- [ ] Test in Eclipse IDE with CTabFolder top-right toolbars

Fixes #3236

🤖 Generated with [Claude Code](https://claude.com/claude-code)