### PR TITLE
[Cocoa] Add generation instruction for file dialog cancel constant

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT PI/cocoa/org/eclipse/swt/internal/cocoa/AppKitFull.bridgesupport.extras
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/cocoa/org/eclipse/swt/internal/cocoa/AppKitFull.bridgesupport.extras
@@ -4425,6 +4425,7 @@
 	<enum name="NSEventTypeMagnify" swt_gen="true"></enum>
 	<enum name="NSEventTypeRotate" swt_gen="true"></enum>
 	<enum name="NSEventTypeSwipe" swt_gen="true"></enum>
+	<enum name="NSFileHandlingPanelCancelButton" swt_gen="true"></enum>
 	<enum name="NSFileHandlingPanelOKButton" swt_gen="true"></enum>
 	<enum name="NSFlagsChanged" swt_gen="true"></enum>
 	<enum name="NSFocusRingTypeNone" swt_gen="true"></enum>


### PR DESCRIPTION
The cancel button constant for the file selection dialog has been added to the OS constants without adding the auto-generation instruction for the MacGenerator to the bridgesupport.extras. As a consequence, a MacGenerator tool execution removes the constant from the OS class. This change adds the according instruction.

Follow-up to https://github.com/eclipse-platform/eclipse.platform.swt/pull/1026