### PR TITLE
Make Shell.setSize() test compatible with fractional scaling

### DIFF
--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Shell.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Shell.java
@@ -807,18 +807,29 @@ public void test_setSizeLorg_eclipse_swt_graphics_Point() {
 		Point newSize = new Point(112, 27);
 		for (int i = 0; i < 10; i++) {
 			testShell.setSize(newSize);
-			assertEquals(newSize, testShell.getSize());
+			assertShellProperlySized(testShell, newSize);
 			newSize.x += 100;
 			newSize.y += 100;
 		}
 		newSize = new Point(1292, 1036);
 		for (int i = 0; i < 10; i++) {
 			testShell.setSize(newSize);
-			assertEquals(newSize, testShell.getSize());
+			assertShellProperlySized(testShell, newSize);
 			newSize.x -= 100;
 			newSize.y -= 100;
 		}
 	}
+}
+
+private void assertShellProperlySized(Shell shell, Point expectedSize) {
+	int tolerance = shell.getZoom() != 100 ? 1 : 0;
+	Point actualSize = shell.getSize();
+	assertTrue(
+			Math.abs(expectedSize.x - actualSize.x) <= tolerance
+					&& Math.abs(expectedSize.y - actualSize.y) <= tolerance,
+			"Shell is not sized correctly" //
+					+ " (expected size: " + expectedSize + " ± " + tolerance //
+					+ ", actual size: " + actualSize + ")");
 }
 
 Shell testShell;


### PR DESCRIPTION
The test case `test_setSizeLorg_eclipse_swt_graphics_Point` in `Test_org_eclipse_swt_widgets_Shell` sporadically fails in I-Builds and constantly fails when executed locally on a non-100% monitor. Due to rounding of the point-based size when converting to pixels upon setting the shell size, the value yielded by getSize() used for result validation is not necessarily equal. This change adapts the test case to apply an according tolerance value whenever the shell zoom is not 100%.

Supposed to fix this kind of failures sporadically seen in I-Build tests:
```
expected: <Point {792, 536}> but was: <Point {792, 535}>

org.opentest4j.AssertionFailedError: expected: <Point {792, 536}> but was: <Point {792, 535}>
at org.junit.jupiter.api.AssertionFailureBuilder.build(AssertionFailureBuilder.java:151)
at org.junit.jupiter.api.AssertionFailureBuilder.buildAndThrow(AssertionFailureBuilder.java:132)
at org.junit.jupiter.api.AssertEquals.failNotEqual(AssertEquals.java:197)
at org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:182)
at org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:177)
at org.junit.jupiter.api.Assertions.assertEquals(Assertions.java:1145)
at org.eclipse.swt.tests.junit.Test_org_eclipse_swt_widgets_Shell.test_setSizeLorg_eclipse_swt_graphics_Point(Test_org_eclipse_swt_widgets_Shell.java:817)
at java.base/java.lang.reflect.Method.invoke(Method.java:580)
at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)
at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)
Suppressed: java.lang.RuntimeException: AwtScreenshot VM finished with exit code 1:
Exception in thread "main" java.awt.AWTError: no screen devices
at java.desktop/sun.awt.Win32GraphicsEnvironment.getDefaultScreenDevice(Win32GraphicsEnvironment.java:101)
at java.desktop/java.awt.Robot.<init>(Robot.java:135)
at org.eclipse.test.AwtScreenshot.main(AwtScreenshot.java:43)

at org.eclipse.test.AwtScreenshot.dumpAwtScreenshot(AwtScreenshot.java:113)
at org.eclipse.test.Screenshots.takeScreenshot(Screenshots.java:102)
at org.eclipse.swt.tests.junit.Test_org_eclipse_swt_widgets_Widget.lambda$1(Test_org_eclipse_swt_widgets_Widget.java:79)
at java.base/java.util.Optional.ifPresent(Optional.java:178)
at org.eclipse.swt.tests.junit.Test_org_eclipse_swt_widgets_Widget.lambda$0(Test_org_eclipse_swt_widgets_Widget.java:75)
```

Similar to:
- https://github.com/eclipse-platform/eclipse.platform.ui/pull/3732