### PR TITLE
ci: declare workflow-level `contents: read` on maven, pr-checks, version-increments

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -20,6 +20,9 @@ on:
     branches: [ master ]
     types: [opened, reopened, synchronize, labeled]
 
+permissions:
+  contents: read
+
 jobs:
   event_file:
     name: "Event File"

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -9,6 +9,9 @@ on:
   pull_request:
     branches: [ master ]
 
+permissions:
+  contents: read
+
 jobs:
   check-freeze-period:
     uses: eclipse-platform/eclipse.platform.releng.aggregator/.github/workflows/verifyFreezePeriod.yml@master

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -9,9 +9,6 @@ on:
   pull_request:
     branches: [ master ]
 
-permissions:
-  contents: read
-
 jobs:
   check-freeze-period:
     uses: eclipse-platform/eclipse.platform.releng.aggregator/.github/workflows/verifyFreezePeriod.yml@master
@@ -25,6 +22,8 @@ jobs:
 
   check-javadoc-consistency:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
     - uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493 # v5.0.0
     - uses: actions/setup-java@de5a937a1dc73fbc1a67d7d1aa4bebc1082f3190 # v5.0.0

--- a/.github/workflows/version-increments.yml
+++ b/.github/workflows/version-increments.yml
@@ -5,6 +5,9 @@ on:
     workflows: [ 'Pull-Request Checks' ]
     types: [ completed ]
 
+permissions:
+  contents: read
+
 jobs:
   publish-version-check-results:
     uses: eclipse-platform/eclipse.platform.releng.aggregator/.github/workflows/publishVersionCheckResults.yml@master


### PR DESCRIPTION
Adds workflow-level `permissions: contents: read` to three workflows that just run build / checks: `maven`, `pr-checks`, `version-increments`. No GitHub API writes.

Same post-CVE-2025-30066 (`tj-actions/changed-files`) hardening pattern. YAML validated locally.