### PR TITLE
Suppress resource leak reports from failing Image tests

### DIFF
--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_Image.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_Image.java
@@ -213,16 +213,22 @@ public void test_ConstructorLorg_eclipse_swt_graphics_DeviceLorg_eclipse_swt_gra
 	// set red pixel at x=9, y=9
 	data.setPixel(9, 9, 0x30);
 	final Image imageFromImageData = new Image(display, data);
-	ImageGcDrawer gcDrawer = (gc, width, height) -> {
-		gc.drawImage(imageFromImageData, 0, 0);
-	};
-	Image gcImage = new Image(display, gcDrawer, 10, 10);
-	ImageData gcImageData = gcImage.getImageData();
-	int redPixel = gcImageData.getPixel(9, 9);
-	assertEquals(getRealRGB(display.getSystemColor(SWT.COLOR_RED)), gcImageData.palette.getRGB(redPixel));
-	gcImage.dispose();
-	image.dispose();
-	imageFromImageData.dispose();
+	try {
+		ImageGcDrawer gcDrawer = (gc, width, height) -> {
+			gc.drawImage(imageFromImageData, 0, 0);
+		};
+		Image gcImage = new Image(display, gcDrawer, 10, 10);
+		try {
+			ImageData gcImageData = gcImage.getImageData();
+			int redPixel = gcImageData.getPixel(9, 9);
+			assertEquals(getRealRGB(display.getSystemColor(SWT.COLOR_RED)), gcImageData.palette.getRGB(redPixel));
+		} finally {
+			gcImage.dispose();
+		}
+		image.dispose();
+	} finally {
+		imageFromImageData.dispose();
+	}
 }
 
 @Test
@@ -264,13 +270,15 @@ public void test_ConstructorLorg_eclipse_swt_graphics_DeviceLorg_eclipse_swt_gra
 		gc.drawImage(image2, 0, 0);
 	};
 	Image gcImage = new Image(display, gcDrawer, 10, 10);
-
-	ImageData gcImageData = gcImage.getImageData();
-	int redPixel = gcImageData.getPixel(9, 9);
-	assertEquals(getRealRGB(display.getSystemColor(SWT.COLOR_RED)), gcImageData.palette.getRGB(redPixel));
-	int bluePixel = gcImageData.getPixel(0, 0);
-	assertEquals(getRealRGB(backgroundColor), gcImageData.palette.getRGB(bluePixel));
-	gcImage.dispose();
+	try {
+		ImageData gcImageData = gcImage.getImageData();
+		int redPixel = gcImageData.getPixel(9, 9);
+		assertEquals(getRealRGB(display.getSystemColor(SWT.COLOR_RED)), gcImageData.palette.getRGB(redPixel));
+		int bluePixel = gcImageData.getPixel(0, 0);
+		assertEquals(getRealRGB(backgroundColor), gcImageData.palette.getRGB(bluePixel));
+	} finally {
+		gcImage.dispose();
+	}
 	image.dispose();
 	image2.dispose();
 }


### PR DESCRIPTION
When launching tests on

```
Apache Maven 3.9.10 (5f519b97e944483d878815739f519b2eade0a91d)
Maven home: /opt/apache-maven-3.9.10
Java version: 21.0.10, vendor: Eclipse Adoptium, runtime: /Library/Java/JavaVirtualMachines/temurin-21.jdk/Contents/Home
Default locale: en_GE, platform encoding: UTF-8
OS name: "mac os x", version: "26.4.1", arch: "aarch64", family: "mac"
```

 Test_org_eclipse_swt_graphics_Image always fail:
