### PR TITLE
[Edge] Use getWebView(false) in registerFunctionScript to avoid pumping past NavigationCompleted

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Browser/win32/org/eclipse/swt/browser/Edge.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Browser/win32/org/eclipse/swt/browser/Edge.java
@@ -1858,7 +1858,7 @@ public void createFunction(BrowserFunction function) {
 private void registerFunctionScript(int functionIndex, String functionString) {
 	String[] scriptId = new String[1];
 	callAndWait(scriptId, completion ->
-		webViewProvider.getWebView(true).AddScriptToExecuteOnDocumentCreated(
+		webViewProvider.getWebView(false).AddScriptToExecuteOnDocumentCreated(
 			stringToWstr(functionString), completion.getAddress()));
 	if (scriptId[0] != null) {
 		functionScriptIds.put(functionIndex, scriptId[0]);


### PR DESCRIPTION
## Problem

`registerFunctionScript` called `getWebView(true)`, which pumps the event loop via `processOSMessagesUntil` until all pending WebView2 tasks in `lastWebViewTask` are done. When `createFunction()` is called after `setUrl()`, the pending tasks include the `Navigate` call scheduled by `setUrl`. Pumping until that task completes gives WebView2 enough time to also fire `NavigationCompleted` — before the caller of `createFunction()` has had a chance to register a `ProgressListener`.

As a result, the `NavigationCompleted` event is dispatched and lost inside `registerFunctionScript`, the `ProgressListener` never fires, and any test that registers a `ProgressListener` after creating a `BrowserFunction` will time out. This manifested as a flaky failure of `test_BrowserFunction_availableOnLoad_concurrentInstances_issue20` in CI builds (see issue #3254).

The `asyncExec` deferral in `createFunction` does not help in this scenario because it only triggers when `createFunction` is called from inside a WebView2 callback (`inCallback > 0`). When called from regular Java code, `inCallback == 0` and `registerFunctionScript` is entered synchronously.

## Fix

Change `getWebView(true)` to `getWebView(false)` in `registerFunctionScript`. `getWebView(false)` limits the event loop pump to waiting only for WebView2 initialization (`webViewWrapperFuture::isDone`). The `Navigate` call is chained on the ForkJoinPool *after* initialization completes and cannot have executed yet when `getWebView(false)` returns, so `NavigationCompleted` cannot fire during `registerFunctionScript`. `AddScriptToExecuteOnDocumentCreated` is still called on a fully initialized WebView2 instance, so the behaviour is otherwise identical.

The currently loaded document is not affected by this change: `super.createFunction()` already injects the function script into the current document via `nonBlockingExecute()` before `registerFunctionScript` is entered.

## Related

- Resolves #3254
- Complemented by #3255, which improves the test itself to produce better debug output should it keep failing for any other reason.