### PR TITLE
[Gtk4] Guard gtk_tree_view_get_bin_window usage

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Control.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Control.java
@@ -6808,7 +6808,9 @@ void update (boolean all, boolean flush) {
 	if(GTK.GTK4) GTK.gtk_widget_queue_draw(handle);
 	if (!GTK.gtk_widget_get_visible (topHandle ())) return;
 	if (!GTK.gtk_widget_get_realized (handle)) return;
-	if (flush && OS.isX11()) {
+	// flushExposes drains X11 Expose events and is a no-op on GTK4, which uses a
+	// frame-clock/render-node draw model and no longer has GdkWindows to flush.
+	if (flush && OS.isX11() && !GTK.GTK4) {
 		long window = paintWindow ();
 		display.flushExposes (window, all);
 	}

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Display.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Display.java
@@ -1756,6 +1756,9 @@ static long rendererSnapshotProc (long cell, long snapshot, long handle, long ba
 }
 
 void flushExposes (long window, boolean all) {
+	// GTK4 uses a frame-clock/render-node draw model and has no X11 Expose events
+	// or GdkWindows to flush, so checkIfEventProc rejects everything: skip the scan.
+	if (GTK.GTK4) return;
 	if (OS.isX11()) {
 		this.flushWindow = window;
 		this.flushAll = all;

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/List.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/List.java
@@ -1083,7 +1083,10 @@ public boolean isSelected (int index) {
 @Override
 long paintWindow () {
 	GTK.gtk_widget_realize (handle);
-	// TODO: this function has been removed on GTK4
+	if (GTK.GTK4) {
+		// gtk_tree_view_get_bin_window was removed in GTK4; fall back to the widget surface
+		return gtk_widget_get_surface (handle);
+	}
 	return GTK3.gtk_tree_view_get_bin_window (handle);
 }
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Table.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Table.java
@@ -2513,7 +2513,10 @@ boolean mnemonicMatch (char key) {
 @Override
 long paintWindow () {
 	GTK.gtk_widget_realize (handle);
-	// TODO: this function has been removed on GTK4
+	if (GTK.GTK4) {
+		// gtk_tree_view_get_bin_window was removed in GTK4; fall back to the widget surface
+		return gtk_widget_get_surface (handle);
+	}
 	return GTK3.gtk_tree_view_get_bin_window (handle);
 }
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Tree.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Tree.java
@@ -2800,7 +2800,10 @@ boolean mnemonicMatch (char key) {
 @Override
 long paintWindow () {
 	GTK.gtk_widget_realize (handle);
-	// TODO: this function has been removed on GTK4
+	if (GTK.GTK4) {
+		// gtk_tree_view_get_bin_window was removed in GTK4; fall back to the widget surface
+		return gtk_widget_get_surface (handle);
+	}
 	return GTK3.gtk_tree_view_get_bin_window (handle);
 }
 


### PR DESCRIPTION
Happened only on X11 but the effect was that Ctrl+3 was not working on Gtk4/x11. Guarded a number of calls to make sure they return early on Gtk 4 as practically they are no-ops.