### PR TITLE
[Win32] Normalise \r and \r\n to \n in GDI+ text rendering

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/GC.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/GC.java
@@ -3057,6 +3057,10 @@ private void drawTextGDIP(long gdipGraphics, String string, int x, int y, int fl
 	char[] buffer;
 	if ((flags & SWT.DRAW_DELIMITER) == 0) {
 		string = string.replaceAll("[\\r\\n]+", "");
+	} else {
+		// Graphics_DrawString only recognises \n as a line break, not bare \r.
+		// Normalise \r\n -> \n first, then lone \r -> \n (order matters).
+		string = string.replace("\r\n", "\n").replace("\r", "\n");
 	}
 	int length = string.length();
 	if (length != 0) {

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_GC.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_GC.java
@@ -1007,6 +1007,45 @@ public void test_textExtentLjava_lang_StringI_disabledLineDelimiter() {
 	gc.dispose();
 }
 
+/**
+ * @see <a href="https://github.com/eclipse-platform/eclipse.platform.swt/issues/3091">Issue 3091</a>
+ */
+@Test
+public void test_textExtentLjava_lang_StringI_lineDelimiterVariants() {
+	// 中 has no glyph in common Latin fonts; on Win32 this causes useGDIP() to
+	// return true, routing text through drawTextGDIP() / Graphics_DrawString.
+	String withLF   = "a中\nb";
+	String withCR   = "a中\rb";
+	String withCRLF = "a中\r\nb";
+	int flags = SWT.DRAW_DELIMITER;
+
+	gc.setAdvanced(false);
+	Point lfNonAdv   = gc.textExtent(withLF,   flags);
+	Point crNonAdv   = gc.textExtent(withCR,   flags);
+	Point crlfNonAdv = gc.textExtent(withCRLF, flags);
+
+	gc.setAdvanced(true);
+	Point lfAdv   = gc.textExtent(withLF,   flags);
+	Point crAdv   = gc.textExtent(withCR,   flags);
+	Point crlfAdv = gc.textExtent(withCRLF, flags);
+
+	// All three line-ending types must produce the same text height in non-advanced mode.
+	assertEquals(lfNonAdv.y, crNonAdv.y,
+			"Non-advanced: CR must produce the same height as LF with DRAW_DELIMITER");
+	assertEquals(lfNonAdv.y, crlfNonAdv.y,
+			"Non-advanced: CRLF must produce the same height as LF with DRAW_DELIMITER");
+
+	// Advanced mode must agree with non-advanced within minor rendering tolerance.
+	// On Win32, \r and \r\n must be normalised to \n before passing to
+	// Graphics_DrawString, which does not treat bare \r as a line delimiter.
+	assertTrue(Math.abs(lfAdv.y   - lfNonAdv.y)   <= 2,
+			"LF: advanced height must match non-advanced");
+	assertTrue(Math.abs(crAdv.y   - crNonAdv.y)   <= 2,
+			"CR: advanced height must match non-advanced");
+	assertTrue(Math.abs(crlfAdv.y - crlfNonAdv.y) <= 2,
+			"CRLF: advanced height must match non-advanced");
+}
+
 @Test
 public void test_toString() {
 	String s = gc.toString();


### PR DESCRIPTION
## Summary

GDI+ `Graphics_DrawString` only treats `\n` as a line delimiter; bare `\r` is silently ignored rather than treated as a line break. The GDI `DrawText` path (non-advanced mode) and the old `DrawDriverString` path both accept `\r` and `\r\n` as line delimiters, so callers that pass Windows-style (CRLF) or old Mac-style (CR-only) line endings with `DRAW_DELIMITER` set get different results depending on whether advanced mode is active.

- Fix: in `drawTextGDIP()`, when `DRAW_DELIMITER` is active, normalise `\r\n` → `\n` first (to avoid double line breaks), then convert any remaining lone `\r` → `\n` before passing the string to `Graphics_DrawString`.
- Add a cross-platform regression test (`test_textExtentLjava_lang_StringI_lineDelimiterVariants`) that verifies all three line-ending variants produce the same `textExtent` height in both advanced and non-advanced mode.

Contributes to https://github.com/eclipse-platform/eclipse.platform.swt/issues/3091

## Manual verification

The following snippet renders the same two-line text with `\n`, `\r`, and `\r\n` in both GDI (reference) and GDI+ mode side by side. Before the fix, the CR column in the GDI+ row shows both lines collapsed onto one line. After the fix all six cells look identical.

The `中` character is included in the GDI+ strings to force the `drawTextGDIP()` path via `useGDIP()` (it has no glyph in Courier New). It appears at the end of line 2 and can be ignored.

```java
import org.eclipse.swt.*;
import org.eclipse.swt.graphics.*;
import org.eclipse.swt.layout.*;
import org.eclipse.swt.widgets.*;

public class SnippetGdipLineEndings {

    private static final String GDIP_TRIGGER = "中";

    private static final String[][] CASES = {
        { "LF  (\n)",     "Line1\nLine2",   "Line1\nLine2 "   + GDIP_TRIGGER },
        { "CR  (\r)",     "Line1\rLine2",   "Line1\rLine2 "   + GDIP_TRIGGER },
        { "CRLF (\r\n)", "Line1\r\nLine2", "Line1\r\nLine2 " + GDIP_TRIGGER },
    };

    public static void main(String[] args) {
        Display display = new Display();
        Shell shell = new Shell(display);
        shell.setText("GDI+ line-ending test");
        shell.setSize(660, 340);
        shell.setLayout(new FillLayout());

        Canvas canvas = new Canvas(shell, SWT.DOUBLE_BUFFERED);
        Font font = new Font(display, "Courier New", 11, SWT.NORMAL);
        canvas.setFont(font);

        canvas.addPaintListener(e -> {
            GC gc = e.gc;
            gc.setFont(font);
            int colW = 200, rowH = 120, labelH = 18, margin = 10;

            for (int i = 0; i < CASES.length; i++) {
                gc.setAdvanced(false);
                gc.drawText(CASES[i][0], margin + i * colW, 5, SWT.DRAW_TRANSPARENT);
            }

            gc.setAdvanced(false);
            gc.drawText("GDI (reference):", margin, labelH + 8, SWT.DRAW_TRANSPARENT);
            for (int i = 0; i < CASES.length; i++) {
                int x = margin + i * colW, y = labelH + 24;
                gc.setAdvanced(false);
                gc.drawText(CASES[i][1], x, y, SWT.DRAW_DELIMITER | SWT.DRAW_TRANSPARENT);
                gc.drawRectangle(x - 2, y - 2, colW - 16, rowH - labelH - 24);
            }

            int row2Y = rowH + 10;
            gc.setAdvanced(false);
            gc.drawText("GDI+ (drawTextGDIP):", margin, row2Y + labelH + 8, SWT.DRAW_TRANSPARENT);
            gc.setAdvanced(true);
            for (int i = 0; i < CASES.length; i++) {
                int x = margin + i * colW, y = row2Y + labelH + 24;
                gc.drawText(CASES[i][2], x, y, SWT.DRAW_DELIMITER | SWT.DRAW_TRANSPARENT);
            }
            gc.setAdvanced(false);
            for (int i = 0; i < CASES.length; i++) {
                int x = margin + i * colW, y = row2Y + labelH + 24;
                gc.drawRectangle(x - 2, y - 2, colW - 16, rowH - labelH - 24);
            }
        });

        shell.open();
        while (!shell.isDisposed()) {
            if (!display.readAndDispatch()) display.sleep();
        }
        font.dispose();
        display.dispose();
    }
}
```