### PR TITLE
[GTK] Use primary monitor for device zoom on multi-monitor setups

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/graphics/Device.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/graphics/Device.java
@@ -1107,7 +1107,7 @@ protected int getDeviceZoom() {
 		long surface = GTK4.gtk_native_get_surface(GTK4.gtk_widget_get_native(shellHandle));
 		monitor = GDK.gdk_display_get_monitor_at_surface(display, surface);
 	} else {
-		monitor = GDK.gdk_display_get_monitor_at_point(display, 0, 0);
+		monitor = getPrimaryMonitor(display);
 	}
 
 	// GDK can return null monitor in some cases thus play safe
@@ -1118,6 +1118,20 @@ protected int getDeviceZoom() {
 	}
 
 	return DPIUtil.mapDPIToZoom (dpi);
+}
+
+/**
+ * Returns the GDK primary monitor handle, falling back to the monitor at
+ * virtual coordinate (0,0) when no primary monitor is reported (e.g. on Wayland).
+ *
+ * @noreference This method is not intended to be referenced by clients.
+ */
+protected long getPrimaryMonitor(long display) {
+	long monitor = GDK.gdk_display_get_primary_monitor(display);
+	if (monitor == 0) {
+		monitor = GDK.gdk_display_get_monitor_at_point(display, 0, 0);
+	}
+	return monitor;
 }
 
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Display.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Display.java
@@ -2712,7 +2712,7 @@ public Monitor[] getMonitors() {
 					int scaleFactor = (int) GDK.gdk_monitor_get_scale_factor(gdkMonitor);
 					monitor.zoom = scaleFactor * 100;
 				} else {
-					monitor.zoom = Display._getDeviceZoom(monitor.handle);
+					monitor.zoom = _getDeviceZoom(monitor.handle);
 				}
 
 				/* workarea was defined in GTK 3.4. If present, it will return the best results
@@ -6256,16 +6256,19 @@ long gdk_device_get_surface_at_position (double[] win_x, double[] win_y) {
 	return GDK.gdk_device_get_surface_at_position (device, win_x, win_y);
 }
 
-static int _getDeviceZoom (long monitor_num) {
+int _getDeviceZoom (long monitor) {
 	/*
 	 * We can hard-code 96 as gdk_screen_get_resolution will always return -1
 	 * if gdk_screen_set_resolution has not been called.
 	 */
 	int dpi = 96;
-	long display = GDK.gdk_display_get_default();
-	long monitor = GDK.gdk_display_get_monitor_at_point(display, 0, 0);
-	int scale = GDK.gdk_monitor_get_scale_factor(monitor);
-	dpi = dpi * scale;
+	if (monitor == 0) {
+		monitor = getPrimaryMonitor(GDK.gdk_display_get_default());
+	}
+	if (monitor != 0) {
+		int scale = GDK.gdk_monitor_get_scale_factor(monitor);
+		dpi = dpi * scale;
+	}
 	return DPIUtil.mapDPIToZoom (dpi);
 }
 


### PR DESCRIPTION
On GTK, `Display._getDeviceZoom(long)` ignored its monitor argument and always queried the monitor at virtual coordinate (0,0); `Device.getDeviceZoom()` did the same on GTK3. On mixed-DPI multi-monitor setups this made every shell pick up the (0,0) monitor's scale factor, so a HiDPI laptop panel positioned at the top-left of the virtual screen would force shells on a standard-density secondary monitor to render at 2x.

This change honors the passed monitor handle in `_getDeviceZoom` and selects the GDK primary monitor for the initial Display zoom on GTK3, falling back to the (0,0) monitor only when no primary is available (e.g. on Wayland). `Monitor.zoom` values returned by `getMonitors()` on X11/Xwayland are now per-monitor instead of all reflecting the (0,0) monitor.

Fixes #3273