### PR TITLE
[Gtk4] Fix lazily populated menus being empty

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Menu.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Menu.java
@@ -983,6 +983,10 @@ long gtk_show (long widget) {
 		return 0;
 	}
 	sendEvent (SWT.Show);
+	/* Retry cascade submenu signal hookup once the DROP_DOWN popover is shown. */
+	if (GTK.GTK4 && (style & SWT.DROP_DOWN) != 0 && popoverHandle != 0) {
+		connectCascadeSubMenuSignals(this, popoverHandle);
+	}
 	if (OS.ubuntu_menu_proxy_get() != 0) {
 		MenuItem[] items = getItems();
 		for (int i=0; i<items.length; i++) {
@@ -1535,4 +1539,3 @@ public void setVisible (boolean visible) {
 	}
 }
 }
-


### PR DESCRIPTION
The first attempt to wire submenu  SHOW/HIDE  listeners happens too early, at bar map time. On GTK4 those nested  GtkPopoverMenu  children may not be fully reachable yet, so Eclipse never receives  SWT.Show  for the cascade submenu and never runs  menuAboutToShow() . The retry in  gtk_show()  runs after the parent dropdown is actually shown, when GTK has built the widget tree, so the nested submenu popovers can be found and connected.

Fixes https://github.com/eclipse-platform/eclipse.platform.swt/issues/3423