### PR TITLE
[Gtk4] Make resizeCalculationsGTK3 noop on Gtk 4

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Control.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Control.java
@@ -1075,7 +1075,12 @@ Point resizeCalculationsGTK3 (long widget, int width, int height) {
 	 * Feature in GTK3.20+: size calculations take into account GtkCSSNode
 	 * elements which we cannot access. If the to-be-allocated size minus
 	 * these elements is < 0, allocate the preferred size instead. See bug 486068.
+	 *
+	 * On GTK4 the widget is sized via its own
+	 * gtk_widget_size_allocate(), which clamps to the minimum size internally,
+	 * so this adjustment is unnecessary. Return the requested size unchanged on GTK4.
 	 */
+	if (GTK.GTK4) return sizes;
 	GtkRequisition minimumSize = new GtkRequisition();
 	GtkRequisition naturalSize = new GtkRequisition();
 	GTK.gtk_widget_get_preferred_size(widget, minimumSize, naturalSize);


### PR DESCRIPTION
On GTK4 the widget is sized via its own
gtk_widget_size_allocate(), which clamps to the minimum size internally, so this adjustment is unnecessary. Worse, when a widget reports a large (possibly stale, pre-realization) minimum size, inflating the allocation to that size leaves an oversized widget that paints as a blank rectangle over the content on first show until an interactive resize re-measures it (e.g. a GtkScrolledWindow whose content's natural height exceeds the requested height). Return the requested size unchanged on GTK4.