### PR TITLE
[Win32] Fix underline/strikeout styles lost for fallback fonts in GC

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/graphics/GCWin32Tests.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/graphics/GCWin32Tests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 Yatta Solutions
+ * Copyright (c) 2024, 2026 Yatta Solutions
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -14,6 +14,8 @@
 package org.eclipse.swt.graphics;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.concurrent.*;
 
@@ -61,5 +63,83 @@ class GCWin32Tests {
 		gc.getGCData().nativeZoom = zoom * scalingFactor;
 		gc.getGCData().lineWidth = 10;
 		assertEquals("Drawn elements should scale to the right value", gc.getGCData().lineWidth, gc.getLineWidth() * scalingFactor, 0);
+	}
+
+	/**
+	 * Verifies that underline and strikeout styles requested via a font's
+	 * {@link FontData} are preserved when GDI+ cannot find the font family and
+	 * constructs a substitute font from the {@code LOGFONT} fields instead.
+	 * <p>
+	 * "Courier" (without "New") is used because it is a legacy GDI font whose
+	 * family is not available in GDI+, triggering the fallback. The fallback
+	 * remaps it to "Courier New", which is available to both GDI and GDI+,
+	 * ensuring that glyph rendering remains consistent between the two.
+	 * <p>
+	 * The test string includes U+FFFE, a Unicode non-character with no glyph in
+	 * any standard font. Its absence forces SWT to use the GDI+ rendering path
+	 * that honours the font's underline and strikeout decoration; the path used
+	 * for plain ASCII text does not render those decorations. Advanced (GDI+)
+	 * mode must be enabled on the GC so the fallback font's style flags are
+	 * applied at all.
+	 *
+	 * @see <a href="https://github.com/eclipse-platform/eclipse.platform.swt/issues/2978">Issue 2978</a>
+	 */
+	@Test
+	public void fallbackFontPreservesUnderlineAndStrikeout() {
+		Display display = Display.getDefault();
+		Font normalFont = new Font(display, "Courier", 24, SWT.NORMAL);
+		FontData underlineFD = new FontData("Courier", 24, SWT.NORMAL);
+		underlineFD.data.lfUnderline = 1;
+		Font underlineFont = new Font(display, underlineFD);
+		FontData strikeoutFD = new FontData("Courier", 24, SWT.NORMAL);
+		strikeoutFD.data.lfStrikeOut = 1;
+		Font strikeoutFont = new Font(display, strikeoutFD);
+		Image testImage = new Image(display, 400, 100);
+		try {
+			// U+FFFE has no glyph in any standard font; forces the rendering path
+			// that honours font decoration flags such as underline and strikeout.
+			String testString = "Hello" + (char) 0xFFFE;
+			int normalPixelCount = renderTextAndCountNonWhitePixels(testImage, normalFont, testString);
+			int underlinePixelCount = renderTextAndCountNonWhitePixels(testImage, underlineFont, testString);
+			int strikeoutPixelCount = renderTextAndCountNonWhitePixels(testImage, strikeoutFont, testString);
+			assertAll(
+				() -> assertTrue(underlinePixelCount > normalPixelCount,
+					"Underline font via fallback path should produce more pixels than normal font. "
+					+ "Normal: " + normalPixelCount + ", Underline: " + underlinePixelCount),
+				() -> assertTrue(strikeoutPixelCount > normalPixelCount,
+					"Strikeout font via fallback path should produce more pixels than normal font. "
+					+ "Normal: " + normalPixelCount + ", Strikeout: " + strikeoutPixelCount)
+			);
+		} finally {
+			normalFont.dispose();
+			underlineFont.dispose();
+			strikeoutFont.dispose();
+			testImage.dispose();
+		}
+	}
+
+	private static int renderTextAndCountNonWhitePixels(Image target, Font font, String text) {
+		GC testGC = new GC(target);
+		try {
+			testGC.setAdvanced(true); // required so font style flags (underline, strikeout) are applied during rendering
+			testGC.setBackground(new Color(255, 255, 255));
+			testGC.fillRectangle(target.getBounds());
+			testGC.setForeground(new Color(0, 0, 0));
+			testGC.setFont(font);
+			testGC.drawText(text, 5, 5);
+		} finally {
+			testGC.dispose();
+		}
+		ImageData imageData = target.getImageData(DPIUtil.getDeviceZoom());
+		int count = 0;
+		for (int y = 0; y < imageData.height; y++) {
+			for (int x = 0; x < imageData.width; x++) {
+				RGB rgb = imageData.palette.getRGB(imageData.getPixel(x, y));
+				if (rgb.red != 255 || rgb.green != 255 || rgb.blue != 255) {
+					count++;
+				}
+			}
+		}
+		return count;
 	}
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/GC.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/GC.java
@@ -650,6 +650,8 @@ static long createGdipFont(long hDC, long hFont, long graphics, long fontCollect
 		int style = Gdip.FontStyleRegular;
 		if (logFont.lfWeight == 700) style |= Gdip.FontStyleBold;
 		if (logFont.lfItalic != 0) style |= Gdip.FontStyleItalic;
+		if (logFont.lfUnderline != 0) style |= Gdip.FontStyleUnderline;
+		if (logFont.lfStrikeOut != 0) style |= Gdip.FontStyleStrikeout;
 		char[] chars = logFont.lfFaceName;
 		int index = 0;
 		while (index < chars.length) {


### PR DESCRIPTION
## Summary

When GDI+ cannot find a requested font family and falls back to constructing a substitute font from the `LOGFONT` fields, the underline and strikeout style flags (`lfUnderline`, `lfStrikeOut`) were silently ignored. Text drawn with such a fallback font would render without those decorations even when explicitly requested.

The fix maps `lfUnderline` → `FontStyleUnderline` and `lfStrikeOut` → `FontStyleStrikeout` in the fallback-font style computation inside `GC.createGdipFont()`.

A regression test (`GCWin32Tests.fallbackFontPreservesUnderlineAndStrikeout`) verifies the fix by comparing pixel counts of text rendered with plain, underline, and strikeout fonts through the fallback path; the decorated variants must produce
more pixels than the plain one.

See https://github.com/eclipse-platform/eclipse.platform.swt/issues/2978

🤖 Generated with [Claude Code](https://claude.com/claude-code)