### PR TITLE
Control.gtk4_draw: do not send paint events if the control is zero-sized

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Control.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Control.java
@@ -3845,6 +3845,9 @@ void cairoClipRegion (long cairo) {
 @Override
 void gtk4_draw(long widget, long cairo, Rectangle bounds) {
 	if (!hooksPaint()) return;
+	if (bounds.width == 0 || bounds.height == 0) {
+		return;
+	}
 
 	GCData data = new GCData();
 	data.cairo = cairo;


### PR DESCRIPTION
A control without width or height can't display anything.