### PR TITLE
[Win32] Replace magic GDI+ image arrays

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/GC.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/GC.java
@@ -1326,10 +1326,23 @@ private class DrawImageToImageOperation extends ImageOperation {
 }
 
 private void drawImage(Image srcImage, int srcX, int srcY, int srcWidth, int srcHeight, int destX, int destY, int destWidth, int destHeight, boolean simple, ImageHandle tempImageHandle) {
-	if (data.gdipGraphics != 0) {
-		//TODO - cache bitmap
-		long [] gdipImage = srcImage.createGdipImageFromHandle(tempImageHandle);
-		long img = gdipImage[0];
+	if (data.gdipGraphics == 0) {
+		switch (srcImage.type) {
+			case SWT.BITMAP:
+				drawBitmap(srcImage, tempImageHandle, srcX, srcY, srcWidth, srcHeight, destX, destY, destWidth, destHeight,
+						simple);
+				break;
+			case SWT.ICON:
+				drawIcon(tempImageHandle.handle(), srcX, srcY, srcWidth, srcHeight, destX, destY, destWidth, destHeight, simple);
+				break;
+		}
+		return;
+	}
+
+	//TODO - cache bitmap
+	Image.GdipImage gdipImage = srcImage.createGdipImageFromHandle(tempImageHandle);
+	try {
+		long img = gdipImage.bitmap();
 		int imgWidth = Gdip.Image_GetWidth(img);
 		int imgHeight = Gdip.Image_GetHeight(img);
 
@@ -1380,21 +1393,8 @@ private void drawImage(Image srcImage, int srcX, int srcY, int srcWidth, int src
 			Gdip.Graphics_Restore(data.gdipGraphics, gstate);
 		}
 		Gdip.ImageAttributes_delete(attrib);
-		Gdip.Bitmap_delete(img);
-		if (gdipImage[1] != 0) {
-			long hHeap = OS.GetProcessHeap ();
-			OS.HeapFree(hHeap, 0, gdipImage[1]);
-		}
-		return;
-	}
-	switch (srcImage.type) {
-		case SWT.BITMAP:
-			drawBitmap(srcImage, tempImageHandle, srcX, srcY, srcWidth, srcHeight, destX, destY, destWidth, destHeight,
-					simple);
-			break;
-		case SWT.ICON:
-			drawIcon(tempImageHandle.handle(), srcX, srcY, srcWidth, srcHeight, destX, destY, destWidth, destHeight, simple);
-			break;
+	} finally {
+		gdipImage.destroy();
 	}
 }
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Image.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Image.java
@@ -969,15 +969,22 @@ public static void drawAtSize(GC gc, ImageData imageData, int width, int height)
 		imageToDraw.dispose();
 	});
 }
+record GdipImage(long bitmap, long pixels) {
+	void destroy() {
+		Gdip.Bitmap_delete(bitmap);
+		if (pixels != 0) {
+			long hHeap = OS.GetProcessHeap();
+			OS.HeapFree(hHeap, 0, pixels);
+		}
+	}
+}
 
