### PR TITLE
Move JSVGRasterizer unit test to SVG fragment

### DIFF
--- a/bundles/org.eclipse.swt.svg/.classpath
+++ b/bundles/org.eclipse.swt.svg/.classpath
@@ -2,7 +2,13 @@
 <classpath>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/5"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="src" path="resources"/>
+	<classpathentry kind="src" output="bin_test" path="test">
+		<attributes>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/bundles/org.eclipse.swt.svg/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.swt.svg/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.swt.svg
-Bundle-Version: 3.133.0.qualifier
+Bundle-Version: 3.133.100.qualifier
 Automatic-Module-Name: org.eclipse.swt.svg
 Bundle-Name: %fragmentName
 Bundle-Vendor: %providerName

--- a/bundles/org.eclipse.swt.svg/pom.xml
+++ b/bundles/org.eclipse.swt.svg/pom.xml
@@ -1,0 +1,54 @@
+<!--  
+###############################################################################
+# Copyright (c) 2026 Vector Informatik GmbH and others.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which accompanies this distribution,
+# and is available at https://www.eclipse.org/legal/epl-2.0/
+###############################################################################
+ -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.eclipse.platform</groupId>
+		<artifactId>eclipse.platform.swt</artifactId>
+		<version>4.41.0-SNAPSHOT</version>
+		<relativePath>../../</relativePath>
+	</parent>
+	<artifactId>org.eclipse.swt.svg</artifactId>
+	<version>3.133.100-SNAPSHOT</version>
+	<packaging>eclipse-plugin</packaging>
+	<properties>
+		<tycho.extraClasspathJars>IGNORE</tycho.extraClasspathJars>
+	</properties>
+	<build>
+		<sourceDirectory>src</sourceDirectory>
+		<testSourceDirectory>test</testSourceDirectory>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<dependencies>
+					<dependency>
+						<groupId>org.apache.maven.surefire</groupId>
+						<artifactId>surefire-junit-platform</artifactId>
+						<version>${surefire.version}</version>
+					</dependency>
+				</dependencies>
+				<executions>
+					<execution>
+						<id>execute-tests</id>
+						<goals>
+							<goal>test</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+
+
+</project>

--- a/bundles/org.eclipse.swt.svg/test/org/eclipse/swt/svg/JSVGRasterizerTest.java
+++ b/bundles/org.eclipse.swt.svg/test/org/eclipse/swt/svg/JSVGRasterizerTest.java
@@ -11,9 +11,8 @@
  * Contributors:
  *     Yatta Solutions - initial API and implementation
  *******************************************************************************/
-package org.eclipse.swt.tests.junit;
+package org.eclipse.swt.svg;
 
-import static org.eclipse.swt.tests.junit.SwtTestUtil.assertSWTProblem;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -23,10 +22,8 @@ import java.nio.charset.StandardCharsets;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.SWTException;
 import org.eclipse.swt.graphics.ImageData;
-import org.eclipse.swt.svg.JSVGRasterizer;
 import org.junit.jupiter.api.Test;
 
-@SuppressWarnings("restriction")
 class JSVGRasterizerTest {
 
 	private final JSVGRasterizer rasterizer = new JSVGRasterizer();
@@ -51,13 +48,7 @@ class JSVGRasterizerTest {
 
 	@Test
 	void testRasterizeWithZoomNegative() {
-		try {
-			rasterizer.rasterizeSVG(svgStream(svgString), -100);
-
-		} catch (IllegalArgumentException e) {
-			assertSWTProblem("Incorrect exception thrown for negative zoom", SWT.ERROR_INVALID_ARGUMENT, e);
-		}
-
+		assertThrows(IllegalArgumentException.class, () -> rasterizer.rasterizeSVG(svgStream(svgString), -100));
 	}
 
 	@Test

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/AllNonBrowserTests.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/AllNonBrowserTests.java
@@ -48,7 +48,6 @@ public class AllNonBrowserTests {
 			AllWidgetTests.class, //
 			// Rest of tests alphabetically
 			DPIUtilTests.class, //
-			JSVGRasterizerTest.class, //
 			Test_org_eclipse_swt_accessibility_Accessible.class, //
 			Test_org_eclipse_swt_accessibility_AccessibleControlEvent.class, //
 			Test_org_eclipse_swt_accessibility_AccessibleEvent.class, //


### PR DESCRIPTION
The JSVGRasterizerTest is currently implemented in the ordinary SWT test bundle, even though the JSVGRasterizer is only one possible (and the current default) SVGRasterizer implementation. The test is actually a unit test for the provider, thus it is properly placed in the SVG fragment that provides the rasterizer implementation itself.

This change moves the test class to the SVG fragment and enables it via pure surefire execution. This is similar to what is already done regarding execution of OS-specific unit tests in the OS fragments.