### PR TITLE
Promote CTabFolder.setItemOrder(int[]) to public API and add moveItem

### DIFF
--- a/binaries/org.eclipse.swt.cocoa.macosx.aarch64/META-INF/MANIFEST.MF
+++ b/binaries/org.eclipse.swt.cocoa.macosx.aarch64/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Fragment-Host: org.eclipse.swt;bundle-version="[3.128.0,4.0.0)"
 Bundle-Name: %fragmentName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.swt.cocoa.macosx.aarch64; singleton:=true
-Bundle-Version: 3.134.100.qualifier
+Bundle-Version: 3.135.0.qualifier
 Bundle-ManifestVersion: 2
 Bundle-Localization: fragment
 Export-Package: 

--- a/binaries/org.eclipse.swt.cocoa.macosx.x86_64/META-INF/MANIFEST.MF
+++ b/binaries/org.eclipse.swt.cocoa.macosx.x86_64/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Fragment-Host: org.eclipse.swt;bundle-version="[3.128.0,4.0.0)"
 Bundle-Name: %fragmentName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.swt.cocoa.macosx.x86_64; singleton:=true
-Bundle-Version: 3.134.100.qualifier
+Bundle-Version: 3.135.0.qualifier
 Bundle-ManifestVersion: 2
 Bundle-Localization: fragment
 Export-Package: 

--- a/binaries/org.eclipse.swt.gtk.linux.aarch64/META-INF/MANIFEST.MF
+++ b/binaries/org.eclipse.swt.gtk.linux.aarch64/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Fragment-Host: org.eclipse.swt;bundle-version="[3.128.0,4.0.0)"
 Bundle-Name: %fragmentName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.swt.gtk.linux.aarch64; singleton:=true
-Bundle-Version: 3.134.100.qualifier
+Bundle-Version: 3.135.0.qualifier
 Bundle-ManifestVersion: 2
 Bundle-Localization: fragment
 Export-Package: 

--- a/binaries/org.eclipse.swt.gtk.linux.ppc64le/META-INF/MANIFEST.MF
+++ b/binaries/org.eclipse.swt.gtk.linux.ppc64le/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Fragment-Host: org.eclipse.swt;bundle-version="[3.128.0,4.0.0)"
 Bundle-Name: %fragmentName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.swt.gtk.linux.ppc64le;singleton:=true
-Bundle-Version: 3.134.100.qualifier
+Bundle-Version: 3.135.0.qualifier
 Bundle-ManifestVersion: 2
 Bundle-Localization: fragment
 Export-Package: 

--- a/binaries/org.eclipse.swt.gtk.linux.riscv64/META-INF/MANIFEST.MF
+++ b/binaries/org.eclipse.swt.gtk.linux.riscv64/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Fragment-Host: org.eclipse.swt;bundle-version="[3.128.0,4.0.0)"
 Bundle-Name: %fragmentName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.swt.gtk.linux.riscv64; singleton:=true
-Bundle-Version: 3.134.100.qualifier
+Bundle-Version: 3.135.0.qualifier
 Bundle-ManifestVersion: 2
 Bundle-Localization: fragment
 Export-Package: 

--- a/binaries/org.eclipse.swt.gtk.linux.x86_64/META-INF/MANIFEST.MF
+++ b/binaries/org.eclipse.swt.gtk.linux.x86_64/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Fragment-Host: org.eclipse.swt;bundle-version="[3.128.0,4.0.0)"
 Bundle-Name: %fragmentName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.swt.gtk.linux.x86_64; singleton:=true
-Bundle-Version: 3.134.100.qualifier
+Bundle-Version: 3.135.0.qualifier
 Bundle-ManifestVersion: 2
 Bundle-Localization: fragment
 Export-Package: 

--- a/binaries/org.eclipse.swt.win32.win32.aarch64/META-INF/MANIFEST.MF
+++ b/binaries/org.eclipse.swt.win32.win32.aarch64/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Fragment-Host: org.eclipse.swt;bundle-version="[3.128.0,4.0.0)"
 Bundle-Name: %fragmentName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.swt.win32.win32.aarch64; singleton:=true
