### PR TITLE
Proper Maven command to run tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,8 +99,8 @@ If needed, add packages to `Import-Package` or `Require-Bundle`.
 # Run all tests
 mvn clean verify
 
-# Run specific test class
-mvn test -Dtest=ClassName
+# Run specific test class (append `#testMethodName` for a single test)
+mvn verify -pl :THE_BUNDLE_WITH_THE_ACTUAL_TEST -am -DskipNativeTests=false -Dsurefire.failIfNoSpecifiedTests=false -Dtest=ClassName
 ```
 
 ### Test Location


### PR DESCRIPTION
`mvn test` command does not work in Tycho Surefire context.

Added a proper command.

Do not fail Linux and MacOS testing because of absence of platform-specific tests.

Fixes #3261.