### PR TITLE
Enable anti-aliasing for dirty indicator rendering

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CTabFolderRenderer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CTabFolderRenderer.java
@@ -747,7 +747,10 @@ public class CTabFolderRenderer {
 		if (!selected) {
 			gc.setAlpha(140);
 		}
+		int originalAntialias = gc.getAntialias();
+		gc.setAntialias(SWT.ON);
 		gc.fillOval(x, y, diameter, diameter);
+		gc.setAntialias(originalAntialias);
 		gc.setAlpha(originalAlpha);
 		gc.setBackground(originalBackground);
 	}


### PR DESCRIPTION
The dirty indicator for editor tabs does currently not use anti-aliasing which makes it look quite jagged. This change enables anti-aliasing for the rendering of the dirty indicator.

Left is current state, right is with this change:
<img width="300" height="42" alt="image" src="https://github.com/user-attachments/assets/d3b73a56-cc23-4f05-b4d0-300ac81add5f" />
