### PR TITLE
Dim dirty tab bullet on inactive tabs in CTabFolderRenderer

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CTabFolderRenderer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CTabFolderRenderer.java
@@ -692,17 +692,17 @@ public class CTabFolderRenderer {
 	}
 
 	void drawClose(GC gc, Rectangle closeRect, int closeImageState) {
-		drawClose(gc, closeRect, closeImageState, false);
+		drawClose(gc, closeRect, closeImageState, false, false);
 	}
 
-	void drawClose(GC gc, Rectangle closeRect, int closeImageState, boolean showDirtyIndicator) {
+	void drawClose(GC gc, Rectangle closeRect, int closeImageState, boolean showDirtyIndicator, boolean selected) {
 		if (closeRect.width == 0 || closeRect.height == 0) return;
 
 		// When dirty and not hovered/pressed, draw bullet instead of X
 		if (showDirtyIndicator) {
 			int maskedState = closeImageState & (SWT.HOT | SWT.SELECTED | SWT.BACKGROUND);
 			if (maskedState != SWT.HOT && maskedState != SWT.SELECTED) {
-				drawDirtyIndicator(gc, closeRect);
+				drawDirtyIndicator(gc, closeRect, selected);
 				return;
 			}
 		}
@@ -737,13 +737,18 @@ public class CTabFolderRenderer {
 		gc.setForeground(originalForeground);
 	}
 
-	private void drawDirtyIndicator(GC gc, Rectangle closeRect) {
+	private void drawDirtyIndicator(GC gc, Rectangle closeRect, boolean selected) {
 		int diameter = 8;
 		int x = closeRect.x + (closeRect.width - diameter) / 2;
 		int y = closeRect.y + (closeRect.height - diameter) / 2;
 		Color originalBackground = gc.getBackground();
+		int originalAlpha = gc.getAlpha();
 		gc.setBackground(gc.getForeground());
+		if (!selected) {
+			gc.setAlpha(140);
+		}
 		gc.fillOval(x, y, diameter, diameter);
+		gc.setAlpha(originalAlpha);
 		gc.setBackground(originalBackground);
 	}
 
@@ -1142,7 +1147,7 @@ public class CTabFolderRenderer {
 				}
 			}
 			if (shouldAllocateCloseRect(item)) {
-				drawClose(gc, item.closeRect, item.closeImageState, shouldDrawDirtyIndicator(item));
+				drawClose(gc, item.closeRect, item.closeImageState, shouldDrawDirtyIndicator(item), true);
 			}
 		}
 	}
@@ -1317,7 +1322,7 @@ public class CTabFolderRenderer {
 			}
 			// draw close or dirty indicator
 			if (shouldAllocateCloseRect(item)) {
-				drawClose(gc, item.closeRect, item.closeImageState, shouldDrawDirtyIndicator(item));
+				drawClose(gc, item.closeRect, item.closeImageState, shouldDrawDirtyIndicator(item), false);
 			}
 		}
 	}


### PR DESCRIPTION
The dirty indicator bullet in CTabFolder previously inherited the tab text foreground color. That color only differs between selected and unselected tabs in dark themes via CSS, so in light themes the bullet looked identical on active and inactive tabs. Fixing this in CSS would also dim the tab title text, which is undesirable.

This change applies a reduced alpha (140, roughly 55%) when drawing the bullet on unselected tabs, so the active/inactive distinction shows up in any theme without configuration. The 3-arg drawClose overload is preserved for binary compatibility.

Fixes https://github.com/eclipse-platform/eclipse.platform.swt/issues/3278