### PR TITLE
Simplify browser regression test for unused timers in Edge #2806

### DIFF
--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_browser_Browser.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_browser_Browser.java
@@ -2987,7 +2987,6 @@ public void test_TabTraversalOutOfBrowser() {
 public void test_TimerRegression_Issue2806() {
 	for (int i = 0; i < 10000; i++) {
 		browser.setText("Iteration " + i);
-		new BrowserFunction(browser, "name");
 	}
 	new Composite(shell, SWT.NONE);
 	processUiEvents();


### PR DESCRIPTION
The regression test added for an issue with the Edge implementation running out of handles because of too many timer being instantiated currently creates thousands of browser functions. The actual issue occurs because of too many calls to processOSMessagesUntil(), each creating a timer. This already happens when accessing the WebView instance through the setText() call inside the test. Thus, the creation of browser functions in the test is obsolete, which is why this change removes it.

Contributes to https://github.com/eclipse-platform/eclipse.platform.swt/issues/2806

Executing the adapted test method with reverted #2806 shows that the test stays a proper regression test:
<img width="480" height="152" alt="image" src="https://github.com/user-attachments/assets/2affea35-b8b3-465f-a82a-0ce7b3fc1782" />
