### PR TITLE
[Win32] Copy patterns in GC only when necessary

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/GC.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/GC.java
@@ -4900,16 +4900,31 @@ public void setBackgroundPattern (Pattern pattern) {
 	storeAndApplyOperationForExistingHandle(new SetBackgroundPatternOperation(pattern));
 }
 
-private class SetBackgroundPatternOperation extends Operation {
-	private final Pattern pattern;
+private abstract class PatternOperation extends Operation {
+	private Pattern pattern;
 
+	PatternOperation(Pattern pattern) {
+		this.pattern = pattern;
+	}
+
+	protected Pattern getPattern() {
+		if (pattern != null && pattern.isDisposed()) {
+			// recreate locally managed pattern if the original was disposed
+			pattern = pattern.copy();
+			registerForDisposal(pattern);
+		}
+		return pattern;
+	}
+}
+
+private class SetBackgroundPatternOperation extends PatternOperation {
 	SetBackgroundPatternOperation(Pattern pattern) {
-		this.pattern = pattern == null ? null : pattern.copy();
-		registerForDisposal(this.pattern);
+		super(pattern);
 	}
 
 	@Override
 	void apply() {
+		Pattern pattern = getPattern();
 		if (data.gdipGraphics == 0 && pattern == null) return;
 		initGdip();
 		if (data.backgroundPattern == pattern) return;
@@ -5247,16 +5262,15 @@ public void setForegroundPattern (Pattern pattern) {
 	storeAndApplyOperationForExistingHandle(new SetForegroundPatternOperation(pattern));
 }
 
-private class SetForegroundPatternOperation extends Operation {
-	private final Pattern pattern;
+private class SetForegroundPatternOperation extends PatternOperation {
 
 	SetForegroundPatternOperation(Pattern pattern) {
-		this.pattern = pattern == null ? null : pattern.copy();
-		registerForDisposal(this.pattern);
+		super(pattern);
 	}
 
 	@Override
 	void apply() {
+		Pattern pattern = getPattern();
 		if (data.gdipGraphics == 0 && pattern == null) return;
 		initGdip();
 		if (data.foregroundPattern == pattern) return;


### PR DESCRIPTION
GC operations for background/foreground Pattern currently copy the passed pattern upon creation. In case the GC is short living and the passed Pattern outlives it, this copy (including a handle allocation) is unnecessary.

With this change, the passed Pattern is only copied/recreated when it became disposed.

Contributes to https://github.com/eclipse-platform/eclipse.platform.swt/issues/3296