-
-
-long [] createGdipImage(Integer zoom) {
+GdipImage createGdipImage(Integer zoom) {
 	ImageHandle handle = this.getHandle(zoom, zoom);
 	return createGdipImageFromHandle(handle);
 }
 
-long[] createGdipImageFromHandle(ImageHandle imageHandle) {
+GdipImage createGdipImageFromHandle(ImageHandle imageHandle) {
 	long handle = imageHandle.handle();
 	int transparentPixel = imageHandle.transparentPixel();
 	switch (type) {
@@ -1071,9 +1078,9 @@ long[] createGdipImageFromHandle(ImageHandle imageHandle) {
 				OS.DeleteObject(memHdc);
 				OS.DeleteObject(memDib);
 				int pixelFormat = hasAlpha ? Gdip.PixelFormat32bppPARGB : Gdip.PixelFormat32bppARGB;
-				return new long []{Gdip.Bitmap_new(imgWidth, imgHeight, dibBM.bmWidthBytes, pixelFormat, pixels), pixels};
+				return new GdipImage(Gdip.Bitmap_new(imgWidth, imgHeight, dibBM.bmWidthBytes, pixelFormat, pixels), pixels);
 			}
-			return new long []{Gdip.Bitmap_new(handle, 0), 0};
+			return new GdipImage(Gdip.Bitmap_new(handle, 0), 0);
 		}
 		case SWT.ICON: {
 			/*
@@ -1139,7 +1146,7 @@ long[] createGdipImageFromHandle(ImageHandle imageHandle) {
 			}
 			if (iconInfo.hbmColor != 0) OS.DeleteObject(iconInfo.hbmColor);
 			if (iconInfo.hbmMask != 0) OS.DeleteObject(iconInfo.hbmMask);
-			return new long []{img, pixels};
+			return new GdipImage(img, pixels);
 		}
 		default: SWT.error(SWT.ERROR_INVALID_IMAGE);
 	}

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Pattern.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Pattern.java
@@ -18,7 +18,6 @@ import java.util.*;
 import org.eclipse.swt.*;
 import org.eclipse.swt.internal.*;
 import org.eclipse.swt.internal.gdip.*;
-import org.eclipse.swt.internal.win32.*;
 
 /**
  * Instances of this class represent patterns to use while drawing. Patterns
@@ -300,7 +299,7 @@ private class BasePatternHandle extends PatternHandle {
 }
 
 private class ImagePatternHandle extends PatternHandle {
-	private long[] gdipImage;
+	private Image.GdipImage gdipImage;
 
 	public ImagePatternHandle(int zoom) {
 		super(zoom);
@@ -309,7 +308,7 @@ private class ImagePatternHandle extends PatternHandle {
 	@Override
 	long createHandle(int zoom) {
 		gdipImage = image.createGdipImage(zoom);
-		long img = gdipImage[0];
+		long img = gdipImage.bitmap();
 		int width = Gdip.Image_GetWidth(img);
 		int height = Gdip.Image_GetHeight(img);
 		long handle = Gdip.TextureBrush_new(img, Gdip.WrapModeTile, 0, 0, width, height);
@@ -327,13 +326,10 @@ private class ImagePatternHandle extends PatternHandle {
 	}
 
 	private void cleanupBitmap() {
-		if (gdipImage.length < 2) return;
-		long img = gdipImage[0];
-		Gdip.Bitmap_delete(img);
-		if (gdipImage[1] != 0) {
-			long hHeap = OS.GetProcessHeap ();
-			OS.HeapFree(hHeap, 0, gdipImage[1]);
-		}
+		if (gdipImage == null) return;
+		Image.GdipImage tempGdipImage = gdipImage;
+		gdipImage = null;
+		tempGdipImage.destroy();
 	}
 }
 


### PR DESCRIPTION
## Summary
- replace the magic `long[2]` GDI+ image return value with a dedicated `Image.GdipImage` record
- centralize temporary bitmap and heap buffer cleanup through `GdipImage.destroy()` in `GC` and `Pattern`
- remove the stale Win32 import from `Pattern`

## Why
`createGdipImageFromHandle()` always returns the same two-part result: the temporary GDI+ bitmap and an optional heap-backed pixel buffer that must be freed together. Representing that value as `long[2]` leaves the meaning of `gdipImage[0]` and `gdipImage[1]` implicit and pushes cleanup knowledge into each caller.

This change gives that result explicit semantics via `Image.GdipImage`, moves ownership cleanup to `GdipImage.destroy()`, and updates `Pattern.cleanupBitmap()` to track whether a temporary image is present directly instead of inferring state from the returned array length.

## Notes
- `Pattern.cleanupBitmap()` now tracks ownership explicitly instead of relying on the returned array length
- This draft PR was created with Copilot.