### PR TITLE
[macOS] Enable TextField borders on macOS 26

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Text.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Text.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2014 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -518,6 +518,10 @@ void createHandle () {
 		if ((style & SWT.BORDER) == 0) {
 			widget.setFocusRingType (OS.NSFocusRingTypeNone);
 			widget.setBordered (false);
+		} else {
+			if (OS.VERSION >= OS.VERSION(26, 0, 0)) {
+				widget.setBordered (true);
+			}
 		}
 		/*
 		 * Bug in Cocoa: On OSX 10.10, setting the alignment on the search field


### PR DESCRIPTION
Restore visible borders for SWT text controls on macOS 26 and later to improve control visibility and readability.

Part of https://github.com/eclipse-platform/eclipse.platform.swt/issues/3286 and https://github.com/eclipse-platform/eclipse.platform.ui/issues/3885

**Before [Light]**
<img width="851" height="711" alt="Screenshot 2026-05-07 at 5 24 23 PM" src="https://github.com/user-attachments/assets/13e70c20-544c-4990-8cf2-d890914e6479" />

**After[Light]**
<img width="872" height="773" alt="Screenshot 2026-05-07 at 5 25 09 PM" src="https://github.com/user-attachments/assets/7d235c4d-2435-42f0-b6b6-28feb6490b5c" />


**Before [Dark]**
<img width="891" height="803" alt="Screenshot 2026-05-07 at 5 26 01 PM" src="https://github.com/user-attachments/assets/c188fc78-997f-4c0c-9514-61beba6fee70" />

**After [Dark]**
<img width="879" height="783" alt="Screenshot 2026-05-07 at 5 26 23 PM" src="https://github.com/user-attachments/assets/df05d537-39e5-4e9c-a01a-89fa737ae2c3" />

