### PR TITLE
Add robust log level handling in JVSGLoggerLogManager

### DIFF
--- a/bundles/org.eclipse.swt.svg/src/org/eclipse/swt/svg/logging/JVSGLoggerLogManager.java
+++ b/bundles/org.eclipse.swt.svg/src/org/eclipse/swt/svg/logging/JVSGLoggerLogManager.java
@@ -17,7 +17,17 @@ import com.github.weisj.jsvg.logging.Logger;
 
 public class JVSGLoggerLogManager implements LogManager {
 
-	private static final Logger.Level LEVEL = Logger.Level.valueOf(System.getProperty("org.eclipse.swt.svg.logging", "ERROR"));
+	private static final Logger.Level LEVEL = getLogLevel();
+
+	private static Logger.Level getLogLevel() {
+		try {
+			return Enum.valueOf(Logger.Level.class, System.getProperty("org.eclipse.swt.svg.logging", "ERROR").toUpperCase());			
+		} catch (IllegalArgumentException e) {
+			System.err.format("JSVGRasterizer: Invalid log level specified: %s. Defaulting to ERROR.",
+					System.getProperty("org.eclipse.swt.svg.logging")).println();
+			return Logger.Level.ERROR;
+		}
+	}
 
 	@Override
 	public Logger createLogger(String name) {


### PR DESCRIPTION
The JVSGLoggerLogManager allows to customize the log level with a system property. When an invalid log level is passed, the call currently throws an exception and makes the whole rasterizer initialization fail, leading to the non-availability of an SVG rasterizer throughout the whole application lifecycle.

This change makes the system property processing more robust: when an invalid level is used, an error is printed and the implementation falls back to using "ERROR" as default log level. In addition, capitalization is ignored by always making the passed value upper case. As a result of this change, it not be possible to make the rasterizer implementation fail with an invalid system property anymore.

Resolves https://github.com/eclipse-platform/eclipse.platform.swt/pull/3283#discussion_r3196119236
