### PR TITLE
StyledText treats shortcuts incorrectly with Japanese keyboard layout #3306

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/StyledText.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/StyledText.java
@@ -5728,12 +5728,13 @@ void handleHorizontalScroll(Event event) {
  * @param event keyboard event
  */
 void handleKey(Event event) {
-	int action;
 	caretAlignment = PREVIOUS_OFFSET_TRAILING;
+	int action = SWT.NULL;
 	if (event.keyCode != 0) {
 		// special key pressed (e.g., F1)
 		action = getKeyBinding(event.keyCode | event.stateMask);
-	} else {
+	}
+	if (action == SWT.NULL && event.character != 0) {
 		// character key pressed
 		action = getKeyBinding(event.character | event.stateMask);
 		if (action == SWT.NULL) {


### PR DESCRIPTION
On MacOS 14 with "Japanese Kana" keyboard pressing Cmd+A results in event.keycode == 12385 while event.character == 'a'.

This PR fixes the problem for me.