### PR TITLE
[Cocoa] Add generation instructions for PDF export functions

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT PI/cocoa/library/os.c
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/cocoa/library/os.c
@@ -1605,7 +1605,7 @@ JNIEXPORT jlong JNICALL OS_NATIVE(CGPDFContextCreateWithURL)
 	jlong rc = 0;
 	OS_NATIVE_ENTER(env, that, CGPDFContextCreateWithURL_FUNC);
 	if (arg1) if ((lparg1 = getCGRectFields(env, arg1, &_arg1)) == NULL) goto fail;
-	rc = (jlong)CGPDFContextCreateWithURL((CFURLRef)arg0, (const CGRect *)lparg1, (CFDictionaryRef)arg2);
+	rc = (jlong)CGPDFContextCreateWithURL((CFURLRef)arg0, (CGRect*)lparg1, (CFDictionaryRef)arg2);
 fail:
 	if (arg1 && lparg1) setCGRectFields(env, arg1, lparg1);
 	OS_NATIVE_EXIT(env, that, CGPDFContextCreateWithURL_FUNC);

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/cocoa/org/eclipse/swt/internal/cocoa/CoreGraphicsFull.bridgesupport.extras
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/cocoa/org/eclipse/swt/internal/cocoa/CoreGraphicsFull.bridgesupport.extras
@@ -247,6 +247,25 @@
 		<arg swt_gen="true"></arg>
 		<retval></retval>
 	</function>
+	<function name="CGPDFContextBeginPage" swt_gen="true">
+		<arg swt_gen="true"></arg>
+		<arg swt_gen="true"></arg>
+		<retval></retval>
+	</function>
+	<function name="CGPDFContextClose" swt_gen="true">
+		<arg swt_gen="true"></arg>
+		<retval></retval>
+	</function>
+	<function name="CGPDFContextCreateWithURL" swt_gen="true">
+		<arg swt_gen="true"></arg>
+		<arg swt_gen="true" swt_java_type="CGRect"></arg>
+		<arg swt_gen="true"></arg>
+		<retval swt_gen="true"></retval>
+	</function>
+	<function name="CGPDFContextEndPage" swt_gen="true">
+		<arg swt_gen="true"></arg>
+		<retval></retval>
+	</function>
 	<function name="CGPathAddCurveToPoint" swt_gen="true">
 		<arg swt_gen="true"></arg>
 		<arg swt_gen="true"></arg>

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/cocoa/org/eclipse/swt/internal/cocoa/OS.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/cocoa/org/eclipse/swt/internal/cocoa/OS.java
@@ -3175,12 +3175,6 @@ public static final native long CGImageGetWidth(long image);
  */
 public static final native void CGImageRelease(long image);
 /**
- * @param url cast=(CFURLRef)
- * @param mediaBox cast=(const CGRect *)
- * @param auxiliaryInfo cast=(CFDictionaryRef)
- */
-public static final native long CGPDFContextCreateWithURL(long url, CGRect mediaBox, long auxiliaryInfo);
-/**
  * @param context cast=(CGContextRef)
  * @param pageInfo cast=(CFDictionaryRef)
  */
@@ -3188,11 +3182,17 @@ public static final native void CGPDFContextBeginPage(long context, long pageInf
 /**
  * @param context cast=(CGContextRef)
  */
-public static final native void CGPDFContextEndPage(long context);
+public static final native void CGPDFContextClose(long context);
+/**
+ * @param url cast=(CFURLRef)
+ * @param mediaBox cast=(CGRect*)
+ * @param auxiliaryInfo cast=(CFDictionaryRef)
+ */
+public static final native long CGPDFContextCreateWithURL(long url, CGRect mediaBox, long auxiliaryInfo);
 /**
  * @param context cast=(CGContextRef)
  */
-public static final native void CGPDFContextClose(long context);
+public static final native void CGPDFContextEndPage(long context);
 /**
  * @param path cast=(CGMutablePathRef)
  * @param m cast=(CGAffineTransform*)


### PR DESCRIPTION
The `CGPDFContext*` functions are all present in the CoreGraphicsFull.bridgesupport files but were never registered in the corresponding .extras files, so MacGenerator silently dropped them on the next regeneration. This adds the missing `swt_gen="true"` entries and reruns the MacGenerator to adopt its ordering of generated entries in the OS class.

Follow-up to:
- https://github.com/eclipse-platform/eclipse.platform.swt/pull/2882

@laeubi fyi in case this unexpectedly breaks something for PDFDocument on MacOS