### PR TITLE
[Cocoa] Fix in-place editor freeze by forcing TextKit 1

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Shell.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Shell.java
@@ -773,7 +773,15 @@ void createHandle () {
 	id id = fieldEditorWindow.fieldEditor (true, null);
 	if (id != null) {
 		OS.object_setClass (id.id, OS.objc_getClass ("SWTEditorView"));
-		new NSTextView(id).setAllowsUndo(true);
+		NSTextView fieldEditor = new NSTextView(id);
+		fieldEditor.setAllowsUndo(true);
+		/*
+		 * Accessing layoutManager forces the field editor off TextKit 2 onto
+		 * TextKit 1 for its lifetime, avoiding an AppKit freeze during
+		 * mouseDown:. See eclipse.platform.ui#1069. Side-effecting call -
+		 * the returned value is intentionally unused.
+		 */
+		fieldEditor.layoutManager();
 	}
 
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Text.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Text.java
@@ -587,6 +587,8 @@ void createWidget () {
 		if (fieldEditor != null && nsSecureTextViewClass != 0 && fieldEditor.isKindOfClass(nsSecureTextViewClass)) {
 			long editorClass = OS.objc_getClass("SWTSecureEditorView");
 			OS.object_setClass(fieldEditor.id, editorClass);
+			/* Force TextKit 1 on the secure field editor too (see Shell.createHandle). */
+			new NSTextView(fieldEditor).layoutManager();
 		}
 	}
 	doubleClick = true;


### PR DESCRIPTION
On macOS the AppKit field editor SWT wraps can freeze during mouseDown: due to a TextKit 2 bug (_bellerophonTrack...). Accessing an NSTextView's layoutManager forces a permanent downgrade to TextKit 1 for that view.

Force this downgrade eagerly at field-editor promotion time, before any mouse interaction, rather than relying on the existing lazy layoutManager() calls in getCaretLocation() which run too late:

 - Shell.createHandle(): the per-window field editor (SWTEditorView), covering SWT.SINGLE Text and editable Combo.
 - Text.createWidget(): the separate secure field editor for SWT.PASSWORD (SWTSecureEditorView).

See eclipse-platform/eclipse.platform.ui#1069