-Bundle-Version: 3.134.100.qualifier
+Bundle-Version: 3.135.0.qualifier
 Bundle-ManifestVersion: 2
 Bundle-Localization: fragment
 Export-Package: 

--- a/binaries/org.eclipse.swt.win32.win32.x86_64/META-INF/MANIFEST.MF
+++ b/binaries/org.eclipse.swt.win32.win32.x86_64/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Fragment-Host: org.eclipse.swt;bundle-version="[3.128.0,4.0.0)"
 Bundle-Name: %fragmentName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.swt.win32.win32.x86_64; singleton:=true
-Bundle-Version: 3.134.100.qualifier
+Bundle-Version: 3.135.0.qualifier
 Bundle-ManifestVersion: 2
 Bundle-Localization: fragment
 Export-Package: 

--- a/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CTabFolder.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CTabFolder.java
@@ -2843,8 +2843,22 @@ boolean setItemLocation(GC gc) {
 	return changed;
 }
 /**
- * Reorder the items of the receiver.
- * @param indices an array containing the new indices for all items
+ * Sets the order that the items in the receiver should be displayed in to the
+ * given argument.
+ * <p>
+ * The argument is described in terms of the zero-relative ordering of the
+ * receiver's current items: <code>indices[i]</code> is the index of the item
+ * that should be moved to position <code>i</code>. In other words, the item
+ * currently at index <code>indices[i]</code> becomes the new item at index
+ * <code>i</code>. The argument must contain every index of the receiver's items
+ * exactly once.
+ * </p><p>
+ * The currently selected item remains selected after the reorder, and the set
+ * of visible tabs is preserved as far as the new ordering allows.
+ * </p>
+ *
+ * @param indices the new display order of the receiver's items, expressed as a
+ *        permutation of their current indices
  *
  * @exception IllegalArgumentException <ul>
  *    <li>ERROR_NULL_ARGUMENT - if the indices array is null</li>
@@ -2856,14 +2870,20 @@ boolean setItemLocation(GC gc) {
  *    <li>ERROR_WIDGET_DISPOSED - if the receiver has been disposed</li>
  *    <li>ERROR_THREAD_INVALID_ACCESS - if not called from the thread that created the receiver</li>
  * </ul>
+ *
+ * @see #moveItem(int, int)
+ *
+ * @since 3.135
  */
