### PR TITLE
[Win32] Add format for VS 2026 path to binaries build script

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT PI/win32/library/build.bat
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/win32/library/build.bat
@@ -21,7 +21,9 @@ echo INFO Starting build of binaries. Detailed system setup instructions can be 
 @rem Specify VisualStudio Edition: 'Community', 'Enterprise', 'Professional' etc.
 IF "x.%MSVC_EDITION%"=="x." set "MSVC_EDITION=auto"
 
-@rem Specify VisualStudio Version: '2022', '2019', '2017' etc.
+@rem Specify VisualStudio Version:
+@rem Up to VisualStudio 2022 the version year is relevant for the installation path ('2022', '2019', '2017' etc.)
+@rem Starting with VisualStudio 2026, the internal version number is relevant ('18' for VS2026) 
 IF "x.%MSVC_VERSION%"=="x." set "MSVC_VERSION=auto"
 
 @rem Search for a usable Visual Studio
@@ -100,6 +102,7 @@ GOTO :EOF
 @rem %1 = path template with '$MSVC_VERSION$' and '$MSVC_EDITION$' tokens
 :FindVisualStudio
 	IF "%MSVC_VERSION%"=="auto" (
+		CALL :FindVisualStudio2 "%~1" "18"
 		CALL :FindVisualStudio2 "%~1" "2022"
 		CALL :FindVisualStudio2 "%~1" "2019"
 		CALL :FindVisualStudio2 "%~1" "2017"


### PR DESCRIPTION
Visual Studio 2026 uses a new default path pattern containing the internal version number instead of the external version year. This change adapts the logic for searching the visual studio installation in the build script to match this Visual Studio 2026 path.

Fixes these issues that arised when the GHA runner image was updated with one that includes VS 2026, see https://github.com/actions/runner-images/blob/win25-vs2026/20260608.135/images/windows/Windows2025-VS2026-Readme.md#visual-studio-enterprise-2026:
```
[INFO]      [exec] WARNING: Microsoft Visual Studio was not found (for edition=auto version=auto)
[INFO]      [exec]          Refer steps for SWT Windows native setup: https://eclipse.dev/eclipse/swt/swt_win_native.html
[INFO]      [exec] The system cannot find the path specified.
[INFO]      [exec] INFO: Could not find files for the given pattern(s).ERROR: cl (Microsoft C compiler) not found on path. Please install Microsoft Visual Studio.
[INFO]      [exec] 
[INFO]      [exec]          If already installed, try launching eclipse from the 'Developer Command Prompt for VS'
[INFO]      [exec]          Refer steps for SWT Windows native setup: https://eclipse.dev/eclipse/swt/swt_win_native.html
[INFO]      [exec] ERROR: exit 1
```