### PR TITLE
[Cocoa] Remove deprecated CFURLCreateFromFSRef from bridge support

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT PI/cocoa/org/eclipse/swt/internal/cocoa/CoreFoundationFull.bridgesupport
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/cocoa/org/eclipse/swt/internal/cocoa/CoreFoundationFull.bridgesupport
@@ -5451,11 +5451,6 @@
 <arg declared_type='CFErrorRef*' name='error' type='^^{__CFError}'/>
 <retval already_retained='true' declared_type='CFURLRef' type='^{__CFURL=}'/>
 </function>
-<function name='CFURLCreateFromFSRef'>
-<arg declared_type='CFAllocatorRef' name='allocator' type='^{__CFAllocator=}'/>
-<arg const='true' declared_type='struct FSRef*' name='fsRef' type='^{FSRef=[80C]}'/>
-<retval already_retained='true' declared_type='CFURLRef' type='^{__CFURL=}'/>
-</function>
 <function name='CFURLCreateFromFileSystemRepresentation'>
 <arg declared_type='CFAllocatorRef' name='allocator' type='^{__CFAllocator=}'/>
 <arg const='true' declared_type='UInt8*' name='buffer' type='*'/>

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/cocoa/org/eclipse/swt/internal/cocoa/CoreFoundationFull.bridgesupport.extras
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/cocoa/org/eclipse/swt/internal/cocoa/CoreFoundationFull.bridgesupport.extras
@@ -43,11 +43,6 @@
 		<arg swt_gen="true"></arg>
 		<retval></retval>
 	</function>
-	<function name="CFURLCreateFromFSRef" swt_gen="true">
-		<arg swt_gen="true"></arg>
-		<arg swt_gen="true" swt_java_type="byte[]"></arg>
-		<retval swt_gen="true"></retval>
-	</function>
 	<function name="CFURLCreateStringByAddingPercentEscapes" swt_gen="true">
 		<arg swt_gen="true"></arg>
 		<arg swt_gen="true"></arg>


### PR DESCRIPTION
The usages of deprecated `CFURLCreateFromFSRef` have been replaced in a recent change with `URLForApplicationToOpenURL/URLForApplicationToOpenContentType` and the generated code for this function has been removed. However, the the function was still declared in the bridge support which makes the MacGenerator regenerate code for that function upon execution.

This change cleans up the declaration of the function in bridge support.

Follow-up to https://github.com/eclipse-platform/eclipse.platform.swt/pull/3187