### PR TITLE
[Win] Enabled Image+Text button ignores alignment #3277

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Button.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Button.java
@@ -1403,7 +1403,9 @@ LRESULT wmNotifyChild (NMHDR hdr, long wParam, long lParam) {
 							gc.dispose ();
 						}
 
-						left += isRadioOrCheck() ? radioOrCheckTextPadding : 0;
+						left += isRadioOrCheck()
+								? radioOrCheckTextPadding
+								: image != null ? MARGIN : 0;
 						RECT textRect = new RECT ();
 						OS.SetRect (textRect, left, nmcd.top + border, right, nmcd.bottom - border);
 
@@ -1420,13 +1422,7 @@ LRESULT wmNotifyChild (NMHDR hdr, long wParam, long lParam) {
 						}
 						OS.DrawText(nmcd.hdc, buffer, buffer.length, textRect, flags | OS.DT_CALCRECT);
 						OS.OffsetRect(textRect, 0, Math.max(0, (nmcd.bottom  - textRect.bottom - border) / 2));
-						if (image != null) {
-							// The default button with an image doesn't respect the text alignment. So we do the same for styled buttons.
-							flags |= OS.DT_LEFT;
-							if (!isRadioOrCheck()) {
-								OS.OffsetRect(textRect, Math.max(MARGIN, (right - textRect.right) / 2 + 1), 0);
-							}
-						} else if ((style & SWT.LEFT) != 0) {
+						if ((style & SWT.LEFT) != 0) {
 							flags |= OS.DT_LEFT;
 						} else if ((style & SWT.RIGHT) != 0) {
 							flags |= OS.DT_RIGHT;

--- a/tests/org.eclipse.swt.tests/ManualTests/org/eclipse/swt/tests/manual/Issue0519_ButtonAlignmentExample.java
+++ b/tests/org.eclipse.swt.tests/ManualTests/org/eclipse/swt/tests/manual/Issue0519_ButtonAlignmentExample.java
@@ -1,9 +1,11 @@
 package org.eclipse.swt.tests.manual;
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Button;
+import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
 
@@ -20,36 +22,27 @@ public class Issue0519_ButtonAlignmentExample {
 		Image image = new Image(display, "data/eclipse32.png");
 
 		// Create a button with text and image
-		Button button;
-		button = new Button(shell, SWT.PUSH);
-		button.setText("Right Text");
-		button.setImage(image);
-		button.setSize(200, 50);
-		button.setAlignment(SWT.RIGHT);
-		button.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
+		Button btnRight = createButton("Right Text", image, shell);
+		btnRight.setAlignment(SWT.RIGHT);
 
-		button = new Button(shell, SWT.PUSH);
-		button.setText("Left Text");
-		button.setImage(image);
-		button.setSize(200, 50);
-		button.setAlignment(SWT.LEFT);
-		button.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
+		Button btnLeft = createButton("Left Text", image, shell);
+		btnLeft.setAlignment(SWT.LEFT);
 
-		button = new Button(shell, SWT.PUSH);
-		button.setText("Center Text");
-		button.setImage(image);
-		button.setSize(200, 50);
-		button.setAlignment(SWT.CENTER);
+		Button btnCenter = createButton("Center Text", image, shell);
+		btnCenter.setAlignment(SWT.CENTER);
 
-		// Set layout data to take up the whole shell
-		button.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
+		Button btnNoAlign = createButton("No Alignment assumes CENTER", image, shell);
 
-		button = new Button(shell, SWT.PUSH);
-		button.setText("No Alignment assumes CENTER");
-		button.setImage(image);
-		button.setSize(200, 50);
-		//button.setAlignment(SWT.CENTER);
-		button.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
+		Button enabledCheckbox = new Button(shell, SWT.CHECK);
+		enabledCheckbox.setText("Enable");
+		enabledCheckbox.setSelection(true);
+		enabledCheckbox.addListener(SWT.Selection, event -> {
+			boolean enabled = enabledCheckbox.getSelection();
+			btnRight.setEnabled(enabled);
+			btnLeft.setEnabled(enabled);
+			btnCenter.setEnabled(enabled);
+			btnNoAlign.setEnabled(enabled);
+		});
 
 		shell.setSize(500, 300);
 		shell.open();
@@ -63,5 +56,15 @@ public class Issue0519_ButtonAlignmentExample {
 		// Dispose of the image and resources
 		image.dispose();
 		display.dispose();
+	}
+
+	private static Button createButton(String text, Image image, Composite parent) {
+		Button button = new Button(parent, SWT.PUSH);
+		button.setText(text);
+		button.setImage(image);
+		button.setForeground(new Color(0, 0, 128));
+		button.setSize(200, 50);
+		button.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
+		return button;
 	}
 }


### PR DESCRIPTION
It looks like the old comment `The default button with an image doesn't respect the text alignment. So we do the same for styled buttons.` is outdated.
