### PR TITLE
[Win32] Add double-dispose guard in DestroyableImageHandle.destroy()

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Image.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Image.java
@@ -3312,6 +3312,7 @@ private class DestroyableImageHandle implements InternalImageHandle {
 	}
 
 	void destroy() {
+		if (isDisposed) return;
 		if (type == SWT.ICON) {
 			OS.DestroyIcon (handle());
 		} else {


### PR DESCRIPTION
## Summary

- Add an early-return guard in `DestroyableImageHandle.destroy()` to prevent passing an already-freed GDI handle to `OS.DestroyIcon`/`OS.DeleteObject` when `destroy()` is called more than once
- The `isDisposed` flag was already being set at the end of `destroy()` but was not checked on entry

## Test plan

- [x] Verify existing SWT Image tests still pass
- [x] Confirm no regressions in Image disposal on Win32

🤖 Generated with [Claude Code](https://claude.com/claude-code)