### PR TITLE
[Win32] Remove runtime change of process DPI awareness

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT PI/win32/library/os.c
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/win32/library/os.c
@@ -8772,18 +8772,6 @@ JNIEXPORT jint JNICALL OS_NATIVE(SetPolyFillMode)
 }
 #endif
 
-#ifndef NO_SetProcessDPIAware
-JNIEXPORT jboolean JNICALL OS_NATIVE(SetProcessDPIAware)
-	(JNIEnv *env, jclass that)
-{
-	jboolean rc = 0;
-	OS_NATIVE_ENTER(env, that, SetProcessDPIAware_FUNC);
-	rc = (jboolean)SetProcessDPIAware();
-	OS_NATIVE_EXIT(env, that, SetProcessDPIAware_FUNC);
-	return rc;
-}
-#endif
-
 #ifndef NO_SetProp
 JNIEXPORT jboolean JNICALL OS_NATIVE(SetProp)
 	(JNIEnv *env, jclass that, jlong arg0, jlong arg1, jlong arg2)

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/win32/library/os_stats.h
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/win32/library/os_stats.h
@@ -654,7 +654,6 @@ typedef enum {
 	SetPixel_FUNC,
 	SetPolyFillMode_FUNC,
 	SetPreferredAppMode_FUNC,
-	SetProcessDPIAware_FUNC,
 	SetProp_FUNC,
 	SetROP2_FUNC,
 	SetRect_FUNC,

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/win32/org/eclipse/swt/internal/win32/OS.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/win32/org/eclipse/swt/internal/win32/OS.java
@@ -59,9 +59,6 @@ public class OS extends C {
 			*/
 		}
 
-		/* Make the process DPI aware for Windows Vista */
-		OS.SetProcessDPIAware ();
-
 		/* Get the DBCS flag */
 		IsDBLocale = OS.GetSystemMetrics (SM_IMMENABLED) != 0;
 	}
@@ -4346,7 +4343,6 @@ public static final native long SetParent (long hWndChild, long hWndNewParent);
 public static final native int SetPixel (long hdc, int X, int Y, int crColor);
 /** @param hdc cast=(HDC) */
 public static final native int SetPolyFillMode (long hdc, int iPolyFillMode);
-public static final native boolean SetProcessDPIAware ();
 /**
  * @method flags=dynamic
  * @param dpiContext cast=(DPI_AWARENESS_CONTEXT)


### PR DESCRIPTION
SWT initialization modifies the process DPI awareness via the static initializer of the OS class. This has been implemented for DPI awareness on Windows Vista long time ago (https://github.com/eclipse-platform/eclipse.platform.swt/commit/c9bc8bf1f3346d67fe47becef3a67f96a08bd20f). Changing process DPI awareness programmatically is discouraged and should rather be done by the application's manifest: https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-setprocessdpiaware

In addition, relevant executables into which SWT is embedded (JVM, Equinox launcher etc.) already have state-of-the-art settings for DPI awareness, which even activate higher levels of DPI awareness than what the call to `setProcessDPIAware` (conforming to "System" DPI awareness) does. In consequence, this call has no benefit but may rather interfere with DPI awareness settings already done via the manifest.

This change thus removes the obsolete programmatic setting of process DPI awareness along with the now unused native method.