### PR TITLE
[Win32] Reinitialize tool bar item images in place on DPI change

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/widgets/ToolBarWin32Tests.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/widgets/ToolBarWin32Tests.java
@@ -1,0 +1,191 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Vector Informatik GmbH and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.swt.widgets;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.*;
+import java.util.function.*;
+
+import org.eclipse.swt.*;
+import org.eclipse.swt.graphics.*;
+import org.eclipse.swt.internal.*;
+import org.eclipse.swt.layout.*;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.*;
+
+/**
+ * Windows-specific tests for {@link ToolBar}'s image handling across monitor
+ * zoom changes.
+ */
+@ExtendWith(PlatformSpecificExecutionExtension.class)
+class ToolBarWin32Tests {
+
+	private static final int TIMEOUT_MILLIS = 5000;
+
+	private record ToolItemWithExpectedColor(ToolItem toolItem, RGB expectedColor) {
+	}
+
+	/**
+	 * Regression test for a tool bar item rendering the wrong or a blank icon after
+	 * a monitor zoom (DPI) change, as reported in <a href=
+	 * "https://github.com/eclipse-platform/eclipse.platform.swt/issues/3466">issue
+	 * #3466</a>.
+	 * <p>
+	 * The bug is triggered by clearing one item's image (which leaves the image
+	 * list in a state that a later zoom change mishandles); neither disposing an
+	 * image nor multiple monitors are required. The test observes the actual
+	 * rendered result via public API only: each item gets a distinctly colored
+	 * icon, and after the zoom change the dominant color under each item must still
+	 * match that item's own icon.
+	 */
+	@Test
+	void testIconsRenderedCorrectlyAfterZoomChangeWithImageListHole() {
+		Display display = new Display();
+		RGB[] colors = { new RGB(220, 40, 40), new RGB(40, 180, 40), new RGB(40, 40, 220), new RGB(230, 200, 30) };
+		Image[] icons = new Image[colors.length];
+		for (int i = 0; i < colors.length; i++) {
+			icons[i] = solidIcon(display, 16, colors[i]);
+		}
+		try {
+			Shell shell = new Shell(display);
+			shell.setLayout(new FillLayout());
+			ToolBar bar = new ToolBar(shell, SWT.FLAT);
+			ToolItem[] items = new ToolItem[colors.length];
+			for (int i = 0; i < colors.length; i++) {
+				items[i] = new ToolItem(bar, SWT.PUSH);
+				items[i].setImage(icons[i]);
+			}
+			shell.setSize(500, 90);
+			shell.open();
+
+			// Punch a hole below the other items: clear the first item's image.
+			items[0].setImage(null);
+
+			int zoom = bar.getAutoscalingZoom();
+			DPITestUtil.changeDPIZoom(bar.getShell(), zoom * 2);
+
+			// Only the first item is expected to rendered blank
+			Set<ToolItemWithExpectedColor> itemsToCheck = new HashSet<>();
+			for (int i = 1; i < items.length; i++) {
+				itemsToCheck.add(new ToolItemWithExpectedColor(items[i], colors[i]));
+			}
+			// Dispatch events until every item renders its own icon color, or fail on
+			// timeout. With the bug an item permanently renders another item's icon or
+			// a blank one, so the condition is never met and the timeout triggers.
+			assertTrue(waitUntilIconsRenderOwnColor(display, () -> iconsRenderOwnColor(bar, itemsToCheck, colors),
+					TIMEOUT_MILLIS), "every tool item must render its own icon color after a zoom change");
+		} finally {
+			for (Image icon : icons)
+				icon.dispose();
+			display.dispose();
+		}
+	}
+
+	private static boolean waitUntilIconsRenderOwnColor(Display display, BooleanSupplier condition,
+			long timeoutMillis) {
+		long deadline = System.currentTimeMillis() + timeoutMillis;
+		while (System.currentTimeMillis() < deadline) {
+			if (condition.getAsBoolean()) {
+				return true;
+			}
+			if (!display.readAndDispatch()) {
+				try {
+					Thread.sleep(10);
+				} catch (InterruptedException e) {
+					Thread.currentThread().interrupt();
+					break;
+				}
+			}
+		}
+		return condition.getAsBoolean();
+	}
+
+	private static boolean iconsRenderOwnColor(ToolBar bar, Set<ToolItemWithExpectedColor> items, RGB[] candidateColors) {
+		Image snapshot = renderToolBar(bar);
+		try {
+			for (ToolItemWithExpectedColor item : items) {
+				if (!item.expectedColor().equals(dominantIconColor(snapshot, item.toolItem().getBounds(), candidateColors))) {
+					return false;
+				}
+			}
+			return true;
+		} finally {
+			snapshot.dispose();
+		}
+	}
+
+	private static Image solidIcon(Display display, int size, RGB rgb) {
+		Image image = new Image(display, size, size);
+		GC gc = new GC(image);
+		Color color = new Color(display, rgb);
+		gc.setBackground(color);
+		gc.fillRectangle(0, 0, size, size);
+		gc.dispose();
+		return image;
+	}
+
+	private static Image renderToolBar(ToolBar bar) {
+		Point size = bar.getSize();
+		Image snapshot = new Image(bar.getDisplay(), Math.max(1, size.x), Math.max(1, size.y));
+		GC gc = new GC(snapshot);
+		bar.print(gc);
+		gc.dispose();
+		return snapshot;
+	}
+
+	/**
+	 * Returns which of the given candidate icon colors dominates the area of an
+	 * item. Each sufficiently saturated pixel is classified to its nearest
+	 * candidate color; the candidate matching the most pixels wins. Classifying to
+	 * a fixed palette (rather than comparing exact RGB values) makes the result
+	 * deterministic despite anti-aliasing, DPI interpolation and theming.
+	 */
+	private static RGB dominantIconColor(Image snapshot, Rectangle bounds, RGB[] candidates) {
+		ImageData data = snapshot.getImageData();
+		PaletteData palette = data.palette;
+		int[] votes = new int[candidates.length];
+		int x0 = Math.max(0, bounds.x), y0 = Math.max(0, bounds.y);
+		int x1 = Math.min(data.width, bounds.x + bounds.width);
+		int y1 = Math.min(data.height, bounds.y + bounds.height);
+		for (int y = y0; y < y1; y++) {
+			for (int x = x0; x < x1; x++) {
+				RGB rgb = palette.getRGB(data.getPixel(x, y));
+				int max = Math.max(rgb.red, Math.max(rgb.green, rgb.blue));
+				int min = Math.min(rgb.red, Math.min(rgb.green, rgb.blue));
+				if (max - min < 60) {
+					continue; // ignore low-saturation background/borders
+				}
+				int best = -1, bestDist = Integer.MAX_VALUE;
+				for (int c = 0; c < candidates.length; c++) {
+					int dr = rgb.red - candidates[c].red;
+					int dg = rgb.green - candidates[c].green;
+					int db = rgb.blue - candidates[c].blue;
+					int dist = dr * dr + dg * dg + db * db;
+					if (dist < bestDist) {
+						bestDist = dist;
+						best = c;
+					}
+				}
+				if (best >= 0)
+					votes[best]++;
+			}
+		}
+		int winner = -1, most = 0;
+		for (int c = 0; c < candidates.length; c++) {
+			if (votes[c] > most) {
+				most = votes[c];
+				winner = c;
+			}
+		}
+		return winner < 0 ? null : candidates[winner];
+	}
+}

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/Item.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/Item.java
@@ -230,7 +230,6 @@ private void handleDPIChange(Event event) {
 	// Refresh the image
 	Image image = getImage();
 	if (image != null) {
-		setImage(null);
 		setImage(image);
 	}
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ToolBar.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ToolBar.java
@@ -1738,6 +1738,11 @@ void handleDPIChange(Event event, float scalingFactor) {
 			}
 		}
 	}
