### PR TITLE
[Gtk3] Fix crash in TreeItem.setImage

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/TreeItem.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/TreeItem.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2025 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -1516,18 +1516,20 @@ public void setImage(int index, Image image) {
 				 * Feature in GTK: a Tree with the style SWT.VIRTUAL has
 				 * fixed-height-mode enabled. This will limit the size of
 				 * any cells, including renderers. In order to prevent
-				 * images from disappearing/being cropped, we re-create
-				 * the renderers when the first image is set. Fix for
+				 * images from disappearing/being cropped, GTK's cached
+				 * row height must be invalidated so it re-measures with
+				 * the new pixbuf renderer size (set above). Fix for
 				 * bug 480261.
+				 *
+				 * Toggle the fixed-height-mode GObject property
+				 * off and back on. This resets GTK's cached row height
+				 * (fixed_height = -1) and schedules an async widget resize,
+				 * so GTK will re-measure on the next layout pass and pick
+				 * up the updated renderer size.
 				 */
 				if ((parent.style & SWT.VIRTUAL) != 0) {
-					/*
-					 * Only re-create SWT.CHECK renderers if this is the first column.
-					 * Otherwise check-boxes will be rendered in columns they are not
-					 * supposed to be rendered in. See bug 513761.
-					 */
-					boolean check = modelIndex == Tree.FIRST_COLUMN && (parent.style & SWT.CHECK) != 0;
-					parent.createRenderers(column, modelIndex, check, parent.style);
+					OS.g_object_set(parent.handle, OS.fixed_height_mode, false, 0);
+					OS.g_object_set(parent.handle, OS.fixed_height_mode, true, 0);
 				}
 			}
 		}


### PR DESCRIPTION
Calling createRenderers() (which invokes
gtk_tree_view_column_clear()) is unsafe when setImage() call originates from a SWT.SetData listener, because GTK is currently iterating the column's cell renderer list inside
gtk_tree_view_column_cell_set_cell_data().
This frees that list while GTK still holds a pointer into it, causing a use-after-free SIGSEGV on GTK3
(https://github.com/eclipse-platform/eclipse.platform.swt/issues/678 ). Instead, toggle the fixed-height-mode GObject property off and back on. This resets GTK's cached row height (fixed_height = -1) and schedules an async widget resize, so GTK will re-measure on the next layout pass and pick up the updated renderer size. Unlike gtk_tree_view_column_clear(), this does not modify the renderer list and is therefore safe to call from within a cell_data_func callback.

Tested that Debug and variable views don't have icons without the fixed_height_mode off/on setting and icons are fine with it.