### PR TITLE
Fix possible NPE in scrollwheel

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Control.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Control.java
@@ -2505,6 +2505,7 @@ Decorations menuShell () {
 
 @Override
 void scrollWheel (long id, long sel, long theEvent) {
+	if (display==null) return;
 	boolean handled = false;
 	if (id == view.id) {
 		NSEvent nsEvent = new NSEvent(theEvent);


### PR DESCRIPTION
Add a null check for display in Control.scrollWheel() to prevent a possible NPE on macOS

Fixes: https://github.com/eclipse-platform/eclipse.platform.swt/issues/358