### PR TITLE
Update jsvg to 2.1.0 in org.eclipse.swt.svg

### DIFF
--- a/bundles/org.eclipse.swt.svg/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.swt.svg/META-INF/MANIFEST.MF
@@ -8,8 +8,19 @@ Bundle-Vendor: %providerName
 Bundle-Localization: fragment
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Fragment-Host: org.eclipse.swt
-Import-Package: com.github.weisj.jsvg;version="[2.0.0,3.0.0)",
- com.github.weisj.jsvg.parser;version="[2.0.0,3.0.0)",
- com.github.weisj.jsvg.view;version="[2.0.0,3.0.0)"
+Import-Package: com.github.weisj.jsvg;version="[2.1.0,3.0.0)",
+ com.github.weisj.jsvg.logging;version="[2.1.0,3.0.0)",
+ com.github.weisj.jsvg.parser;version="[2.1.0,3.0.0)",
+ com.github.weisj.jsvg.view;version="[2.1.0,3.0.0)"
 Export-Package: org.eclipse.swt.svg;x-internal:=true
-Provide-Capability: eclipse.swt;image.format="svg";version:Version="1.0"
+Provide-Capability: 
+ eclipse.swt;
+   image.format="svg";
+   version:Version="1.0",
+ osgi.service;
+   objectClass:List<String>="com.github.weisj.jsvg.logging.LogManager";
+   effective:=active,
+ osgi.serviceloader;
+  osgi.serviceloader="com.github.weisj.jsvg.logging.LogManager";
+  register:="org.eclipse.swt.svg.logging.JVSGLoggerLogManager"
+

--- a/bundles/org.eclipse.swt.svg/resources/META-INF/services/com.github.weisj.jsvg.logging.LogManager
+++ b/bundles/org.eclipse.swt.svg/resources/META-INF/services/com.github.weisj.jsvg.logging.LogManager
@@ -1,0 +1,1 @@
+org.eclipse.swt.svg.logging.JVSGLoggerLogManager

--- a/bundles/org.eclipse.swt.svg/src/org/eclipse/swt/svg/JSVGRasterizer.java
+++ b/bundles/org.eclipse.swt.svg/src/org/eclipse/swt/svg/JSVGRasterizer.java
@@ -55,7 +55,18 @@ import com.github.weisj.jsvg.parser.SVGLoader;
  */
 public class JSVGRasterizer implements SVGRasterizer {
 
-	private static final SVGLoader SVG_LOADER = new SVGLoader();
+	private static final SVGLoader SVG_LOADER;
+
+	static {
+		Thread thread = Thread.currentThread();
+		ClassLoader contextClassLoader = thread.getContextClassLoader();
+		try {
+			thread.setContextClassLoader(JSVGRasterizer.class.getClassLoader());
+			SVG_LOADER = new SVGLoader();
+		} finally {
+			thread.setContextClassLoader(contextClassLoader);
+		}
+	}
 
 	private final static Map<Key, Object> RENDERING_HINTS = Map.of( //
 			KEY_ANTIALIASING, VALUE_ANTIALIAS_ON, //

--- a/bundles/org.eclipse.swt.svg/src/org/eclipse/swt/svg/logging/JVSGLoggerLogManager.java
+++ b/bundles/org.eclipse.swt.svg/src/org/eclipse/swt/svg/logging/JVSGLoggerLogManager.java
@@ -1,0 +1,55 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Eclipse contributors and others.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse
+ * Public License 2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ *******************************************************************************/
+package org.eclipse.swt.svg.logging;
+
+import java.util.function.Supplier;
+
+import com.github.weisj.jsvg.logging.LogManager;
+import com.github.weisj.jsvg.logging.Logger;
+
+public class JVSGLoggerLogManager implements LogManager {
+
+	private static final Logger.Level LEVEL = Logger.Level.valueOf(System.getProperty("org.eclipse.swt.svg.logging", "ERROR"));
+
+	@Override
+	public Logger createLogger(String name) {
+		return new Logger() {
+			@Override
+			public void log(Logger.Level level, String message, Throwable e) {
+				if (level.compareTo(LEVEL) <= 0) {
+					return;
+				}
+				doLog(level, message);
+				e.printStackTrace();
+			}
+
+			@Override
+			public void log(Logger.Level level, Supplier<String> messageSupplier) {
+				if (level.compareTo(LEVEL) < 0) {
+					return;
+				}
+				doLog(level, messageSupplier.get());
+			}
+
+			@Override
+			public void log(Logger.Level level, String message) {
+				if (level.compareTo(LEVEL) < 0) {
+					return;
+				}
+				doLog(level, message);
+			}
+
+			private void doLog(Logger.Level level, String message) {
+				System.err.format("JSVGRasterizer: %s: %s: %s", level, name, message).println();
+			}
+		};
+	}
+}


### PR DESCRIPTION
Update jsvg to 2.1.0 in org.eclipse.swt.svg

- Add class org.eclipse.swt.svg.logging.JVSGLoggerLogManager to
implement the new logging service required by jsvg 2.1.0.
  - Simply print to System.err.
  - Only print ERROR level.
  - Support system property org.eclipse.swt.svg.logging to support other
levels.
- Update the lower bounds to 2.1.0 because that provides the export of
the com.github.weisj.jsvg.logging package which is needed for
JVSGLoggerLogManager.
- Add /org.eclipse.swt.svg/resources/META-INF/services/com.github.weisj.jsvg.logging.LogManager
which declares the org.eclipse.swt.svg.logging.JVSGLoggerLogManager
service.
- Add Provide-Capability declarations for the service.
- Ensure that org.eclipse.swt.svg.JSVGRasterizer.SVG_LOADER is
initialized while the context class loader references the bundle class
loader of org.eclipse.swt.svg because the services are loaded using
plain old Java which requires the service to be on the classpath.
- Do not export the org.eclipse.swt.svg.logging package because it's not
needed outside of the fragment.