### PR TITLE
Handle Cmd+A shortcut in Cocoa browser 

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT WebKit/cocoa/org/eclipse/swt/browser/WebKit.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT WebKit/cocoa/org/eclipse/swt/browser/WebKit.java
@@ -212,6 +212,18 @@ public void create (Composite parent, int style) {
 			case SWT.FocusIn:
 				WebKit.this.webView.window().makeFirstResponder(WebKit.this.webView);
 				break;
+			case SWT.KeyDown:
+				if ((e.stateMask & SWT.MOD1) != 0 && Character.toUpperCase((char)e.keyCode) == 'A') {
+					NSWindow window = WebKit.this.webView.window();
+					if (window != null) {
+						NSResponder responder = window.firstResponder();
+						if (responder != null) {
+							OS.objc_msgSend(responder.id, OS.sel_selectAll_, 0);
+							e.doit = false;
+						}
+					}
+				}
+				break;
 			case SWT.Dispose: {
 				/* make this handler run after other dispose listeners */
 				if (ignoreDispose) {


### PR DESCRIPTION
This PR adds handling for the command+A keyboard shortcut in the internal web browser implementation.

While normal browsers support the standard command+A shortcut for Select All, it is not currently handled inside SWT for Mac. This change forwards the shortcut to the native Cocoa responder action for the currently focused control.


https://github.com/user-attachments/assets/2844c616-bc4b-4243-b7a3-8e4838b33888

