### PR TITLE
[Cocoa] Support architecture-specific enum values in MacGenerator

### DIFF
--- a/bundles/org.eclipse.swt.tools/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.swt.tools/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.swt.tools; singleton:=true
-Bundle-Version: 3.112.0.qualifier
+Bundle-Version: 3.112.100.qualifier
 Bundle-ManifestVersion: 2
 Export-Package: org.eclipse.swt.tools.internal; x-internal:=true
 Bundle-ActivationPolicy: lazy

--- a/bundles/org.eclipse.swt.tools/Mac Generation/org/eclipse/swt/tools/internal/MacGenerator.java
+++ b/bundles/org.eclipse.swt.tools/Mac Generation/org/eclipse/swt/tools/internal/MacGenerator.java
@@ -982,6 +982,8 @@ public String[] getExtraAttributeNames(Node node) {
 		}
 	} else if (name.equals("class")) {
 		return new String[]{"swt_superclass"};
+	} else if (name.equals("enum")) {
+		return new String[]{"swt_value_aarch64"};
 	} else if (name.equals("struct")) {
 		return new String[]{"swt_gen_memmove", "swt_gen_tostring"};
 	} else if (name.equals("retval")) {
@@ -1147,10 +1149,10 @@ void generateEnums() {
 						if (value.indexOf('.') != -1) {
 							out("double ");
 						} else {
-							if (value.equals("4294967295")) {
+							if (isUint32Max(value)) {
 								out("int ");
 								value = "-1";
-							} else if (value.equals("18446744073709551615")) {
+							} else if (isUint64Max(value)) {
 								out("long ");
 								value = "-1L";
 							} else {
@@ -1165,8 +1167,20 @@ void generateEnums() {
 						}
 						out(attributes.getNamedItem("name").getNodeValue());
 						out(" = ");
-						out(value);
-						if (isLong && !value.endsWith("L")) out("L");
+						Node aarch64ValueNode = attributes.getNamedItem("swt_value_aarch64");
+						if (aarch64ValueNode != null) {
+							out("IS_X86_64 ? ");
+							out(value);
+							if (isLong && !value.endsWith("L")) out("L");
+							out(" : ");
+							String aarch64Value = aarch64ValueNode.getNodeValue();
+							aarch64Value = isUint32Max(aarch64Value) ? "-1" : isUint64Max(aarch64Value) ? "-1L" : aarch64Value;
+							out(aarch64Value);
+							if (isLong && !aarch64Value.endsWith("L")) out("L");
+						} else {
+							out(value);
+							if (isLong && !value.endsWith("L")) out("L");
+						}
 						out(";");
 						outln();
 					} else {
@@ -1176,6 +1190,17 @@ void generateEnums() {
 			}
 		}
 	}
+}
+
+private static final String UINT32_MAX = "4294967295";
+private static final String UINT64_MAX = "18446744073709551615";
+
+private boolean isUint32Max(String value) {
+	return value.equals(UINT32_MAX);
+}
+
+private boolean isUint64Max(String value) {
+	return value.equals(UINT64_MAX);
 }
 
 boolean getGen(Node node) {

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/cocoa/org/eclipse/swt/internal/cocoa/AppKitFull.bridgesupport.extras
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/cocoa/org/eclipse/swt/internal/cocoa/AppKitFull.bridgesupport.extras
@@ -4542,10 +4542,10 @@
 	<enum name="NSTableViewSolidVerticalGridLineMask" swt_gen="true"></enum>
 	<enum name="NSTerminateCancel" swt_gen="true"></enum>
 	<enum name="NSTerminateNow" swt_gen="true"></enum>
-	<enum name="NSTextAlignmentCenter" swt_gen="true"></enum>
+	<enum name="NSTextAlignmentCenter" swt_gen="true" swt_value_aarch64="1"></enum>
 	<enum name="NSTextAlignmentJustified" swt_gen="true"></enum>
 	<enum name="NSTextAlignmentLeft" swt_gen="true"></enum>
-	<enum name="NSTextAlignmentRight" swt_gen="true"></enum>
+	<enum name="NSTextAlignmentRight" swt_gen="true" swt_value_aarch64="2"></enum>
 	<enum name="NSToolbarDisplayModeIconOnly" swt_gen="true"></enum>
 	<enum name="NSTouchPhaseAny" swt_gen="true"></enum>
 	<enum name="NSTouchPhaseBegan" swt_gen="true"></enum>

--- a/features/org.eclipse.swt.tools.feature/feature.xml
+++ b/features/org.eclipse.swt.tools.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.swt.tools.feature"
       label="%featureName"
-      version="3.111.0.qualifier"
+      version="3.111.100.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">


### PR DESCRIPTION
## Summary
- Some macOS enum constants have different numeric values on x86_64 vs aarch64 (aarch64 values were inherited from iOS headers and diverge from the x86_64/bridgesupport definitions). Until now this required hand-editing the generated `OS.java` after every MacGenerator run, since the divergence isn't present in the (machine-generated, non-editable) `.bridgesupport` files, and the generator had no way to express an architecture-dependent value.
- `MacGenerator` now supports a new `swt_value_aarch64` attribute on `<enum>` elements in `*.bridgesupport.extras` files. When set, it declares the aarch64-specific value while the regular `value`/`value64` attribute continues to describe the x86_64 value; the generator derives the `IS_X86_64 ? ... : ...` expression from both, removing the need to manually patch generated code after each run.
- Applied this to `NSTextAlignmentCenter`/`NSTextAlignmentRight` in `AppKitFull.bridgesupport.extras`, replacing the two hand-maintained ternaries that previously lived directly in `OS.java`.

Follow-up to 0ffafe6d8e6bf13e386b1839f7721b07751efb38 (which introduced the manual macro code).

## Test plan
- [x] Regenerate `OS.java` via MacGenerator on macOS and confirm `NSTextAlignmentCenter`/`NSTextAlignmentRight` produce the same `IS_X86_64 ? ... : ...` expressions as before, with no other unintended diff
- [x] Confirm `MacGeneratorUI`'s attribute editor shows/edits `swt_value_aarch64` for enum nodes
- [x] Confirm `swt_value_aarch64` round-trips correctly when extras are re-saved from the tool

🤖 Generated with [Claude Code](https://claude.com/claude-code)