### PR TITLE
[Win32] Fix wrong CTabFolder header height after zoom change

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CTabFolder.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CTabFolder.java
@@ -172,6 +172,7 @@ public class CTabFolder extends Composite {
 	int[] priority = new int[0];
 	boolean mru = false;
 	Listener listener;
+	Listener tabControlZoomListener;
 	boolean ignoreTraverse;
 	boolean useDefaultRenderer;
 
@@ -344,6 +345,10 @@ void init(int style) {
 			case SWT.ZoomChanged:	   onZoomChange(event); break;
 		}
 	};
+
+	// A tab control is rescaled after the folder itself, so its size can only be
+	// measured reliably once it has processed the zoom change on its own.
+	tabControlZoomListener = event -> updateFolder(UPDATE_TAB_HEIGHT | REDRAW);
 
 	int[] folderEvents = new int[]{
 		SWT.Dispose,
@@ -4186,6 +4191,7 @@ void addTabControl(Control control, int flags, int index, boolean update) {
 	int length = controls.length;
 
 	control.addListener(SWT.Resize, listener);
+	control.addListener(SWT.ZoomChanged, tabControlZoomListener);
 
 	//Grow all 4 arrays
 	Control[] newControls = new Control [length + 1];
@@ -4247,6 +4253,7 @@ void removeTabControl (Control control, boolean update) {
 
 	if (!control.isDisposed()) {
 		control.removeListener(SWT.Resize, listener);
+		control.removeListener(SWT.ZoomChanged, tabControlZoomListener);
 		control.setBackground (null);
 		control.setBackgroundImage (null);
 		if (control instanceof Composite) ((Composite) control).setBackgroundMode(SWT.INHERIT_NONE);

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_custom_CTabFolder.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_custom_CTabFolder.java
@@ -45,7 +45,9 @@ import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.Font;
 import org.eclipse.swt.graphics.FontData;
 import org.eclipse.swt.graphics.Image;
+import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.graphics.Rectangle;
+import org.eclipse.swt.internal.DPIUtil;
 import org.eclipse.swt.layout.FillLayout;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
@@ -54,6 +56,7 @@ import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Label;
+import org.eclipse.swt.widgets.Layout;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.Text;
 import org.eclipse.swt.widgets.ToolBar;
@@ -69,6 +72,7 @@ import org.junit.jupiter.api.Test;
  *
  * @see org.eclipse.swt.custom.CTabFolder
  */
+@SuppressWarnings("restriction")
 public class Test_org_eclipse_swt_custom_CTabFolder extends Test_org_eclipse_swt_widgets_Composite {
 
 @Override
@@ -520,6 +524,51 @@ public void test_topRightWrapOverflow() {
 	assertTrue(topRightBounds.y >= tabBounds.y + tabBounds.height,
 			"topRight should wrap below tabs when space is tight. "
 			+ "topRight.y=" + topRightBounds.y + " tab.bottom=" + (tabBounds.y + tabBounds.height));
+}
+
+/**
+ * A tab control is rescaled after the folder itself, so the folder must recompute
+ * its tab height once a tab control reports a zoom change. Test for issue 3456.
+ */
+@Test
+public void test_tabHeightRecomputedOnTabControlZoomChange() {
+	makeCleanEnvironment();
+	shell.setSize(800, 400);
+
+	CTabItem item = new CTabItem(ctabFolder, SWT.NONE);
+	item.setText("Tab 1");
+	ctabFolder.setSelection(0);
+
+	int topRightHeight = 20;
+	Composite topRight = new Composite(ctabFolder, SWT.NONE);
+	FixedSizeLayout topRightLayout = new FixedSizeLayout(60, topRightHeight);
+	topRight.setLayout(topRightLayout);
+	ctabFolder.setTopRight(topRight, SWT.RIGHT | SWT.WRAP);
+
+	SwtTestUtil.openShell(shell);
+	processEvents();
+
+	int defaultTabHeight = ctabFolder.getTabHeight();
+
+	// A taller tab control makes the folder grow its tab height
+	topRightLayout.height = defaultTabHeight * 3;
+	ctabFolder.setTabHeight(SWT.DEFAULT);
+	processEvents();
+	int grownTabHeight = ctabFolder.getTabHeight();
+	assertTrue(grownTabHeight > defaultTabHeight, "tab height should grow with the tab control");
+
+	// Shrinking the tab control alone leaves the tab height stale, which is the state
+	// the folder ends up in after measuring a control that was not yet rescaled
+	topRightLayout.height = topRightHeight;
+	assertEquals(grownTabHeight, ctabFolder.getTabHeight(), "precondition: tab height is stale");
+
+	Event zoomChanged = new Event();
+	zoomChanged.detail = DPIUtil.getDeviceZoom();
+	topRight.notifyListeners(SWT.ZoomChanged, zoomChanged);
+	processEvents();
+
+	assertEquals(defaultTabHeight, ctabFolder.getTabHeight(),
+			"tab height should be recomputed after a zoom change of a tab control");
 }
 
 /**
@@ -1115,6 +1164,26 @@ public void test_moveItem_errorCases() {
 			"negative to index must be rejected");
 	assertThrows(IllegalArgumentException.class, () -> ctabFolder.moveItem(0, 3),
 			"out-of-range to index must be rejected");
+}
+
+/** Layout with a preferred size the test can change at will. */
+private static final class FixedSizeLayout extends Layout {
+	int width;
+	int height;
+
+	FixedSizeLayout(int width, int height) {
+		this.width = width;
+		this.height = height;
+	}
+
+	@Override
+	protected Point computeSize(Composite composite, int wHint, int hHint, boolean flushCache) {
+		return new Point(wHint == SWT.DEFAULT ? width : wHint, hHint == SWT.DEFAULT ? height : hHint);
+	}
+
+	@Override
+	protected void layout(Composite composite, boolean flushCache) {
+	}
 }
 
 }


### PR DESCRIPTION
When an application window is moved between monitors with different zoom levels, the header of a `CTabFolder` with a top-right control can end up too high and stays that way until the folder is updated for another reason, for example by selecting a different tab.

Since PR #3139 the tab height also accounts for the top-left/top-right tab controls, so it depends on `Control#computeSize()` of those controls. A control converts its pixel size to points using its parent's zoom, and on a DPI change the folder is rescaled before its children are. Measuring a child in that window mixes the old zoom's pixel size with the new zoom, which produces a too large tab height when moving from a higher to a lower zoom. Nothing recomputed the tab height afterwards, so the wrong value persisted.

This adds a `SWT.ZoomChanged` listener on each tab control that triggers a folder update. Because the listener is registered after the control's own internal zoom handling, the control is already rescaled by the time the folder measures it again. Non-Windows platforms are unaffected at runtime, as rescaling only happens there.

The new test puts the folder into the same state by letting a tab control report a stale size and then sending a zoom change to it, so CI validates the recomputation on every platform without needing monitors with different scaling. It fails on current master and passes with the fix.

Still a draft because I cannot verify the original scenario locally on a multi-DPI Windows setup.

Fixes https://github.com/eclipse-platform/eclipse.platform.swt/issues/3456