+	// Refresh the image lists so the image list for the correct zoom is used
+	setImageList(getImageList());
+	setDisabledImageList(getDisabledImageList());
+	setHotImageList(getHotImageList());
+	boolean toolBarEnabled = getEnabled();
 	for (int i = 0; i < itemCount; i++) {
 		ToolItem item = toolItems[i];
 		// If the separator is used with a control, we must reset the size to the cached value,
@@ -1745,12 +1750,9 @@ void handleDPIChange(Event event, float scalingFactor) {
 		if ((item.style & SWT.SEPARATOR) != 0 && item.getControl() != null) {
 			item.setWidth(seperatorWidth[i]);
 		}
+		// Make sure the tool item is resized with the new image and font size
+		toolItems[i].updateImages(toolItems[i].getEnabled() && toolBarEnabled);
 	}
-
-	// Refresh the image lists so the image list for the correct zoom is used
-	setImageList(getImageList());
-	setDisabledImageList(getDisabledImageList());
-	setHotImageList(getHotImageList());
 	OS.SendMessage(handle, OS.TB_AUTOSIZE, 0, 0);
 	clearSizeCache(true);
 }


### PR DESCRIPTION
## What & why

Fixes #3466: on Windows, a `ToolBar` item can render another item's icon — or a blank one — after a monitor zoom (DPI) change.

The regression was introduced while fixing #3073 (via #3074), which forced a full image refresh for every `ToolItem` on every DPI change by nulling and re-setting the image in `Item.handleDPIChange` to ensure proper item resizing. That is both costly and fragile:

- **Costly:** it removes and re-adds every item's image on every zoom change.
- **Fragile:** for tool bars it can relocate an item to a lower free slot in the image list when a *hole* is present (a slot freed by an earlier `ToolItem.setImage(null)`). The native button was re-added with a previously captured image index, so it ended up pointing at a stale slot — the item then shows another item's icon or a blank one.

Neither disposing an image nor multiple monitors are required to hit this — only a hole in the image list plus any DPI change.

## The fix

- Revert `Item.handleDPIChange` to the cheap no-op refresh.
- Let `ToolBar.handleDPIChange` reinitialize each item's image *in place* via `ToolItem.updateImages`, after the buttons have been re-added and the image lists refreshed.

`updateImages` writes the rescaled image at the item's **existing** image-list slot (no clear/re-add, so no relocation) and forces the button width to be recomputed. This keeps #3073 fixed without the per-zoom overhead and without the wrong-icon regression.

## Testing

Adds `ToolBarWin32Tests.testIconsRenderedCorrectlyAfterZoomChangeWithImageListHole`, a regression test for #3466 using **public API only**: each item gets a distinctly colored icon, a hole is punched via `setImage(null)`, a DPI change is triggered, and the test asserts (by rendering the tool bar and sampling colors under each item's bounds) that every item still renders its own icon. The test fails on current `master` and passes with this change.

The #3073 scenario (a labelled item disappearing after a DPI change + enable/disable in the RCP workbench) is inherently workbench-level and can't be reproduced headlessly, so it is covered by manual verification with the reproducer from #3073.

## Manual reproduction (#3466)

A standalone SWT reproducer is attached in #3466: four PUSH items with distinct colored icons, a button to clear one item's icon (punch the hole), then drag the window between two monitors of different scaling — without the fix the icons become swapped/blank.
