### PR TITLE
CTabFolder: support circular page traversal in MRU mode without chevron

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CTabFolder.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CTabFolder.java
@@ -2057,6 +2057,8 @@ void onPageTraversal(Event event) {
 					if (e.doit && !isDisposed()) {
 						showList(chevronRect);
 					}
+				} else {
+					index = visible [(current + offset + idx) % idx];
 				}
 			}
 		}

--- a/examples/org.eclipse.swt.examples/META-INF/MANIFEST.MF
+++ b/examples/org.eclipse.swt.examples/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %plugin.SWTStandaloneExampleSet.name
 Bundle-SymbolicName: org.eclipse.swt.examples; singleton:=true
-Bundle-Version: 3.109.100.qualifier
+Bundle-Version: 3.109.200.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-21

--- a/examples/org.eclipse.swt.examples/src/examples_control.properties
+++ b/examples/org.eclipse.swt.examples/src/examples_control.properties
@@ -232,6 +232,7 @@ Set_Min_Visible     = Minimize
 Set_Max_Visible     = Maximize
 Set_Unselected_Close_Visible = Close on Unselected Tabs
 Set_Unselected_Image_Visible = Image on Unselected Tabs
+Set_MRU_Active		= Activate MRU
 Selection_Foreground_Color = Selection Foreground Color
 Selection_Background_Color = Selection Background Color
 Item_Foreground_Color = Item Foreground Color

--- a/examples/org.eclipse.swt.examples/src/org/eclipse/swt/examples/controlexample/CTabFolderTab.java
+++ b/examples/org.eclipse.swt.examples/src/org/eclipse/swt/examples/controlexample/CTabFolderTab.java
@@ -63,7 +63,7 @@ class CTabFolderTab extends Tab {
 
 	/* Other widgets added to the "Other" group */
 	Button singleTabButton, imageButton, showMinButton, showMaxButton,
-	topRightButton, unselectedCloseButton, unselectedImageButton;
+	topRightButton, unselectedCloseButton, unselectedImageButton, activateMRUButton;
 
 	ToolBar topRightControl;
 
@@ -233,6 +233,12 @@ class CTabFolderTab extends Tab {
 		unselectedCloseButton.setText (ControlExample.getResourceString("Set_Unselected_Close_Visible"));
 		unselectedCloseButton.setSelection(true);
 		unselectedCloseButton.addSelectionListener (widgetSelectedAdapter(event -> setUnselectedCloseVisible()));
+
+		activateMRUButton = new Button (otherGroup, SWT.CHECK);
+		activateMRUButton.setText (ControlExample.getResourceString("Set_MRU_Active"));
+		activateMRUButton.setSelection(false);
+		activateMRUButton.addSelectionListener (widgetSelectedAdapter(event -> setMRUActive()));
+
 	}
 
 	/**
@@ -412,6 +418,7 @@ class CTabFolderTab extends Tab {
 		setImages();
 		setMinimizeVisible();
 		setMaximizeVisible();
+		setMRUActive();
 		setUnselectedCloseVisible();
 		setUnselectedImageVisible();
 		setSelectionBackground ();
@@ -456,6 +463,13 @@ class CTabFolderTab extends Tab {
 	 */
 	void setMaximizeVisible () {
 		tabFolder1.setMaximizeVisible(showMaxButton.getSelection ());
+		setExampleWidgetSize();
+	}
+	/**
+	 * Activates/deactivates the MRU setting
+	 */
+	void setMRUActive () {
+		tabFolder1.setMRUVisible(activateMRUButton.getSelection ());
 		setExampleWidgetSize();
 	}
 	/**


### PR DESCRIPTION
## What
Fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/4135

`CTabFolder.onPageTraversal` now supports circular keyboard page traversal when `setMRUVisible(true)` is enabled and all tabs fit without a chevron:

- Pressing **Ctrl+PageDown** (`SWT.TRAVERSE_PAGE_NEXT`) on the **last** tab now wraps around to the **first** tab.
- Pressing **Ctrl+PageUp** (`SWT.TRAVERSE_PAGE_PREVIOUS`) on the **first** tab now wraps around to the **last** tab.

Previously, in MRU mode with no chevron shown, traversing past the last/first tab had no effect at all (selection stayed put).

This only affects the MRU branch of `onPageTraversal`. The non-MRU path already wrapped correctly via modulo arithmetic, so its behavior is unchanged. **The chevron behavior is intentionally preserved**: if there are more tabs than fit and the chevron is shown, traversing past the last/first visible tab still opens the chevron drop-down list exactly as before.

## How to test

1. Run `Snippet395` (added in `examples/org.eclipse.swt.snippets`), which creates a `CTabFolder` with `setMRUVisible(true)` and 4 tabs that all fit without a chevron.
2. Give the `CTabFolder` focus (click a tab) and select the **last** tab, then press **Ctrl+PageDown**: it should now wrap to the **first** tab.
3. Select the **first** tab and press **Ctrl+PageUp**: it should now wrap to the **last** tab.
4. **Resize the window (make it narrower) so that the chevron appears** (more tabs than fit), and confirm this PR **preserves the original behavior**: traversing past the last/first visible tab opens the chevron drop-down list instead of wrapping around.

## Files changed
- `bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CTabFolder.java`
- `examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet395.java` (new)
