### PR TITLE
[Cocoa] Fix GC.copyArea(Image,int,int) ignoring scale factor in Y translation on HiDPI

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/graphics/GC.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/graphics/GC.java
@@ -539,7 +539,7 @@ public void copyArea(Image image, int x, int y) {
 			NSGraphicsContext.setCurrentContext(context);
 			NSAffineTransform transform = NSAffineTransform.transform();
 			NSSize size = image.handle.size();
-			transform.translateXBy(0, size.height-(destHeight + 2 * destY));
+			transform.translateXBy(0, (size.height - (destHeight + 2 * destY)) * scaleFactor);
 			transform.concat();
 			NSRect srcRect = new NSRect();
 			srcRect.x = srcX;


### PR DESCRIPTION
## Problem

`GC.copyArea(Image image, int x, int y)` on macOS (Cocoa) copies the wrong portion of the source image into the destination image whenever the source image (the image the GC draws on) has a different height than the destination image, on monitors with a zoom level above 100%.

The method works correctly at 100% zoom because at that scale, logical points and physical pixels are identical.

## Root Cause

When the GC is backed by a source image (`data.image != null`), the implementation draws the source image into a bitmap context backed by the destination image's representation. It applies an `NSAffineTransform` translation to position the drawing correctly within that bitmap context, so that clipping exposes only the desired source rows.

The bitmap context created via `NSGraphicsContext.graphicsContextWithBitmapImageRep` operates in **physical pixel coordinates**. The destination rect dimensions are correctly scaled to pixels:

```java
destRect.width  = destWidth  * scaleFactor;  // ✓ in pixels
destRect.height = destHeight * scaleFactor;  // ✓ in pixels
```

However, the Y translation was **not** scaled:

```java
// Before fix — translation in logical points, but context expects pixels:
transform.translateXBy(0, size.height - (destHeight + 2 * destY));
```

Here, `size.height` (destination image logical height, e.g. 12 pt) and `destHeight` (source image logical height minus `y`, e.g. 200 pt) are both in logical points. The resulting translation (e.g. `−188`) is then applied to a pixel-coordinate context where the correct value at 200% zoom would be `−376` (i.e. `−188 × 2`).

This unit mismatch causes the drawing to be shifted by only half the needed amount (at 200% zoom), so the bitmap context's visible region clips out the wrong rows of the source — rows near the middle of the source image rather than rows near the top.

## Concrete Example

Source image: 200×200 logical (400×400 px at 200% zoom)  
Destination image: 12×12 logical (24×24 px at 200% zoom)  
Call: `gc.copyArea(destImage, 0, 0)`

Variables inside the method:
- `scaleFactor = 2`
- `size.height = 12` (dest image, logical)
- `destHeight = 200` (src image height − y=0, logical)
- `destRect.height = 400` (pixels, correctly scaled)

**Before fix:** translation T = `12 − 200 = −188` (logical points used as pixels)  
The 400 px tall drawing spans context y = −188 to y = +212. The visible 24 px (y = 0…23) expose source rows ≈ 94–106 in SWT coordinates — near the **middle** of the source.

**After fix:** translation T = `(12 − 200) × 2 = −376` (pixels)  
The 400 px tall drawing spans context y = −376 to y = +24. The visible 24 px (y = 0…23) expose source rows ≈ 0–12 in SWT coordinates — the correct **top** rows.

## Relation to Bug 552148

This bug is a continuation of [Bug 552148](https://bugs.eclipse.org/bugs/show_bug.cgi?id=552148), which introduced `scaleFactor` support into this method. In that fix, `scaleFactor` was correctly applied to the destination rect dimensions, but the Y translation — which also needs to be in pixel units — was missed:

```java
// scaleFactor applied here (correct, from Bug 552148):
destRect.width  = destWidth  * scaleFactor;
destRect.height = destHeight * scaleFactor;

// scaleFactor NOT applied here (the remaining bug):
transform.translateXBy(0, size.height - (destHeight + 2 * destY));
```

The translation only matters when the source and destination images have **different heights** (or, more precisely, when `srcSize.height − y ≠ image.handle.size().height`). The snippet used back in Bug 552148 happened to use source and destination images of the same logical size (100×100 each), so this code path was never exercised by that reproduction case.

## How to Reproduce / Test

The following is an extended version of the snippet used in Bug 552148, adding the case where source and destination image have different sizes (option 2). Run on a macOS system with a display zoom above 100%. Selecting option 2 shows a wrong image (wrong portion of the source) before the fix, and the correct top-left 100×100 area of the source after the fix:

```java
import org.eclipse.swt.*;
import org.eclipse.swt.events.*;
import org.eclipse.swt.graphics.*;
import org.eclipse.swt.layout.*;
import org.eclipse.swt.widgets.*;

public class Snippet395 {

	public static void main(String[] args) {

		Display display = new Display();
		Shell shell = new Shell(display);
		shell.setSize(700, 200);
		RowLayout layout = new RowLayout();
		layout.marginTop = 120;
		shell.setLayout(layout);

		Button b1 = new Button(shell, SWT.RADIO);
		b1.setText("create image + draw image on shell");
		b1.setSelection(true);
		b1.addSelectionListener(SelectionListener.widgetSelectedAdapter(e -> shell.redraw()));
		Button b2 = new Button(shell, SWT.RADIO);
		b2.setText("create image + copy image + draw image on shell");
		b2.addSelectionListener(SelectionListener.widgetSelectedAdapter(e -> shell.redraw()));

		shell.addListener(SWT.Paint, e -> {
			if (b1.getSelection()) {
				Image image1 = new Image(display, 100, 100);
				GC tempGc = new GC(image1);
				tempGc.setLineWidth(5);
				tempGc.drawRectangle(5, 5, 90, 90);

				// Directly draw Image on Shell GC
				e.gc.drawImage(image1, 0, 0);
			} else {
				Image image1 = new Image(display, 200, 200);
				GC tempGc = new GC(image1);
				tempGc.setLineWidth(5);
				tempGc.drawRectangle(5, 5, 90, 90);

				// Copy Image1 to intermediate Image2 (different size!)
				Image image2 = new Image(display, 100, 100);
				tempGc.copyArea(image2, 0, 0); // <-- buggy before fix

				// Draw copied Image2 on Shell
				e.gc.drawImage(image2, 0, 0);
			}
		});

		shell.open();
		while (!shell.isDisposed()) {
			if (!display.readAndDispatch()) {
				display.sleep();
			}
		}
	}

}
```

In addition, with the extension of the `copyArea` tests to non-100% monitors with https://github.com/eclipse-platform/eclipse.platform.swt/pull/3258, the test case `test_copyAreaLorg_eclipse_swt_graphics_ImageII` serves as a regression test for this fix.

## How the Bug Was Revealed

The bug was uncovered by PR [#3246](https://github.com/eclipse-platform/eclipse.platform.swt/pull/3246), which enabled a test (`test_copyAreaLorg_eclipse_swt_graphics_ImageII`) that exercises `copyArea(Image, int, int)` with a source image larger than the destination. That test had been passing trivially before (or not run) but fails on any system with a display zoom above 100% without this fix.

---
_This fix was created with [Claude Code](https://claude.ai/code)._