### PR TITLE
Remove obsolete and misleading code comment

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Button.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Button.java
@@ -206,11 +206,6 @@ void _setText (String text) {
 		OS.SetWindowLong (handle, OS.GWL_STYLE, newBits);
 		OS.InvalidateRect (handle, null, true);
 	}
-	/*
-	* Bug in Windows.  When a Button control is right-to-left and
-	* is disabled, the first pixel of the text is clipped.  The fix
-	* is to append a space to the text.
-	*/
 	TCHAR buffer = new TCHAR (getCodePage (), text, true);
 	OS.SetWindowText (handle, buffer);
 	if ((state & HAS_AUTO_DIRECTION) != 0) {


### PR DESCRIPTION
The code to which the comment belonged was removed in c77d695e019c8588836e2bfd6f985da5a9a6e968 but the comment was accidentally left in the code:
- https://github.com/eclipse-platform/eclipse.platform.swt/pull/3345