### PR TITLE
Removes System.out.println debug code from ToolItem

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/ToolItem.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/ToolItem.java
@@ -900,7 +900,6 @@ int gtk_gesture_press_event(long gesture, int n_press, double x, double y, long 
 		boolean translated = GTK4.gtk_widget_translate_coordinates(arrowHandle, parent.handle, 0, 0, destX, destY);
 		e.x = translated ? (int) destX[0] : allocation.x;
 		if ((parent.style & SWT.MIRRORED) != 0) e.x = parent.getClientWidth() - allocation.width - e.x;
-		System.out.println(e.x);
 		e.y = translated ? (int) destY[0] + allocation.height : allocation.y + allocation.height;
 		sendSelectionEvent(SWT.Selection, e, false);
 		return GTK4.GTK_EVENT_SEQUENCE_CLAIMED;


### PR DESCRIPTION
PR #3257 accidentally included a system.out, this commit removes this debugging code.