### PR TITLE
Bump version of org.eclipse.swt.svg for JSVG dependency update

### DIFF
--- a/bundles/org.eclipse.swt.svg/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.swt.svg/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.swt.svg
-Bundle-Version: 3.132.100.qualifier
+Bundle-Version: 3.133.0.qualifier
 Automatic-Module-Name: org.eclipse.swt.svg
 Bundle-Name: %fragmentName
 Bundle-Vendor: %providerName


### PR DESCRIPTION
The JSVG dependencies have been updated to a new minor version including an explicit setup of the logging with OSGi capabilities. To properly reflect this change in dependencies, this bumps the version of the SWT SVG fragment to the next minor version.

Follow-up to:
- https://github.com/eclipse-platform/eclipse.platform.swt/pull/3283

@merks in my opinion this better reflects the "complexity" of the dependency change. What do you think?