### PR TITLE
Set Bundle-RequiredExecutionEnvironment in native SWT fragments

### DIFF
--- a/binaries/org.eclipse.swt.cocoa.macosx.aarch64/META-INF/MANIFEST.MF
+++ b/binaries/org.eclipse.swt.cocoa.macosx.aarch64/META-INF/MANIFEST.MF
@@ -4,6 +4,7 @@ Bundle-Name: %fragmentName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.swt.cocoa.macosx.aarch64; singleton:=true
 Bundle-Version: 3.135.0.qualifier
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-ManifestVersion: 2
 Bundle-Localization: fragment
 Export-Package: 

--- a/binaries/org.eclipse.swt.cocoa.macosx.x86_64/META-INF/MANIFEST.MF
+++ b/binaries/org.eclipse.swt.cocoa.macosx.x86_64/META-INF/MANIFEST.MF
@@ -4,6 +4,7 @@ Bundle-Name: %fragmentName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.swt.cocoa.macosx.x86_64; singleton:=true
 Bundle-Version: 3.135.0.qualifier
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-ManifestVersion: 2
 Bundle-Localization: fragment
 Export-Package: 

--- a/binaries/org.eclipse.swt.gtk.linux.aarch64/META-INF/MANIFEST.MF
+++ b/binaries/org.eclipse.swt.gtk.linux.aarch64/META-INF/MANIFEST.MF
@@ -4,6 +4,7 @@ Bundle-Name: %fragmentName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.swt.gtk.linux.aarch64; singleton:=true
 Bundle-Version: 3.135.0.qualifier
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-ManifestVersion: 2
 Bundle-Localization: fragment
 Export-Package: 

--- a/binaries/org.eclipse.swt.gtk.linux.loongarch64/META-INF/MANIFEST.MF
+++ b/binaries/org.eclipse.swt.gtk.linux.loongarch64/META-INF/MANIFEST.MF
@@ -3,7 +3,8 @@ Fragment-Host: org.eclipse.swt;bundle-version="[3.128.0,4.0.0)"
 Bundle-Name: %fragmentName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.swt.gtk.linux.loongarch64; singleton:=true
-Bundle-Version: 3.134.0.qualifier
+Bundle-Version: 3.135.0.qualifier
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-ManifestVersion: 2
 Bundle-Localization: fragment
 Export-Package: 

--- a/binaries/org.eclipse.swt.gtk.linux.ppc64le/META-INF/MANIFEST.MF
+++ b/binaries/org.eclipse.swt.gtk.linux.ppc64le/META-INF/MANIFEST.MF
@@ -4,6 +4,7 @@ Bundle-Name: %fragmentName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.swt.gtk.linux.ppc64le;singleton:=true
 Bundle-Version: 3.135.0.qualifier
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-ManifestVersion: 2
 Bundle-Localization: fragment
 Export-Package: 

--- a/binaries/org.eclipse.swt.gtk.linux.riscv64/META-INF/MANIFEST.MF
+++ b/binaries/org.eclipse.swt.gtk.linux.riscv64/META-INF/MANIFEST.MF
@@ -4,6 +4,7 @@ Bundle-Name: %fragmentName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.swt.gtk.linux.riscv64; singleton:=true
 Bundle-Version: 3.135.0.qualifier
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-ManifestVersion: 2
 Bundle-Localization: fragment
 Export-Package: 

--- a/binaries/org.eclipse.swt.gtk.linux.x86_64/META-INF/MANIFEST.MF
+++ b/binaries/org.eclipse.swt.gtk.linux.x86_64/META-INF/MANIFEST.MF
@@ -4,6 +4,7 @@ Bundle-Name: %fragmentName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.swt.gtk.linux.x86_64; singleton:=true
 Bundle-Version: 3.135.0.qualifier
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-ManifestVersion: 2
 Bundle-Localization: fragment
 Export-Package: 

--- a/binaries/org.eclipse.swt.win32.win32.aarch64/META-INF/MANIFEST.MF
+++ b/binaries/org.eclipse.swt.win32.win32.aarch64/META-INF/MANIFEST.MF
@@ -4,6 +4,7 @@ Bundle-Name: %fragmentName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.swt.win32.win32.aarch64; singleton:=true
 Bundle-Version: 3.135.0.qualifier
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-ManifestVersion: 2
 Bundle-Localization: fragment
 Export-Package: 

--- a/binaries/org.eclipse.swt.win32.win32.x86_64/META-INF/MANIFEST.MF
+++ b/binaries/org.eclipse.swt.win32.win32.x86_64/META-INF/MANIFEST.MF
@@ -4,6 +4,7 @@ Bundle-Name: %fragmentName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.swt.win32.win32.x86_64; singleton:=true
 Bundle-Version: 3.135.0.qualifier
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-ManifestVersion: 2
 Bundle-Localization: fragment
 Export-Package: 


### PR DESCRIPTION
Because the native SWT fragments don't have a BREE set and the I/Y-build run the build with the `bree-libs` profile activated, the following warning is emitted:
```
[INFO] --- tycho-compiler:5.0.3:compile (default-compile) @ org.eclipse.swt.cocoa.macosx.aarch64 ---
[WARNING] useJDK=BREE configured, but no BREE is set in bundle. Fail back to currently running execution environment (JavaSE-21).
```
This sets the BREE for all native SWT fragments (like it's already done for the SVG fragment) to avoid that warning.

In the context of https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/3891, it might otherwise happen that the SWT native fragment will be compiled with Java-25.

This was also requested in
- https://github.com/eclipse-platform/eclipse.platform.swt/issues/3310