### PR TITLE
[Win] StyledText with paint artifacts

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/Win32DPIUtils.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/Win32DPIUtils.java
@@ -178,7 +178,13 @@ public class Win32DPIUtils {
 	}
 
 	public static Rectangle pixelToPointWithSufficientlyLargeSize(Rectangle rect, int zoom) {
-		return pixelToPoint(rect, zoom, RoundingMode.UP);
+		if (zoom == 100 || rect == null) return rect;
+
+		Point scaledTopLeft = pixelToPoint(new Point(rect.x, rect.y), zoom, RoundingMode.DOWN);
+		Point scaledBottomRight = pixelToPoint(new Point(rect.x + rect.width, rect.y + rect.height), zoom, RoundingMode.UP);
+		return new Rectangle(scaledTopLeft.x, scaledTopLeft.y,
+		                     scaledBottomRight.x - scaledTopLeft.x,
+		                     scaledBottomRight.y - scaledTopLeft.y);
 	}
 
 	private static Rectangle pixelToPoint(Rectangle rect, int zoom, RoundingMode sizeRounding) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Composite.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Composite.java
@@ -1532,7 +1532,7 @@ LRESULT WM_PAINT (long wParam, long lParam) {
 
 					Event event = new Event ();
 					event.gc = gc;
-					event.setBounds(Win32DPIUtils.pixelToPoint(new Rectangle.OfFloat(ps.left, ps.top, width, height), getAutoscalingZoom()));
+					event.setBounds(Win32DPIUtils.pixelToPointWithSufficientlyLargeSize(new Rectangle.OfFloat(ps.left, ps.top, width, height), getAutoscalingZoom()));
 					sendEvent (SWT.Paint, event);
 					if (data.focusDrawn && !isDisposed ()) updateUIState ();
 					gc.dispose ();

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Scrollable.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Scrollable.java
@@ -210,7 +210,7 @@ void destroyScrollBar (int type) {
  */
 public Rectangle getClientArea () {
 	checkWidget ();
-	return Win32DPIUtils.pixelToPoint(getClientAreaInPixels(), getAutoscalingZoom());
+	return Win32DPIUtils.pixelToPointWithSufficientlyLargeSize(getClientAreaInPixels(), getAutoscalingZoom());
 }
 
 Rectangle getClientAreaInPixels () {


### PR DESCRIPTION
`Win32DPIUtils.pixelToPointWithSufficientlyLargeSize`: If we need the rectangle that is large enough, the left top corner must be rounded **down** and the right bottom corner rounded **up**.

`Scrollable.getClientArea` and the bounds of the `Paint` event also need to be large enough to contain any pixel. In the worst case, it contains "half" points, but it does not matter if it draws one pixel here and there into the invisible area.

However, it might be better if `Scrollable.getClientArea` might return a special rectangle (similar to `Rectangle.OfFloat`) that can be asked for the "inner" and "outer" rectangle, because only the user of knows what rectangle is important for him: for painting the larger rect is important. But, for example, for a table that resizes a single column depending on the size, the smaller rect might be of interest to prevent horizontal scrollbars.