### PR TITLE
[Win32] Fix swapped arguments in readRegistryDwords null checks

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT PI/win32/org/eclipse/swt/internal/win32/OS.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/win32/org/eclipse/swt/internal/win32/OS.java
@@ -2142,8 +2142,8 @@ public static final boolean OpenPrinter (TCHAR pPrinterName, long [] phPrinter, 
 
 public static final int[] readRegistryDwords(int hkeyLocation, String key, String valueName) {
 	final int ERROR_MORE_DATA = 234;
-	Objects.requireNonNull("key", key);
-	Objects.requireNonNull("valueName", valueName);
+	Objects.requireNonNull(key, "key");
+	Objects.requireNonNull(valueName, "valueName");
 	long[] phkResult = new long[1];
 	TCHAR regKey = new TCHAR(0, key, true);
 	TCHAR lpValueName = new TCHAR(0, valueName, true);


### PR DESCRIPTION
## Summary

- `Objects.requireNonNull(T obj, String message)` takes the object to check as the *first* argument and the error message as the *second*.
- In `OS.readRegistryDwords`, both calls had the arguments reversed: the non-null string literals `"key"` and `"valueName"` were being checked instead of the actual `key` and `valueName` variables.
- As a result, both null guards were complete no-ops — a `null` key or valueName would pass through silently and cause a `NullPointerException` or unexpected behaviour later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)