### PR TITLE
Test CTabItem rendering

### DIFF
--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_custom_CTabFolder.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_custom_CTabFolder.java
@@ -14,13 +14,15 @@
 package org.eclipse.swt.tests.junit;
 
 
+import static org.eclipse.swt.tests.junit.SwtTestUtil.hasPixel;
+import static org.eclipse.swt.tests.junit.SwtTestUtil.openShell;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -33,6 +35,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;
+import java.util.function.BooleanSupplier;
 import java.util.function.Consumer;
 
 import org.eclipse.swt.SWT;
@@ -63,6 +66,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 /**
  * Automated Test Suite for class org.eclipse.swt.custom.CTabFolder
@@ -111,6 +116,8 @@ public void test_setFontLorg_eclipse_swt_graphics_Font() {
 
 /* custom */
 protected CTabFolder ctabFolder;
+private static final Color RED = new Color(255, 0, 0);
+private static final Color BLUE = new Color(0, 0, 255);
 
 /**
  * Dispose all widgets in shell and create a new empty {@link CTabFolder}.
@@ -1048,6 +1055,52 @@ public void test_dirtyIndicator_closesWhenCloseEnabled() {
 	} catch (NoSuchFieldException | IllegalAccessException e) {
 		fail("Failed to access closeRect via reflection: " + e.getMessage());
 	}
+}
+
+@ParameterizedTest
+@CsvSource(value = {"false,0", "false,1", "true,0", "true,1"})
+public void test_tabsAreRendered(boolean nestComposite, int activateTab) throws InterruptedException {
+	Composite parent = shell;
+	Control[] children = shell.getChildren();
+	for (Control child : children) {
+		child.dispose();
+	}
+	if (nestComposite) {
+		parent = new Composite(parent, SWT.NONE);
+		parent.setLayout(new FillLayout());
+	}
+	ctabFolder = new CTabFolder(parent, SWT.NONE);
+	setWidget(ctabFolder);
+	shell.setSize(800, 400);
+	ctabFolder.setBackground(RED);
+	ctabFolder.setForeground(BLUE);
+	ctabFolder.setSelectionForeground(BLUE);
+	CTabItem tab = createTabItem(1);
+	openShell(shell);
+	processEvents();
+	Rectangle bounds = tab.getBounds();
+	assertEventually("First tab is rendered at " + bounds, () -> hasPixel(ctabFolder, BLUE, bounds));
+	tab = createTabItem(2);
+	ctabFolder.setSelection(activateTab);
+	SwtTestUtil.processEvents();
+	Rectangle bounds2 = tab.getBounds();
+	assertEventually("Second tab is redered at " + bounds2, () -> hasPixel(ctabFolder, BLUE, bounds2));
+	tab.dispose();
+	assertEventually("Second tab is erased at " + bounds2, () -> !hasPixel(ctabFolder, BLUE, bounds2));
+}
+
+private void assertEventually(String message, BooleanSupplier condition) throws InterruptedException {
+	SwtTestUtil.processEvents(100, condition);
+	assertTrue(condition.getAsBoolean(), message);
+}
+
+private CTabItem createTabItem(int i) {
+	CTabItem item = new CTabItem(ctabFolder, SWT.CLOSE);
+	item.setText("█".repeat(10));
+	Label content = new Label(ctabFolder, SWT.NONE);
+	content.setText("Content " + i);
+	item.setControl(content);
+	return item;
 }
 
 @Test


### PR DESCRIPTION
Pixel color verification for CTabItem's tabs.

A regression test for #3260 where tabs fail to render if
`NSView.setClipsToBounds()` is omited before scheduling redraw.

This test fails to reproduce the problem, but is useful as rendering is
not tested in this suite yet.