### PR TITLE
Add toString() to Browser showing the underlying browser type

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Browser/common/org/eclipse/swt/browser/Browser.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Browser/common/org/eclipse/swt/browser/Browser.java
@@ -1276,4 +1276,11 @@ public void stop () {
 	checkWidget();
 	webBrowser.stop ();
 }
+
+@Override
+public String toString () {
+	String base = super.toString ();
+	if (webBrowser == null) return base;
+	return base + " [" + webBrowser.getBrowserType () + "]";
+}
 }


### PR DESCRIPTION
## Summary
- Override `Browser.toString()` to append the active browser backend (e.g. `webkit`, `edge`, `ie`, `safari`) returned by `getBrowserType()`.
- Makes it easy to identify which native browser implementation a `Browser` instance is using, both in the debugger and in log output, without having to drill into the internal `webBrowser` field.
- The implementation calls `webBrowser.getBrowserType()` directly (with a null guard) instead of the public `getBrowserType()` method, because the public method calls `checkWidget()` which `toString()` is not expected to trigger (e.g. when called on a disposed widget or from a non-UI thread, mirroring `Widget.toString()` behavior).

## Test plan
- [ ] Open a `Browser` and inspect/print it; the result should look like `Browser {} [webkit]` (or the corresponding backend on Windows/macOS).
- [ ] Inspect a disposed `Browser` and confirm `toString()` does not throw.

🤖 Generated with [Claude Code](https://claude.com/claude-code)