### PR TITLE
[Win32] Silence deprecation warnings in Accessibility

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Accessibility/gtk/org/eclipse/swt/accessibility/AccessibleObject.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Accessibility/gtk/org/eclipse/swt/accessibility/AccessibleObject.java
@@ -2072,6 +2072,7 @@ class AccessibleObject {
 	 *
 	 * @return a pointer to the AtkObject representing the caption, or 0
 	 */
+	@SuppressWarnings("deprecation")
 	static long atkTable_get_caption (long atkObject) {
 		AccessibleObject object = getAccessibleObject (atkObject);
 		if (object != null) {
@@ -2108,6 +2109,7 @@ class AccessibleObject {
 	 *
 	 * @return a pointer to the AtkObject representing the summary, or 0
 	 */
+	@SuppressWarnings("deprecation")
 	static long atkTable_get_summary (long atkObject) {
 		AccessibleObject object = getAccessibleObject (atkObject);
 		if (object != null) {

--- a/bundles/org.eclipse.swt/Eclipse SWT Accessibility/win32/org/eclipse/swt/accessibility/Accessible.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Accessibility/win32/org/eclipse/swt/accessibility/Accessible.java
@@ -3847,6 +3847,7 @@ public class Accessible {
 	}
 
 	/* IAccessibleTable2::get_caption([out] ppAccessible) */
+	@SuppressWarnings("deprecation")
 	int get_caption(long ppAccessible) {
 		if (control != null && control.isDisposed()) return COM.CO_E_OBJNOTCONNECTED;
 		AccessibleTableEvent event = new AccessibleTableEvent(this);
@@ -4035,6 +4036,7 @@ public class Accessible {
 	}
 
 	/* IAccessibleTable2::get_summary([out] ppAccessible) */
+	@SuppressWarnings("deprecation")
 	int get_summary(long ppAccessible) {
 		if (control != null && control.isDisposed()) return COM.CO_E_OBJNOTCONNECTED;
 		AccessibleTableEvent event = new AccessibleTableEvent(this);


### PR DESCRIPTION
Caption and summary for a table are provided via deprecated methods for almost two decades. Since there was not attempt and need to replace those methods with proper implementations yet, so that the warnings do not produce any reasonable insights, this change silences them. In case the deprecated methods are replaced, the callers need to be adapted anyway as the SWT code will otherwise not compile anymore.

Methods deprecated in 2017 via bd447c3a64e9e688af38401a7478d098861973cc

<img width="816" height="37" alt="image" src="https://github.com/user-attachments/assets/b1e90705-cefc-428a-8e50-d1f98d5112f5" />

<img width="368" height="179" alt="image" src="https://github.com/user-attachments/assets/d9e5822b-3312-4597-a25e-26f50ecd169b" />
