### PR TITLE
[Cocoa] Replace deprecated NSProgressIndicatorPreferredThickness

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT PI/cocoa/org/eclipse/swt/internal/cocoa/AppKitFull.bridgesupport.extras
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/cocoa/org/eclipse/swt/internal/cocoa/AppKitFull.bridgesupport.extras
@@ -2376,6 +2376,9 @@
 			<arg swt_gen="true"></arg>
 			<retval swt_gen="true"></retval>
 		</method>
+		<method selector="sizeToFit" swt_gen="true">
+			<retval swt_gen="true"></retval>
+		</method>
 		<method selector="startAnimation:" swt_gen="true">
 			<arg swt_gen="true"></arg>
 			<retval swt_gen="true"></retval>
@@ -4507,7 +4510,6 @@
 	<enum name="NSPortraitOrientation" swt_gen="true"></enum>
 	<enum name="NSPrintPanelShowsPageSetupAccessory" swt_gen="true"></enum>
 	<enum name="NSPrintPanelShowsPrintSelection" swt_gen="true"></enum>
-	<enum name="NSProgressIndicatorPreferredThickness" swt_gen="true"></enum>
 	<enum name="NSRegularSquareBezelStyle" swt_gen="true"></enum>
 	<enum name="NSResizableWindowMask" swt_gen="true"></enum>
 	<enum name="NSRightMouseDown" swt_gen="true"></enum>

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/cocoa/org/eclipse/swt/internal/cocoa/NSProgressIndicator.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/cocoa/org/eclipse/swt/internal/cocoa/NSProgressIndicator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -7,9 +7,6 @@
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *    IBM Corporation - initial API and implementation
  *******************************************************************************/
 package org.eclipse.swt.internal.cocoa;
 
@@ -61,6 +58,10 @@ public void setMinValue(double minValue) {
 
 public void setUsesThreadedAnimation(boolean usesThreadedAnimation) {
 	OS.objc_msgSend(this.id, OS.sel_setUsesThreadedAnimation_, usesThreadedAnimation);
+}
+
+public void sizeToFit() {
+	OS.objc_msgSend(this.id, OS.sel_sizeToFit);
 }
 
 public void startAnimation(id sender) {

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/cocoa/org/eclipse/swt/internal/cocoa/OS.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/cocoa/org/eclipse/swt/internal/cocoa/OS.java
@@ -2281,7 +2281,6 @@ public static final int NSPageUpFunctionKey = 63276;
 public static final int NSPortraitOrientation = 0;
 public static final int NSPrintPanelShowsPageSetupAccessory = 256;
 public static final int NSPrintPanelShowsPrintSelection = 32;
-public static final int NSProgressIndicatorPreferredThickness = 14;
 public static final int NSRegularSquareBezelStyle = 2;
 public static final int NSResizableWindowMask = 8;
 public static final int NSRightMouseDown = 3;

--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/ProgressBar.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/ProgressBar.java
@@ -87,7 +87,11 @@ static int checkStyle (int style) {
 @Override
 public Point computeSize (int wHint, int hHint, boolean changed) {
 	checkWidget();
-	int size = OS.NSProgressIndicatorPreferredThickness;
+	NSProgressIndicator widget = (NSProgressIndicator)view;
+	NSRect oldFrame = widget.frame();
+	widget.sizeToFit();
+	int size = (int)widget.frame().height;
+	widget.setFrame(oldFrame);
 	int width = 0, height = 0;
 	if ((style & SWT.HORIZONTAL) != 0) {
 		height = size;


### PR DESCRIPTION
`NSProgressIndicatorPreferredThickness` is deprecated since macOS 10.14. The deprecation message in the SDK header (`NSProgressIndicator.h`) prescribes the replacement:

> These constants do not accurately represent the geometry of NSProgressIndicator. Use `controlSize` and `sizeToFit` instead.

This change adds a binding for `NSProgressIndicator#sizeToFit` and uses it in `ProgressBar#computeSize` to determine the default thickness, restoring the original frame afterwards since `computeSize` must not have side effects on the widget's bounds. The header documents exactly the semantics this relies on:

> For the spinning style, it will size the view to its default size. For the bar style, the height will be set to the recommended height.

SWT always uses the bar style and never changes the indicator's `controlSize` (it stays at the default `NSControlSizeRegular`), so `sizeToFit` yields the recommended thickness for that control size.

Note that this changes the default thickness of a `ProgressBar` from the hardcoded 14px to the value AppKit actually reports for the current system (18px on macOS 15): the deprecated constant was a stale Aqua-era value that, per the deprecation message, "does not accurately represent the geometry" of the rendered indicator.

## How to test

Open the **ProgressBar tab** of the SWT ControlExample (`org.eclipse.swt.examples.controlexample.ControlExample`). In the **Size** group, the default **Preferred** setting sizes the bars via `computeSize`, i.e., the changed code path. With this change, the horizontal progress bar becomes 18px instead of 14px tall (the vertical one correspondingly wider), matching the geometry AppKit recommends.

Before:
<img width="191" height="65" alt="image" src="https://github.com/user-attachments/assets/bbca539b-217d-47b0-b10e-aa9f0512d5c2" />

After:
<img width="229" height="78" alt="image" src="https://github.com/user-attachments/assets/1616de09-6e45-42c6-9288-9e2bd7d8bedd" />

Contributes to #3214

🤖 Generated with [Claude Code](https://claude.com/claude-code)