### PR TITLE
[Win32] Remove unused ImageList.remove() method

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/ImageList.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/ImageList.java
@@ -394,14 +394,6 @@ public void put (int index, Image image) {
 	images [index] = image;
 }
 
-public void remove (int index) {
-	int count = OS.ImageList_GetImageCount (handle);
-	if (!(0 <= index && index < count)) return;
-	zoomToHandle.values().forEach(handle -> OS.ImageList_Remove (handle, index));
-	System.arraycopy (images, index + 1, images, index, --count - index);
-	images [index] = null;
-}
-
 public int removeRef() {
 	return --refCount;
 }


### PR DESCRIPTION
The ImageList.remove(int) method has no caller anywhere in the SWT codebase and it's not public API either. Besides being dead code, its implementation was also subtly wrong: after shifting the images array down it cleared images[index] instead of the now-vacated last slot images[count], which would corrupt the images-to-native mapping if it were ever used.

Rather than fixing an unreachable method, remove it entirely to avoid accidental usage of a buggy method by future callers.