-/*public*/ void setItemOrder (int[] indices) {
+public void setItemOrder (int[] indices) {
 	checkWidget();
 	if (indices == null) SWT.error (SWT.ERROR_NULL_ARGUMENT);
 	if (indices.length != items.length) SWT.error (SWT.ERROR_INVALID_ARGUMENT);
 	int newSelectedIndex = -1;
 	boolean[] seen = new boolean[items.length];
 	CTabItem[] temp = new CTabItem[items.length];
+	// oldToNew[oldIndex] is the position the item at oldIndex moves to.
+	int[] oldToNew = new int[items.length];
 	for (int i=0; i<indices.length; i++) {
 		int index = indices[i];
 		if (!(0 <= index && index < items.length)) SWT.error (SWT.ERROR_INVALID_ARGUMENT);
@@ -2871,10 +2891,66 @@ boolean setItemLocation(GC gc) {
 		seen[index] = true;
 		if (index == selectedIndex) newSelectedIndex = i;
 		temp[i] = items[index];
+		oldToNew[index] = i;
 	}
 	items = temp;
 	selectedIndex = newSelectedIndex;
+	// priority[] and firstIndex hold indices into items[], so remap them to the
+	// items' new positions to keep the chevron/visible-tab state correct.
+	for (int i=0; i<priority.length; i++) {
+		priority[i] = oldToNew[priority[i]];
+	}
+	if (firstIndex != -1) firstIndex = oldToNew[firstIndex];
 	updateFolder(REDRAW);
+}
+/**
+ * Moves the item at the <code>from</code> index to the <code>to</code> index.
+ * The items between the two indices shift by one position to fill the gap; all
+ * other items keep their relative order. This is a convenience for the common
+ * single-item reorder gesture (such as dragging a tab) and is equivalent to
+ * building the corresponding permutation and passing it to
+ * {@link #setItemOrder(int[])}.
+ * <p>
+ * If <code>from</code> and <code>to</code> are equal this method has no effect.
+ * The currently selected item remains selected after the move.
+ * </p>
+ *
+ * @param from the zero-relative index of the item to move
+ * @param to the zero-relative index the item should be moved to
+ *
+ * @exception IllegalArgumentException <ul>
+ *    <li>ERROR_INVALID_RANGE - if either <code>from</code> or <code>to</code> is
+ *    not between 0 and the number of items minus 1 (inclusive)</li>
+ * </ul>
+ *
+ * @exception SWTException <ul>
+ *    <li>ERROR_WIDGET_DISPOSED - if the receiver has been disposed</li>
+ *    <li>ERROR_THREAD_INVALID_ACCESS - if not called from the thread that created the receiver</li>
+ * </ul>
+ *
+ * @see #setItemOrder(int[])
+ *
+ * @since 3.135
+ */
+public void moveItem (int from, int to) {
+	checkWidget();
+	int count = items.length;
+	if (from < 0 || from >= count) SWT.error (SWT.ERROR_INVALID_RANGE);
+	if (to < 0 || to >= count) SWT.error (SWT.ERROR_INVALID_RANGE);
+	if (from == to) return;
+	// Build the permutation that removes the item at `from` and re-inserts it at
+	// `to`, then delegate so priority[]/firstIndex are remapped in one place.
+	int[] order = new int[count];
+	int next = 0;
+	for (int i = 0; i < count; i++) {
+		if (i == to) {
+			order[i] = from;
+		} else {
+			if (next == from) next++;
+			order[i] = next++;
+		}
+	}
+	setItemOrder(order);
 }
 boolean setItemSize(GC gc) {
 	boolean changed = false;

--- a/bundles/org.eclipse.swt/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.swt/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.swt; singleton:=true
-Bundle-Version: 3.134.100.qualifier
+Bundle-Version: 3.135.0.qualifier
 Bundle-ManifestVersion: 2
 Bundle-Localization: plugin
 DynamicImport-Package: org.eclipse.swt.accessibility2

--- a/bundles/org.eclipse.swt/pom.xml
+++ b/bundles/org.eclipse.swt/pom.xml
@@ -20,7 +20,7 @@
         <relativePath>../../</relativePath>
     </parent>
     <artifactId>org.eclipse.swt</artifactId>
-    <version>3.134.100-SNAPSHOT</version>
+    <version>3.135.0-SNAPSHOT</version>
     <packaging>eclipse-plugin</packaging>
 
     <properties>

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_custom_CTabFolder.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_custom_CTabFolder.java
@@ -14,6 +14,7 @@
 package org.eclipse.swt.tests.junit;
 
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -1047,6 +1048,207 @@ public void test_dirtyIndicator_closesWhenCloseEnabled() {
 	} catch (NoSuchFieldException | IllegalAccessException e) {
 		fail("Failed to access closeRect via reflection: " + e.getMessage());
 	}
+}
+
+@Test
+public void test_setItemOrder_reordersItems() {
+	createTabFolder(null, 4);
+	CTabItem[] original = ctabFolder.getItems();
+
+	// indices[i] is the index of the item that should move to position i
+	ctabFolder.setItemOrder(new int[] { 2, 0, 3, 1 });
+
+	CTabItem[] reordered = ctabFolder.getItems();
+	assertEquals(original[2], reordered[0]);
+	assertEquals(original[0], reordered[1]);
+	assertEquals(original[3], reordered[2]);
+	assertEquals(original[1], reordered[3]);
+}
+
+@Test
+public void test_setItemOrder_keepsSelection() {
+	createTabFolder(null, 4);
+	CTabItem selected = ctabFolder.getItem(1);
+	ctabFolder.setSelection(selected);
+	assertEquals(selected, ctabFolder.getSelection());
+
+	ctabFolder.setItemOrder(new int[] { 3, 1, 0, 2 });
+
+	// the same item must still be selected, with its index updated
+	assertEquals(selected, ctabFolder.getSelection());
+	assertEquals(1, ctabFolder.getSelectionIndex());
+	assertEquals(selected, ctabFolder.getItem(1));
+}
+
+@Test
+public void test_setItemOrder_identityIsNoOp() {
+	createTabFolder(null, 4);
+	CTabItem[] original = ctabFolder.getItems();
+	ctabFolder.setSelection(ctabFolder.getItem(2));
+
+	ctabFolder.setItemOrder(new int[] { 0, 1, 2, 3 });
+
+	assertArrayEquals(original, ctabFolder.getItems());
+	assertEquals(2, ctabFolder.getSelectionIndex());
+}
+
+@Test
+public void test_setItemOrder_chevronStillWorks() {
+	createTabFolder(null, 8);
+	shell.setSize(800, 200);
+	processEvents();
+	// shrink so that not all tabs fit and a chevron is required
+	showChevron();
+	processEvents();
+
+	CTabItem selected = ctabFolder.getItem(0);
+	ctabFolder.setSelection(selected);
+	processEvents();
+
+	// reverse the order
+	int n = ctabFolder.getItemCount();
+	int[] order = new int[n];
+	for (int i = 0; i < n; i++) {
+		order[i] = n - 1 - i;
+	}
+	ctabFolder.setItemOrder(order);
+	processEvents();
+
+	// the chevron must still be present and the internal book-keeping consistent
+	assertNotNull(getChevron(ctabFolder), "Chevron should still be shown after reordering");
+	assertEquals(selected, ctabFolder.getSelection());
+
+	int[] priority = reflection_getIntArray(ctabFolder, "priority");
+	assertTrue(isPermutation(priority, n), "priority[] must remain a permutation of item indices after reorder");
+	int firstIndex = reflection_getInt(ctabFolder, "firstIndex");
+	assertTrue(firstIndex >= -1 && firstIndex < n, "firstIndex must reference a valid item after reorder");
+
+	// no tabs / toolbar items overlap after the reorder
+	checkElementOverlap(ctabFolder);
+}
+
+@Test
+public void test_setItemOrder_errorCases() {
+	createTabFolder(null, 3);
+
+	assertThrows(IllegalArgumentException.class, () -> ctabFolder.setItemOrder(null),
+			"null argument must be rejected");
+	assertThrows(IllegalArgumentException.class, () -> ctabFolder.setItemOrder(new int[] { 0, 1 }),
+			"wrong-length array must be rejected");
+	assertThrows(IllegalArgumentException.class, () -> ctabFolder.setItemOrder(new int[] { 0, 1, 1 }),
+			"duplicate index must be rejected");
+	assertThrows(IllegalArgumentException.class, () -> ctabFolder.setItemOrder(new int[] { 0, 1, 3 }),
+			"out-of-range index must be rejected");
+	assertThrows(IllegalArgumentException.class, () -> ctabFolder.setItemOrder(new int[] { -1, 1, 2 }),
+			"negative index must be rejected");
+
+	// a rejected call must leave the existing order untouched
+	CTabItem[] original = ctabFolder.getItems();
+	assertThrows(IllegalArgumentException.class, () -> ctabFolder.setItemOrder(new int[] { 0, 1, 1 }));
+	assertArrayEquals(original, ctabFolder.getItems());
+}
+
+@Test
+public void test_moveItem_forward() {
+	createTabFolder(null, 5);
+	CTabItem[] original = ctabFolder.getItems();
+
+	// move item 1 to position 3 -> [0, 2, 3, 1, 4]
+	ctabFolder.moveItem(1, 3);
+
+	CTabItem[] reordered = ctabFolder.getItems();
+	assertArrayEquals(
+			new CTabItem[] { original[0], original[2], original[3], original[1], original[4] },
+			reordered);
+}
+
+@Test
+public void test_moveItem_backward() {
+	createTabFolder(null, 5);
+	CTabItem[] original = ctabFolder.getItems();
+
+	// move item 3 to position 0 -> [3, 0, 1, 2, 4]
+	ctabFolder.moveItem(3, 0);
+
+	CTabItem[] reordered = ctabFolder.getItems();
+	assertArrayEquals(
+			new CTabItem[] { original[3], original[0], original[1], original[2], original[4] },
+			reordered);
+}
+
+@Test
+public void test_moveItem_keepsSelection() {
+	createTabFolder(null, 5);
+	CTabItem selected = ctabFolder.getItem(1);
+	ctabFolder.setSelection(selected);
+
+	ctabFolder.moveItem(1, 3);
+
+	assertEquals(selected, ctabFolder.getSelection());
+	assertEquals(3, ctabFolder.getSelectionIndex());
+	assertEquals(selected, ctabFolder.getItem(3));
+}
+
+@Test
+public void test_moveItem_sameIndexIsNoOp() {
+	createTabFolder(null, 4);
+	CTabItem[] original = ctabFolder.getItems();
+	ctabFolder.setSelection(ctabFolder.getItem(2));
+
+	ctabFolder.moveItem(2, 2);
+
+	assertArrayEquals(original, ctabFolder.getItems());
+	assertEquals(2, ctabFolder.getSelectionIndex());
+}
+
+@Test
+public void test_moveItem_errorCases() {
+	createTabFolder(null, 3);
+
+	assertThrows(IllegalArgumentException.class, () -> ctabFolder.moveItem(-1, 0),
+			"negative from index must be rejected");
+	assertThrows(IllegalArgumentException.class, () -> ctabFolder.moveItem(3, 0),
+			"out-of-range from index must be rejected");
+	assertThrows(IllegalArgumentException.class, () -> ctabFolder.moveItem(0, -1),
+			"negative to index must be rejected");
+	assertThrows(IllegalArgumentException.class, () -> ctabFolder.moveItem(0, 3),
+			"out-of-range to index must be rejected");
+}
+
+private static int[] reflection_getIntArray(CTabFolder tabFolder, String fieldName) {
+	try {
+		Field field = CTabFolder.class.getDeclaredField(fieldName);
+		field.setAccessible(true);
+		return (int[]) field.get(tabFolder);
+	} catch (Exception e) {
+		fail("Failed to access " + fieldName + " via reflection: " + e.getMessage());
+		return null;
+	}
+}
+
+private static int reflection_getInt(CTabFolder tabFolder, String fieldName) {
+	try {
+		Field field = CTabFolder.class.getDeclaredField(fieldName);
+		field.setAccessible(true);
+		return field.getInt(tabFolder);
+	} catch (Exception e) {
+		fail("Failed to access " + fieldName + " via reflection: " + e.getMessage());
+		return -1;
+	}
+}
+
+private static boolean isPermutation(int[] values, int size) {
+	if (values.length != size) {
+		return false;
+	}
+	boolean[] seen = new boolean[size];
+	for (int value : values) {
+		if (value < 0 || value >= size || seen[value]) {
+			return false;
+		}
+		seen[value] = true;
+	}
+	return true;
 }
 
 }


### PR DESCRIPTION
Promotes the existing package-private `CTabFolder.setItemOrder(int[])` to public API so consumers such as the Terminal view (eclipse-platform/eclipse.platform#2679) can implement drag-to-reorder without disposing and recreating tab items. The Javadoc now mirrors the `Table.setColumnOrder(int[])` contract so the semantics are unambiguous: `indices[i]` is the index of the item that should move to position `i`.

The previous implementation only updated `selectedIndex`, which left the internal `priority[]` array and `firstIndex` field pointing at stale positions and could corrupt the chevron and visible-tab logic. The reorder now builds an old-to-new lookup and remaps both fields so the scroll/chevron state stays correct after a reorder.

It also adds `moveItem(int from, int to)`, an ergonomic primitive for the common single-tab drag gesture: it moves one item and shifts the rest, implemented on top of `setItemOrder` so the index bookkeeping lives in one place. This avoids forcing consumers to construct a full permutation array just to move a single tab.

No symmetric `getItemOrder()` was added: unlike `Table`, a `CTabFolder`'s item array is itself the canonical order, so a getter would always return the identity permutation. Consumers can derive the order via `getItems()` and `indexOf(...)`. Added unit tests covering reordering, single-item moves, selection preservation, chevron behaviour with overflow, and the documented error cases.