### PR TITLE
[macOS 26] Add layer-based border rendering for Text and Combo widgets

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT PI/cocoa/library/os_custom.c
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/cocoa/library/os_custom.c
@@ -15,6 +15,8 @@
 #include "swt.h"
 #include "os_structs.h"
 #include "os_stats.h"
+#include <mach-o/loader.h>
+#include <crt_externs.h>
 
 #define OS_NATIVE(func) Java_org_eclipse_swt_internal_cocoa_OS_##func
 
@@ -146,6 +148,29 @@ JNIEXPORT jlong JNICALL OS_NATIVE(beginSheetModalForWindow)
 	rc = (jlong)((jlong (*)(jlong, jlong, jlong, void (^)(jlong)))objc_msgSend)(arg0, arg1, arg2, functionToBlock(arg3));
 	
 	OS_NATIVE_EXIT(env, that, beginSheetModalForWindow_FUNC);
+	return rc;
+}
+#endif
+
+#ifndef NO_getMachOSDKVersion
+JNIEXPORT jint JNICALL OS_NATIVE(getMachOSDKVersion)
+	(JNIEnv *env, jclass that)
+{
+	jint rc = 0;
+	OS_NATIVE_ENTER(env, that, getMachOSDKVersion_FUNC);
+	const struct mach_header_64 *header = (const struct mach_header_64 *)_NSGetMachExecuteHeader();
+	const uint8_t *ptr = (const uint8_t *)header + sizeof(struct mach_header_64);
+	for (uint32_t i = 0; i < header->ncmds; i++) {
+		const struct load_command *lc = (const struct load_command *)ptr;
+		if (lc->cmd == LC_BUILD_VERSION) {
+			const struct build_version_command *bv = (const struct build_version_command *)ptr;
+			uint32_t sdk = bv->sdk;
+			rc = (jint)(((sdk >> 16) & 0xff) << 16) | (((sdk >> 8) & 0xff) << 8) | (sdk & 0xff);
+			break;
+		}
+		ptr += lc->cmdsize;
+	}
+	OS_NATIVE_EXIT(env, that, getMachOSDKVersion_FUNC);
 	return rc;
 }
 #endif

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/cocoa/library/os_stats.h
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/cocoa/library/os_stats.h
@@ -369,6 +369,7 @@ typedef enum {
 	class_1getMethodImplementation_FUNC,
 	class_1getName_FUNC,
 	class_1getSuperclass_FUNC,
+	getMachOSDKVersion_FUNC,
 	getpid_FUNC,
 	instrumentObjcMessageSends_FUNC,
 	isFlipped_1CALLBACK_FUNC,

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/cocoa/org/eclipse/swt/internal/cocoa/CALayer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/cocoa/org/eclipse/swt/internal/cocoa/CALayer.java
@@ -27,6 +27,18 @@ public CALayer(id id) {
 	super(id);
 }
 
+public void setBorderColor(long /*CGColorRef*/ color) {
+	OS.objc_msgSend(this.id, OS.sel_setBorderColor_, color);
+}
+
+public void setBorderWidth(double width) {
+	OS.objc_msgSend(this.id, OS.sel_setBorderWidth_, width);
+}
+
+public void setCornerRadius(double cornerRadius) {
+	OS.objc_msgSend(this.id, OS.sel_setCornerRadius_, cornerRadius);
+}
+
 public void setHidden(boolean hidden) {
 	OS.objc_msgSend(this.id, OS.sel_setHidden_, hidden);
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/cocoa/org/eclipse/swt/internal/cocoa/NSColor.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/cocoa/org/eclipse/swt/internal/cocoa/NSColor.java
@@ -27,6 +27,10 @@ public NSColor(id id) {
 	super(id);
 }
 
+public long /*CGColorRef*/ CGColor() {
+	return OS.objc_msgSend(this.id, OS.sel_CGColor);
+}
+
 public double alphaComponent() {
 	return OS.objc_msgSend_fpret(this.id, OS.sel_alphaComponent);
 }
@@ -148,6 +152,11 @@ public static NSColor selectedTextBackgroundColor() {
 
 public static NSColor selectedTextColor() {
 	long result = OS.objc_msgSend(OS.class_NSColor, OS.sel_selectedTextColor);
+	return result != 0 ? new NSColor(result) : null;
+}
+
+public static NSColor separatorColor() {
+	long result = OS.objc_msgSend(OS.class_NSColor, OS.sel_separatorColor);
 	return result != 0 ? new NSColor(result) : null;
 }
 

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/cocoa/org/eclipse/swt/internal/cocoa/NSView.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/cocoa/org/eclipse/swt/internal/cocoa/NSView.java
@@ -276,6 +276,10 @@ public void setToolTip(NSString toolTip) {
 	OS.objc_msgSend(this.id, OS.sel_setToolTip_, toolTip != null ? toolTip.id : 0);
 }
 
+public void setWantsLayer(boolean wantsLayer) {
+	OS.objc_msgSend(this.id, OS.sel_setWantsLayer_, wantsLayer);
+}
+
 public void setWantsRestingTouches(boolean wantsRestingTouches) {
 	OS.objc_msgSend(this.id, OS.sel_setWantsRestingTouches_, wantsRestingTouches);
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/cocoa/org/eclipse/swt/internal/cocoa/OS.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/cocoa/org/eclipse/swt/internal/cocoa/OS.java
@@ -355,6 +355,7 @@ public static final native int getpid();
  * @method flags=no_gen
  */
 public static final native int getMachOSDKVersion();
+public static final int MACH_O_SDK_VERSION = getMachOSDKVersion();
 
 public static final native void call(long proc, long id, long sel);
 
@@ -843,6 +844,7 @@ public static void registerSelector (Long value, Selector selector) {
 public static Selector getSelector (long value) {
 	return SELECTORS.get(value);
 }
+public static final long sel_CGColor = Selector.sel_CGColor.value;
 public static final long sel_CGEvent = Selector.sel_CGEvent.value;
 public static final long sel_DOMDocument = Selector.sel_DOMDocument.value;
 public static final long sel_IBeamCursor = Selector.sel_IBeamCursor.value;
@@ -1673,6 +1675,7 @@ public static final long sel_sendAction_to_ = Selector.sel_sendAction_to_.value;
 public static final long sel_sendAction_to_from_ = Selector.sel_sendAction_to_from_.value;
 public static final long sel_sendEvent_ = Selector.sel_sendEvent_.value;
 public static final long sel_sender = Selector.sel_sender.value;
+public static final long sel_separatorColor = Selector.sel_separatorColor.value;
 public static final long sel_separatorItem = Selector.sel_separatorItem.value;
 public static final long sel_set = Selector.sel_set.value;
 public static final long sel_setAcceptsMouseMovedEvents_ = Selector.sel_setAcceptsMouseMovedEvents_.value;
@@ -1715,6 +1718,7 @@ public static final long sel_setBaseWritingDirection_ = Selector.sel_setBaseWrit
 public static final long sel_setBecomesKeyOnlyIfNeeded_ = Selector.sel_setBecomesKeyOnlyIfNeeded_.value;
 public static final long sel_setBezelStyle_ = Selector.sel_setBezelStyle_.value;
 public static final long sel_setBezeled_ = Selector.sel_setBezeled_.value;
+public static final long sel_setBorderColor_ = Selector.sel_setBorderColor_.value;
 public static final long sel_setBorderType_ = Selector.sel_setBorderType_.value;
 public static final long sel_setBorderWidth_ = Selector.sel_setBorderWidth_.value;
 public static final long sel_setBordered_ = Selector.sel_setBordered_.value;
@@ -1739,6 +1743,7 @@ public static final long sel_setContainerSize_ = Selector.sel_setContainerSize_.
 public static final long sel_setContentView_ = Selector.sel_setContentView_.value;
 public static final long sel_setContentViewMargins_ = Selector.sel_setContentViewMargins_.value;
 public static final long sel_setControlSize_ = Selector.sel_setControlSize_.value;
+public static final long sel_setCornerRadius_ = Selector.sel_setCornerRadius_.value;
 public static final long sel_setCookie_ = Selector.sel_setCookie_.value;
 public static final long sel_setCopiesOnScroll_ = Selector.sel_setCopiesOnScroll_.value;
 public static final long sel_setCurrentContext_ = Selector.sel_setCurrentContext_.value;
@@ -1935,6 +1940,7 @@ public static final long sel_setVerticalScrollElasticity_ = Selector.sel_setVert
 public static final long sel_setVerticalScroller_ = Selector.sel_setVerticalScroller_.value;
 public static final long sel_setView_ = Selector.sel_setView_.value;
 public static final long sel_setVisible_ = Selector.sel_setVisible_.value;
+public static final long sel_setWantsLayer_ = Selector.sel_setWantsLayer_.value;
 public static final long sel_setWantsRestingTouches_ = Selector.sel_setWantsRestingTouches_.value;
 public static final long sel_setWidth_ = Selector.sel_setWidth_.value;
 public static final long sel_setWidthTracksTextView_ = Selector.sel_setWidthTracksTextView_.value;

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/cocoa/org/eclipse/swt/internal/cocoa/OS.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/cocoa/org/eclipse/swt/internal/cocoa/OS.java
@@ -38,6 +38,18 @@ public class OS extends C {
 		return (major << 16) + (minor << 8) + bugfix;
 	}
 
+	public static int VERSION_MAJOR (int version) {
+		return (version >>> 16) & 0xFF;
+	}
+
+	public static int VERSION_MINOR (int version) {
+		return (version >>> 8) & 0xFF;
+	}
+
+	public static int VERSION_BUGFIX (int version) {
+		return version & 0xFF;
+	}
+
 	public static final boolean IS_X86_64 = System.getProperty("os.arch").equals("x86_64"); //$NON-NLS-1$
 
 	/*
@@ -335,6 +347,14 @@ public static final native long PMPrinterGetIndexedPrinterResolution(long pmPrin
 /** C calls */
 
 public static final native int getpid();
+
+/**
+ * Returns the SDK version from LC_BUILD_VERSION in the main executable's
+ * Mach-O header, encoded as {@code (major << 16) + (minor << 8) + bugfix}.
+ * Returns 0 if LC_BUILD_VERSION is not found.
+ * @method flags=no_gen
+ */
+public static final native int getMachOSDKVersion();
 
 public static final native void call(long proc, long id, long sel);
 

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/cocoa/org/eclipse/swt/internal/cocoa/Selector.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/cocoa/org/eclipse/swt/internal/cocoa/Selector.java
@@ -89,6 +89,7 @@ public enum Selector {
 
 	  /** This section is auto generated */
 
+	, sel_CGColor("CGColor")
 	, sel_CGEvent("CGEvent")
 	, sel_DOMDocument("DOMDocument")
 	, sel_IBeamCursor("IBeamCursor")
@@ -919,6 +920,7 @@ public enum Selector {
 	, sel_sendAction_to_from_("sendAction:to:from:")
 	, sel_sendEvent_("sendEvent:")
 	, sel_sender("sender")
+	, sel_separatorColor("separatorColor")
 	, sel_separatorItem("separatorItem")
 	, sel_set("set")
 	, sel_setAcceptsMouseMovedEvents_("setAcceptsMouseMovedEvents:")
@@ -961,6 +963,7 @@ public enum Selector {
 	, sel_setBecomesKeyOnlyIfNeeded_("setBecomesKeyOnlyIfNeeded:")
 	, sel_setBezelStyle_("setBezelStyle:")
 	, sel_setBezeled_("setBezeled:")
+	, sel_setBorderColor_("setBorderColor:")
 	, sel_setBorderType_("setBorderType:")
 	, sel_setBorderWidth_("setBorderWidth:")
 	, sel_setBordered_("setBordered:")
@@ -985,6 +988,7 @@ public enum Selector {
 	, sel_setContentView_("setContentView:")
 	, sel_setContentViewMargins_("setContentViewMargins:")
 	, sel_setControlSize_("setControlSize:")
+	, sel_setCornerRadius_("setCornerRadius:")
 	, sel_setCookie_("setCookie:")
 	, sel_setCopiesOnScroll_("setCopiesOnScroll:")
 	, sel_setCurrentContext_("setCurrentContext:")
@@ -1181,6 +1185,7 @@ public enum Selector {
 	, sel_setVerticalScroller_("setVerticalScroller:")
 	, sel_setView_("setView:")
 	, sel_setVisible_("setVisible:")
+	, sel_setWantsLayer_("setWantsLayer:")
 	, sel_setWantsRestingTouches_("setWantsRestingTouches:")
 	, sel_setWidth_("setWidth:")
 	, sel_setWidthTracksTextView_("setWidthTracksTextView:")

--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Combo.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Combo.java
@@ -510,6 +510,12 @@ void createHandle () {
 		if (cell != null) {
 			cell.setUsesSingleLineMode(true);
 		}
+		if (OS.VERSION_MAJOR(OS.MACH_O_SDK_VERSION) == 26) {
+			// macOS 26 (Tahoe) Liquid Glass requires a visible border on all combo boxes,
+			// so we draw one via the layer.
+			widget.setBordered(false);
+			configureLayerBorder(widget);
+		}
 		view = widget;
 	}
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Combo.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Combo.java
@@ -513,8 +513,10 @@ void createHandle () {
 		if (OS.VERSION_MAJOR(OS.MACH_O_SDK_VERSION) == 26) {
 			// macOS 26 (Tahoe) Liquid Glass requires a visible border on all combo boxes,
 			// so we draw one via the layer.
-			widget.setBordered(false);
-			configureLayerBorder(widget);
+			if (Display.liquidGlassStrategy.equals(Display.LiquidGlassStrategy.LAYER_BORDER)) {
+				widget.setBordered(false);
+				configureLayerBorder(widget);
+			}
 		}
 		view = widget;
 	}

--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Control.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Control.java
@@ -3631,6 +3631,19 @@ void setBackgroundImage (NSImage image) {
 void setBackgroundColor (NSColor nsColor) {
 }
 
+void configureLayerBorder(NSView nsView) {
+	nsView.setWantsLayer(true);
+	CALayer layer = nsView.layer();
+	if (layer != null) {
+		NSColor separatorColor = NSColor.separatorColor();
+		if (separatorColor != null) {
+			layer.setBorderColor(separatorColor.CGColor());
+		}
+		layer.setBorderWidth(1.0);
+		layer.setCornerRadius(4.0);
+	}
+}
+
 /**
  * Sets the receiver's size and location in points to the rectangular
  * area specified by the arguments. The <code>x</code> and

--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Display.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Display.java
@@ -106,6 +106,12 @@ import org.eclipse.swt.internal.cocoa.*;
  */
 public class Display extends Device implements Executor {
 
+	public static enum LiquidGlassStrategy {
+		LAYER_BORDER, SKIP_DISPLAY_OVERRIDES
+	}
+
+	public static LiquidGlassStrategy liquidGlassStrategy=LiquidGlassStrategy.SKIP_DISPLAY_OVERRIDES;
+
 	static byte[] types = {'*','\0'};
 	static int size = C.PTR_SIZEOF, align = C.PTR_SIZEOF == 4 ? 2 : 3;
 
@@ -2822,7 +2828,55 @@ void initClasses () {
 	OS.class_addMethod(cls, OS.sel_comboBoxWillDismiss_, proc3, "@:@");
 	OS.class_addMethod(cls, OS.sel_comboBoxWillPopUp_, proc3, "@:@");
 	OS.class_addMethod(cls, OS.sel_textView_willChangeSelectionFromCharacterRange_toCharacterRange_, textWillChangeSelectionProc, "@:@{NSRange}{NSRange}");
-	addEventMethods(cls, proc2, proc3, drawRectProc, hitTestProc, setNeedsDisplayInRectProc);
+	int comboBoxMachOSDKVersion = OS.getMachOSDKVersion();
+	if (OS.VERSION_MAJOR(comboBoxMachOSDKVersion)==26 && Display.liquidGlassStrategy.equals(Display.LiquidGlassStrategy.SKIP_DISPLAY_OVERRIDES)) {
+		/*
+		 * Bug in macOS 26: Overriding drawRect:, setNeedsDisplay: or
+		 * setNeedsDisplayInRect: on NSComboBox prevents the native bezel
+		 * (rounded border) from being rendered. The new layer-backed rendering
+		 * pipeline in macOS 26 bypasses drawRect: for the bezel. Only register
+		 * the event/input methods from addEventMethods, skipping the display
+		 * invalidation overrides.
+		 */
+		OS.class_addMethod(cls, OS.sel_mouseDown_, proc3, "@:@");
+		OS.class_addMethod(cls, OS.sel_mouseUp_, proc3, "@:@");
+		OS.class_addMethod(cls, OS.sel_scrollWheel_, proc3, "@:@");
+		OS.class_addMethod(cls, OS.sel_rightMouseDown_, proc3, "@:@");
+		OS.class_addMethod(cls, OS.sel_rightMouseUp_, proc3, "@:@");
+		OS.class_addMethod(cls, OS.sel_rightMouseDragged_, proc3, "@:@");
+		OS.class_addMethod(cls, OS.sel_otherMouseDown_, proc3, "@:@");
+		OS.class_addMethod(cls, OS.sel_otherMouseUp_, proc3, "@:@");
+		OS.class_addMethod(cls, OS.sel_otherMouseDragged_, proc3, "@:@");
+		OS.class_addMethod(cls, OS.sel_mouseDragged_, proc3, "@:@");
+		OS.class_addMethod(cls, OS.sel_mouseMoved_, proc3, "@:@");
+		OS.class_addMethod(cls, OS.sel_mouseEntered_, proc3, "@:@");
+		OS.class_addMethod(cls, OS.sel_mouseExited_, proc3, "@:@");
+		OS.class_addMethod(cls, OS.sel_menuForEvent_, proc3, "@:@");
+		OS.class_addMethod(cls, OS.sel_keyDown_, proc3, "@:@");
+		OS.class_addMethod(cls, OS.sel_keyUp_, proc3, "@:@");
+		OS.class_addMethod(cls, OS.sel_flagsChanged_, proc3, "@:@");
+		OS.class_addMethod(cls, OS.sel_cursorUpdate_, proc3, "@:@");
+		OS.class_addMethod(cls, OS.sel_shouldDelayWindowOrderingForEvent_, proc3, "@:@");
+		OS.class_addMethod(cls, OS.sel_acceptsFirstMouse_, proc3, "@:@");
+		OS.class_addMethod(cls, OS.sel_changeColor_, proc3, "@:@");
+		OS.class_addMethod(cls, OS.sel_cancelOperation_, proc3, "@:@");
+		OS.class_addMethod(cls, OS.sel_touchesBeganWithEvent_, proc3, "@:@");
+		OS.class_addMethod(cls, OS.sel_touchesMovedWithEvent_, proc3, "@:@");
+		OS.class_addMethod(cls, OS.sel_touchesEndedWithEvent_, proc3, "@:@");
+		OS.class_addMethod(cls, OS.sel_touchesCancelledWithEvent_, proc3, "@:@");
+		OS.class_addMethod(cls, OS.sel_swipeWithEvent_, proc3, "@:@");
+		OS.class_addMethod(cls, OS.sel_rotateWithEvent_, proc3, "@:@");
+		OS.class_addMethod(cls, OS.sel_magnifyWithEvent_, proc3, "@:@");
+		OS.class_addMethod(cls, OS.sel_resignFirstResponder, proc2, "@:");
+		OS.class_addMethod(cls, OS.sel_becomeFirstResponder, proc2, "@:");
+		OS.class_addMethod(cls, OS.sel_resetCursorRects, proc2, "@:");
+		OS.class_addMethod(cls, OS.sel_updateTrackingAreas, proc2, "@:");
+		OS.class_addMethod(cls, OS.sel_getImageView, proc2, "@:");
+		OS.class_addMethod(cls, OS.sel_mouseDownCanMoveWindow, proc2, "@:");
+		OS.class_addMethod(cls, OS.sel_hitTest_, hitTestProc, "@:{NSPoint}");
+	}else {
+		addEventMethods(cls, proc2, proc3, drawRectProc, hitTestProc, setNeedsDisplayInRectProc);
+	}
 	addFrameMethods(cls, setFrameOriginProc, setFrameSizeProc);
 	addAccessibilityMethods(cls, proc2, proc3, proc4, accessibilityHitTestProc);
 	OS.objc_registerClassPair(cls);
@@ -3160,7 +3214,55 @@ void initClasses () {
 	className = "SWTTextField";
 	cls = OS.objc_allocateClassPair(OS.class_NSTextField, className, 0);
 	OS.class_addIvar(cls, SWT_OBJECT, size, (byte)align, types);
-	addEventMethods(cls, proc2, proc3, drawRectProc, hitTestProc, setNeedsDisplayInRectProc);
+	int machOSDKVersion = OS.getMachOSDKVersion();
+	if (OS.VERSION_MAJOR(machOSDKVersion)==26 && Display.liquidGlassStrategy.equals(Display.LiquidGlassStrategy.SKIP_DISPLAY_OVERRIDES)) {
+		/*
+		 * Bug in macOS 26: Overriding drawRect:, setNeedsDisplay: or
+		 * setNeedsDisplayInRect: on NSTextField prevents the native bezel
+		 * (rounded border) from being rendered. The new layer-backed rendering
+		 * pipeline in macOS 26 bypasses drawRect: for the bezel. Only register
+		 * the event/input methods from addEventMethods, skipping the display
+		 * invalidation overrides.
+		 */
+		OS.class_addMethod(cls, OS.sel_mouseDown_, proc3, "@:@");
+		OS.class_addMethod(cls, OS.sel_mouseUp_, proc3, "@:@");
+		OS.class_addMethod(cls, OS.sel_scrollWheel_, proc3, "@:@");
+		OS.class_addMethod(cls, OS.sel_rightMouseDown_, proc3, "@:@");
+		OS.class_addMethod(cls, OS.sel_rightMouseUp_, proc3, "@:@");
+		OS.class_addMethod(cls, OS.sel_rightMouseDragged_, proc3, "@:@");
+		OS.class_addMethod(cls, OS.sel_otherMouseDown_, proc3, "@:@");
+		OS.class_addMethod(cls, OS.sel_otherMouseUp_, proc3, "@:@");
+		OS.class_addMethod(cls, OS.sel_otherMouseDragged_, proc3, "@:@");
+		OS.class_addMethod(cls, OS.sel_mouseDragged_, proc3, "@:@");
+		OS.class_addMethod(cls, OS.sel_mouseMoved_, proc3, "@:@");
+		OS.class_addMethod(cls, OS.sel_mouseEntered_, proc3, "@:@");
+		OS.class_addMethod(cls, OS.sel_mouseExited_, proc3, "@:@");
+		OS.class_addMethod(cls, OS.sel_menuForEvent_, proc3, "@:@");
+		OS.class_addMethod(cls, OS.sel_keyDown_, proc3, "@:@");
+		OS.class_addMethod(cls, OS.sel_keyUp_, proc3, "@:@");
+		OS.class_addMethod(cls, OS.sel_flagsChanged_, proc3, "@:@");
+		OS.class_addMethod(cls, OS.sel_cursorUpdate_, proc3, "@:@");
+		OS.class_addMethod(cls, OS.sel_shouldDelayWindowOrderingForEvent_, proc3, "@:@");
+		OS.class_addMethod(cls, OS.sel_acceptsFirstMouse_, proc3, "@:@");
+		OS.class_addMethod(cls, OS.sel_changeColor_, proc3, "@:@");
+		OS.class_addMethod(cls, OS.sel_cancelOperation_, proc3, "@:@");
+		OS.class_addMethod(cls, OS.sel_touchesBeganWithEvent_, proc3, "@:@");
+		OS.class_addMethod(cls, OS.sel_touchesMovedWithEvent_, proc3, "@:@");
+		OS.class_addMethod(cls, OS.sel_touchesEndedWithEvent_, proc3, "@:@");
+		OS.class_addMethod(cls, OS.sel_touchesCancelledWithEvent_, proc3, "@:@");
+		OS.class_addMethod(cls, OS.sel_swipeWithEvent_, proc3, "@:@");
+		OS.class_addMethod(cls, OS.sel_rotateWithEvent_, proc3, "@:@");
+		OS.class_addMethod(cls, OS.sel_magnifyWithEvent_, proc3, "@:@");
+		OS.class_addMethod(cls, OS.sel_resignFirstResponder, proc2, "@:");
+		OS.class_addMethod(cls, OS.sel_becomeFirstResponder, proc2, "@:");
+		OS.class_addMethod(cls, OS.sel_resetCursorRects, proc2, "@:");
+		OS.class_addMethod(cls, OS.sel_updateTrackingAreas, proc2, "@:");
+		OS.class_addMethod(cls, OS.sel_getImageView, proc2, "@:");
+		OS.class_addMethod(cls, OS.sel_mouseDownCanMoveWindow, proc2, "@:");
+		OS.class_addMethod(cls, OS.sel_hitTest_, hitTestProc, "@:{NSPoint}");
+	}else {
+		addEventMethods(cls, proc2, proc3, drawRectProc, hitTestProc, setNeedsDisplayInRectProc);
+	}
 	addFrameMethods(cls, setFrameOriginProc, setFrameSizeProc);
 	addAccessibilityMethods(cls, proc2, proc3, proc4, accessibilityHitTestProc);
 	OS.class_addMethod(cls, OS.sel_acceptsFirstResponder, proc2, "@:");

--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Text.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Text.java
@@ -518,8 +518,10 @@ void createHandle () {
 		if (OS.VERSION_MAJOR(OS.MACH_O_SDK_VERSION) == 26) {
 			// macOS 26 (Tahoe) Liquid Glass requires a visible border on all text fields
 			// regardless of SWT.BORDER style, so we draw one via the layer.
-			widget.setBordered(false);
-			configureLayerBorder(widget);
+			if (Display.liquidGlassStrategy.equals(Display.LiquidGlassStrategy.LAYER_BORDER)) {
+				widget.setBordered(false);
+				configureLayerBorder(widget);
+			}
 		} else {
 			if ((style & SWT.BORDER) == 0) {
 				widget.setFocusRingType (OS.NSFocusRingTypeNone);

--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Text.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Text.java
@@ -515,9 +515,16 @@ void createHandle () {
 		widget.init ();
 		widget.setSelectable (true);
 		widget.setEditable((style & SWT.READ_ONLY) == 0);
-		if ((style & SWT.BORDER) == 0) {
-			widget.setFocusRingType (OS.NSFocusRingTypeNone);
-			widget.setBordered (false);
+		if (OS.VERSION_MAJOR(OS.MACH_O_SDK_VERSION) == 26) {
+			// macOS 26 (Tahoe) Liquid Glass requires a visible border on all text fields
+			// regardless of SWT.BORDER style, so we draw one via the layer.
+			widget.setBordered(false);
+			configureLayerBorder(widget);
+		} else {
+			if ((style & SWT.BORDER) == 0) {
+				widget.setFocusRingType (OS.NSFocusRingTypeNone);
+				widget.setBordered (false);
+			}
 		}
 		/*
 		 * Bug in Cocoa: On OSX 10.10, setting the alignment on the search field


### PR DESCRIPTION
On macOS 26 (Tahoe) Liquid Glass, all text fields and combo boxes
require a visible border regardless of SWT.BORDER style. This adds
the necessary Cocoa bindings (NSView.setWantsLayer,
CALayer.setBorderColor/
setBorderWidth/setCornerRadius, NSColor.separatorColor/CGColor) and
draws borders via the layer pipeline. The shared logic is extracted
into Control.configureLayerBorder() and the SDK version is cached in
OS.MACH_O_SDK_VERSION.