### PR TITLE
[Gtk4] Fix missing space between TreeItem icon and label

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/TableItem.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/TableItem.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2025 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -336,16 +336,13 @@ Rectangle getBoundsinPixels () {
 	rect.width = w [0];
 
 	int horizontalSeparator;
+	int[] buffer = new int[1];
 	if (GTK.GTK4) {
-		long separator = GTK.gtk_separator_new(GTK.GTK_ORIENTATION_HORIZONTAL);
-		GtkAllocation allocation = new GtkAllocation ();
-		GTK.gtk_widget_get_allocation(separator, allocation);
-		horizontalSeparator = allocation.height;
+		GTK.gtk_cell_renderer_get_padding(textRenderer, buffer, null);
 	} else {
-		int[] buffer = new int[1];
 		GTK3.gtk_widget_style_get (parentHandle, OS.horizontal_separator, buffer, 0);
-		horizontalSeparator = buffer[0];
 	}
+	horizontalSeparator = buffer[0];
 	rect.x += horizontalSeparator;
 
 	gtk_tree_view_column_cell_get_position (column, textRenderer, x, null);
@@ -769,16 +766,13 @@ public Rectangle getTextBounds (int index) {
 	parent.ignoreSize = false;
 
 	int horizontalSeparator;
+	int[] buffer = new int[1];
 	if (GTK.GTK4) {
-		long separator = GTK.gtk_separator_new(GTK.GTK_ORIENTATION_HORIZONTAL);
-		GtkAllocation allocation = new GtkAllocation ();
-		GTK.gtk_widget_get_allocation(separator, allocation);
-		horizontalSeparator = allocation.height;
+		GTK.gtk_cell_renderer_get_padding(textRenderer, buffer, null);
 	} else {
-		int[] buffer = new int[1];
 		GTK3.gtk_widget_style_get (parentHandle, OS.horizontal_separator, buffer, 0);
-		horizontalSeparator = buffer[0];
 	}
+	horizontalSeparator = buffer[0];
 	rect.x += horizontalSeparator;
 
 	gtk_tree_view_column_cell_get_position (column, textRenderer, x, null);

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/TreeItem.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/TreeItem.java
@@ -481,14 +481,11 @@ public Rectangle getBounds () {
 
 	int horizontalSeparator;
 	if (GTK.GTK4) {
-		long separator = GTK.gtk_separator_new(GTK.GTK_ORIENTATION_HORIZONTAL);
-		GtkAllocation allocation = new GtkAllocation ();
-		GTK.gtk_widget_get_allocation(separator, allocation);
-		horizontalSeparator = allocation.height;
+		GTK.gtk_cell_renderer_get_padding(textRenderer, buffer, null);
 	} else {
 		GTK3.gtk_widget_style_get (parentHandle, OS.horizontal_separator, buffer, 0);
-		horizontalSeparator = buffer[0];
 	}
+	horizontalSeparator = buffer[0];
 	rect.x += horizontalSeparator;
 
 	gtk_tree_view_column_cell_get_position (column, textRenderer, x, null);
@@ -948,14 +945,11 @@ public Rectangle getTextBounds (int index) {
 
 	int horizontalSeparator;
 	if (GTK.GTK4) {
-		long separator = GTK.gtk_separator_new(GTK.GTK_ORIENTATION_HORIZONTAL);
-		GtkAllocation allocation = new GtkAllocation ();
-		GTK.gtk_widget_get_allocation(separator, allocation);
-		horizontalSeparator = allocation.height;
+		GTK.gtk_cell_renderer_get_padding(textRenderer, buffer, null);
 	} else {
 		GTK3.gtk_widget_style_get (parentHandle, OS.horizontal_separator, buffer, 0);
-		horizontalSeparator = buffer[0];
 	}
+	horizontalSeparator = buffer[0];
 	rect.x += horizontalSeparator;
 	gtk_tree_view_column_cell_get_position (column, textRenderer, x, null);
 	/*


### PR DESCRIPTION
Measuring the allocation of GtkSeparator before it's realized always gives 0x0 so icon and label are really glued.
Use gtk_cell_renderer_get_padding to query the cell renderer for that info. Gtk 3 could use same code but I decided to not do it as separator has bigger width than cellrenderer padding and I don't want to change Gtk 3 visual behavior (make trees more "condensed").