### PR TITLE
[Win32] Capture tool bar button image index after zoom refresh

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ToolBar.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ToolBar.java
@@ -1712,8 +1712,6 @@ void handleDPIChange(Event event, float scalingFactor) {
 	// Remove and re-add all button the let Windows resize the tool bar
 	Stack<ToolItemData> buttondata = new Stack<>();
 	for (int i = itemCount - 1; i >= 0; i--) {
-		TBBUTTON lpButton = new TBBUTTON ();
-		OS.SendMessage (handle, OS.TB_GETBUTTON, i, lpButton);
 		ToolItem item = toolItems[i];
 		if ((item.style & SWT.SEPARATOR) != 0 && item.getControl() != null) {
 			// Take note of widths of separators with control, so they can be resized
@@ -1721,6 +1719,13 @@ void handleDPIChange(Event event, float scalingFactor) {
 			seperatorWidth[i] = item.getWidth();
 		}
 		item.notifyListeners(SWT.ZoomChanged, event);
+		// Capture the button data AFTER handling the zoom change. The zoom refresh
+		// may update the item's image-list slot (iBitmap), so capturing the button
+		// beforehand could re-add it with a stale image index, resulting in the
+		// wrong (or a blank) icon being shown. Reading the button here ensures the
+		// current, post-refresh image index is preserved.
+		TBBUTTON lpButton = new TBBUTTON ();
+		OS.SendMessage (handle, OS.TB_GETBUTTON, i, lpButton);
 		buttondata.push(new ToolItemData(item, lpButton));
 		OS.SendMessage(handle, OS.TB_DELETEBUTTON, i, 0);
 	}


### PR DESCRIPTION
## Problem

On a monitor zoom (DPI) change, `ToolBar.handleDPIChange` removes and re-adds every button so Windows re-lays out the tool bar at the new zoom. For each button it takes a snapshot via `TB_GETBUTTON` — including the button's image-list slot index (`iBitmap`) — and re-adds the button from that snapshot.

So far the snapshot was taken *before* the item was notified of the zoom change (`notifyListeners(SWT.ZoomChanged, ...)`). If handling that notification changes an item's image-list slot — for example when a re-added image is placed into a free (previously freed) slot — the re-added button carries a **stale** image index. The item then shows another item's icon or a blank one. This is the wrong-icon symptom tracked in #3466.

## Fix

Capture the button with `TB_GETBUTTON` *after* `notifyListeners(SWT.ZoomChanged, ...)`, so the current, post-refresh image index is always the one that is re-added. This makes the image-index capture correct by construction and guards against an item's image-list slot changing while the zoom change is handled.

## Relation to #3468

This change on its own also fixes #3466. However, PR #3468 (the primary fix for #3466) is going to be applied anyway: it stops relocating an item's image during the zoom notification, which means the image index no longer changes between the capture and the re-add — and therefore hides this ordering bug again. So once #3468 is merged, the symptom is not observable even without this change.

This PR is nonetheless valuable as **hardening**: it removes the ordering fragility at its source, so the tool bar stays correct even if a future change once again updates an item's image while handling the zoom change. The regression test for the symptom is delivered with #3468, so no test is added here.
