### PR TITLE
[Win32] Replace deprecated URL constructor with URI in examples

### DIFF
--- a/examples/org.eclipse.swt.examples.ole.win32/META-INF/MANIFEST.MF
+++ b/examples/org.eclipse.swt.examples.ole.win32/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %plugin.SWTOLEExample.name
 Bundle-SymbolicName: org.eclipse.swt.examples.ole.win32; singleton:=true
-Bundle-Version: 3.110.0.qualifier
+Bundle-Version: 3.110.100.qualifier
 Bundle-Activator: org.eclipse.swt.examples.ole.win32.OlePlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/examples/org.eclipse.swt.examples.ole.win32/pom.xml
+++ b/examples/org.eclipse.swt.examples.ole.win32/pom.xml
@@ -20,7 +20,7 @@
     <relativePath>../../</relativePath>
   </parent>
   <artifactId>org.eclipse.swt.examples.ole.win32</artifactId>
-  <version>3.110.0-SNAPSHOT</version>
+  <version>3.110.100-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
   <build>

--- a/examples/org.eclipse.swt.examples.ole.win32/src/org/eclipse/swt/examples/ole/win32/OlePlugin.java
+++ b/examples/org.eclipse.swt.examples.ole.win32/src/org/eclipse/swt/examples/ole/win32/OlePlugin.java
@@ -172,8 +172,8 @@ public class OlePlugin extends AbstractUIPlugin {
 	 * @return the image, or null if not found
 	 */
 	private static Image getImageFromPlugin(Bundle bundle, String iconPath) {
-		URL installUrl = bundle.getEntry("/");
-		try (InputStream is = new URL(installUrl, iconPath).openConnection().getInputStream()) {
+		URL iconUrl = bundle.getEntry(iconPath);
+		try (InputStream is = iconUrl.openConnection().getInputStream()) {
 			ImageData source = new ImageData(is);
 			ImageData mask = source.getTransparencyMask();
 			Image image = new Image(null, source, mask);


### PR DESCRIPTION
The URL(URL context, String spec) constructor used in OlePlugin.getImageFromPlugin() of the OLE examples project is deprecated since Java 20. This replaces it with an URI-based approach.