### PR TITLE
[Win32] Dispose all handles in an ImageList

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/ImageList.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/ImageList.java
@@ -322,7 +322,8 @@ long createMask (long hBitmap, int destWidth, int destHeight, int background, in
 }
 
 public void dispose () {
-	if (handle != 0) OS.ImageList_Destroy (handle);
+	zoomToHandle.values().stream().filter(it -> it != 0).forEach(OS::ImageList_Destroy);
+	zoomToHandle.clear();
 	handle = 0;
 	images = null;
 }


### PR DESCRIPTION
The ImageList's dispose method erroneously only destroys the handle for the image list that first created first and is stored as the primary handle. Further image list handles created for other zoom are not destroyed at all.

This change ensures that all handles created for an ImageList instance are properly destroyed on disposal.

Contributes to https://github.com/eclipse-platform/eclipse.platform.swt/issues/3385