### PR TITLE
[Win32] Remove unnecessary color disposal in GC

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/GC.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/GC.java
@@ -4859,7 +4859,6 @@ private class SetBackgroundOperation extends ReplaceableOperation  {
 	SetBackgroundOperation(Color color) {
 		RGB rgb = color.getRGB();
 		this.color = new Color(rgb);
-		registerForDisposal(this.color);
 	}
 
 	@Override
@@ -5208,7 +5207,6 @@ private class SetForegroundOperation extends ReplaceableOperation  {
 	SetForegroundOperation(Color color) {
 		RGB rgb = color.getRGB();
 		this.color = new Color(rgb);
-		registerForDisposal(this.color);
 	}
 
 	@Override


### PR DESCRIPTION
GC operations unnecessarily register stored colors for disposal, though colors do not need to be disposed anymore. This change removes the obsolete disposal tracking.

Contributes to https://github.com/eclipse-platform/eclipse.platform.swt/issues/3296