### PR TITLE
[Win32] Suppress deprecation warnings in IE implementation

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Browser/win32/org/eclipse/swt/browser/IE.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Browser/win32/org/eclipse/swt/browser/IE.java
@@ -2017,6 +2017,7 @@ void hookDOMListeners(OleAutomation webBrowser, final boolean isTop) {
 	documents = newDocuments;
 }
 
+@SuppressWarnings("deprecation")
 void unhookDOMListeners(OleAutomation[] documents) {
 	char[] buffer = (COM.IIDIHTMLDocumentEvents2 + '\0').toCharArray();
 	GUID guid = new GUID();


### PR DESCRIPTION
The IE implementation uses deprecated methods from OleClientSite for removing event listener. There does not seem to be any intent in actually removing that method. Since IE is EOL, there is no need to updating that code to something else either. Thus, this silences the internal deprecation warnings as it does not provide any useful information.

<img width="375" height="254" alt="image" src="https://github.com/user-attachments/assets/11baf22e-e60c-484c-80d4-91f209d80fb2" />
