### PR TITLE
[Win32] Remove obsolete codePage parameter from TCHAR constructors

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Browser/win32/org/eclipse/swt/browser/IE.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Browser/win32/org/eclipse/swt/browser/IE.java
@@ -154,13 +154,13 @@ class IE extends WebBrowser {
 		};
 
 		NativeGetCookie = () -> {
-			TCHAR url = new TCHAR (0, CookieUrl, true);
-			TCHAR cookieData = new TCHAR (0, 8192);
+			TCHAR url = new TCHAR (CookieUrl, true);
+			TCHAR cookieData = new TCHAR (8192);
 			int[] size = new int[] {cookieData.length ()};
 			if (!OS.InternetGetCookie (url, null, cookieData, size)) {
 				/* original cookieData size was not large enough */
 				size[0] /= TCHAR.sizeof;
-				cookieData = new TCHAR (0, size[0]);
+				cookieData = new TCHAR (size[0]);
 				if (!OS.InternetGetCookie (url, null, cookieData, size)) return;
 			}
 			String allCookies = cookieData.toString (0, size[0]);
@@ -179,8 +179,8 @@ class IE extends WebBrowser {
 		};
 
 		NativeSetCookie = () -> {
-			TCHAR url = new TCHAR (0, CookieUrl, true);
-			TCHAR value = new TCHAR (0, CookieValue, true);
+			TCHAR url = new TCHAR (CookieUrl, true);
+			TCHAR value = new TCHAR (CookieValue, true);
 			CookieResult = OS.InternetSetCookie (url, null, value);
 		};
 
@@ -191,18 +191,18 @@ class IE extends WebBrowser {
 		* IE releases prior to IE10).  Check this value in order to determine
 		* version-specific features that can be enabled.
 		*/
-		TCHAR key = new TCHAR (0, "Software\\Microsoft\\Internet Explorer", true);	//$NON-NLS-1$
+		TCHAR key = new TCHAR ("Software\\Microsoft\\Internet Explorer", true);	//$NON-NLS-1$
 		long [] phkResult = new long [1];
 		if (OS.RegOpenKeyEx (OS.HKEY_LOCAL_MACHINE, key, 0, OS.KEY_READ, phkResult) == 0) {
 			int [] lpcbData = new int [1];
-			TCHAR buffer = new TCHAR (0, "svcVersion", true); //$NON-NLS-1$
+			TCHAR buffer = new TCHAR ("svcVersion", true); //$NON-NLS-1$
 			int result = OS.RegQueryValueEx (phkResult [0], buffer, 0, null, (TCHAR) null, lpcbData);
 			if (result != 0) {
-				buffer = new TCHAR (0, "Version", true); //$NON-NLS-1$
+				buffer = new TCHAR ("Version", true); //$NON-NLS-1$
 				result = OS.RegQueryValueEx (phkResult [0], buffer, 0, null, (TCHAR) null, lpcbData);
 			}
 			if (result == 0) {
-				TCHAR lpData = new TCHAR (0, lpcbData [0] / TCHAR.sizeof);
+				TCHAR lpData = new TCHAR (lpcbData [0] / TCHAR.sizeof);
 				result = OS.RegQueryValueEx (phkResult [0], buffer, 0, null, lpData, lpcbData);
 				if (result == 0) {
 					String versionString = lpData.toString (0, lpData.strlen ());
@@ -231,19 +231,19 @@ class IE extends WebBrowser {
 		* If it is detected in the registry to be Shell.Explorer.1 then change the progId that
 		* will be embedded to explicitly specify Shell.Explorer.2.
 		*/
-		key = new TCHAR (0, "Shell.Explorer\\CLSID", true);	//$NON-NLS-1$
+		key = new TCHAR ("Shell.Explorer\\CLSID", true);	//$NON-NLS-1$
 		phkResult = new long [1];
 		if (OS.RegOpenKeyEx (OS.HKEY_CLASSES_ROOT, key, 0, OS.KEY_READ, phkResult) == 0) {
 			int [] lpcbData = new int [1];
 			int result = OS.RegQueryValueEx (phkResult [0], null, 0, null, (TCHAR) null, lpcbData);
 			if (result == 0) {
-				TCHAR lpData = new TCHAR (0, lpcbData [0] / TCHAR.sizeof);
+				TCHAR lpData = new TCHAR (lpcbData [0] / TCHAR.sizeof);
 				result = OS.RegQueryValueEx (phkResult [0], null, 0, null, lpData, lpcbData);
 				if (result == 0) {
 					String clsid = lpData.toString (0, lpData.strlen ());
 					if (clsid.equals (CLSID_SHELLEXPLORER1)) {
 						/* Shell.Explorer.1 is the default, ensure that Shell.Explorer.2 is available */
-						key = new TCHAR (0, "Shell.Explorer.2", true);	//$NON-NLS-1$
+						key = new TCHAR ("Shell.Explorer.2", true);	//$NON-NLS-1$
 						long [] phkResult2 = new long [1];
 						if (OS.RegOpenKeyEx (OS.HKEY_CLASSES_ROOT, key, 0, OS.KEY_READ, phkResult2) == 0) {
 							/* specify that Shell.Explorer.2 is to be used */
@@ -322,14 +322,14 @@ public void create(Composite parent, int style) {
 
 		if (version != -1) {
 			long[] key = new long[1];
-			final TCHAR subkey = new TCHAR(0, "Software\\Microsoft\\Internet Explorer\\Main\\FeatureControl\\FEATURE_BROWSER_EMULATION", true);	//$NON-NLS-1$
+			final TCHAR subkey = new TCHAR("Software\\Microsoft\\Internet Explorer\\Main\\FeatureControl\\FEATURE_BROWSER_EMULATION", true);	//$NON-NLS-1$
 			if (OS.RegCreateKeyEx(OS.HKEY_CURRENT_USER, subkey, 0, null, OS.REG_OPTION_VOLATILE, OS.KEY_WRITE | OS.KEY_QUERY_VALUE, 0, key, null) == 0) {
-				TCHAR lpszFile = new TCHAR(0, OS.MAX_PATH);
+				TCHAR lpszFile = new TCHAR(OS.MAX_PATH);
 				OS.GetModuleFileName(0, lpszFile, lpszFile.length());
 				String path = lpszFile.toString(0, lpszFile.strlen());
 				int index = path.lastIndexOf(SEPARATOR_OS);
 				String executable = index != -1 ? path.substring(index + 1) : path;
-				final TCHAR lpValueName = new TCHAR(0, executable, true);
+				final TCHAR lpValueName = new TCHAR(executable, true);
 				/*
 				 * Program name & IE version entry is added to the Windows
 				 * registry and same gets deleted during the dispose cycle.
@@ -496,8 +496,8 @@ public void create(Composite parent, int style) {
 					* case is detected and the string is changed to be a proper url string.
 					*/
 					if (url1.indexOf(":/") == -1 && url1.indexOf(":\\") != -1) { //$NON-NLS-1$ //$NON-NLS-2$
-						TCHAR filePath1 = new TCHAR(0, url1, true);
-						TCHAR urlResult1 = new TCHAR(0, OS.INTERNET_MAX_URL_LENGTH);
+						TCHAR filePath1 = new TCHAR(url1, true);
+						TCHAR urlResult1 = new TCHAR(OS.INTERNET_MAX_URL_LENGTH);
 						int[] size1 = new int[] {urlResult1.length()};
 						if (OS.UrlCreateFromPath(filePath1, urlResult1, size1, 0) == COM.S_OK) {
 							url1 = urlResult1.toString(0, size1[0]);
@@ -580,8 +580,8 @@ public void create(Composite parent, int style) {
 					* case is detected and the string is changed to be a proper url string.
 					*/
 					if (url2.indexOf(":/") == -1 && url2.indexOf(":\\") != -1) { //$NON-NLS-1$ //$NON-NLS-2$
-						TCHAR filePath2 = new TCHAR(0, url2, true);
-						TCHAR urlResult2 = new TCHAR(0, OS.INTERNET_MAX_URL_LENGTH);
+						TCHAR filePath2 = new TCHAR(url2, true);
+						TCHAR urlResult2 = new TCHAR(OS.INTERNET_MAX_URL_LENGTH);
 						int[] size2 = new int[] {urlResult2.length()};
 						if (OS.UrlCreateFromPath(filePath2, urlResult2, size2, 0) == COM.S_OK) {
 							url2 = urlResult2.toString(0, size2[0]);

--- a/bundles/org.eclipse.swt/Eclipse SWT Browser/win32/org/eclipse/swt/browser/WebSite.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Browser/win32/org/eclipse/swt/browser/WebSite.java
@@ -693,11 +693,11 @@ int Authenticate (long hwnd, long szUsername, long szPassword) {
 		authenticationListener.authenticate (event);
 		if (!event.doit) return COM.E_ACCESSDENIED;
 		if (event.user != null && event.password != null) {
-			TCHAR user = new TCHAR (0, event.user, true);
+			TCHAR user = new TCHAR (event.user, true);
 			int size = user.length () * TCHAR.sizeof;
 			long userPtr = OS.CoTaskMemAlloc (size);
 			OS.MoveMemory (userPtr, user, size);
-			TCHAR password = new TCHAR (0, event.password, true);
+			TCHAR password = new TCHAR (event.password, true);
 			size = password.length () * TCHAR.sizeof;
 			long passwordPtr = OS.CoTaskMemAlloc (size);
 			OS.MoveMemory (passwordPtr, password, size);

--- a/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/win32/org/eclipse/swt/dnd/Clipboard.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/win32/org/eclipse/swt/dnd/Clipboard.java
@@ -72,7 +72,7 @@ public Clipboard(Display display) {
 		DND.error(SWT.ERROR_THREAD_INVALID_ACCESS);
 	}
 	this.display = display;
-	TCHAR chFormatName = new TCHAR(0, "Preferred DropEffect", true); //$NON-NLS-1$
+	TCHAR chFormatName = new TCHAR("Preferred DropEffect", true); //$NON-NLS-1$
 	CFSTR_PREFERREDDROPEFFECT = OS.RegisterClipboardFormat(chFormatName);
 	createCOMInterfaces();
 	this.AddRef();

--- a/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/win32/org/eclipse/swt/dnd/DragSource.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/win32/org/eclipse/swt/dnd/DragSource.java
@@ -123,7 +123,7 @@ public class DragSource extends Widget {
 
 	static final String DEFAULT_DRAG_SOURCE_EFFECT = "DEFAULT_DRAG_SOURCE_EFFECT"; //$NON-NLS-1$
 	static final int CFSTR_PERFORMEDDROPEFFECT  = Transfer.registerType("Performed DropEffect");	 //$NON-NLS-1$
-	static final TCHAR WindowClass = new TCHAR (0, "#32770", true);
+	static final TCHAR WindowClass = new TCHAR ("#32770", true);
 
 	private class COMIDropSource extends COMObject {
 

--- a/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/win32/org/eclipse/swt/dnd/FileTransfer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/win32/org/eclipse/swt/dnd/FileTransfer.java
@@ -173,7 +173,7 @@ private long generateCidaFromFilepaths(String[] fileNames) {
 		int[] pidlSizes = new int[n];
 		int pidlSizeSum = 2; // initialize with 2 for the empty (but double null terminated) parent pidl
 		for (int i = 0; i < n; i++) {
-			TCHAR szfileName = new TCHAR(0, fileNames[i], true);
+			TCHAR szfileName = new TCHAR(fileNames[i], true);
 			long [] ppv = new long [1];
 			int hr = COM.PathToPIDL(szfileName.chars, ppv);
 			if (hr != OS.S_OK) {

--- a/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/win32/org/eclipse/swt/dnd/TableDragSourceEffect.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/win32/org/eclipse/swt/dnd/TableDragSourceEffect.java
@@ -85,7 +85,7 @@ public class TableDragSourceEffect extends DragSourceEffect {
 		if (dragSourceImage != null) dragSourceImage.dispose();
 		dragSourceImage = null;
 		SHDRAGIMAGE shdi = new SHDRAGIMAGE();
-		int DI_GETDRAGIMAGE = OS.RegisterWindowMessage (new TCHAR (0, "ShellGetDragImage", true)); //$NON-NLS-1$
+		int DI_GETDRAGIMAGE = OS.RegisterWindowMessage (new TCHAR ("ShellGetDragImage", true)); //$NON-NLS-1$
 		if (OS.SendMessage (control.handle, DI_GETDRAGIMAGE, 0, shdi) != 0) {
 			if ((control.getStyle() & SWT.MIRRORED) != 0) {
 				event.offsetX = shdi.sizeDragImage.cx - shdi.ptOffset.x;

--- a/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/win32/org/eclipse/swt/dnd/Transfer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/win32/org/eclipse/swt/dnd/Transfer.java
@@ -159,7 +159,7 @@ public static int registerType(String formatName) {
 	// Look name up in the registry
 	// If name is not in registry, add it and return assigned value.
 	// If name already exists in registry, return its assigned value
-	TCHAR chFormatName = new TCHAR(0, formatName, true);
+	TCHAR chFormatName = new TCHAR(formatName, true);
 	return OS.RegisterClipboardFormat(chFormatName);
 }
 

--- a/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/win32/org/eclipse/swt/dnd/TreeDragSourceEffect.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/win32/org/eclipse/swt/dnd/TreeDragSourceEffect.java
@@ -84,7 +84,7 @@ public class TreeDragSourceEffect extends DragSourceEffect {
 		if (dragSourceImage != null) dragSourceImage.dispose();
 		dragSourceImage = null;
 		SHDRAGIMAGE shdi = new SHDRAGIMAGE();
-		int DI_GETDRAGIMAGE = OS.RegisterWindowMessage (new TCHAR (0, "ShellGetDragImage", true)); //$NON-NLS-1$
+		int DI_GETDRAGIMAGE = OS.RegisterWindowMessage (new TCHAR ("ShellGetDragImage", true)); //$NON-NLS-1$
 		if (OS.SendMessage (control.handle, DI_GETDRAGIMAGE, 0, shdi) != 0) {
 			if ((control.getStyle() & SWT.MIRRORED) != 0) {
 				event.offsetX = shdi.sizeDragImage.cx - shdi.ptOffset.x;

--- a/bundles/org.eclipse.swt/Eclipse SWT OLE Win32/win32/org/eclipse/swt/ole/win32/OLE.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT OLE Win32/win32/org/eclipse/swt/ole/win32/OLE.java
@@ -374,17 +374,17 @@ public static String findProgramID (String extension) {
 
 	if (extension.charAt (0) != '.') extension = "." + extension; //$NON-NLS-1$
 
-	TCHAR extensionKey = new TCHAR(0, extension, true);
+	TCHAR extensionKey = new TCHAR(extension, true);
 	String result = getKeyValue(extensionKey);
 	if (result != null) {
 		// look for "<programID>\NotInsertable"
-		TCHAR notInsertableKey = new TCHAR(0, result+"\\NotInsertable", true); //$NON-NLS-1$
+		TCHAR notInsertableKey = new TCHAR(result+"\\NotInsertable", true); //$NON-NLS-1$
 		if (getKeyExists(notInsertableKey)) return ""; //$NON-NLS-1$
 		// look for "<programID>\Insertable"
-		TCHAR insertableKey = new TCHAR(0, result+"\\Insertable", true); //$NON-NLS-1$
+		TCHAR insertableKey = new TCHAR(result+"\\Insertable", true); //$NON-NLS-1$
 		if (getKeyExists(insertableKey)) return result;
 		// look for "<programID>\protocol\StdFileEditing\server"
-		TCHAR serverKey = new TCHAR(0, result+"\\protocol\\StdFileEditing\\server", true); //$NON-NLS-1$
+		TCHAR serverKey = new TCHAR(result+"\\protocol\\StdFileEditing\\server", true); //$NON-NLS-1$
 		if (getKeyExists(serverKey)) return result;
 	}
 
@@ -402,7 +402,7 @@ static String getKeyValue (TCHAR key) {
 		if (length == 0) {
 			result = "";
 		} else {
-			TCHAR lpData = new TCHAR (0, length);
+			TCHAR lpData = new TCHAR (length);
 			if (OS.RegQueryValueEx (phkResult [0], null, 0, null, lpData, lpcbData) == 0) {
 				length = Math.max(0, lpData.length () - 1);
 				result = lpData.toString (0, length);

--- a/bundles/org.eclipse.swt/Eclipse SWT OLE Win32/win32/org/eclipse/swt/ole/win32/OleControlSite.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT OLE Win32/win32/org/eclipse/swt/ole/win32/OleControlSite.java
@@ -737,7 +737,7 @@ void onFocusOut(Event e) {
 	OS.GetGUIThreadInfo(threadId, lpgui1);
 	objIOleInPlaceObject.UIDeactivate();
 	if (SWT_RESTORECARET == 0) {
-		SWT_RESTORECARET = OS.RegisterWindowMessage (new TCHAR (0, "SWT_RESTORECARET", true));
+		SWT_RESTORECARET = OS.RegisterWindowMessage (new TCHAR ("SWT_RESTORECARET", true));
 	}
 	if (lpgui1.hwndCaret != 0) {
 		GUITHREADINFO lpgui2 = new GUITHREADINFO();

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/win32/org/eclipse/swt/internal/win32/OS.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/win32/org/eclipse/swt/internal/win32/OS.java
@@ -290,7 +290,6 @@ public class OS extends C {
 	public static final int COLOR_WINDOWFRAME = 0x6;
 	public static final int COLOR_WINDOWTEXT = 0x8;
 	public static final int COMPLEXREGION = 0x3;
-	public static final int CP_ACP = 0x0;
 	public static final int CP_UTF8 = 65001;
 	public static final int CP_DROPDOWNBUTTON = 1;
 	public static final int CPS_COMPLETE = 0x1;
@@ -2130,8 +2129,8 @@ public static final int[] readRegistryDwords(int hkeyLocation, String key, Strin
 	Objects.requireNonNull(key, "key");
 	Objects.requireNonNull(valueName, "valueName");
 	long[] phkResult = new long[1];
-	TCHAR regKey = new TCHAR(0, key, true);
-	TCHAR lpValueName = new TCHAR(0, valueName, true);
+	TCHAR regKey = new TCHAR(key, true);
+	TCHAR lpValueName = new TCHAR(valueName, true);
 	if (OS.RegOpenKeyEx(hkeyLocation, regKey, 0, OS.KEY_READ, phkResult) != 0) {
 		return null; // Registry entry not found
 	}

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/win32/org/eclipse/swt/internal/win32/TCHAR.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/win32/org/eclipse/swt/internal/win32/TCHAR.java
@@ -16,12 +16,8 @@ package org.eclipse.swt.internal.win32;
 import java.util.Arrays;
 
 /**
- * This class implements the conversions between unicode characters
- * and the <em>platform supported</em> representation for characters.
- * <p>
- * Note that unicode characters which can not be found in the platform
- * encoding will be converted to an arbitrary platform specific character.
- * </p>
+ * A char[] buffer wrapper with optional null-terminator support,
+ * used to pass Java strings to Win32 Unicode (W) APIs via JNI.
  *
  * @jniclass flags=no_gen
  */
@@ -30,15 +26,15 @@ public class TCHAR {
 
 public final static int sizeof = 2;
 
-public TCHAR (int codePage, int length) {
+public TCHAR (int length) {
 	chars = new char [length];
 }
 
-public TCHAR (int codePage, char ch, boolean terminate) {
-	this (codePage, terminate ? new char [] {ch, '\0'} : new char [] {ch}, false);
+public TCHAR (char ch, boolean terminate) {
+	this (terminate ? new char [] {ch, '\0'} : new char [] {ch}, false);
 }
 
-public TCHAR (int codePage, char [] chars, boolean terminate) {
+public TCHAR (char [] chars, boolean terminate) {
 	int charCount = chars.length;
 	if (terminate) {
 		if (charCount == 0 || (charCount > 0 && chars [charCount - 1] != 0)) {
@@ -50,8 +46,8 @@ public TCHAR (int codePage, char [] chars, boolean terminate) {
 	this.chars = chars;
 }
 
-public TCHAR (int codePage, String string, boolean terminate) {
-	this (codePage, getChars (string, terminate), false);
+public TCHAR (String string, boolean terminate) {
+	this (getChars (string, terminate), false);
 }
 
 static char [] getChars (String string, boolean terminate) {

--- a/bundles/org.eclipse.swt/Eclipse SWT Printing/win32/org/eclipse/swt/printing/PDFDocument.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Printing/win32/org/eclipse/swt/printing/PDFDocument.java
@@ -263,8 +263,8 @@ public final class PDFDocument extends Device {
 		this.actualHeightInPoints = bestMatch.heightInPoints;
 
 		// Create printer DC for "Microsoft Print to PDF"
-		TCHAR driver = new TCHAR(0, "WINSPOOL", true);
-		TCHAR deviceName = new TCHAR(0, PDF_PRINTER_NAME, true);
+		TCHAR driver = new TCHAR("WINSPOOL", true);
+		TCHAR deviceName = new TCHAR(PDF_PRINTER_NAME, true);
 
 		// Get printer settings
 		long[] hPrinter = new long[1];
@@ -305,14 +305,14 @@ public final class PDFDocument extends Device {
 			long hHeap = OS.GetProcessHeap();
 
 			// Set output filename
-			TCHAR buffer = new TCHAR(0, filename, true);
+			TCHAR buffer = new TCHAR(filename, true);
 			int byteCount = buffer.length() * TCHAR.sizeof;
 			long lpszOutput = OS.HeapAlloc(hHeap, OS.HEAP_ZERO_MEMORY, byteCount);
 			OS.MoveMemory(lpszOutput, buffer, byteCount);
 			di.lpszOutput = lpszOutput;
 
 			// Set document name
-			TCHAR docName = new TCHAR(0, "SWT PDF Document", true);
+			TCHAR docName = new TCHAR("SWT PDF Document", true);
 			int docByteCount = docName.length() * TCHAR.sizeof;
 			long lpszDocName = OS.HeapAlloc(hHeap, OS.HEAP_ZERO_MEMORY, docByteCount);
 			OS.MoveMemory(lpszDocName, docName, docByteCount);

--- a/bundles/org.eclipse.swt/Eclipse SWT Printing/win32/org/eclipse/swt/printing/PrintDialog.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Printing/win32/org/eclipse/swt/printing/PrintDialog.java
@@ -32,7 +32,7 @@ import org.eclipse.swt.widgets.*;
  * @noextend This class is not intended to be subclassed by clients.
  */
 public class PrintDialog extends Dialog {
-	static final TCHAR DialogClass = new TCHAR (0, "#32770", true);
+	static final TCHAR DialogClass = new TCHAR ("#32770", true);
 	PrinterData printerData = new PrinterData();
 
 /**
@@ -335,7 +335,7 @@ public PrinterData open() {
 		}
 		if (success) {
 			/* Initialize PRINTDLG DEVNAMES for the specified printer. */
-			TCHAR buffer = new TCHAR(0, printerData.name, true);
+			TCHAR buffer = new TCHAR(printerData.name, true);
 			int size = buffer.length() * TCHAR.sizeof;
 			short[] offsets = new short[4]; // DEVNAMES (4 offsets)
 			int offsetsSize = offsets.length * 2; // 2 bytes each

--- a/bundles/org.eclipse.swt/Eclipse SWT Printing/win32/org/eclipse/swt/printing/Printer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Printing/win32/org/eclipse/swt/printing/Printer.java
@@ -72,9 +72,9 @@ public final class Printer extends Device {
 	static TCHAR appName;
 	static TCHAR keyName;
 	static {
-		profile = new TCHAR(0, "PrinterPorts", true); //$NON-NLS-1$
-		appName = new TCHAR(0, "windows", true); //$NON-NLS-1$
-		keyName = new TCHAR(0, "device", true); //$NON-NLS-1$
+		profile = new TCHAR("PrinterPorts", true); //$NON-NLS-1$
+		appName = new TCHAR("windows", true); //$NON-NLS-1$
+		keyName = new TCHAR("device", true); //$NON-NLS-1$
 	}
 
 /**
@@ -86,8 +86,8 @@ public final class Printer extends Device {
  */
 public static PrinterData[] getPrinterList() {
 	int length = 1024;
-	TCHAR buf = new TCHAR(0, length);
-	TCHAR nullBuf = new TCHAR(0, 1);
+	TCHAR buf = new TCHAR(length);
+	TCHAR nullBuf = new TCHAR(1);
 	int n = OS.GetProfileString(profile, null, nullBuf, buf, length);
 	if (n == 0) return new PrinterData[0];
 	String[] deviceNames = new String[5];
@@ -109,7 +109,7 @@ public static PrinterData[] getPrinterList() {
 	for (int p = 0; p < nameCount; p++) {
 		String device = deviceNames[p];
 		String driver = ""; //$NON-NLS-1$
-		if (OS.GetProfileString(profile, new TCHAR(0, device, true), nullBuf, buf, length) > 0) {
+		if (OS.GetProfileString(profile, new TCHAR(device, true), nullBuf, buf, length) > 0) {
 			int commaIndex = 0;
 			while (buf.tcharAt(commaIndex) != ',' && commaIndex < length) commaIndex++;
 			if (commaIndex < length) {
@@ -133,8 +133,8 @@ public static PrinterData[] getPrinterList() {
 public static PrinterData getDefaultPrinterData() {
 	String deviceName = null;
 	int length = 1024;
-	TCHAR buf = new TCHAR(0, length);
-	TCHAR nullBuf = new TCHAR(0, 1);
+	TCHAR buf = new TCHAR(length);
+	TCHAR nullBuf = new TCHAR(1);
 	int n = OS.GetProfileString(appName, keyName, nullBuf, buf, length);
 	if (n == 0) return null;
 	int commaIndex = 0;
@@ -144,7 +144,7 @@ public static PrinterData getDefaultPrinterData() {
 	}
 	if (deviceName == null) return null;
 	String driver = ""; //$NON-NLS-1$
-	if (OS.GetProfileString(profile, new TCHAR(0, deviceName, true), nullBuf, buf, length) > 0) {
+	if (OS.GetProfileString(profile, new TCHAR(deviceName, true), nullBuf, buf, length) > 0) {
 		commaIndex = 0;
 		while (buf.tcharAt(commaIndex) != ',' && commaIndex < length) commaIndex++;
 		if (commaIndex < length) {
@@ -213,8 +213,8 @@ public Printer(PrinterData data) {
 @Override
 protected void create(DeviceData deviceData) {
 	data = (PrinterData)deviceData;
-	TCHAR driver = new TCHAR(0, data.driver, true);
-	TCHAR device = new TCHAR(0, data.name, true);
+	TCHAR driver = new TCHAR(data.driver, true);
+	TCHAR device = new TCHAR(data.name, true);
 	long lpInitData = 0;
 	byte devmodeData [] = data.otherData;
 	long hHeap = OS.GetProcessHeap();
@@ -364,7 +364,7 @@ public boolean startJob(String jobName) {
 	long hHeap = OS.GetProcessHeap();
 	long lpszDocName = 0;
 	if (jobName != null && jobName.length() != 0) {
-		TCHAR buffer = new TCHAR(0, jobName, true);
+		TCHAR buffer = new TCHAR(jobName, true);
 		int byteCount = buffer.length() * TCHAR.sizeof;
 		lpszDocName = OS.HeapAlloc(hHeap, OS.HEAP_ZERO_MEMORY, byteCount);
 		OS.MoveMemory(lpszDocName, buffer, byteCount);
@@ -376,7 +376,7 @@ public boolean startJob(String jobName) {
 			/* Prompt the user for a file name. */
 			data.fileName = "FILE:"; //$NON-NLS-1$
 		}
-		TCHAR buffer = new TCHAR(0, data.fileName, true);
+		TCHAR buffer = new TCHAR(data.fileName, true);
 		int byteCount = buffer.length() * TCHAR.sizeof;
 		lpszOutput = OS.HeapAlloc(hHeap, OS.HEAP_ZERO_MEMORY, byteCount);
 		OS.MoveMemory(lpszOutput, buffer, byteCount);

--- a/bundles/org.eclipse.swt/Eclipse SWT Program/win32/org/eclipse/swt/program/Program.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Program/win32/org/eclipse/swt/program/Program.java
@@ -44,20 +44,20 @@ Program () {
 }
 
 static String assocQueryString (int assocStr, TCHAR key, boolean expand) {
-	TCHAR pszOut = new TCHAR(0, 1024);
+	TCHAR pszOut = new TCHAR(1024);
 	int[] pcchOut = new int[1];
 	pcchOut[0] = pszOut.length();
 	int flags = OS.ASSOCF_NOTRUNCATE | OS.ASSOCF_INIT_IGNOREUNKNOWN;
 	int result = OS.AssocQueryString (flags, assocStr, key, null, pszOut, pcchOut);
 	if (result == OS.E_POINTER) {
-		pszOut = new TCHAR(0, pcchOut [0]);
+		pszOut = new TCHAR(pcchOut [0]);
 		result = OS.AssocQueryString (flags, assocStr, key, null, pszOut, pcchOut);
 	}
 	if (result == 0) {
 		if (expand) {
 			int length = OS.ExpandEnvironmentStrings (pszOut, null, 0);
 			if (length != 0) {
-				TCHAR lpDst = new TCHAR (0, length);
+				TCHAR lpDst = new TCHAR (length);
 				OS.ExpandEnvironmentStrings (pszOut, lpDst, length);
 				return lpDst.toString (0, Math.max (0, length - 1));
 			} else {
@@ -87,7 +87,7 @@ public static Program findProgram (String extension) {
 	if (extension == null) SWT.error (SWT.ERROR_NULL_ARGUMENT);
 	if (extension.length () == 0) return null;
 	if (extension.charAt (0) != '.') extension = "." + extension; //$NON-NLS-1$
-	TCHAR key = new TCHAR (0, extension, true);
+	TCHAR key = new TCHAR (extension, true);
 	Program program = null;
 	String command = assocQueryString (OS.ASSOCSTR_COMMAND, key, true);
 	if (command != null) {
@@ -140,7 +140,7 @@ public static String [] getExtensions () {
 }
 
 static String getKeyValue (String string, boolean expand) {
-	TCHAR key = new TCHAR (0, string, true);
+	TCHAR key = new TCHAR (string, true);
 	long [] phkResult = new long [1];
 	if (OS.RegOpenKeyEx (OS.HKEY_CLASSES_ROOT, key, 0, OS.KEY_READ, phkResult) != 0) {
 		return null;
@@ -285,14 +285,14 @@ public static boolean launch (String fileName, String workingDir) {
 	if (fileName == null) SWT.error (SWT.ERROR_NULL_ARGUMENT);
 
 	long hHeap = OS.GetProcessHeap ();
-	TCHAR buffer = new TCHAR (0, fileName, true);
+	TCHAR buffer = new TCHAR (fileName, true);
 	int byteCount = buffer.length () * TCHAR.sizeof;
 	long lpFile = OS.HeapAlloc (hHeap, OS.HEAP_ZERO_MEMORY, byteCount);
 	OS.MoveMemory (lpFile, buffer, byteCount);
 
 	long lpDirectory = 0;
 	if (workingDir != null && OS.PathIsExe(lpFile)) {
-		TCHAR buffer1 = new TCHAR (0, workingDir, true);
+		TCHAR buffer1 = new TCHAR (workingDir, true);
 		byteCount = buffer1.length () * TCHAR.sizeof;
 		lpDirectory = OS.HeapAlloc (hHeap, OS.HEAP_ZERO_MEMORY, byteCount);
 		OS.MoveMemory (lpDirectory, buffer1, byteCount);
@@ -340,7 +340,7 @@ public boolean execute (String fileName) {
 	if (append) fileName = " \"" + fileName + "\"";
 	String commandLine = prefix + fileName + suffix;
 	long hHeap = OS.GetProcessHeap ();
-	TCHAR buffer = new TCHAR (0, commandLine, true);
+	TCHAR buffer = new TCHAR (commandLine, true);
 	int byteCount = buffer.length () * TCHAR.sizeof;
 	long lpCommandLine = OS.HeapAlloc (hHeap, OS.HEAP_ZERO_MEMORY, byteCount);
 	OS.MoveMemory (lpCommandLine, buffer, byteCount);
@@ -400,7 +400,7 @@ private ImageData getImageDataUsingIconFilePath(int zoom) {
 			fileName = fileName.substring (1, length - 1);
 		}
 	}
-	TCHAR lpszFile = new TCHAR (0, fileName, true);
+	TCHAR lpszFile = new TCHAR (fileName, true);
 	long [] hIcon = new long[1];
 	int size = OS.GetSystemMetricsForDpi(OS.SM_CXSMICON, DPIUtil.mapZoomToDPI(zoom));
 	OS.SHDefExtractIcon (lpszFile, nIconIndex, 0, hIcon, null, size);
@@ -427,7 +427,7 @@ private ImageData getImageDataUsingExtension(int zoom) {
 		} else {
 			flags |= OS.SHGFI_SMALLICON;
 		}
-		TCHAR pszPath = new TCHAR (0, extension, true);
+		TCHAR pszPath = new TCHAR (extension, true);
 		OS.SHGetFileInfo (pszPath.chars, OS.FILE_ATTRIBUTE_NORMAL, shfi, SHFILEINFO.sizeof, flags);
 		if (shfi.hIcon != 0) {
 			Image image = Image.win32_new (null, SWT.ICON, shfi.hIcon, initialNativeZoom);

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Device.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Device.java
@@ -600,7 +600,7 @@ public FontData [] getFontList (String faceName, boolean scalable) {
 			OS.EnumFontFamilies (hDC, lf.lfFaceName, lpEnumFontFamProc, scalable ? 1 : 0);
 		}
 	} else {
-		TCHAR lpFaceName = new TCHAR (0, faceName, true);
+		TCHAR lpFaceName = new TCHAR (faceName, true);
 		OS.EnumFontFamilies (hDC, lpFaceName.chars, lpEnumFontFamProc, scalable ? 1 : 0);
 	}
 	int logPixelsY = OS.GetDeviceCaps(hDC, OS.LOGPIXELSY);
@@ -820,7 +820,7 @@ public boolean isDisposed () {
 public boolean loadFont (String path) {
 	checkDevice();
 	if (path == null) SWT.error (SWT.ERROR_NULL_ARGUMENT);
-	TCHAR lpszFilename = new TCHAR (0, path, true);
+	TCHAR lpszFilename = new TCHAR (path, true);
 	boolean loaded = OS.AddFontResourceEx (lpszFilename, OS.FR_PRIVATE, 0) != 0;
 	if (loaded) {
 		if (gdipToken != null) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/FontData.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/FontData.java
@@ -374,7 +374,7 @@ long EnumLocalesProc(long lpLocaleString) {
 
 	/* Get the locale ID */
 	int length = 8;
-	TCHAR buffer = new TCHAR(0, length);
+	TCHAR buffer = new TCHAR(length);
 	int byteCount = length * TCHAR.sizeof;
 	OS.MoveMemory(buffer, lpLocaleString, byteCount);
 	int lcid = Integer.parseInt(buffer.toString(0, buffer.strlen ()), 16);

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Button.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Button.java
@@ -60,7 +60,7 @@ public class Button extends Control {
 	static /*final*/ boolean COMMAND_LINK = false;
 	static final char[] STRING_WITH_ZERO_CHAR = new char[] {'0'};
 	static final long ButtonProc;
-	static final TCHAR ButtonClass = new TCHAR (0, "BUTTON", true);
+	static final TCHAR ButtonClass = new TCHAR ("BUTTON", true);
 	static {
 		WNDCLASS lpWndClass = new WNDCLASS ();
 		OS.GetClassInfo (0, ButtonClass, lpWndClass);
@@ -206,7 +206,7 @@ void _setText (String text) {
 		OS.SetWindowLong (handle, OS.GWL_STYLE, newBits);
 		OS.InvalidateRect (handle, null, true);
 	}
-	TCHAR buffer = new TCHAR (getCodePage (), text, true);
+	TCHAR buffer = new TCHAR (text, true);
 	OS.SetWindowText (handle, buffer);
 	if ((state & HAS_AUTO_DIRECTION) != 0) {
 		updateTextDirection (AUTO_TEXT_DIRECTION);

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ColorDialog.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ColorDialog.java
@@ -100,7 +100,7 @@ long CCHookProc (long hdlg, long uiMsg, long lParam, long lpData) {
 	switch ((int)uiMsg) {
 		case OS.WM_INITDIALOG: {
 			if (title != null && title.length () != 0) {
-				TCHAR buffer = new TCHAR (0, title, true);
+				TCHAR buffer = new TCHAR (title, true);
 				OS.SetWindowText (hdlg, buffer);
 			}
 			break;

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Combo.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Combo.java
@@ -99,7 +99,7 @@ public class Combo extends Composite {
 	static /*final*/ long EditProc, ListProc;
 
 	static final long ComboProc;
-	static final TCHAR ComboClass = new TCHAR (0, "COMBOBOX", true);
+	static final TCHAR ComboClass = new TCHAR ("COMBOBOX", true);
 	static {
 		WNDCLASS lpWndClass = new WNDCLASS ();
 		OS.GetClassInfo (0, ComboClass, lpWndClass);
@@ -166,7 +166,7 @@ public Combo (Composite parent, int style) {
 public void add (String string) {
 	checkWidget ();
 	if (string == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TCHAR buffer = new TCHAR (getCodePage (), string, true);
+	TCHAR buffer = new TCHAR (string, true);
 	int result = (int)OS.SendMessage (handle, OS.CB_ADDSTRING, 0, buffer);
 	if (result == OS.CB_ERR) error (SWT.ERROR_ITEM_NOT_ADDED);
 	if (result == OS.CB_ERRSPACE) error (SWT.ERROR_ITEM_NOT_ADDED);
@@ -206,7 +206,7 @@ public void add (String string, int index) {
 	if (!(0 <= index && index <= count)) {
 		error (SWT.ERROR_INVALID_RANGE);
 	}
-	TCHAR buffer = new TCHAR (getCodePage (), string, true);
+	TCHAR buffer = new TCHAR (string, true);
 	int result = (int)OS.SendMessage (handle, OS.CB_INSERTSTRING, index, buffer);
 	if (result == OS.CB_ERRSPACE || result == OS.CB_ERR) {
 		error (SWT.ERROR_ITEM_NOT_ADDED);
@@ -418,7 +418,6 @@ void applyListSegments () {
 	if (add) items = new String [count];
 	int index = items.length;
 	int selection = OS.CB_ERR;
-	int cp = getCodePage ();
 	String string;
 	TCHAR buffer;
 	if (!noSelection) {
@@ -429,14 +428,14 @@ void applyListSegments () {
 		if (add) {
 			int length = (int)OS.SendMessage (handle, OS.CB_GETLBTEXTLEN, index, 0);
 			if (length == OS.CB_ERR) error (SWT.ERROR);
-			buffer = new TCHAR (cp, length + 1);
+			buffer = new TCHAR (length + 1);
 			if (OS.SendMessage (handle, OS.CB_GETLBTEXT, index, buffer) == OS.CB_ERR) return;
 			items [index] = string = buffer.toString (0, length);
 		} else {
 			string = items [index];
 		}
 		if (OS.SendMessage (handle, OS.CB_DELETESTRING, index, 0) == OS.CB_ERR) return;
-		if (buffer == null) buffer = new TCHAR (cp, string, true);
+		if (buffer == null) buffer = new TCHAR (string, true);
 		if (OS.SendMessage (handle, OS.CB_INSERTSTRING, index, buffer) == OS.CB_ERR) return;
 	}
 	if (selection != OS.CB_ERR) {
@@ -547,8 +546,7 @@ void clearSegments (boolean applyText) {
 	boolean oldIgnoreCharacter = ignoreCharacter, oldIgnoreModify = ignoreModify;
 	ignoreCharacter = ignoreModify = true;
 	int length = OS.GetWindowTextLength (hwndText);
-	int cp = getCodePage ();
-	TCHAR buffer = new TCHAR (cp, length + 1);
+	TCHAR buffer = new TCHAR (length + 1);
 	if (length > 0) OS.GetWindowText (hwndText, buffer, length + 1);
 	buffer = deprocessText (buffer, 0, -1, true);
 	/* Get the current selection */
@@ -813,7 +811,7 @@ TCHAR deprocessText (TCHAR text, int start, int end, boolean terminate) {
 	if (start != 0 || end != length) {
 		char [] newChars = new char [length];
 		System.arraycopy(chars, start, newChars, 0, length);
-		return new TCHAR (getCodePage (), newChars, terminate);
+		return new TCHAR (newChars, terminate);
 	}
 	return text;
 }
@@ -1323,7 +1321,7 @@ public String getText () {
 	checkWidget ();
 	int length = OS.GetWindowTextLength (handle);
 	if (length == 0) return "";
-	TCHAR buffer = new TCHAR (getCodePage (), length + 1);
+	TCHAR buffer = new TCHAR (length + 1);
 	OS.GetWindowText (handle, buffer, length + 1);
 	if (segments != null) {
 		buffer = deprocessText (buffer, 0, -1, false);
@@ -1479,7 +1477,7 @@ public int indexOf (String string, int start) {
 	int count = (int)OS.SendMessage (handle, OS.CB_GETCOUNT, 0, 0);
 	if (!(0 <= start && start < count)) return -1;
 	int index = start - 1, last = 0;
-	TCHAR buffer = new TCHAR (getCodePage (), string, true);
+	TCHAR buffer = new TCHAR (string, true);
 	do {
 		index = (int)OS.SendMessage (handle, OS.CB_FINDSTRINGEXACT, last = index, buffer);
 		if (index == OS.CB_ERR || index <= last) return -1;
@@ -1914,7 +1912,7 @@ boolean sendKeyEvent (int type, int msg, long wParam, long lParam, Event event) 
 	String newText = verifyText (oldText, start [0], end [0], event);
 	if (newText == null) return false;
 	if (newText == oldText) return true;
-	TCHAR buffer = new TCHAR (getCodePage (), newText, true);
+	TCHAR buffer = new TCHAR (newText, true);
 	OS.SendMessage (hwndText, OS.EM_SETSEL, start [0], end [0]);
 	OS.SendMessage (hwndText, OS.EM_REPLACESEL, 0, buffer);
 	return false;
@@ -2098,9 +2096,8 @@ public void setItems (String... items) {
 		setScrollWidth (0);
 	}
 	OS.SendMessage (handle, OS.CB_RESETCONTENT, 0, 0);
-	int codePage = getCodePage ();
 	for (String item : items) {
-		TCHAR buffer = new TCHAR (codePage, item, true);
+		TCHAR buffer = new TCHAR (item, true);
 		int code = (int)OS.SendMessage (handle, OS.CB_ADDSTRING, 0, buffer);
 		if (code == OS.CB_ERR) error (SWT.ERROR_ITEM_NOT_ADDED);
 		if (code == OS.CB_ERRSPACE) error (SWT.ERROR_ITEM_NOT_ADDED);
@@ -2290,7 +2287,7 @@ public void setText (String string) {
 		limit = (int)OS.SendMessage (hwndText, OS.EM_GETLIMITTEXT, 0, 0) & 0x7FFFFFFF;
 	}
 	if (string.length () > limit) string = string.substring (0, limit);
-	TCHAR buffer = new TCHAR (getCodePage (), string, true);
+	TCHAR buffer = new TCHAR (string, true);
 	if (OS.SetWindowText (handle, buffer)) {
 		applyEditSegments ();
 		sendEvent (SWT.Modify);
@@ -2741,12 +2738,12 @@ long windowProc (long hwnd, int msg, long wParam, long lParam) {
 			if (lParam != 0 && (hooks (SWT.Segments) || filters (SWT.Segments) || ((state & HAS_AUTO_DIRECTION) != 0))) {
 				long code = OS.CB_ERR;
 				int length = OS.wcslen (lParam);
-				TCHAR buffer = new TCHAR (getCodePage (), length);
+				TCHAR buffer = new TCHAR (length);
 				OS.MoveMemory (buffer, lParam, buffer.length () * TCHAR.sizeof);
 				String string = buffer.toString (0, length);
 				Event event = getSegments (string);
 				if (event != null && event.segments != null) {
-					buffer = new TCHAR (getCodePage (), getSegmentsText (string, event), true);
+					buffer = new TCHAR (getSegmentsText (string, event), true);
 					long hHeap = OS.GetProcessHeap ();
 					length = buffer.length() * TCHAR.sizeof;
 					long pszText = OS.HeapAlloc (hHeap, OS.HEAP_ZERO_MEMORY, length);
@@ -3136,7 +3133,7 @@ LRESULT wmClipboard (long hwndText, int msg, long wParam, long lParam) {
 			if (lockText) return null;
 			end [0] = OS.GetWindowTextLength (hwndText);
 			int length = OS.wcslen (lParam);
-			TCHAR buffer = new TCHAR (getCodePage (), length);
+			TCHAR buffer = new TCHAR (length);
 			int byteCount = buffer.length () * TCHAR.sizeof;
 			OS.MoveMemory (buffer, lParam, byteCount);
 			newText = buffer.toString (0, length);
@@ -3150,7 +3147,7 @@ LRESULT wmClipboard (long hwndText, int msg, long wParam, long lParam) {
 			if (call) {
 				OS.CallWindowProc (EditProc, hwndText, msg, wParam, lParam);
 			}
-			TCHAR buffer = new TCHAR (getCodePage (), newText, true);
+			TCHAR buffer = new TCHAR (newText, true);
 			if (msg == OS.WM_SETTEXT) {
 				long hHeap = OS.GetProcessHeap ();
 				int byteCount = buffer.length () * TCHAR.sizeof;

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Control.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Control.java
@@ -1239,10 +1239,6 @@ Rectangle getBoundsInPixels () {
 	return new Rectangle (rect.left, rect.top, width, height);
 }
 
-int getCodePage () {
-	return OS.CP_ACP;
-}
-
 String getClipboardText () {
 	String string = "";
 	if (OS.OpenClipboard (0)) {
@@ -1252,7 +1248,7 @@ String getClipboardText () {
 			int byteCount = OS.GlobalSize (hMem) / TCHAR.sizeof * TCHAR.sizeof;
 			long ptr = OS.GlobalLock (hMem);
 			if (ptr != 0) {
-				TCHAR buffer = new TCHAR (0, byteCount / TCHAR.sizeof);
+				TCHAR buffer = new TCHAR (byteCount / TCHAR.sizeof);
 				OS.MoveMemory (buffer, ptr, byteCount);
 				string = buffer.toString (0, buffer.strlen ());
 				OS.GlobalUnlock (hMem);

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/CoolBar.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/CoolBar.java
@@ -53,7 +53,7 @@ public class CoolBar extends Composite {
 	boolean locked;
 	boolean ignoreResize;
 	static final long ReBarProc;
-	static final TCHAR ReBarClass = new TCHAR (0, OS.REBARCLASSNAME, true);
+	static final TCHAR ReBarClass = new TCHAR (OS.REBARCLASSNAME, true);
 	static {
 		WNDCLASS lpWndClass = new WNDCLASS ();
 		OS.GetClassInfo (0, ReBarClass, lpWndClass);

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/DateTime.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/DateTime.java
@@ -55,9 +55,9 @@ public class DateTime extends Composite {
 	SYSTEMTIME lastSystemTime;
 	SYSTEMTIME time = new SYSTEMTIME (); // only used in calendar mode
 	static final long DateTimeProc;
-	static final TCHAR DateTimeClass = new TCHAR (0, OS.DATETIMEPICK_CLASS, true);
+	static final TCHAR DateTimeClass = new TCHAR (OS.DATETIMEPICK_CLASS, true);
 	static final long CalendarProc;
-	static final TCHAR CalendarClass = new TCHAR (0, OS.MONTHCAL_CLASS, true);
+	static final TCHAR CalendarClass = new TCHAR (OS.MONTHCAL_CLASS, true);
 	static {
 		WNDCLASS lpWndClass = new WNDCLASS ();
 		OS.GetClassInfo (0, DateTimeClass, lpWndClass);
@@ -159,7 +159,7 @@ public DateTime (Composite parent, int style) {
 	super (parent, checkStyle (style));
 	if ((this.style & SWT.SHORT) != 0) {
 		String buffer = ((this.style & SWT.DATE) != 0) ? getCustomShortDateFormat() : getCustomShortTimeFormat();
-		TCHAR lpszFormat = new TCHAR (0, buffer, true);
+		TCHAR lpszFormat = new TCHAR (buffer, true);
 		OS.SendMessage (handle, OS.DTM_SETFORMAT, 0, lpszFormat);
 	}
 }
@@ -273,7 +273,7 @@ int defaultBackground () {
 }
 
 String getCustomShortDateFormat () {
-	TCHAR tchar = new TCHAR (getCodePage (), 80);
+	TCHAR tchar = new TCHAR (80);
 	int size = OS.GetLocaleInfo (OS.LOCALE_USER_DEFAULT, OS.LOCALE_SYEARMONTH, tchar, 80);
 	return size != 0 ? tchar.toString (0, size - 1) : "M/yyyy"; //$NON-NLS-1$
 }
@@ -301,7 +301,7 @@ String getCustomShortTimeFormat () {
 }
 
 String getTimeFormat () {
-	TCHAR tchar = new TCHAR (getCodePage (), 80);
+	TCHAR tchar = new TCHAR (80);
 	int size = OS.GetLocaleInfo (OS.LOCALE_USER_DEFAULT, OS.LOCALE_STIMEFORMAT, tchar, 80);
 	return size > 0 ? tchar.toString (0, size - 1) : "h:mm:ss tt"; //$NON-NLS-1$
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Decorations.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Decorations.java
@@ -1259,7 +1259,7 @@ void setSystemMenu () {
 public void setText (String string) {
 	checkWidget ();
 	if (string == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TCHAR buffer = new TCHAR (0, string, true);
+	TCHAR buffer = new TCHAR (string, true);
 	/* Ensure that the title appears in the task bar.*/
 	if ((state & FOREIGN_HANDLE) != 0) {
 		long hHeap = OS.GetProcessHeap ();

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Display.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Display.java
@@ -1993,17 +1993,17 @@ public int getIconDepth () {
 	checkDevice ();
 	if (getDepth () >= 24) return 32;
 
-	TCHAR buffer1 = new TCHAR (0, "Control Panel\\Desktop\\WindowMetrics", true); //$NON-NLS-1$
+	TCHAR buffer1 = new TCHAR ("Control Panel\\Desktop\\WindowMetrics", true); //$NON-NLS-1$
 	long [] phkResult = new long [1];
 	int result = OS.RegOpenKeyEx (OS.HKEY_CURRENT_USER, buffer1, 0, OS.KEY_READ, phkResult);
 	if (result != 0) return 4;
 	int depth = 4;
 	int [] lpcbData = new int [1];
 
-	TCHAR buffer2 = new TCHAR (0, "Shell Icon BPP", true); //$NON-NLS-1$
+	TCHAR buffer2 = new TCHAR ("Shell Icon BPP", true); //$NON-NLS-1$
 	result = OS.RegQueryValueEx (phkResult [0], buffer2, 0, null, (TCHAR) null, lpcbData);
 	if (result == 0) {
-		TCHAR lpData = new TCHAR (0, lpcbData [0] / TCHAR.sizeof);
+		TCHAR lpData = new TCHAR (lpcbData [0] / TCHAR.sizeof);
 		result = OS.RegQueryValueEx (phkResult [0], buffer2, 0, null, lpData, lpcbData);
 		if (result == 0) {
 			try {
@@ -2850,9 +2850,9 @@ protected void init () {
 	/* Remember the current thread id */
 	threadId = OS.GetCurrentThreadId ();
 
-	windowClass = new TCHAR (0, WindowName + WindowClassCount, true);
-	windowShadowClass = new TCHAR (0, WindowShadowName + WindowClassCount, true);
-	windowOwnDCClass = new TCHAR (0, WindowOwnDCName + WindowClassCount, true);
+	windowClass = new TCHAR (WindowName + WindowClassCount, true);
+	windowShadowClass = new TCHAR (WindowShadowName + WindowClassCount, true);
+	windowOwnDCClass = new TCHAR (WindowOwnDCName + WindowClassCount, true);
 	WindowClassCount++;
 
 	/* Register the SWT window class */
@@ -2884,7 +2884,7 @@ protected void init () {
 		hInstance,
 		null);
 	String title = "SWT_Window_"+APP_NAME;
-	OS.SetWindowText(hwndMessage, new TCHAR(0, title, true));
+	OS.SetWindowText(hwndMessage, new TCHAR(title, true));
 	messageCallback = new Callback (this, "messageProc", 4); //$NON-NLS-1$
 	messageProc = messageCallback.getAddress ();
 	OS.SetWindowLongPtr (hwndMessage, OS.GWLP_WNDPROC, messageProc);
@@ -2900,11 +2900,11 @@ protected void init () {
 	idleHook = OS.SetWindowsHookEx (OS.WH_FOREGROUNDIDLE, foregroundIdleProc, 0, threadId);
 
 	/* Register window messages */
-	TASKBARCREATED = OS.RegisterWindowMessage (new TCHAR (0, "TaskbarCreated", true)); //$NON-NLS-1$
-	TASKBARBUTTONCREATED = OS.RegisterWindowMessage (new TCHAR (0, "TaskbarButtonCreated", true)); //$NON-NLS-1$
-	SWT_RESTORECARET = OS.RegisterWindowMessage (new TCHAR (0, "SWT_RESTORECARET", true)); //$NON-NLS-1$
-	DI_GETDRAGIMAGE = OS.RegisterWindowMessage (new TCHAR (0, "ShellGetDragImage", true)); //$NON-NLS-1$
-	SWT_OPENDOC = OS.RegisterWindowMessage(new TCHAR (0, "SWT_OPENDOC", true)); //$NON-NLS-1$
+	TASKBARCREATED = OS.RegisterWindowMessage (new TCHAR ("TaskbarCreated", true)); //$NON-NLS-1$
+	TASKBARBUTTONCREATED = OS.RegisterWindowMessage (new TCHAR ("TaskbarButtonCreated", true)); //$NON-NLS-1$
+	SWT_RESTORECARET = OS.RegisterWindowMessage (new TCHAR ("SWT_RESTORECARET", true)); //$NON-NLS-1$
+	DI_GETDRAGIMAGE = OS.RegisterWindowMessage (new TCHAR ("ShellGetDragImage", true)); //$NON-NLS-1$
+	SWT_OPENDOC = OS.RegisterWindowMessage(new TCHAR ("SWT_OPENDOC", true)); //$NON-NLS-1$
 
 	/* Initialize OLE */
 	OS.OleInitialize (0);
@@ -3422,7 +3422,7 @@ String getSharedData(int pid, int  handle) {
 	long sharedData = OS.MapViewOfFile(mapHandle[0], OS.FILE_MAP_READ, 0, 0, 0);
 	if (sharedData == 0) return null;
 	int length = OS.wcslen (sharedData);
-	TCHAR buffer = new TCHAR (0, length);
+	TCHAR buffer = new TCHAR (length);
 	int byteCount = buffer.length () * TCHAR.sizeof;
 	OS.MoveMemory (buffer, sharedData, byteCount);
 	String result = buffer.toString (0, length);

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Group.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Group.java
@@ -47,7 +47,7 @@ public class Group extends Composite {
 	String text = "";
 	static final int CLIENT_INSET = 3;
 	static final long GroupProc;
-	static final TCHAR GroupClass = new TCHAR (0, "SWT_GROUP", true);
+	static final TCHAR GroupClass = new TCHAR ("SWT_GROUP", true);
 	static {
 		/*
 		* Feature in Windows.  The group box window class
@@ -58,7 +58,7 @@ public class Group extends Composite {
 		* implement special code that damages only the control.
 		*/
 		WNDCLASS lpWndClass = new WNDCLASS ();
-		TCHAR WC_BUTTON = new TCHAR (0, "BUTTON", true);
+		TCHAR WC_BUTTON = new TCHAR ("BUTTON", true);
 		OS.GetClassInfo (0, WC_BUTTON, lpWndClass);
 		GroupProc = lpWndClass.lpfnWndProc;
 		long hInstance = OS.GetModuleHandle (null);
@@ -206,7 +206,7 @@ void enableWidget (boolean enabled) {
 	super.enableWidget (enabled);
 	String string = fixText ();
 	if (string != null) {
-		TCHAR buffer = new TCHAR (getCodePage (), string, true);
+		TCHAR buffer = new TCHAR (string, true);
 		OS.SetWindowText (handle, buffer);
 	}
 	if (enabled && hasCustomForeground()) {
@@ -402,7 +402,7 @@ public void setText (String string) {
 	text = string;
 	if ((state & HAS_AUTO_DIRECTION) == 0 || !updateTextDirection (AUTO_TEXT_DIRECTION)) {
 		string = fixText ();
-		TCHAR buffer = new TCHAR (getCodePage (), string == null ? text : string, true);
+		TCHAR buffer = new TCHAR (string == null ? text : string, true);
 		OS.SetWindowText (handle, buffer);
 	}
 }
@@ -411,7 +411,7 @@ public void setText (String string) {
 boolean updateTextDirection(int textDirection) {
 	if (super.updateTextDirection(textDirection)) {
 		String string = fixText ();
-		TCHAR buffer = new TCHAR (getCodePage (), string == null ? text : string, true);
+		TCHAR buffer = new TCHAR (string == null ? text : string, true);
 		OS.SetWindowText (handle, buffer);
 		return true;
 	}

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/IME.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/IME.java
@@ -50,7 +50,7 @@ public class IME extends Widget {
 	int [] ranges;
 	TextStyle [] styles;
 
-	static final int WM_MSIME_MOUSE = OS.RegisterWindowMessage (new TCHAR (0, "MSIMEMouseOperation", true)); //$NON-NLS-1$
+	static final int WM_MSIME_MOUSE = OS.RegisterWindowMessage (new TCHAR ("MSIMEMouseOperation", true)); //$NON-NLS-1$
 
 	/* TextLayout has a copy of these constants */
 	static final int UNDERLINE_IME_DOT = 1 << 16;
@@ -534,7 +534,7 @@ LRESULT WM_KEYDOWN (long wParam, long lParam) {
 				}
 				long hwnd = parent.handle;
 				long hIMC = OS.ImmGetContext (hwnd);
-				TCHAR buffer = new TCHAR (0, event.text, true);
+				TCHAR buffer = new TCHAR (event.text, true);
 				long rc = OS.ImmEscape(hKL, hIMC, OS.IME_ESC_HANJA_MODE, buffer);
 				if (rc != 0) {
 					sendEvent (SWT.ImeComposition, event);

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Label.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Label.java
@@ -58,7 +58,7 @@ public class Label extends Control {
 	boolean isImageMode;	// Resolves ambiguity when both image and text are set
 	static final int MARGIN = 4;
 	static final long LabelProc;
-	static final TCHAR LabelClass = new TCHAR (0, "STATIC", true);
+	static final TCHAR LabelClass = new TCHAR ("STATIC", true);
 	static {
 		WNDCLASS lpWndClass = new WNDCLASS ();
 		OS.GetClassInfo (0, LabelClass, lpWndClass);
@@ -402,7 +402,7 @@ public void setText (String string) {
 	if (string.equals (text)) return;
 	text = string;
 	string = Display.withCrLf (string);
-	TCHAR buffer = new TCHAR (getCodePage (), string, true);
+	TCHAR buffer = new TCHAR (string, true);
 	OS.SetWindowText (handle, buffer);
 	if ((state & HAS_AUTO_DIRECTION) != 0) {
 		updateTextDirection (AUTO_TEXT_DIRECTION);

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Link.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Link.java
@@ -51,7 +51,7 @@ public class Link extends Control {
 	char [] mnemonics;
 	int nextFocusItem = -1;
 	static final long LinkProc;
-	static final TCHAR LinkClass = new TCHAR (0, OS.WC_LINK, true);
+	static final TCHAR LinkClass = new TCHAR (OS.WC_LINK, true);
 	static {
 		WNDCLASS lpWndClass = new WNDCLASS ();
 		OS.GetClassInfo (0, LinkClass, lpWndClass);
@@ -567,7 +567,7 @@ public void setText (String string) {
 	if ((state & HAS_AUTO_DIRECTION) != 0) {
 		updateTextDirection (AUTO_TEXT_DIRECTION);
 	}
-	TCHAR buffer = new TCHAR (getCodePage (), string, true);
+	TCHAR buffer = new TCHAR (string, true);
 	OS.SetWindowText (handle, buffer);
 	parse(string);
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/List.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/List.java
@@ -44,7 +44,7 @@ import org.eclipse.swt.internal.win32.*;
 public class List extends Scrollable {
 	static final int INSET = 3;
 	static final long ListProc;
-	static final TCHAR ListClass = new TCHAR (0, "LISTBOX", true);
+	static final TCHAR ListClass = new TCHAR ("LISTBOX", true);
 	boolean addedUCC = false; // indicates whether Bidi UCC were added; 'state & HAS_AUTO_DIRECTION' isn't a sufficient indicator
 	static {
 		WNDCLASS lpWndClass = new WNDCLASS ();
@@ -105,7 +105,7 @@ public List (Composite parent, int style) {
 public void add (String string) {
 	checkWidget ();
 	if (string == null) error (SWT.ERROR_NULL_ARGUMENT);
-	TCHAR buffer = new TCHAR (getCodePage (), string, true);
+	TCHAR buffer = new TCHAR (string, true);
 	int result = (int)OS.SendMessage (handle, OS.LB_ADDSTRING, 0, buffer);
 	if (result == OS.LB_ERR) error (SWT.ERROR_ITEM_NOT_ADDED);
 	if (result == OS.LB_ERRSPACE) error (SWT.ERROR_ITEM_NOT_ADDED);
@@ -141,7 +141,7 @@ public void add (String string, int index) {
 	checkWidget ();
 	if (string == null) error (SWT.ERROR_NULL_ARGUMENT);
 	if (index == -1) error (SWT.ERROR_INVALID_RANGE);
-	TCHAR buffer = new TCHAR (getCodePage (), string, true);
+	TCHAR buffer = new TCHAR (string, true);
 	int result = (int)OS.SendMessage (handle, OS.LB_INSERTSTRING, index, buffer);
 	if (result == OS.LB_ERRSPACE) error (SWT.ERROR_ITEM_NOT_ADDED);
 	if (result == OS.LB_ERR) {
@@ -696,7 +696,7 @@ public int indexOf (String string, int start) {
 	int count = (int)OS.SendMessage (handle, OS.LB_GETCOUNT, 0, 0);
 	if (!(0 <= start && start < count)) return -1;
 	int index = start - 1, last;
-	TCHAR buffer = new TCHAR (getCodePage (), string, true);
+	TCHAR buffer = new TCHAR (string, true);
 	do {
 		index = (int)OS.SendMessage (handle, OS.LB_FINDSTRINGEXACT, last = index, buffer);
 		if (index == OS.LB_ERR || index <= last) return -1;
@@ -1235,10 +1235,9 @@ public void setItems (String... items) {
 	OS.SendMessage (handle, OS.LB_RESETCONTENT, 0, 0);
 	OS.SendMessage (handle, OS.LB_INITSTORAGE, length, length * 32);
 	int index = 0;
-	int cp = getCodePage ();
 	while (index < length) {
 		String string = items [index];
-		TCHAR buffer = new TCHAR (cp, string, true);
+		TCHAR buffer = new TCHAR (string, true);
 		int result = (int)OS.SendMessage (handle, OS.LB_ADDSTRING, 0, buffer);
 		if (result == OS.LB_ERR || result == OS.LB_ERRSPACE) break;
 		if ((style & SWT.H_SCROLL) != 0) {
@@ -1634,8 +1633,7 @@ long windowProc (long hwnd, int msg, long wParam, long lParam) {
 			case OS.LB_INSERTSTRING:
 			case OS.LB_FINDSTRINGEXACT:
 				int length = OS.wcslen (lParam); // we are always Unicode here
-				int cp = getCodePage ();
-				TCHAR buffer = new TCHAR (cp, length);
+				TCHAR buffer = new TCHAR (length);
 				OS.MoveMemory (buffer, lParam, buffer.length () * TCHAR.sizeof);
 				String string = buffer.toString (0, length);
 				int direction = BidiUtil.resolveTextDirection (string);
@@ -1648,7 +1646,7 @@ long windowProc (long hwnd, int msg, long wParam, long lParam) {
 					direction = (style & SWT.RIGHT_TO_LEFT) != 0 ? SWT.RIGHT_TO_LEFT : SWT.LEFT_TO_RIGHT;
 				}
 				string = (direction == SWT.RIGHT_TO_LEFT ? RLE : LRE) + string;
-				buffer = new TCHAR (cp, string, true);
+				buffer = new TCHAR (string, true);
 				long hHeap = OS.GetProcessHeap ();
 				length = buffer.length() * TCHAR.sizeof;
 				long pszText = OS.HeapAlloc (hHeap, OS.HEAP_ZERO_MEMORY, length);

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/MenuItem.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/MenuItem.java
@@ -1159,7 +1159,7 @@ public void setText (String string) {
 	info.cbSize = MENUITEMINFO.sizeof;
 	long hMenu = parent.handle;
 
-	TCHAR buffer = new TCHAR (0, string, true);
+	TCHAR buffer = new TCHAR (string, true);
 	int byteCount = buffer.length () * TCHAR.sizeof;
 	pszText = OS.HeapAlloc (hHeap, OS.HEAP_ZERO_MEMORY, byteCount);
 	OS.MoveMemory (pszText, buffer, byteCount);

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/MessageBox.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/MessageBox.java
@@ -142,7 +142,7 @@ void setButtonText (long wParam, int style, int id) {
 	if (labels.get (style) != null) {
 		long hwnd = OS.GetDlgItem (wParam, id);
 		if (hwnd != 0) {
-			OS.SetWindowText (hwnd, new TCHAR (0, labels.get (style), true));
+			OS.SetWindowText (hwnd, new TCHAR (labels.get (style), true));
 		}
 	}
 }
@@ -265,8 +265,8 @@ public int open () {
 
 	/* Open the message box */
 	display.sendPreExternalEventDispatchEvent ();
-	TCHAR buffer1 = new TCHAR (0, message, true);
-	TCHAR buffer2 = new TCHAR (0, title, true);
+	TCHAR buffer1 = new TCHAR (message, true);
+	TCHAR buffer2 = new TCHAR (title, true);
 	display.externalEventLoop = true;
 
 	Callback cbtCallback = null;

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ProgressBar.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ProgressBar.java
@@ -45,7 +45,7 @@ public class ProgressBar extends Control {
 	static final int TIMER_ID = 100;
 	static final int MINIMUM_WIDTH = 100;
 	static final long ProgressBarProc;
-	static final TCHAR ProgressBarClass = new TCHAR (0, OS.PROGRESS_CLASS, true);
+	static final TCHAR ProgressBarClass = new TCHAR (OS.PROGRESS_CLASS, true);
 	static {
 		WNDCLASS lpWndClass = new WNDCLASS ();
 		OS.GetClassInfo (0, ProgressBarClass, lpWndClass);

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Scale.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Scale.java
@@ -45,7 +45,7 @@ import org.eclipse.swt.internal.win32.*;
 public class Scale extends Control {
 	boolean ignoreResize, ignoreSelection;
 	static final long TrackBarProc;
-	static final TCHAR TrackBarClass = new TCHAR (0, OS.TRACKBAR_CLASS, true);
+	static final TCHAR TrackBarClass = new TCHAR (OS.TRACKBAR_CLASS, true);
 	boolean createdAsRTL;
 	static {
 		WNDCLASS lpWndClass = new WNDCLASS ();

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Shell.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Shell.java
@@ -135,7 +135,7 @@ public class Shell extends Decorations {
 	Control lastActive;
 	static /*final*/ long ToolTipProc;
 	static final long DialogProc;
-	static final TCHAR DialogClass = new TCHAR (0, "#32770", true);
+	static final TCHAR DialogClass = new TCHAR ("#32770", true);
 	final static int [] SYSTEM_COLORS = {
 		OS.COLOR_BTNFACE,
 		OS.COLOR_WINDOW,
@@ -552,7 +552,7 @@ public void close () {
 void createBalloonTipHandle () {
 	balloonTipHandle = OS.CreateWindowEx (
 		0,
-		new TCHAR (0, OS.TOOLTIPS_CLASS, true),
+		new TCHAR (OS.TOOLTIPS_CLASS, true),
 		null,
 		OS.TTS_ALWAYSTIP | OS.TTS_NOPREFIX | OS.TTS_BALLOON,
 		OS.CW_USEDEFAULT, 0, OS.CW_USEDEFAULT, 0,
@@ -707,7 +707,7 @@ void createToolTipHandle () {
 long createToolTipHandle (long parent) {
 	long toolTipHandle = OS.CreateWindowEx (
 		0,
-		new TCHAR (0, OS.TOOLTIPS_CLASS, true),
+		new TCHAR (OS.TOOLTIPS_CLASS, true),
 		null,
 		OS.TTS_ALWAYSTIP | OS.TTS_NOPREFIX,
 		OS.CW_USEDEFAULT, 0, OS.CW_USEDEFAULT, 0,
@@ -1284,7 +1284,7 @@ long hwndMDIClient () {
 		int widgetStyle = OS.MDIS_ALLCHILDSTYLES | OS.WS_CHILD | OS.WS_CLIPCHILDREN | OS.WS_CLIPSIBLINGS;
 		hwndMDIClient = OS.CreateWindowEx (
 			0,
-			new TCHAR (0, "MDICLIENT", true),
+			new TCHAR ("MDICLIENT", true),
 			null,
 			widgetStyle,
 			0, 0, 0, 0,
@@ -2129,7 +2129,7 @@ void setToolTipTitle (long hwndToolTip, String text, int icon) {
 		* the null terminator.
 		*/
 		if (text.length () > 99) text = text.substring (0, 99);
-		TCHAR pszTitle = new TCHAR (getCodePage (), text, true);
+		TCHAR pszTitle = new TCHAR (text, true);
 		OS.SendMessage (hwndToolTip, OS.TTM_SETTITLE, icon, pszTitle);
 	} else {
 		OS.SendMessage (hwndToolTip, OS.TTM_SETTITLE, 0, 0);

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Slider.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Slider.java
@@ -78,7 +78,7 @@ public class Slider extends Control {
 	int increment, pageIncrement;
 	boolean ignoreFocus;
 	static final long ScrollBarProc;
-	static final TCHAR ScrollBarClass = new TCHAR (0, "SCROLLBAR", true);
+	static final TCHAR ScrollBarClass = new TCHAR ("SCROLLBAR", true);
 	static {
 		WNDCLASS lpWndClass = new WNDCLASS ();
 		OS.GetClassInfo (0, ScrollBarClass, lpWndClass);

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Spinner.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Spinner.java
@@ -50,9 +50,9 @@ public class Spinner extends Composite {
 	boolean ignoreModify, ignoreCharacter;
 	int pageIncrement, digits;
 	static final long EditProc;
-	static final TCHAR EditClass = new TCHAR (0, "EDIT", true);
+	static final TCHAR EditClass = new TCHAR ("EDIT", true);
 	static final long UpDownProc;
-	static final TCHAR UpDownClass = new TCHAR (0, OS.UPDOWN_CLASS, true);
+	static final TCHAR UpDownClass = new TCHAR (OS.UPDOWN_CLASS, true);
 	static {
 		WNDCLASS lpWndClass = new WNDCLASS ();
 		OS.GetClassInfo (0, EditClass, lpWndClass);
@@ -775,7 +775,7 @@ boolean sendKeyEvent (int type, int msg, long wParam, long lParam, Event event) 
 	String newText = verifyText (oldText, start [0], end [0], event);
 	if (newText == null) return false;
 	if (newText == oldText) return true;
-	TCHAR buffer = new TCHAR (getCodePage (), newText, true);
+	TCHAR buffer = new TCHAR (newText, true);
 	OS.SendMessage (hwndText, OS.EM_SETSEL, start [0], end [0]);
 	OS.SendMessage (hwndText, OS.EM_REPLACESEL, 0, buffer);
 	return false;
@@ -976,7 +976,7 @@ void setSelection (int value, boolean setPos, boolean setText, boolean notify) {
 			string = verifyText (string, 0, length, null);
 			if (string == null) return;
 		}
-		TCHAR buffer = new TCHAR (getCodePage (), string, true);
+		TCHAR buffer = new TCHAR (string, true);
 		OS.SetWindowText (hwndText, buffer);
 		OS.SendMessage (hwndText, OS.EM_SETSEL, 0, -1);
 		OS.NotifyWinEvent (OS.EVENT_OBJECT_FOCUS, hwndText, OS.OBJID_CLIENT, 0);
@@ -1345,7 +1345,7 @@ LRESULT wmClipboard (long hwndText, int msg, long wParam, long lParam) {
 			if (call) {
 				OS.CallWindowProc (EditProc, hwndText, msg, wParam, lParam);
 			}
-			TCHAR buffer = new TCHAR (getCodePage (), newText, true);
+			TCHAR buffer = new TCHAR (newText, true);
 			if (msg == OS.WM_SETTEXT) {
 				long hHeap = OS.GetProcessHeap ();
 				int byteCount = buffer.length () * TCHAR.sizeof;

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TabFolder.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TabFolder.java
@@ -54,7 +54,7 @@ public class TabFolder extends Composite {
 	TabItem [] items;
 	ImageList imageList;
 	static final long TabFolderProc;
-	static final TCHAR TabFolderClass = new TCHAR (0, OS.WC_TABCONTROL, true);
+	static final TCHAR TabFolderClass = new TCHAR (OS.WC_TABCONTROL, true);
 	boolean createdAsRTL;
 
 	/*

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TabItem.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TabItem.java
@@ -137,7 +137,7 @@ void _setText (int index, String string) {
 	}
 	long hwnd = parent.handle;
 	long hHeap = OS.GetProcessHeap ();
-	TCHAR buffer = new TCHAR (parent.getCodePage (), string, true);
+	TCHAR buffer = new TCHAR (string, true);
 	int byteCount = buffer.length () * TCHAR.sizeof;
 	long pszText = OS.HeapAlloc (hHeap, OS.HEAP_ZERO_MEMORY, byteCount);
 	OS.MoveMemory (pszText, buffer, byteCount);

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Table.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Table.java
@@ -104,8 +104,8 @@ public class Table extends Composite {
 	static final int DRAG_IMAGE_SIZE = 301;
 	static boolean COMPRESS_ITEMS = true;
 	static final long TableProc;
-	static final TCHAR TableClass = new TCHAR (0, OS.WC_LISTVIEW, true);
-	static final TCHAR HeaderClass = new TCHAR (0, OS.WC_HEADER, true);
+	static final TCHAR TableClass = new TCHAR (OS.WC_LISTVIEW, true);
+	static final TCHAR HeaderClass = new TCHAR (OS.WC_HEADER, true);
 	static {
 		WNDCLASS lpWndClass = new WNDCLASS ();
 		OS.GetClassInfo (0, TableClass, lpWndClass);
@@ -1574,7 +1574,7 @@ void createHeaderToolTips () {
 	if ((style & SWT.RIGHT_TO_LEFT) != 0) bits |= OS.WS_EX_LAYOUTRTL;
 	headerToolTipHandle = OS.CreateWindowEx (
 		bits,
-		new TCHAR (0, OS.TOOLTIPS_CLASS, true),
+		new TCHAR (OS.TOOLTIPS_CLASS, true),
 		null,
 		OS.TTS_NOPREFIX,
 		OS.CW_USEDEFAULT, 0, OS.CW_USEDEFAULT, 0,
@@ -4799,7 +4799,7 @@ boolean setScrollWidth (TableItem item, boolean force) {
 					OS.ReleaseDC (handle, hDC);
 					newWidth = Math.max (newWidth, rect.right - rect.left);
 				} else {
-					TCHAR buffer = new TCHAR (getCodePage (), string, true);
+					TCHAR buffer = new TCHAR (string, true);
 					newWidth = Math.max (newWidth, (int)OS.SendMessage (handle, OS.LVM_GETSTRINGWIDTH, 0, buffer));
 				}
 			}

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TableColumn.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TableColumn.java
@@ -400,7 +400,7 @@ public void pack () {
 	if (index == -1) return;
 	long hwnd = parent.handle;
 	int oldWidth = (int)OS.SendMessage (hwnd, OS.LVM_GETCOLUMNWIDTH, index, 0);
-	TCHAR buffer = new TCHAR (parent.getCodePage (), text, true);
+	TCHAR buffer = new TCHAR (text, true);
 	int headerWidth = (int) (OS.SendMessage (hwnd, OS.LVM_GETSTRINGWIDTH, 0, buffer) + Win32DPIUtils.pointToPixel(Table.HEADER_MARGIN + Table.HEADER_EXTRA, getAutoscalingZoom()));
 	boolean hasHeaderImage = false;
 	if (image != null) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TableItem.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/TableItem.java
@@ -277,7 +277,7 @@ RECT getBounds (int row, int column, boolean getText, boolean getImage, boolean 
 				int width = 0;
 				long hFont = fontHandle (column);
 				if (hFont == -1 && hDC == 0) {
-					TCHAR buffer = new TCHAR (parent.getCodePage (), text, true);
+					TCHAR buffer = new TCHAR (text, true);
 					width = (int)OS.SendMessage (hwnd, OS.LVM_GETSTRINGWIDTH, 0, buffer);
 				} else {
 					char [] buffer = text.toCharArray ();

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Text.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Text.java
@@ -107,7 +107,7 @@ public class Text extends Scrollable {
 	}
 
 	static final long EditProc;
-	static final TCHAR EditClass = new TCHAR (0, "EDIT", true);
+	static final TCHAR EditClass = new TCHAR ("EDIT", true);
 	static {
 		WNDCLASS lpWndClass = new WNDCLASS ();
 		OS.GetClassInfo (0, EditClass, lpWndClass);
@@ -517,7 +517,7 @@ public void append (String string) {
 	}
 	OS.SendMessage (handle, OS.EM_SETSEL, length, length);
 	clearSegments (true);
-	TCHAR buffer = new TCHAR (getCodePage (), string, true);
+	TCHAR buffer = new TCHAR (string, true);
 	/*
 	* Feature in Windows.  When an edit control with ES_MULTILINE
 	* style that does not have the WS_VSCROLL style is full (i.e.
@@ -666,8 +666,7 @@ void clearSegments (boolean applyText) {
 	boolean oldIgnoreCharacter = ignoreCharacter, oldIgnoreModify = ignoreModify, oldIgnoreVerify = ignoreVerify;
 	ignoreCharacter = ignoreModify = ignoreVerify = true;
 	int length = OS.GetWindowTextLength (handle);
-	int cp = getCodePage ();
-	TCHAR buffer = new TCHAR (cp, length + 1);
+	TCHAR buffer = new TCHAR (length + 1);
 	if (length > 0) OS.GetWindowText (handle, buffer, length + 1);
 	buffer = deprocessText (buffer, 0, -1, true);
 	/* Get the current selection */
@@ -868,7 +867,7 @@ TCHAR deprocessText (TCHAR text, int start, int end, boolean terminate) {
 	if (start != 0 || end != length) {
 		char [] newChars = new char [length];
 		System.arraycopy(chars, start, newChars, 0, length);
-		return new TCHAR (getCodePage (), newChars, terminate);
+		return new TCHAR (newChars, terminate);
 	}
 	return text;
 }
@@ -1349,7 +1348,7 @@ public String getSelectionText () {
 	int [] start = new int [1], end = new int [1];
 	OS.SendMessage (handle, OS.EM_GETSEL, start, end);
 	if (start [0] == end [0]) return "";
-	TCHAR buffer = new TCHAR (getCodePage (), length + 1);
+	TCHAR buffer = new TCHAR (length + 1);
 	OS.GetWindowText (handle, buffer, length + 1);
 	if (segments != null) {
 		buffer = deprocessText (buffer, start [0], end [0], false);
@@ -1409,7 +1408,7 @@ public String getText () {
 	checkWidget ();
 	int length = OS.GetWindowTextLength (handle);
 	if (length == 0) return "";
-	TCHAR buffer = new TCHAR (getCodePage (), length + 1);
+	TCHAR buffer = new TCHAR (length + 1);
 	OS.GetWindowText (handle, buffer, length + 1);
 	if (segments != null) {
 		buffer = deprocessText (buffer, 0, -1, false);
@@ -1447,7 +1446,7 @@ public char[] getTextChars () {
 	checkWidget ();
 	int length = OS.GetWindowTextLength (handle);
 	if (length == 0) return new char[0];
-	TCHAR buffer = new TCHAR (getCodePage (), length + 1);
+	TCHAR buffer = new TCHAR (length + 1);
 	OS.GetWindowText (handle, buffer, length + 1);
 	if (segments != null) buffer = deprocessText (buffer, 0, -1, false);
 	char [] chars = new char [length];
@@ -1596,7 +1595,7 @@ public void insert (String string) {
 		if (string == null) return;
 	}
 	clearSegments (true);
-	TCHAR buffer = new TCHAR (getCodePage (), string, true);
+	TCHAR buffer = new TCHAR (string, true);
 	/*
 	* Feature in Windows.  When an edit control with ES_MULTILINE
 	* style that does not have the WS_VSCROLL style is full (i.e.
@@ -1757,7 +1756,7 @@ int resolveTextDirection() {
 	int textDirection = SWT.NONE;
 	int length = OS.GetWindowTextLength (handle);
 	if (length > 0) {
-		TCHAR buffer = new TCHAR (getCodePage (), length + 1);
+		TCHAR buffer = new TCHAR (length + 1);
 		OS.GetWindowText (handle, buffer, length + 1);
 		if (segments != null) {
 			buffer = deprocessText (buffer, 0, -1, false);
@@ -1872,7 +1871,7 @@ boolean sendKeyEvent (int type, int msg, long wParam, long lParam, Event event) 
 	if (newText == null) return false;
 	if (newText == oldText) return true;
 	newText = Display.withCrLf (newText);
-	TCHAR buffer = new TCHAR (getCodePage (), newText, true);
+	TCHAR buffer = new TCHAR (newText, true);
 	OS.SendMessage (handle, OS.EM_SETSEL, start [0], end [0]);
 	/*
 	* Feature in Windows.  When an edit control with ES_MULTILINE
@@ -2316,7 +2315,7 @@ public void setText (String string) {
 	clearSegments (false);
 	int limit = (int)OS.SendMessage (handle, OS.EM_GETLIMITTEXT, 0, 0) & 0x7FFFFFFF;
 	if (string.length () > limit) string = string.substring (0, limit);
-	TCHAR buffer = new TCHAR (getCodePage (), string, true);
+	TCHAR buffer = new TCHAR (string, true);
 	OS.SetWindowText (handle, buffer);
 	if ((state & HAS_AUTO_DIRECTION) != 0) {
 		super.updateTextDirection(AUTO_TEXT_DIRECTION);
@@ -2380,7 +2379,7 @@ public void setTextChars (char[] text) {
 		System.arraycopy(text, 0, temp, 0, limit);
 		text = temp;
 	}
-	TCHAR buffer = new TCHAR (getCodePage (), text, true);
+	TCHAR buffer = new TCHAR (text, true);
 	OS.SetWindowText (handle, buffer);
 	buffer.clear ();
 	if ((state & HAS_AUTO_DIRECTION) != 0) {
@@ -3001,7 +3000,7 @@ LRESULT wmClipboard (int msg, long wParam, long lParam) {
 				callWindowProc (handle, msg, wParam, lParam);
 			}
 			newText = Display.withCrLf (newText);
-			TCHAR buffer = new TCHAR (getCodePage (), newText, true);
+			TCHAR buffer = new TCHAR (newText, true);
 			/*
 			* Feature in Windows.  When an edit control with ES_MULTILINE
 			* style that does not have the WS_VSCROLL style is full (i.e.

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ToolBar.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ToolBar.java
@@ -57,7 +57,7 @@ public class ToolBar extends Composite {
 	boolean ignoreResize, ignoreMouse;
 	ImageList imageList, disabledImageList, hotImageList;
 	static final long ToolBarProc;
-	static final TCHAR ToolBarClass = new TCHAR (0, OS.TOOLBARCLASSNAME, true);
+	static final TCHAR ToolBarClass = new TCHAR (OS.TOOLBARCLASSNAME, true);
 	static {
 		WNDCLASS lpWndClass = new WNDCLASS ();
 		OS.GetClassInfo (0, ToolBarClass, lpWndClass);

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ToolItem.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ToolItem.java
@@ -947,12 +947,12 @@ void _setText (String string) {
 		if ((style & SWT.FLIP_TEXT_DIRECTION) != 0) {
 			int bits  = OS.GetWindowLong (hwnd, OS.GWL_EXSTYLE);
 			if ((bits & OS.WS_EX_LAYOUTRTL) != 0) {
-				buffer = new TCHAR (parent.getCodePage (), LRE + string, true);
+				buffer = new TCHAR (LRE + string, true);
 			} else {
-				buffer = new TCHAR (parent.getCodePage (), RLE + string, true);
+				buffer = new TCHAR (RLE + string, true);
 			}
 		} else {
-			buffer = new TCHAR(parent.getCodePage (), string, true);
+			buffer = new TCHAR(string, true);
 		}
 		int byteCount = buffer.length () * TCHAR.sizeof;
 		pszText = OS.HeapAlloc (hHeap, OS.HEAP_ZERO_MEMORY, byteCount);

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Tree.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Tree.java
@@ -122,9 +122,9 @@ public class Tree extends Composite {
 	// The default Indent at 100 dpi
 	static final int DEFAULT_INDENT = 16;
 	static final long TreeProc;
-	static final TCHAR TreeClass = new TCHAR (0, OS.WC_TREEVIEW, true);
+	static final TCHAR TreeClass = new TCHAR (OS.WC_TREEVIEW, true);
 	static final long HeaderProc;
-	static final TCHAR HeaderClass = new TCHAR (0, OS.WC_HEADER, true);
+	static final TCHAR HeaderClass = new TCHAR (OS.WC_HEADER, true);
 	static {
 		WNDCLASS lpWndClass = new WNDCLASS ();
 		OS.GetClassInfo (0, TreeClass, lpWndClass);
@@ -1910,7 +1910,7 @@ void createHeaderToolTips () {
 	if ((style & SWT.RIGHT_TO_LEFT) != 0) bits |= OS.WS_EX_LAYOUTRTL;
 	headerToolTipHandle = OS.CreateWindowEx (
 		bits,
-		new TCHAR (0, OS.TOOLTIPS_CLASS, true),
+		new TCHAR (OS.TOOLTIPS_CLASS, true),
 		null,
 		OS.TTS_NOPREFIX,
 		OS.CW_USEDEFAULT, 0, OS.CW_USEDEFAULT, 0,
@@ -2221,7 +2221,7 @@ void createItemToolTips () {
 	bits2 |= OS.WS_EX_TRANSPARENT;
 	itemToolTipHandle = OS.CreateWindowEx (
 		bits2,
-		new TCHAR (0, OS.TOOLTIPS_CLASS, true),
+		new TCHAR (OS.TOOLTIPS_CLASS, true),
 		null,
 		OS.TTS_NOPREFIX | OS.TTS_NOANIMATE | OS.TTS_NOFADE,
 		OS.CW_USEDEFAULT, 0, OS.CW_USEDEFAULT, 0,


### PR DESCRIPTION
## Summary

The `TCHAR.codePage` parameter has been silently ignored since Win9x/ANSI support was dropped. All Win32 calls in SWT use Unicode APIs exclusively, so the parameter was vestigial.

- Remove `codePage` from all four `TCHAR` constructors
- Update call sites
- Remove the dead `Control.getCodePage()` method (it unconditionally returned `OS.CP_ACP = 0`)
- Remove the dead `OS.CP_ACP = 0x0` constant
- Remove local `cp`/`codePage` variables that existed solely to pass to `TCHAR` constructors
- Update the `TCHAR` class Javadoc to reflect its actual purpose as a null-terminated `char[]` buffer for Win32 Unicode APIs

🤖 Generated with [Claude Code](https://claude.com/claude-code)