### PR TITLE
[Gtk4] Set proper MenuItem.section on destroy

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/MenuItem.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/MenuItem.java
@@ -762,6 +762,7 @@ void destroyWidget() {
 			aboveSection.sectionItems.addAll(section.sectionItems);
 
 			for (MenuItem item : section.sectionItems) {
+				item.section = aboveSection;
 				OS.g_menu_insert_item(aboveSection.getSectionHandle(), aboveSection.sectionItems.indexOf(item), item.handle);
 			}
 


### PR DESCRIPTION
Fixes many problems like the following on editor switching:
```
(Eclipse:326795): GLib-GIO-CRITICAL **: 13:57:51.527:
g_menu_insert_item: assertion 'G_IS_MENU_ITEM (item)' failed

(Eclipse:326795): GLib-GIO-CRITICAL **: 13:57:51.527: g_menu_remove:
assertion '0 <= position && (guint) position < menu->items->len' failed
```