### PR TITLE
[GTK4] Implement DragSource content provider for drag-and-drop

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/gtk/org/eclipse/swt/dnd/DragSource.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/gtk/org/eclipse/swt/dnd/DragSource.java
@@ -123,14 +123,13 @@ public class DragSource extends Widget {
 	static final String DEFAULT_DRAG_SOURCE_EFFECT = "DEFAULT_DRAG_SOURCE_EFFECT"; //$NON-NLS-1$
 
 	/* GTK4 GtkDragSource event controller signal callbacks */
-	static Callback dragBeginProc, dragPrepareProc, dragEndProc;
+	static Callback dragPrepareProc, dragEndProc;
 
 	/* GTK3 GtkWidget drag event signal callbacks */
 	static Callback DragBegin, DragGetData, DragEnd, DragDataDelete;
 
 	static {
 		if (GTK.GTK4) {
-			dragBeginProc = new Callback(DragSource.class, "dragBeginProc", void.class, new Type[] { long.class, long.class });
 			dragPrepareProc = new Callback(DragSource.class, "dragPrepareProc", long.class, new Type[] { long.class, double.class, double.class });
 			dragEndProc = new Callback(DragSource.class, "dragEndProc", void.class, new Type[] { long.class, long.class, boolean.class });
 		} else {
@@ -175,7 +174,7 @@ public DragSource(Control control, int style) {
 	this.control = control;
 
 	if (GTK.GTK4) {
-		if (dragBeginProc == null || dragPrepareProc == null || dragEndProc == null) {
+		if (dragPrepareProc == null || dragEndProc == null) {
 			DND.error(DND.ERROR_CANNOT_INIT_DRAG);
 		}
 		if (control.getData(DND.DRAG_SOURCE_KEY) != null) {
@@ -186,7 +185,6 @@ public DragSource(Control control, int style) {
 		long dragSourceController = GTK4.gtk_drag_source_new();
 		GTK4.gtk_widget_add_controller(control.handle, dragSourceController);
 
-		OS.g_signal_connect(dragSourceController, OS.drag_begin, dragBeginProc.getAddress(), 0);
 		OS.g_signal_connect(dragSourceController, OS.prepare, dragPrepareProc.getAddress(), 0);
 		OS.g_signal_connect(dragSourceController, OS.drag_end, dragEndProc.getAddress(), 0);
 
@@ -244,51 +242,71 @@ static int checkStyle (int style) {
 	return style;
 }
 
-static void dragBeginProc(long source, long drag) {
+static long dragPrepareProc(long source, double x, double y) {
 	long widgetHandle = GTK.gtk_event_controller_get_widget(source);
 	DragSource dragSource = FindDragSource(widgetHandle);
-	if (dragSource == null) return;
+	if (dragSource == null) return 0;
 
-	dragSource.dragBeginGtk4(source);
+	return dragSource.dragPrepare(source);
 }
 
-void dragBeginGtk4(long source) {
-	DNDEvent event = new DNDEvent();
-	event.widget = this;
-	event.doit = true;
-	notifyListeners(DND.DragStart, event);
-	if (!event.doit || transferAgents == null || transferAgents.length == 0) return;
+long dragPrepare(long source) {
+	if (transferAgents == null || transferAgents.length == 0) return 0;
+
+	DNDEvent startEvent = new DNDEvent();
+	startEvent.widget = this;
+	startEvent.doit = true;
+	notifyListeners(DND.DragStart, startEvent);
+	if (!startEvent.doit) return 0;
 
 	// If specified, setup drag icon
-	Image dragIcon = event.image;
+	Image dragIcon = startEvent.image;
 	if (source != 0 && dragIcon != null) {
 		long pixbuf = ImageList.createPixbuf(dragIcon);
 		long texture = GDK.gdk_texture_new_for_pixbuf(pixbuf);
 		OS.g_object_unref(pixbuf);
 		GTK4.gtk_drag_source_set_icon(source, texture, 0, 0);
 	}
-}
 
-static long dragPrepareProc(long source, double x, double y) {
-	long widgetHandle = GTK.gtk_event_controller_get_widget(source);
-	DragSource dragSource = FindDragSource(widgetHandle);
-	if (dragSource == null) return 0;
+	// Collect the data to be transferred for every supported transfer type.
+	Object[] data = new Object[transferAgents.length];
+	Transfer[] transfers = new Transfer[transferAgents.length];
+	int count = 0;
+	for (Transfer transfer : transferAgents) {
+		if (transfer == null) continue;
+		TransferData[] supportedTypes = transfer.getSupportedTypes();
+		if (supportedTypes == null || supportedTypes.length == 0) continue;
 
-	return dragSource.dragPrepare();
-}
+		DNDEvent event = new DNDEvent();
+		event.widget = this;
+		event.dataType = supportedTypes[0];
+		event.doit = true;
+		notifyListeners(DND.DragSetData, event);
+		if (!event.doit || event.data == null) continue;
 
-long dragPrepare() {
-	TransferData transferData = new TransferData();
+		transfers[count] = transfer;
+		data[count] = event.data;
+		count++;
+	}
+	if (count == 0) return 0;
+	if (count < transferAgents.length) {
+		Object[] trimmedData = new Object[count];
+		Transfer[] trimmedTransfers = new Transfer[count];
+		System.arraycopy(data, 0, trimmedData, 0, count);
+		System.arraycopy(transfers, 0, trimmedTransfers, 0, count);
+		data = trimmedData;
+		transfers = trimmedTransfers;
+	}
 
-	DNDEvent event = new DNDEvent();
-	event.widget = this;
-	event.dataType = transferData;
-	notifyListeners(DND.DragSetData, event);
-	if (!event.doit) return 0;
+	long providers = ContentProviders.getInstance().createContentProviders(data, transfers,
+			ContentProviders.CLIPBOARD_DATA.DRAG);
+	if (providers == 0) return 0;
 
-	// TODO: Need to return GdkContentProvider for the data given from event.data
-	// Data from event.data also has to be converted to native through the Transfer class
-	return 0;
+	// The "prepare" return is transfer-full and unref'd when the drag ends, but
+	// ContentProviders keeps its own reference (unref'd on the next drag). Add a
+	// ref so both owners balance; otherwise the next drag unrefs a freed provider.
+	OS.g_object_ref(providers);
+	return providers;
 }
 
 static void dragEndProc(long source, long drag, boolean delete_data) {
@@ -619,25 +637,33 @@ void onDispose() {
 
 int opToOsOp(int operation){
 	int osOperation = 0;
+	// GTK4 redefined the GdkDragAction values, so they differ from GTK3.
+	int copy = GTK.GTK4 ? GTK4.GDK_ACTION_COPY : GDK.GDK_ACTION_COPY;
+	int move = GTK.GTK4 ? GTK4.GDK_ACTION_MOVE : GDK.GDK_ACTION_MOVE;
+	int link = GTK.GTK4 ? GTK4.GDK_ACTION_LINK : GDK.GDK_ACTION_LINK;
 
 	if ((operation & DND.DROP_COPY) == DND.DROP_COPY)
-		osOperation |= GDK.GDK_ACTION_COPY;
+		osOperation |= copy;
 	if ((operation & DND.DROP_MOVE) == DND.DROP_MOVE)
-		osOperation |= GDK.GDK_ACTION_MOVE;
+		osOperation |= move;
 	if ((operation & DND.DROP_LINK) == DND.DROP_LINK)
-		osOperation |= GDK.GDK_ACTION_LINK;
+		osOperation |= link;
 
 	return osOperation;
 }
 
 int osOpToOp(int osOperation){
 	int operation = DND.DROP_NONE;
+	// GTK4 redefined the GdkDragAction values, so they differ from GTK3.
+	int copy = GTK.GTK4 ? GTK4.GDK_ACTION_COPY : GDK.GDK_ACTION_COPY;
+	int move = GTK.GTK4 ? GTK4.GDK_ACTION_MOVE : GDK.GDK_ACTION_MOVE;
+	int link = GTK.GTK4 ? GTK4.GDK_ACTION_LINK : GDK.GDK_ACTION_LINK;
 
-	if ((osOperation & GDK.GDK_ACTION_COPY) == GDK.GDK_ACTION_COPY)
+	if ((osOperation & copy) == copy)
 		operation |= DND.DROP_COPY;
-	if ((osOperation & GDK.GDK_ACTION_MOVE) == GDK.GDK_ACTION_MOVE)
+	if ((osOperation & move) == move)
 		operation |= DND.DROP_MOVE;
-	if ((osOperation & GDK.GDK_ACTION_LINK) == GDK.GDK_ACTION_LINK)
+	if ((osOperation & link) == link)
 		operation |= DND.DROP_LINK;
 
 	return operation;

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/org/eclipse/swt/internal/gtk4/GTK4.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/org/eclipse/swt/internal/gtk4/GTK4.java
@@ -22,6 +22,17 @@ public class GTK4 {
 
 	public static final int GTK_POPOVER_MENU_NESTED = 1 << 0;
 
+	/*
+	 * GdkDragAction values. Note that GTK4 redefined these compared to GTK3
+	 * (GTK3 used COPY=1<<1, MOVE=1<<2, LINK=1<<3). The GDK.GDK_ACTION_*
+	 * constants still hold the GTK3 values, so the GTK4 drag-and-drop code
+	 * must use these values instead when talking to the native toolkit.
+	 */
+	public static final int GDK_ACTION_COPY = 1 << 0;
+	public static final int GDK_ACTION_MOVE = 1 << 1;
+	public static final int GDK_ACTION_LINK = 1 << 2;
+	public static final int GDK_ACTION_ASK = 1 << 3;
+
 	public static final int GTK_EVENT_SEQUENCE_NONE = 0;
 	public static final int GTK_EVENT_SEQUENCE_CLAIMED = 1;
 	public static final int GTK_EVENT_SEQUENCE_DENIED = 2;


### PR DESCRIPTION
Implement DragSource.dragPrepare on GTK4 to build a real GdkContentProvider from the transfer data collected via DND.DragSetData, replacing the previous stub that returned no data. The DragStart event is
now fired from the GtkDragSource "prepare" signal.

Map drag operations to the GTK4 GdkDragAction values, which differ from the GTK3 values, via new GTK4.GDK_ACTION_* constants.