```
[ERROR] org.eclipse.swt.tests.junit.Test_org_eclipse_swt_graphics_Image.test_getImageDataCurrentZoom -- Time elapsed: 0.003 s <<< FAILURE!
org.opentest4j.AssertionFailedError: expected: <Rectangle {0, 0, 20, 40}> but was: <Rectangle {0, 0, 10, 20}>
	at org.junit.jupiter.api.AssertionFailureBuilder.build(AssertionFailureBuilder.java:151)
	at org.junit.jupiter.api.AssertionFailureBuilder.buildAndThrow(AssertionFailureBuilder.java:132)
	at org.junit.jupiter.api.AssertEquals.failNotEqual(AssertEquals.java:197)
	at org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:182)
	at org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:177)
	at org.junit.jupiter.api.Assertions.assertEquals(Assertions.java:1145)
	at org.eclipse.swt.tests.junit.Test_org_eclipse_swt_graphics_Image.test_getImageDataCurrentZoom(Test_org_eclipse_swt_graphics_Image.java:699)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)

[ERROR] org.eclipse.swt.tests.junit.Test_org_eclipse_swt_graphics_Image.test_getBoundsInPixels -- Time elapsed: 0.001 s <<< FAILURE!
org.opentest4j.AssertionFailedError: expected: <Rectangle {0, 0, 10, 20}> but was: <Rectangle {0, 0, 20, 40}>
	at org.junit.jupiter.api.AssertionFailureBuilder.build(AssertionFailureBuilder.java:151)
	at org.junit.jupiter.api.AssertionFailureBuilder.buildAndThrow(AssertionFailureBuilder.java:132)
	at org.junit.jupiter.api.AssertEquals.failNotEqual(AssertEquals.java:197)
	at org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:182)
	at org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:177)
	at org.junit.jupiter.api.Assertions.assertEquals(Assertions.java:1145)
	at org.eclipse.swt.tests.junit.Test_org_eclipse_swt_graphics_Image.test_getBoundsInPixels(Test_org_eclipse_swt_graphics_Image.java:650)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)

[ERROR] org.eclipse.swt.tests.junit.Test_org_eclipse_swt_graphics_Image.test_ConstructorLorg_eclipse_swt_graphics_DeviceLorg_eclipse_swt_graphics_ImageDataLorg_eclipse_swt_graphics_ImageData -- Time elapsed: 0.003 s <<< FAILURE!
org.opentest4j.AssertionFailedError: expected: <RGB {255, 0, 0}> but was: <RGB {249, 0, 6}>
	at org.junit.jupiter.api.AssertionFailureBuilder.build(AssertionFailureBuilder.java:151)
	at org.junit.jupiter.api.AssertionFailureBuilder.buildAndThrow(AssertionFailureBuilder.java:132)
	at org.junit.jupiter.api.AssertEquals.failNotEqual(AssertEquals.java:197)
	at org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:182)
	at org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:177)
	at org.junit.jupiter.api.Assertions.assertEquals(Assertions.java:1145)
	at org.eclipse.swt.tests.junit.Test_org_eclipse_swt_graphics_Image.test_ConstructorLorg_eclipse_swt_graphics_DeviceLorg_eclipse_swt_graphics_ImageDataLorg_eclipse_swt_graphics_ImageData(Test_org_eclipse_swt_graphics_Image.java:270)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)

[ERROR] org.eclipse.swt.tests.junit.Test_org_eclipse_swt_graphics_Image.test_ConstructorLorg_eclipse_swt_graphics_DeviceLorg_eclipse_swt_graphics_ImageData -- Time elapsed: 0.001 s <<< FAILURE!
org.opentest4j.AssertionFailedError: expected: <RGB {255, 0, 0}> but was: <RGB {249, 0, 0}>
	at org.junit.jupiter.api.AssertionFailureBuilder.build(AssertionFailureBuilder.java:151)
	at org.junit.jupiter.api.AssertionFailureBuilder.buildAndThrow(AssertionFailureBuilder.java:132)
	at org.junit.jupiter.api.AssertEquals.failNotEqual(AssertEquals.java:197)
	at org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:182)
	at org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:177)
	at org.junit.jupiter.api.Assertions.assertEquals(Assertions.java:1145)
	at org.eclipse.swt.tests.junit.Test_org_eclipse_swt_graphics_Image.test_ConstructorLorg_eclipse_swt_graphics_DeviceLorg_eclipse_swt_graphics_ImageData(Test_org_eclipse_swt_graphics_Image.java:222)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)
```

This PR fixes associated resource leaks to facilitate analysis.

Full build log with leaks: [swt_test_failures4.txt.zip](https://github.com/user-attachments/files/27493160/swt_test_failures4.txt.zip)
