### PR TITLE
[Win32] Fix width check in Image.HandleAtSize.isReusable

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Image.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Image.java
@@ -232,7 +232,7 @@ public final class Image extends Resource implements Drawable {
 				return false;
 			}
 			return (requestedHeight == height && requestedWidth == width)
-					|| (handleContainer.height() == height && handleContainer.height() == width);
+					|| (handleContainer.height() == height && handleContainer.width() == width);
 		}
 
 		private Optional<InternalImageHandle> createHandleAtExactSize(int width, int height) {


### PR DESCRIPTION
## Summary
- Fix copy-paste error in `HandleAtSize.isReusable()` where `handleContainer.height()` was compared against `width` instead of using `handleContainer.width()`
- This caused unnecessary image handle recreation for non-square images, as the second condition in the `||` could only match when height == width

## Details
In `Image.java` (Win32), the `isReusable()` method's fallback condition checked:
```java
handleContainer.height() == height && handleContainer.height() == width
```
The second comparison should use `handleContainer.width()` instead.

## Test plan
- [x] Verify non-square images reuse handles correctly when the container dimensions match
- [x] Verify square images continue to work as before
- [x] Run SWT test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)