### PR TITLE
[Win32] Fix drawImage() failing for an empty image

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Image.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Image.java
@@ -175,6 +175,15 @@ public final class Image extends Resource implements Drawable {
 			return zoomLevelToImageHandle.keySet();
 		}
 
+		Integer getNearestAvailableZoom(int zoom) {
+			TreeSet<Integer> availableZooms = new TreeSet<>(getAllZooms());
+			if (availableZooms.contains(zoom)) {
+				return zoom;
+			}
+			Integer higher = availableZooms.higher(zoom);
+			return higher != null ? higher : availableZooms.lower(zoom);
+		}
+
 		void destroyHandles(Predicate<Integer> filter) {
 		    zoomLevelToImageHandle.entrySet().removeIf(entry -> {
 		    	if (filter.test(entry.getKey())) {
@@ -2155,8 +2164,7 @@ private abstract class AbstractImageProviderWrapper {
 	abstract AbstractImageProviderWrapper createCopy(Image image);
 
 	ElementAtZoom<ImageData> getClosestAvailableImageData(int zoom) {
-		TreeSet<Integer> availableZooms = new TreeSet<>(imageHandleManager.getAllZooms());
-		int closestZoom = availableZooms.contains(zoom) ? zoom : Optional.ofNullable(availableZooms.higher(zoom)).orElse(availableZooms.lower(zoom));
+		int closestZoom = imageHandleManager.getNearestAvailableZoom(zoom);
 		ImageData imageData = imageHandleManager.get(closestZoom).getImageData();
 		return new ElementAtZoom<>(imageData, closestZoom);
 	}
@@ -2467,7 +2475,10 @@ private class PlainImageProviderWrapper extends AbstractImageProviderWrapper {
 
 	@Override
 	int nearestAvailableZoom(int zoom) {
-		return getClosestAvailableImageData(zoom).zoom();
+		if (imageHandleManager.isEmpty()) {
+			return 100;
+		}
+		return imageHandleManager.getNearestAvailableZoom(zoom);
 	}
 
 	@Override

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_GC.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_GC.java
@@ -382,6 +382,20 @@ public void test_drawImageLorg_eclipse_swt_graphics_ImageIIIIIIII() {
 	images.dispose();
 }
 
+/**
+ * See https://github.com/eclipse-platform/eclipse.platform.swt/issues/3442
+ */
+@Test
+public void test_drawImage_emptyImage() {
+	Image emptyImage = new Image(display, IMAGE_SIZE, IMAGE_SIZE);
+	try {
+		gc.drawImage(emptyImage, 0, 0, IMAGE_SIZE, IMAGE_SIZE, 0, 0, IMAGE_SIZE / 3, IMAGE_SIZE / 3);
+		ImageDataTestHelper.assertImageDataEqual(image.getImageData(), emptyImage.getImageData(), image.getImageData());
+	} finally {
+		emptyImage.dispose();
+	}
+}
+
 
 @Test
 public void test_drawImageLorg_eclipse_swt_graphics_ImageIIII() {


### PR DESCRIPTION
Fixes drawing an empty (blank) `Image` via `GC.drawImage()` with a scaled source/destination region.

## Problem

Drawing a blank image with a scaled region failed with a `NullPointerException`. The nearest-zoom lookup in `PlainImageProviderWrapper` tried to derive the zoom from an existing image handle, but an empty image has no handle yet, so the lookup resolved to `null`.

Reproducible with the updated `Snippet6` taken from the issue.

## Fix

The nearest-zoom lookup now falls back to using an empty image at 100% zoom when no image handle exists yet, so drawing an empty image succeeds.

## Test

Adds an OS-independent test to `Test_org_eclipse_swt_graphics_GC` that draws an empty image with a scaled region to guard against this regression.

Fixes https://github.com/eclipse-platform/eclipse.platform.swt/issues/3442
