### PR TITLE
[Gtk4] Stop undersizing toolbar buttons

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/org/eclipse/swt/internal/gtk/swt_theming_fixes_gtk_4_0_0.css
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/org/eclipse/swt/internal/gtk/swt_theming_fixes_gtk_4_0_0.css
@@ -5,9 +5,6 @@ button {
 	min-height: 0px;
 	min-width: 0px;
 }
-.toolbar button {
-	padding: 1px;
-}
 modelbutton {
     padding-top: 2px;
     padding-bottom: 2px;


### PR DESCRIPTION
With all the recent fixes this is no longer needed and it even makes toolbar look weird (one might say - slightly broken). Remove the custom css instea.