### PR TITLE
Save test failure screenshots

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -141,6 +141,7 @@ jobs:
         if-no-files-found: warn
         path: |
           ${{ github.workspace }}/**/target/surefire-reports/*.xml
+          ${{ github.workspace }}/**/target/screenshots/*.png
           ${{ github.workspace }}/**/*.log
           ${{ github.workspace }}/**/*.dump
           ${{ github.workspace }}/**/*.dumpstream


### PR DESCRIPTION
This is a continuation of [Screenshot saving in Platform aggregator][1].

Tests attempt to save screenshots on failure, but so far, the save location has been incorrect (`/tmp`) and screenshots were wasted. Now screenshots are saved in Maven output directory and this PR captures them in artifacts, so that contributors can inspect CI failures in more detail.

[1]: https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/3819

Fixes #3303.