### PR TITLE
[Win32] Improve size calculation for cropped and scaled image drawing

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/graphics/GCWin32Tests.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/graphics/GCWin32Tests.java
@@ -14,16 +14,19 @@
 package org.eclipse.swt.graphics;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
+import java.util.*;
 import java.util.concurrent.*;
+import java.util.stream.*;
 
 import org.eclipse.swt.*;
 import org.eclipse.swt.internal.*;
 import org.eclipse.swt.widgets.*;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.*;
+import org.junit.jupiter.params.*;
+import org.junit.jupiter.params.provider.*;
 
 @ExtendWith(PlatformSpecificExecutionExtension.class)
 @ExtendWith(WithMonitorSpecificScalingExtension.class)
@@ -141,5 +144,70 @@ class GCWin32Tests {
 			}
 		}
 		return count;
+	}
+
+	/**
+	 * Regression test for the size calculation in scaling/cropping GC.drawImage()
+	 * operations with asymmetric source dimensions (smaller height than width) at
+	 * fractional zoom levels.
+	 * <p>
+	 * At fractional zoom levels the effective X and Y scale factors diverge because
+	 * each axis is rounded independently (e.g. at 125%:
+	 * scaleFactorX&nbsp;=&nbsp;625/500&nbsp;=&nbsp;1.25 but
+	 * scaleFactorY&nbsp;=&nbsp;24/19&nbsp;&asymp;&nbsp;1.263).
+	 */
+	@ParameterizedTest
+	@MethodSource("zoomAndHeightArguments")
+	public void drawImage_asymmetricDimensionsAtFractionalZoom(int zoom, int height) {
+		Display display = Display.getDefault();
+
+		int logicalWidth = 500;
+		int logicalHeight = height;
+
+		PaletteData palette = new PaletteData(0xFF0000, 0xFF00, 0xFF);
+		ImageData srcData = new ImageData(logicalWidth, logicalHeight, 32, palette);
+		for (int y = 0; y < logicalHeight; y++) {
+			for (int x = 0; x < logicalWidth; x++) {
+				// left half red, right half blue – makes wrong-rectangle errors visible
+				srcData.setPixel(x, y, x < logicalWidth / 2 ? 0xFF0000 : 0x0000FF);
+			}
+		}
+		Image srcImage = new Image(display, srcData);
+
+		int previousZoom = DPIUtil.getDeviceZoom();
+		try {
+			DPIUtil.setDeviceZoom(zoom);
+
+			Image referenceImage = new Image(display, logicalWidth + 5, logicalHeight + 5);
+			GC referenceGC = new GC(referenceImage);
+			referenceGC.drawImage(srcImage, 0, 0);
+			referenceGC.dispose();
+
+			Image testImageScaled = new Image(display, logicalWidth + 5, logicalHeight + 5);
+			GC testGC = new GC(testImageScaled);
+			testGC.drawImage(srcImage, 0, 0, logicalWidth, logicalHeight);
+			testGC.dispose();
+			assertArrayEquals(referenceImage.getImageData(zoom).data, testImageScaled.getImageData(zoom).data);
+			testImageScaled.dispose();
+
+			Image testImageScaledCropped = new Image(display, logicalWidth + 5, logicalHeight + 5);
+			testGC = new GC(testImageScaledCropped);
+			testGC.drawImage(srcImage, 0, 0, logicalWidth, logicalHeight, 0, 0, logicalWidth, logicalHeight);
+			testGC.dispose();
+			assertArrayEquals(referenceImage.getImageData(zoom).data, testImageScaledCropped.getImageData(zoom).data);
+			testImageScaledCropped.dispose();
+
+			referenceImage.dispose();
+		} finally {
+			DPIUtil.setDeviceZoom(previousZoom);
+			srcImage.dispose();
+		}
+	}
+
+	private static Stream<Arguments> zoomAndHeightArguments() {
+		int[] zooms = { 25, 50, 75, 100, 125, 150, 175, 200 };
+		int[] heights = IntStream.rangeClosed(4, 20).toArray();
+		return Arrays.stream(zooms).boxed()
+				.flatMap(zoom -> Arrays.stream(heights).mapToObj(height -> Arguments.of(zoom, height)));
 	}
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/GC.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/GC.java
@@ -1250,11 +1250,15 @@ private class DrawScalingImageToImageOperation extends ImageOperation {
 		 * computed to pixels depending on the factor of the full image bounds to the
 		 * actual OS handle size that will be used.
 		 */
-		float scaleFactor = Math.min(1f * imageHandle.width() / fullImageBounds.width, 1f * imageHandle.height() / fullImageBounds.height);
-		int closestZoomOfHandle = Math.round(scaleFactor * 100);
-		Rectangle srcPixels = Win32DPIUtils.pointToPixel(drawable, src, closestZoomOfHandle);
+		float scaleFactorX = (1f * imageHandle.width()) / fullImageBounds.width;
+		float scaleFactorY = (1f * imageHandle.height()) / fullImageBounds.height;
+		int srcXPixels = Math.round(scaleFactorX * src.x);
+		int srcWidthPixels = Math.round(scaleFactorX * (src.x + src.width)) - srcXPixels;
+		int srcYPixels = Math.round(scaleFactorY * src.y);
+		int srcHeightPixels = Math.round(scaleFactorY * (src.y + src.height)) - srcYPixels;
+		Rectangle srcPixels = new Rectangle(srcXPixels, srcYPixels, srcWidthPixels, srcHeightPixels);
 
-		if (closestZoomOfHandle != 100) {
+		if (Math.abs(scaleFactorX - 1f) >= 0.01f || Math.abs(scaleFactorY - 1f) >= 0.01f) {
 			/*
 			 * This is a HACK! Due to rounding errors at fractional scale factors,
 			 * the coordinates may be slightly off. The workaround is to restrict
@@ -1263,7 +1267,7 @@ private class DrawScalingImageToImageOperation extends ImageOperation {
 			int errX = srcPixels.x + srcPixels.width - imageHandle.width();
 			int errY = srcPixels.y + srcPixels.height - imageHandle.height();
 			if (errX != 0 || errY != 0) {
-				if (errX <= closestZoomOfHandle / 100 && errY <= closestZoomOfHandle / 100) {
+				if (errX <= Math.max(1, scaleFactorX) && errY <= Math.max(1, scaleFactorY)) {
 					srcPixels.intersect(new Rectangle(0, 0, imageHandle.width(), imageHandle.height()));
 				} else {
 					SWT.error (SWT.ERROR_INVALID_ARGUMENT);


### PR DESCRIPTION
## Summary

`GC.drawImage` with explicit source and destination rectangles has several bugs in how it maps the logical source rectangle to the pixel coordinates of the image handle used for rendering. The image handle selection in `Image` also picks the wrong zoom level for asymmetric images. This PR fixes both.

<s>
> [!IMPORTANT]
> This change is based on and should be merged after (or together with):
> - https://github.com/eclipse-platform/eclipse.platform.swt/pull/3455
</s>

Fixes https://github.com/eclipse-platform/eclipse.platform.swt/issues/3454

May also fix https://github.com/eclipse-gef/gef-classic/issues/1146 

## Reproduction / How to Test

See https://github.com/eclipse-platform/eclipse.platform.swt/issues/3454

The snippet should show an image rendered equally two times (in particular at 125% monitor zoom).

### Before this change
<img width="484" height="242" alt="image" src="https://github.com/user-attachments/assets/5a27bf90-f4b3-4385-9228-63ed343e514c" />

### After this change
<img width="484" height="242" alt="image" src="https://github.com/user-attachments/assets/88c8b2e1-33b4-4c48-b548-196d6a267d6d" />


## Problems and fixes

### Wrong image handle zoom for asymmetric images (`Image.java`)

When selecting which zoom-level handle to use, the code estimated the required zoom separately for each axis and then took the maximum. For asymmetric images the smaller axis produces a larger integer-division truncation error, so `Math.max` reliably picks the *wrong* zoom.

> **Example:** a 500×19 image at 125% maps the width to zoom 125 (exact) but the height to zoom 126 (truncated from 126.3). `Math.max` picks 126, requesting a handle at the wrong zoom level and feeding incorrect pixel dimensions into all downstream calculations.

**Fix:** use the zoom estimate from the larger hint dimension, which has more pixels and therefore less relative rounding error.

### X and Y axes treated as a single scale factor (`GC.java`)

When converting the source rectangle from logical points to handle pixels, the old code collapsed the independent per-axis scale factors into one value using `Math.min`, then applied it to both axes. For asymmetric images the X and Y factors diverge because each axis is rounded independently when the handle is created.

> **Example:** the 625×24 handle for the 500×19 image above gives scaleFactorX = 1.25 but scaleFactorY ≈ 1.263. Using 1.25 for Y shifts crop boundaries by one pixel for tall sub-regions.

**Fix:** compute and apply `scaleFactorX` and `scaleFactorY` independently for each axis, using the same endpoint-subtraction rounding that `Image` uses when scaling image data — guaranteeing consistent results between the two.

### Error tolerance collapses to zero at sub-100% zoom (`GC.java`)

After computing the pixel source rectangle, the code checks whether it slightly overflows the handle bounds (an expected rounding side-effect) and clamps it within a tolerance. The tolerance was computed as an integer division, which truncates to zero for any zoom below 100%, turning every normal rounding artifact into a spurious `ERROR_INVALID_ARGUMENT`.

> **Example:** at 75% zoom the tolerance was `75 / 100 = 0`, so even a 1-pixel overshoot was rejected as an error.

**Fix:** use `Math.ceil(scaleFactor)` instead, which always allows at least 1 pixel of tolerance regardless of zoom level. Additionally, the bounds correction was previously guarded so it was skipped entirely when only one axis had a non-unity scale factor; the guard is corrected to apply whenever *either* axis is scaled.

## Tests

A new `@ParameterizedTest` in `GCWin32Tests` verifies that the 3-arg, 5-arg, and 9-arg `drawImage` overloads all produce identical pixel output for a 500-wide source image across a 5×9 matrix of zoom levels (100%–200%) and prime image heights (1–19). Prime heights maximise the chance of exposing per-axis rounding divergence.