### PR TITLE
[Gtk4] Fix Button image size by using GtkPicture instead of GtkImage

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Button.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Button.java
@@ -385,7 +385,11 @@ void createHandle (int index) {
 		labelHandle = GTK.gtk_label_new_with_mnemonic(null);
 		if (labelHandle == 0) error(SWT.ERROR_NO_HANDLES);
 
-		imageHandle = GTK.gtk_image_new();
+		if (GTK.GTK4) {
+			imageHandle = GTK4.gtk_picture_new();
+		} else {
+			imageHandle = GTK.gtk_image_new();
+		}
 		if (imageHandle == 0) error(SWT.ERROR_NO_HANDLES);
 
 		if (GTK.GTK4) {
@@ -1156,13 +1160,14 @@ private void _setImage (Image image) {
 			long pixbuf = ImageList.createPixbuf(image);
 			long texture = GDK.gdk_texture_new_for_pixbuf(pixbuf);
 			OS.g_object_unref(pixbuf);
-			GTK4.gtk_image_set_from_paintable(imageHandle, texture);
+			GTK4.gtk_picture_set_paintable(imageHandle, texture);
+			OS.g_object_unref(texture);
 		} else {
 			GTK3.gtk_image_set_from_surface(imageHandle, image.surface);
 		}
 	} else {
 		if (GTK.GTK4) {
-			GTK4.gtk_image_set_from_paintable(imageHandle, 0);
+			GTK4.gtk_picture_set_paintable(imageHandle, 0);
 		} else {
 			GTK3.gtk_image_set_from_surface(imageHandle, 0);
 		}

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Label.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Label.java
@@ -651,6 +651,7 @@ public void setImage (Image image) {
 			long texture = GDK.gdk_texture_new_for_pixbuf(pixbuf);
 			OS.g_object_unref(pixbuf);
 			GTK4.gtk_picture_set_paintable(imageHandle, texture);
+			OS.g_object_unref(texture);
 		} else {
 			GTK3.gtk_image_set_from_surface(imageHandle, image.surface);
 		}


### PR DESCRIPTION
Gtk 4 works in logical points while Cairo works in pixel thus this is needed for proper size of the pixbuf scale to the original image size.

This makes Button consistent with Label, which already uses GtkPicture for the same reason (see commit
https://github.com/eclipse-platform/eclipse.platform.swt/pull/2766 ).

Also fix a memory leak in Label where the GdkTexture created by gdk_texture_new_for_pixbuf() was not unreffed after being handed to gtk_picture_set_paintable().