### PR TITLE
[Edge] Allow SSO with primary account by default

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Browser/win32/org/eclipse/swt/browser/Edge.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Browser/win32/org/eclipse/swt/browser/Edge.java
@@ -611,7 +611,7 @@ WebViewEnvironment createEnvironment() {
 	String browserArgs = System.getProperty(BROWSER_ARGS_PROP);
 	String language = System.getProperty(LANGUAGE_PROP);
 
-	boolean allowSSO = Boolean.getBoolean(ALLOW_SINGLE_SIGN_ON_USING_OS_PRIMARY_ACCOUNT_PROP);
+	boolean allowSSO = !"false".equalsIgnoreCase(System.getProperty(ALLOW_SINGLE_SIGN_ON_USING_OS_PRIMARY_ACCOUNT_PROP));
 
 	String dataDir = getDataDir(display);
 

--- a/bundles/org.eclipse.swt/Readme.WebView2.md
+++ b/bundles/org.eclipse.swt/Readme.WebView2.md
@@ -67,7 +67,9 @@ language+country code that defines the browser UI language and preferred
 language for HTTP requests (`Accept-Languages` header).
 Example values: `en`, `ja`, `en-GB`, `de-AT`.
 
-The property `org.eclipse.swt.browser.Edge.allowSingleSignOnUsingOSPrimaryAccount` enables Single Sign-On with Azure Active Directory (AAD) resources using the logged-in Windows account. This also enables SSO with websites using Microsoft accounts associated with the Windows login. Setting this property to true enables this feature. The default value is false.
+The WebView2 runtime in SWT automatically enables Single Sign-On with Azure Active Directory (AAD) resources using the logged-in Windows account.
+This also enables SSO with websites using Microsoft accounts associated with the Windows login.
+This feature can be disabled by setting the system property `org.eclipse.swt.browser.EdgeAllowSingleSignOnUsingOSPrimaryAccount` to `false`.
 
 See also: https://learn.microsoft.com/en-us/dotnet/api/microsoft.web.webview2.core.corewebview2environmentoptions.allowsinglesignonusingosprimaryaccount
 


### PR DESCRIPTION
The WebView feature to allow SSO has been made accessible but disabled by default. With this change, the feature is enabled by default, still allowing to opt-out via system property. This aligns with the previous behavior of the IE engine.

Fixes https://github.com/eclipse-platform/eclipse.platform.swt/issues/2658