### PR TITLE
[GTK4] Re-layout Composite subtree when shown to fix collapsed content

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Control.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Control.java
@@ -6166,6 +6166,20 @@ public void setVisible (boolean visible) {
 				if (enableWindow != 0) GDK.gdk_window_show_unraised(enableWindow);
 			}
 			gtk_widget_show (topHandle);
+			/*
+			 * On GTK4, a Composite laid out while it (or an ancestor) is hidden can end
+			 * up with its children sized against a stale 0x0 client area, because
+			 * gtk_widget_hide() resets allocations to 0x0 (issue #3330) and setBounds on a
+			 * hidden widget shows/allocates/re-hides it. The size given while hidden is
+			 * still stored in the parent's swt_fixed child list, so re-running the parent's
+			 * size allocation re-applies this control's real size (restoring its client
+			 * area), after which a re-layout of its own subtree lets the children pick up
+			 * the now-correct client area. See issue #3450.
+			 */
+			if (GTK.GTK4 && this instanceof Composite composite && composite.layout != null) {
+				parent.forceResize ();
+				composite.layout (true, true);
+			}
 		}
 	} else {
 		/*


### PR DESCRIPTION
On GTK4, gtk_widget_hide() resets a widget's allocation to 0x0. A Composite that is laid out while it (or an ancestor) is hidden therefore sizes its children against a stale 0x0 client area, leaving them collapsed at their minimum size once the Composite is finally shown. The content only expands after a manual resize forces a re-layout.

The size given while hidden is still stored in the parent's swt_fixed child list. When such a Composite is shown, re-run the parent's size allocation to re-apply this control's real size (restoring its client area), then re-layout its own subtree so the children pick up the now-correct client area.

Fixes https://github.com/eclipse-platform/eclipse.platform.swt/issues/3450