### PR TITLE
Fix GTK accessibility relation cleanup during dispose

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Control.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Control.java
@@ -2501,7 +2501,9 @@ public void removePaintListener(PaintListener listener) {
 void removeRelation () {
 	if (!isDescribedByLabel ()) return;		/* there will not be any */
 	if (labelRelation != null) {
-		_getAccessible().removeRelation (ACC.RELATION_LABELLED_BY, labelRelation._getAccessible());
+		if (accessible != null && labelRelation.accessible != null) {
+			accessible.removeRelation (ACC.RELATION_LABELLED_BY, labelRelation.accessible);
+		}
 		labelRelation = null;
 	}
 }


### PR DESCRIPTION
Avoid creating a new Accessible from Control.removeRelation() while a control is already being torn down. Reuse existing accessibility objects instead to prevent GTK handle access after disposal. Fixes https://github.com/eclipse-platform/eclipse.platform.swt/issues/1367