### PR TITLE
Mark long-deprecated and unused SWT constants for removal

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Accessibility/cocoa/org/eclipse/swt/accessibility/Accessible.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Accessibility/cocoa/org/eclipse/swt/accessibility/Accessible.java
@@ -118,7 +118,7 @@ public class Accessible {
 	 * @since 3.5
 	 * @deprecated
 	 */
-	@Deprecated
+	@Deprecated(forRemoval = true, since = "2026-06")
 	protected Accessible() {
 	}
 

--- a/bundles/org.eclipse.swt/Eclipse SWT Accessibility/cocoa/org/eclipse/swt/accessibility/Accessible.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Accessibility/cocoa/org/eclipse/swt/accessibility/Accessible.java
@@ -118,7 +118,7 @@ public class Accessible {
 	 * @since 3.5
 	 * @deprecated
 	 */
-	@Deprecated
+	@Deprecated(forRemoval = true, since = "2026-09")
 	protected Accessible() {
 	}
 

--- a/bundles/org.eclipse.swt/Eclipse SWT Accessibility/gtk/org/eclipse/swt/accessibility/Accessible.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Accessibility/gtk/org/eclipse/swt/accessibility/Accessible.java
@@ -107,7 +107,7 @@ public class Accessible {
 	 * @since 3.5
 	 * @deprecated
 	 */
-	@Deprecated
+	@Deprecated(forRemoval = true, since = "2026-06")
 	protected Accessible() {
 	}
 

--- a/bundles/org.eclipse.swt/Eclipse SWT Accessibility/gtk/org/eclipse/swt/accessibility/Accessible.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Accessibility/gtk/org/eclipse/swt/accessibility/Accessible.java
@@ -107,7 +107,7 @@ public class Accessible {
 	 * @since 3.5
 	 * @deprecated
 	 */
-	@Deprecated
+	@Deprecated(forRemoval = true, since = "2026-09")
 	protected Accessible() {
 	}
 

--- a/bundles/org.eclipse.swt/Eclipse SWT Accessibility/win32/org/eclipse/swt/accessibility/Accessible.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Accessibility/win32/org/eclipse/swt/accessibility/Accessible.java
@@ -117,7 +117,7 @@ public class Accessible {
 	 * @since 3.5
 	 * @deprecated
 	 */
-	@Deprecated
+	@Deprecated(forRemoval = true, since = "2026-06")
 	protected Accessible() {
 	}
 

--- a/bundles/org.eclipse.swt/Eclipse SWT Accessibility/win32/org/eclipse/swt/accessibility/Accessible.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Accessibility/win32/org/eclipse/swt/accessibility/Accessible.java
@@ -117,7 +117,7 @@ public class Accessible {
 	 * @since 3.5
 	 * @deprecated
 	 */
-	@Deprecated
+	@Deprecated(forRemoval = true, since = "2026-09")
 	protected Accessible() {
 	}
 

--- a/bundles/org.eclipse.swt/Eclipse SWT Browser/common/org/eclipse/swt/browser/Browser.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Browser/common/org/eclipse/swt/browser/Browser.java
@@ -855,7 +855,7 @@ public String getUrl () {
  * @since 3.3
  * @deprecated SWT.MOZILLA is deprecated and XULRunner as a browser renderer is no longer supported.
  */
-@Deprecated
+@Deprecated(forRemoval = true, since = "2026-06")
 public Object getWebBrowser () {
 	checkWidget();
 	return webBrowser.getWebBrowser ();

--- a/bundles/org.eclipse.swt/Eclipse SWT Browser/common/org/eclipse/swt/browser/Browser.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Browser/common/org/eclipse/swt/browser/Browser.java
@@ -855,7 +855,7 @@ public String getUrl () {
  * @since 3.3
  * @deprecated SWT.MOZILLA is deprecated and XULRunner as a browser renderer is no longer supported.
  */
-@Deprecated
+@Deprecated(forRemoval = true, since = "2026-09")
 public Object getWebBrowser () {
 	checkWidget();
 	return webBrowser.getWebBrowser ();

--- a/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CTabFolder.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CTabFolder.java
@@ -90,7 +90,7 @@ public class CTabFolder extends Composite {
 	 *
 	 * @deprecated drop shadow border is no longer drawn in 3.0
 	 */
-	@Deprecated
+	@Deprecated(forRemoval = true, since = "2026-06")
 	public static RGB borderInsideRGB  = new RGB (132, 130, 132);
 	/**
 	 * Color of middle line of drop shadow border.
@@ -100,7 +100,7 @@ public class CTabFolder extends Composite {
 	 *
 	 * @deprecated drop shadow border is no longer drawn in 3.0
 	 */
-	@Deprecated
+	@Deprecated(forRemoval = true, since = "2026-06")
 	public static RGB borderMiddleRGB  = new RGB (143, 141, 138);
 	/**
 	 * Color of outermost line of drop shadow border.
@@ -110,7 +110,7 @@ public class CTabFolder extends Composite {
 	 *
 	 * @deprecated drop shadow border is no longer drawn in 3.0
 	 */
-	@Deprecated
+	@Deprecated(forRemoval = true, since = "2026-06")
 	public static RGB borderOutsideRGB = new RGB (171, 168, 165);
 
 	/* sizing, positioning */

--- a/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CTabFolder.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CTabFolder.java
@@ -90,7 +90,7 @@ public class CTabFolder extends Composite {
 	 *
 	 * @deprecated drop shadow border is no longer drawn in 3.0
 	 */
-	@Deprecated
+	@Deprecated(forRemoval = true, since = "2026-09")
 	public static RGB borderInsideRGB  = new RGB (132, 130, 132);
 	/**
 	 * Color of middle line of drop shadow border.
@@ -100,7 +100,7 @@ public class CTabFolder extends Composite {
 	 *
 	 * @deprecated drop shadow border is no longer drawn in 3.0
 	 */
-	@Deprecated
+	@Deprecated(forRemoval = true, since = "2026-09")
 	public static RGB borderMiddleRGB  = new RGB (143, 141, 138);
 	/**
 	 * Color of outermost line of drop shadow border.
@@ -110,7 +110,7 @@ public class CTabFolder extends Composite {
 	 *
 	 * @deprecated drop shadow border is no longer drawn in 3.0
 	 */
-	@Deprecated
+	@Deprecated(forRemoval = true, since = "2026-09")
 	public static RGB borderOutsideRGB = new RGB (171, 168, 165);
 
 	/* sizing, positioning */

--- a/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CTabItem.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CTabItem.java
@@ -185,7 +185,7 @@ public Control getControl () {
  *
  * @deprecated the disabled image is not used
  */
-@Deprecated
+@Deprecated(forRemoval = true, since = "2026-06")
 public Image getDisabledImage(){
 	checkWidget();
 	return disabledImage;

--- a/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CTabItem.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CTabItem.java
@@ -185,7 +185,7 @@ public Control getControl () {
  *
  * @deprecated the disabled image is not used
  */
-@Deprecated
+@Deprecated(forRemoval = true, since = "2026-09")
 public Image getDisabledImage(){
 	checkWidget();
 	return disabledImage;

--- a/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/ViewForm.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/ViewForm.java
@@ -81,7 +81,7 @@ public class ViewForm extends Composite {
 	 *
 	 * @deprecated
 	 */
-	@Deprecated
+	@Deprecated(forRemoval = true, since = "2026-06")
 	public static RGB borderInsideRGB  = new RGB (132, 130, 132);
 	/**
 	 * Color of middle line of drop shadow border.
@@ -91,7 +91,7 @@ public class ViewForm extends Composite {
 	 *
 	 * @deprecated
 	 */
-	@Deprecated
+	@Deprecated(forRemoval = true, since = "2026-06")
 	public static RGB borderMiddleRGB  = new RGB (143, 141, 138);
 	/**
 	 * Color of outermost line of drop shadow border.
@@ -101,7 +101,7 @@ public class ViewForm extends Composite {
 	 *
 	 * @deprecated
 	 */
-	@Deprecated
+	@Deprecated(forRemoval = true, since = "2026-06")
 	public static RGB borderOutsideRGB = new RGB (171, 168, 165);
 
 	// SWT widgets

--- a/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/ViewForm.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/ViewForm.java
@@ -81,7 +81,7 @@ public class ViewForm extends Composite {
 	 *
 	 * @deprecated
 	 */
-	@Deprecated
+	@Deprecated(forRemoval = true, since = "2026-09")
 	public static RGB borderInsideRGB  = new RGB (132, 130, 132);
 	/**
 	 * Color of middle line of drop shadow border.
@@ -91,7 +91,7 @@ public class ViewForm extends Composite {
 	 *
 	 * @deprecated
 	 */
-	@Deprecated
+	@Deprecated(forRemoval = true, since = "2026-09")
 	public static RGB borderMiddleRGB  = new RGB (143, 141, 138);
 	/**
 	 * Color of outermost line of drop shadow border.
@@ -101,7 +101,7 @@ public class ViewForm extends Composite {
 	 *
 	 * @deprecated
 	 */
-	@Deprecated
+	@Deprecated(forRemoval = true, since = "2026-09")
 	public static RGB borderOutsideRGB = new RGB (171, 168, 165);
 
 	// SWT widgets

--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Composite.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Composite.java
@@ -17,7 +17,7 @@ package org.eclipse.swt.widgets;
 import org.eclipse.swt.*;
 import org.eclipse.swt.accessibility.*;
 import org.eclipse.swt.graphics.*;
-import org.eclipse.swt.internal.ExceptionStash;
+import org.eclipse.swt.internal.*;
 import org.eclipse.swt.internal.cocoa.*;
 
 /**
@@ -216,7 +216,7 @@ boolean accessibilityIsIgnored(long id, long sel) {
  * @deprecated use {@link Composite#layout(Control[], int)} instead
  * @since 3.1
  */
-@Deprecated
+@Deprecated(forRemoval = true, since = "2026-06")
 public void changed (Control[] changed) {
 	layout(changed, SWT.DEFER);
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Composite.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Composite.java
@@ -17,7 +17,7 @@ package org.eclipse.swt.widgets;
 import org.eclipse.swt.*;
 import org.eclipse.swt.accessibility.*;
 import org.eclipse.swt.graphics.*;
-import org.eclipse.swt.internal.ExceptionStash;
+import org.eclipse.swt.internal.*;
 import org.eclipse.swt.internal.cocoa.*;
 
 /**
@@ -216,7 +216,7 @@ boolean accessibilityIsIgnored(long id, long sel) {
  * @deprecated use {@link Composite#layout(Control[], int)} instead
  * @since 3.1
  */
-@Deprecated
+@Deprecated(forRemoval = true, since = "2026-09")
 public void changed (Control[] changed) {
 	layout(changed, SWT.DEFER);
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/FontDialog.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/FontDialog.java
@@ -116,7 +116,7 @@ public boolean getEffectsVisible () {
  * @return the FontData for the selected font, or null
  * @deprecated use #getFontList ()
  */
-@Deprecated
+@Deprecated(forRemoval = true, since = "2026-06")
 public FontData getFontData () {
 	return fontData;
 }
@@ -231,7 +231,7 @@ public void setEffectsVisible(boolean visible) {
  * @param fontData the FontData to use initially, or null
  * @deprecated use #setFontList (FontData [])
  */
-@Deprecated
+@Deprecated(forRemoval = true, since = "2026-06")
 public void setFontData (FontData fontData) {
 	this.fontData = fontData;
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/FontDialog.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/FontDialog.java
@@ -116,7 +116,7 @@ public boolean getEffectsVisible () {
  * @return the FontData for the selected font, or null
  * @deprecated use #getFontList ()
  */
-@Deprecated
+@Deprecated(forRemoval = true, since = "2026-09")
 public FontData getFontData () {
 	return fontData;
 }
@@ -231,7 +231,7 @@ public void setEffectsVisible(boolean visible) {
  * @param fontData the FontData to use initially, or null
  * @deprecated use #setFontList (FontData [])
  */
-@Deprecated
+@Deprecated(forRemoval = true, since = "2026-09")
 public void setFontData (FontData fontData) {
 	this.fontData = fontData;
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Composite.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Composite.java
@@ -238,7 +238,7 @@ Control [] _getTabList () {
  * @deprecated use {@link Composite#layout(Control[], int)} instead
  * @since 3.1
  */
-@Deprecated
+@Deprecated(forRemoval = true, since = "2026-06")
 public void changed (Control[] changed) {
 	layout(changed, SWT.DEFER);
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Composite.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Composite.java
@@ -238,7 +238,7 @@ Control [] _getTabList () {
  * @deprecated use {@link Composite#layout(Control[], int)} instead
  * @since 3.1
  */
-@Deprecated
+@Deprecated(forRemoval = true, since = "2026-09")
 public void changed (Control[] changed) {
 	layout(changed, SWT.DEFER);
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/FontDialog.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/FontDialog.java
@@ -111,7 +111,7 @@ public boolean getEffectsVisible () {
  * @return the FontData for the selected font, or null
  * @deprecated use #getFontList ()
  */
-@Deprecated
+@Deprecated(forRemoval = true, since = "2026-06")
 public FontData getFontData () {
 	return fontData;
 }
@@ -301,7 +301,7 @@ public void setEffectsVisible(boolean visible) {
  * @param fontData the FontData to use initially, or null
  * @deprecated use #setFontList (FontData [])
  */
-@Deprecated
+@Deprecated(forRemoval = true, since = "2026-06")
 public void setFontData (FontData fontData) {
 	this.fontData = fontData;
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/FontDialog.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/FontDialog.java
@@ -111,7 +111,7 @@ public boolean getEffectsVisible () {
  * @return the FontData for the selected font, or null
  * @deprecated use #getFontList ()
  */
-@Deprecated
+@Deprecated(forRemoval = true, since = "2026-09")
 public FontData getFontData () {
 	return fontData;
 }
@@ -301,7 +301,7 @@ public void setEffectsVisible(boolean visible) {
  * @param fontData the FontData to use initially, or null
  * @deprecated use #setFontList (FontData [])
  */
-@Deprecated
+@Deprecated(forRemoval = true, since = "2026-09")
 public void setFontData (FontData fontData) {
 	this.fontData = fontData;
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Composite.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Composite.java
@@ -160,7 +160,7 @@ Control [] _getTabList () {
  * @deprecated use {@link Composite#layout(Control[], int)} instead
  * @since 3.1
  */
-@Deprecated
+@Deprecated(forRemoval = true, since = "2026-06")
 public void changed (Control[] changed) {
 	layout(changed, SWT.DEFER);
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Composite.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Composite.java
@@ -160,7 +160,7 @@ Control [] _getTabList () {
  * @deprecated use {@link Composite#layout(Control[], int)} instead
  * @since 3.1
  */
-@Deprecated
+@Deprecated(forRemoval = true, since = "2026-09")
 public void changed (Control[] changed) {
 	layout(changed, SWT.DEFER);
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/FontDialog.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/FontDialog.java
@@ -110,7 +110,7 @@ public boolean getEffectsVisible () {
  * @return the FontData for the selected font, or null
  * @deprecated use #getFontList ()
  */
-@Deprecated
+@Deprecated(forRemoval = true, since = "2026-06")
 public FontData getFontData () {
 	return fontData;
 }
@@ -322,7 +322,7 @@ public void setEffectsVisible(boolean visible) {
  * @param fontData the FontData to use initially, or null
  * @deprecated use #setFontList (FontData [])
  */
-@Deprecated
+@Deprecated(forRemoval = true, since = "2026-06")
 public void setFontData (FontData fontData) {
 	this.fontData = fontData;
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/FontDialog.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/FontDialog.java
@@ -110,7 +110,7 @@ public boolean getEffectsVisible () {
  * @return the FontData for the selected font, or null
  * @deprecated use #getFontList ()
  */
-@Deprecated
+@Deprecated(forRemoval = true, since = "2026-09")
 public FontData getFontData () {
 	return fontData;
 }
@@ -322,7 +322,7 @@ public void setEffectsVisible(boolean visible) {
  * @param fontData the FontData to use initially, or null
  * @deprecated use #setFontList (FontData [])
  */
-@Deprecated
+@Deprecated(forRemoval = true, since = "2026-09")
 public void setFontData (FontData fontData) {
 	this.fontData = fontData;
 }


### PR DESCRIPTION
There are few constants in SWT that have been deprecated for a long time and are no longer referenced within the codebase. This change adds Deprecated tags for those to indicate their planned removal in a future releas