### PR TITLE
Remove deprecation warnings for SWTEventListener in deprecated methods

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Widget.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Widget.java
@@ -1527,7 +1527,7 @@ public void removeListener (int eventType, Listener listener) {
  * @deprecated Use {@link #removeListener(int, EventListener)}.
  */
 @Deprecated(forRemoval=true, since="2025-03")
-protected void removeListener (int eventType, SWTEventListener listener) {
+protected void removeListener (int eventType, @SuppressWarnings("removal") SWTEventListener listener) {
 	removeTypedListener(eventType, listener);
 }
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/TypedListener.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/TypedListener.java
@@ -65,7 +65,7 @@ public class TypedListener implements Listener {
  * @noreference This method is not intended to be referenced by clients.
  */
 @Deprecated(forRemoval=true, since="2025-03")
-public TypedListener (SWTEventListener listener) {
+public TypedListener (@SuppressWarnings("removal") SWTEventListener listener) {
 	eventListener = listener;
 }
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Widget.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Widget.java
@@ -1501,7 +1501,7 @@ public void removeListener (int eventType, Listener listener) {
  * @deprecated Use {@link #removeListener(int, EventListener)}.
  */
 @Deprecated(forRemoval=true, since="2025-03")
-protected void removeListener (int eventType, SWTEventListener listener) {
+protected void removeListener (int eventType, @SuppressWarnings("removal") SWTEventListener listener) {
 	removeTypedListener(eventType, listener);
 }
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Widget.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Widget.java
@@ -1052,7 +1052,7 @@ public void removeListener (int eventType, Listener listener) {
  * @deprecated Use {@link #removeListener(int, EventListener)}.
  */
 @Deprecated(forRemoval=true, since="2025-03")
-protected void removeListener (int eventType, SWTEventListener listener) {
+protected void removeListener (int eventType, @SuppressWarnings("removal") SWTEventListener listener) {
 	removeTypedListener(eventType, listener);
 }
 


### PR DESCRIPTION
The SWTEventListener interface is deprecated for removal. Some methods with parameters having the type of that interface are also marked as deprecated for removal but still show a warning because of the usage of that deprecated type. This change suppresses the unnecessary warning as the method is marked for removal consistently with the used type.

<img width="491" height="120" alt="image" src="https://github.com/user-attachments/assets/77d31886-28bd-4a73-b2b4-a080cff27bfe" />
