### PR TITLE
[Win32] Partially revert unnecessary creation of GC operations

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/GC.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/GC.java
@@ -6112,13 +6112,9 @@ int getZoom() {
 }
 
 private void storeAndApplyOperationForExistingHandle(Operation operation) {
+	removePreviousOperationIfSupercededBy(operation);
+	operations.add(operation);
 	operation.apply();
-	if (data.reapplicable) {
-		removePreviousOperationIfSupercededBy(operation);
-		operations.add(operation);
-	} else {
-		operation.disposeAll();
-	}
 }
 
 private void removePreviousOperationIfSupercededBy(Operation operation) {


### PR DESCRIPTION
The recent enhancement to avoid the unnecessary creation of GC operations
- https://github.com/eclipse-platform/eclipse.platform.swt/pull/3318

introduced a regression, which particularly manifests in broken rendering of CTabFolders. For an example in the Manifest editor, see the screenshots below.

The GC's `getClipping()` operation stores region handles representing the clipping region (potentially at different zooms) that is combined with the passed region object. The handles for that passed region object are created lazy, so that the clipping region handle needs to be stored until that point in time. Otherwise it will leads to failures when lazily creating the handle for the passed region later on. To avoid that the clipping handles are not available, this change reverts c6bf2e93607b64fa3670bfa63592c96c2919aa36 that introduced the immediate disposal of GC operations.

This is meant to be a temporary revert until a proper solution for the handling of clipping regions inside the GC is found.

Without this change:
<img width="566" height="587" alt="image" src="https://github.com/user-attachments/assets/1af4ab2f-70da-48d6-9548-67ba182ce219" />

With this change:
<img width="575" height="595" alt="image" src="https://github.com/user-attachments/assets/48f71257-bd71-44f2-b107-4a63cdde8336" />
