### PR TITLE
[Win32] Fix tree tooltips for reordered columns

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Tree.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Tree.java
@@ -5600,11 +5600,13 @@ String toolTipText (NMTTDISPINFO hdr) {
 		RECT [] cellRect = new RECT [1], itemRect = new RECT [1];
 		if (findCell (pt.x, pt.y, item, index, cellRect, itemRect)) {
 			String text = null;
-			if (index [0] == 0) {
+			int[] columnOrder = getColumnOrder();
+			int orderedIndex = columnOrder.length != 0 ? columnOrder [index[0]] : index[0];
+			if (orderedIndex == 0) {
 				text = item [0].text;
 			} else {
 				String[] strings = item [0].strings;
-				if (strings != null) text = strings [index [0]];
+				if (strings != null) text = strings [orderedIndex];
 			}
 			//TEMPORARY CODE
 			if (isCustomToolTip ()) text = " ";


### PR DESCRIPTION
When reordering columns of a tree control, wrong tooltips are shown when hovering over a cell that is too small to show the full content. Instead of the content of the actual cell at that place, the one of the cell that was originally placed at that position (without column reordering) is shown.

This change corrects the index used for retrieving the tooltip content by considering the column order.

Found when working on:
- https://github.com/eclipse-platform/eclipse.platform.swt/pull/801

### How to test

For example with the following snippet:
```java
public static void main (String [] args) {
	Display display = new Display ();
	Shell shell = new Shell(display);
	shell.setLayout(new FillLayout());
	Tree t = new Tree (shell, 0);
	t.setHeaderVisible(true);
	t.setLinesVisible(true);
	TreeColumn col1 = new TreeColumn(t, 0);
	col1.setWidth(100);
	col1.setMoveable(true);
	TreeColumn col2 = new TreeColumn(t, 0);
	col2.setWidth(100);
	col2.setMoveable(true);
	new TreeItem (t, 0).setText(new String [] {"First column content", "Second column content"});

	shell.open ();
	while (!shell.isDisposed ()) {
		if (!display.readAndDispatch ()) display.sleep ();
	}
	display.dispose ();
}
```

When reordering the two columns, you see the following results:

Without the change:
<img width="251" height="66" alt="image" src="https://github.com/user-attachments/assets/106ceff0-1a84-44db-8da3-0e64d8a9417e" />


With the change:
<img width="271" height="55" alt="image" src="https://github.com/user-attachments/assets/887f6a98-346d-4405-8506-c5e722bd8200" />
