### PR TITLE
[Win32] Consolidate ImageList zoom handling into ImageList itself

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/internal/ImageListTests.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/internal/ImageListTests.java
@@ -1,0 +1,135 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Vector Informatik GmbH and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.swt.internal;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.eclipse.swt.*;
+import org.eclipse.swt.graphics.*;
+import org.eclipse.swt.internal.win32.*;
+import org.eclipse.swt.widgets.*;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.*;
+
+@ExtendWith(PlatformSpecificExecutionExtension.class)
+public class ImageListTests {
+
+	@Test
+	public void testGetHandleReturnsDifferentHandlesForDifferentZooms() {
+		ImageList list = new ImageList(SWT.NONE, 16, 16, 100);
+		try {
+			long handle100 = list.getHandle(100);
+			long handle200 = list.getHandle(200);
+			assertNotEquals(0, handle100);
+			assertNotEquals(0, handle200);
+			assertNotEquals(handle100, handle200, "handles for different zooms must differ");
+		} finally {
+			list.dispose();
+		}
+	}
+
+	@Test
+	public void testGetHandleReturnsCorrectPixelDimensionsPerZoom() {
+		int widthPt = 16;
+		int heightPt = 16;
+		ImageList list = new ImageList(SWT.NONE, widthPt, heightPt, 100);
+		try {
+			int[] cx = new int[1], cy = new int[1];
+
+			OS.ImageList_GetIconSize(list.getHandle(100), cx, cy);
+			assertEquals(DPIUtil.pointToPixel(widthPt, 100), cx[0], "width at 100%");
+			assertEquals(DPIUtil.pointToPixel(heightPt, 100), cy[0], "height at 100%");
+
+			OS.ImageList_GetIconSize(list.getHandle(200), cx, cy);
+			assertEquals(DPIUtil.pointToPixel(widthPt, 200), cx[0], "width at 200%");
+			assertEquals(DPIUtil.pointToPixel(heightPt, 200), cy[0], "height at 200%");
+
+			OS.ImageList_GetIconSize(list.getHandle(150), cx, cy);
+			assertEquals(DPIUtil.pointToPixel(widthPt, 150), cx[0], "width at 150%");
+			assertEquals(DPIUtil.pointToPixel(heightPt, 150), cy[0], "height at 150%");
+		} finally {
+			list.dispose();
+		}
+	}
+
+	@Test
+	public void testGetHandleReturnsSameHandleOnRepeatedCall() {
+		ImageList list = new ImageList(SWT.NONE, 16, 16, 100);
+		try {
+			long first = list.getHandle(200);
+			long second = list.getHandle(200);
+			assertEquals(first, second, "repeated getHandle for same zoom must return same handle");
+		} finally {
+			list.dispose();
+		}
+	}
+
+	@Test
+	public void testAddFirstImageAdaptsListSize() {
+		ImageList list = new ImageList(SWT.NONE, 24, 24, 100);
+		Display display = Display.getDefault();
+		Image image = new Image(display, 16, 16);
+		try {
+			list.add(image);
+			Point size = list.getImageSize();
+			assertEquals(new Point(16, 16), size);
+		} finally {
+			list.dispose();
+			image.dispose();
+			display.dispose();
+		}
+	}
+
+	@Test
+	public void testFirstImageSizeAppliedToAllHandles() {
+		ImageList list = new ImageList(SWT.NONE, 24, 24, 100);
+		Display display = Display.getDefault();
+		Image image = new Image(display, 16, 16);
+		try {
+			long handle = list.getHandle(150);
+			list.add(image);
+			int[] cx = new int[1];
+			int[] cy = new int[1];
+			OS.ImageList_GetIconSize(handle, cx, cy);
+			assertEquals(new Point(24, 24), new Point(cx[0], cy[0]));
+			OS.ImageList_GetIconSize(list.getHandle(200), cx, cy);
+			assertEquals(new Point(32, 32), new Point(cx[0], cy[0]));
+
+		} finally {
+			list.dispose();
+			image.dispose();
+			display.dispose();
+		}
+	}
+
+	@Test
+	public void testGetImageSizeReturnsStoredPoints() {
+		ImageList list = new ImageList(SWT.NONE, 24, 24, 100);
+		try {
+			Point size = list.getImageSize();
+			assertEquals(new Point(24, 24), size);
+		} finally {
+			list.dispose();
+		}
+	}
+
+	@Test
+	public void testIsFittingForDistinguishesSize() {
+		ImageList list = new ImageList(SWT.NONE, 16, 16, 100);
+		try {
+			assertTrue(list.isFittingFor(SWT.NONE, 16, 16));
+			assertFalse(list.isFittingFor(SWT.NONE, 32, 32));
+		} finally {
+			list.dispose();
+		}
+	}
+
+}

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/ImageList.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/ImageList.java
@@ -24,8 +24,7 @@ public class ImageList {
 	long handle;
 	int style, refCount;
 	Image [] images;
-	private final int zoom;
-	private final int width, height;
+	private int width, height;
 	private final int flags;
 
 	private HashMap<Integer, Long> zoomToHandle = new HashMap<>();
@@ -41,10 +40,11 @@ public ImageList (int style, int width, int height, int zoom) {
 	this.flags = listFlags;
 	this.height = height;
 	this.width = width;
-	handle = OS.ImageList_Create (width, height, this.flags, 16, 16);
+	int widthInPixels = DPIUtil.pointToPixel(width, zoom);
+	int heightInPixels = DPIUtil.pointToPixel(height, zoom);
+	handle = OS.ImageList_Create (widthInPixels, heightInPixels, this.flags, 16, 16);
 	zoomToHandle.put(zoom, handle);
 	images = new Image [4];
-	this.zoom = zoom;
 }
 
 public int add (Image image) {
@@ -56,8 +56,10 @@ public int add (Image image) {
 		index++;
 	}
 	if (count == 0) {
-		Rectangle rect = Win32DPIUtils.scaleBounds(image.getBounds(), zoom, 100);
-		OS.ImageList_SetIconSize (handle, rect.width, rect.height);
+		Rectangle bounds = image.getBounds();
+		width = bounds.width;
+		height = bounds.height;
+		zoomToHandle.forEach((zoom, handleForZoom) -> OS.ImageList_SetIconSize(handleForZoom, DPIUtil.pointToPixel(width, zoom), DPIUtil.pointToPixel(height, zoom)));
 	}
 	setForAllHandles(index, image, count);
 	if (index == images.length) {
@@ -334,8 +336,8 @@ public Image get (int index) {
 
 public long getHandle(int targetZoom) {
 	if (!zoomToHandle.containsKey(targetZoom)) {
-		int scaledWidth = DPIUtil.pointToPixel(DPIUtil.pixelToPoint(width, this.zoom), targetZoom);
-		int scaledHeight = DPIUtil.pointToPixel(DPIUtil.pixelToPoint(height, this.zoom), targetZoom);
+		int scaledWidth = DPIUtil.pointToPixel(width, targetZoom);
+		int scaledHeight = DPIUtil.pointToPixel(height, targetZoom);
 		long newImageListHandle = OS.ImageList_Create(scaledWidth, scaledHeight, flags, 16, 16);
 		int count = OS.ImageList_GetImageCount (handle);
 		for (int i = 0; i < count; i++) {
@@ -366,14 +368,11 @@ private void addPlaceholderImageToImageList(long imageListHandle, int bitmapWidt
  * {@return size of Images in the ImageList in points}
  */
 public Point getImageSize() {
-	int [] cx = new int [1], cy = new int [1];
-	OS.ImageList_GetIconSize (handle, cx, cy);
-	return Win32DPIUtils.pixelToPointAsSize(new Point (cx [0], cy [0]), zoom);
+	return new Point(width, height);
 }
 
-public boolean isFittingFor(int style, int width, int height, int zoom) {
-	Point imageSize = getImageSize();
-	return this.style == style && imageSize.x == width && imageSize.y == height && this.zoom == zoom;
+public boolean isFittingFor(int style, int width, int height) {
+	return this.style == style && this.width == width && this.height == height;
 }
 
 public int indexOf (Image image) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Display.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Display.java
@@ -2045,7 +2045,7 @@ ImageList getImageList (int style, int width, int height, int zoom) {
 	while (i < length) {
 		ImageList list = imageList [i];
 		if (list == null) break;
-		if (list.isFittingFor(style, width, height, zoom)) {
+		if (list.isFittingFor(style, width, height)) {
 			list.addRef();
 			return list;
 		}
@@ -2058,7 +2058,7 @@ ImageList getImageList (int style, int width, int height, int zoom) {
 		imageList = newList;
 	}
 
-	ImageList list = new ImageList (style, DPIUtil.pointToPixel(width, zoom), DPIUtil.pointToPixel(height, zoom), zoom);
+	ImageList list = new ImageList (style, width, height, zoom);
 	imageList [i] = list;
 	list.addRef();
 	return list;
@@ -2072,7 +2072,7 @@ ImageList getImageListToolBar (int style, int width, int height, int zoom) {
 	while (i < length) {
 		ImageList list = toolImageList [i];
 		if (list == null) break;
-		if (list.isFittingFor(style, width, height, zoom)) {
+		if (list.isFittingFor(style, width, height)) {
 			list.addRef();
 			return list;
 		}
@@ -2085,7 +2085,7 @@ ImageList getImageListToolBar (int style, int width, int height, int zoom) {
 		toolImageList = newList;
 	}
 
-	ImageList list = new ImageList (style, DPIUtil.pointToPixel(width, zoom), DPIUtil.pointToPixel(height, zoom), zoom);
+	ImageList list = new ImageList (style, width, height, zoom);
 	toolImageList [i] = list;
 	list.addRef();
 	return list;
@@ -2099,7 +2099,7 @@ ImageList getImageListToolBarDisabled (int style, int width, int height, int zoo
 	while (i < length) {
 		ImageList list = toolDisabledImageList [i];
 		if (list == null) break;
-		if (list.isFittingFor(style, width, height, zoom)) {
+		if (list.isFittingFor(style, width, height)) {
 			list.addRef();
 			return list;
 		}
@@ -2112,7 +2112,7 @@ ImageList getImageListToolBarDisabled (int style, int width, int height, int zoo
 		toolDisabledImageList = newList;
 	}
 
-	ImageList list = new ImageList (style, DPIUtil.pointToPixel(width, zoom), DPIUtil.pointToPixel(height, zoom), zoom);
+	ImageList list = new ImageList (style, width, height, zoom);
 	toolDisabledImageList [i] = list;
 	list.addRef();
 	return list;
@@ -2126,7 +2126,7 @@ ImageList getImageListToolBarHot (int style, int width, int height, int zoom) {
 	while (i < length) {
 		ImageList list = toolHotImageList [i];
 		if (list == null) break;
-		if (list.isFittingFor(style, width, height, zoom)) {
+		if (list.isFittingFor(style, width, height)) {
 			list.addRef();
 			return list;
 		}
@@ -2139,7 +2139,7 @@ ImageList getImageListToolBarHot (int style, int width, int height, int zoom) {
 		toolHotImageList = newList;
 	}
 
-	ImageList list = new ImageList (style, DPIUtil.pointToPixel(width, zoom), DPIUtil.pointToPixel(height, zoom), zoom);
+	ImageList list = new ImageList (style, width, height, zoom);
 	toolHotImageList [i] = list;
 	list.addRef();
 	return list;


### PR DESCRIPTION
Previously, zoom of ImageLists was managed at two levels: the Display cached image lists for different zooms and ImageList also lazily cached handles per zoom in zoomToHandle. This is a redundant and inconsistent management of image list handles, which was partly the result of 208b5dc85471ca1539ddded9372fdfde868f1f4e.

This change removes the management of multiple image lists for different zooms in the Display. A single ImageList now serves all zoom levels via getHandle(zoom). The width and height stored internally now reflect the managed image sizes in points at every time of the ImageList lifecycle, also leading to a simplification of the getImageSize() method based on these values.

The storage of the original zoom and the usage for comparison on finding a fitting image list is obsolete as an ImageList does not have a single zoom but may contain handles for arbitrary zooms for images of the specified size.

This also fixes a pre-existing bug that secondary zoom handles were not resized when the first image was added.

This change may also fix a non-deterministic bug that led to wrong icons being shown in view toolbars after zoom changes:
Fixes https://github.com/eclipse-platform/eclipse.platform.swt/issues/3385

### How to test

The workflow described in https://github.com/eclipse-platform/eclipse.platform.swt/issues/3385 can be used to verify that the reported problem is fixed at least for that workflow known to produce wrong icons.