### PR TITLE
[Win32] Keep tool bar normal, hot and disabled image lists index-aligned

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/internal/ImageListTests.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/internal/ImageListTests.java
@@ -132,4 +132,158 @@ public class ImageListTests {
 		}
 	}
 
+	@Test
+	public void testAddReturnsConsecutiveIndicesForConsecutiveImages() {
+		ImageList list = new ImageList(SWT.NONE, 16, 16, 100);
+		Image[] images = createImages(3);
+		try {
+			assertEquals(0, list.add(images[0]));
+			assertEquals(1, list.add(images[1]));
+			assertEquals(2, list.add(images[2]));
+		} finally {
+			disposeAll(list, images);
+		}
+	}
+
+	@Test
+	public void testAddReusesSlotOfRemovedImage() {
+		ImageList list = new ImageList(SWT.NONE, 16, 16, 100);
+		Image[] images = createImages(3);
+		try {
+			list.add(images[0]);
+			list.add(images[1]);
+			list.put(0, null);
+
+			assertEquals(0, list.add(images[2]));
+			assertSame(images[2], list.get(0));
+		} finally {
+			disposeAll(list, images);
+		}
+	}
+
+	@Test
+	public void testPutAppendsImageAtEndOfList() {
+		ImageList list = new ImageList(SWT.NONE, 16, 16, 100);
+		Image[] images = createImages(2);
+		try {
+			list.add(images[0]);
+
+			list.put(1, images[1]);
+
+			assertSame(images[1], list.get(1));
+			assertEquals(2, list.size());
+		} finally {
+			disposeAll(list, images);
+		}
+	}
+
+	@Test
+	public void testPutReplacesImageInsideList() {
+		ImageList list = new ImageList(SWT.NONE, 16, 16, 100);
+		Image[] images = createImages(3);
+		try {
+			list.add(images[0]);
+			list.add(images[1]);
+
+			list.put(0, images[2]);
+
+			assertSame(images[2], list.get(0));
+			assertEquals(2, list.size());
+		} finally {
+			disposeAll(list, images);
+		}
+	}
+
+	@Test
+	public void testPutWithoutImageClearsSlotInsideList() {
+		ImageList list = new ImageList(SWT.NONE, 16, 16, 100);
+		Image[] images = createImages(2);
+		try {
+			list.add(images[0]);
+			list.add(images[1]);
+
+			list.put(0, null);
+
+			assertNull(list.get(0));
+			assertSame(images[1], list.get(1));
+			assertEquals(1, list.size());
+		} finally {
+			disposeAll(list, images);
+		}
+	}
+
+	@Test
+	public void testPutBeyondEndOfListIsIgnored() {
+		ImageList list = new ImageList(SWT.NONE, 16, 16, 100);
+		Image[] images = createImages(2);
+		try {
+			list.add(images[0]);
+
+			list.put(2, images[1]);
+
+			assertEquals(1, list.size());
+		} finally {
+			disposeAll(list, images);
+		}
+	}
+
+	@Test
+	public void testPutNegativeIndexIsIgnored() {
+		ImageList list = new ImageList(SWT.NONE, 16, 16, 100);
+		Image[] images = createImages(2);
+		try {
+			list.add(images[0]);
+
+			list.put(-1, images[1]);
+
+			assertSame(images[0], list.get(0));
+			assertEquals(1, list.size());
+		} finally {
+			disposeAll(list, images);
+		}
+	}
+
+	/**
+	 * Tool bars address their normal, hot and disabled image list with a single
+	 * index per item, so an image must be storable at a given index instead of at
+	 * whatever slot the individual list happens to have free.
+	 */
+	@Test
+	public void testPutKeepsListsAlignedWhenTheirFreeSlotsDiffer() {
+		ImageList list = new ImageList(SWT.NONE, 16, 16, 100);
+		ImageList hotList = new ImageList(SWT.NONE, 16, 16, 100);
+		Image[] images = createImages(4);
+		try {
+			list.add(images[0]);
+			hotList.add(images[1]);
+			// only the first list has a free slot from here on
+			list.put(0, null);
+
+			int index = list.add(images[2]);
+			hotList.put(index, images[3]);
+
+			assertEquals(0, index);
+			assertSame(images[2], list.get(index));
+			assertSame(images[3], hotList.get(index));
+		} finally {
+			hotList.dispose();
+			disposeAll(list, images);
+		}
+	}
+
+	private static Image[] createImages(int count) {
+		Image[] images = new Image[count];
+		for (int i = 0; i < count; i++) {
+			images[i] = new Image(Display.getDefault(), 16, 16);
+		}
+		return images;
+	}
+
+	private static void disposeAll(ImageList list, Image[] images) {
+		list.dispose();
+		for (Image image : images) {
+			image.dispose();
+		}
+	}
+
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/ImageList.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/ImageList.java
@@ -55,6 +55,27 @@ public int add (Image image) {
 		if (imageAtIndex == null) break;
 		index++;
 	}
+	putAt (index, image);
+	return index;
+}
+
+/**
+ * Stores {@code image} at the given {@code index}.
+ * <ul>
+ * <li>If {@code image} is non-null and {@code index} equals the current size, a
+ * new slot is appended.</li>
+ * <li>If {@code index} is within the current size, the slot is replaced (or
+ * cleared when {@code image} is null).</li>
+ * <li>If {@code index} is out of range (&lt; 0 or &gt; current size), this
+ * method does nothing.</li>
+ * </ul>
+ */
+public void putAt (int index, Image image) {
+	int count = OS.ImageList_GetImageCount (handle);
+	if (index != count || image == null) {
+		put (index, image);
+		return;
+	}
 	if (count == 0) {
 		Rectangle bounds = image.getBounds();
 		width = bounds.width;
@@ -68,7 +89,6 @@ public int add (Image image) {
 		images = newImages;
 	}
 	images [index] = image;
-	return index;
 }
 
 private Image getOrClearIfDisposed(int index) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/ImageList.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/internal/ImageList.java
@@ -55,6 +55,11 @@ public int add (Image image) {
 		if (imageAtIndex == null) break;
 		index++;
 	}
+	put (index, image);
+	return index;
+}
+
+private void append (int index, Image image, int count) {
 	if (count == 0) {
 		Rectangle bounds = image.getBounds();
 		width = bounds.width;
@@ -68,7 +73,6 @@ public int add (Image image) {
 		images = newImages;
 	}
 	images [index] = image;
-	return index;
 }
 
 private Image getOrClearIfDisposed(int index) {
@@ -386,9 +390,19 @@ public int indexOf (Image image) {
 	return -1;
 }
 
+/**
+ * Stores the given image at the given index, replacing whatever is stored at that index. Passing
+ * no image clears the index. The index may also address the slot right after the last one, in
+ * which case a new slot is appended for the given image. Nothing happens for any other index
+ * outside the list's current size.
+ */
 public void put (int index, Image image) {
 	if ((0 <= index && index < images.length) && (images [index] == image)) return;
 	int count = OS.ImageList_GetImageCount (handle);
+	if (index == count && image != null) {
+		append (index, image, count);
+		return;
+	}
 	if (!(0 <= index && index < count)) return;
 	if (image != null) setForAllHandles(index, image, count);
 	images [index] = image;

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ToolBar.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ToolBar.java
@@ -1246,8 +1246,11 @@ void updateOrientation () {
 				hotImageList.put(info.iImage, null);
 				disabledImageList.put(info.iImage, null);
 				info.iImage = newImageList.add(image);
-				newHotImageList.add(hot);
-				newDisabledImageList.add(disabled);
+				// Keep the new hot and disabled lists index-aligned with the new
+				// normal list by reusing the normal list's index (see
+				// ToolItem.updateImages) instead of three independent add(...) calls.
+				newHotImageList.putAt(info.iImage, hot);
+				newDisabledImageList.putAt(info.iImage, disabled);
 				OS.SendMessage (handle, OS.TB_SETBUTTONINFO, item.id, info);
 			}
 		}

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ToolBarImageLists.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ToolBarImageLists.java
@@ -57,8 +57,12 @@ class ToolBarImageLists {
 
 	int add(Image image, Image hotImage, Image disabledImage) {
 		int index = imageList.add(image);
-		hotImageList.add(hotImage);
-		disabledImageList.add(disabledImage);
+		// Use the slot index from the normal image list as authoritative source
+		// for the image ordering and reuse it for the hot and disabled lists
+		// instead of letting each of them scan for its own free slot, so all
+		// three stay index-aligned.
+		hotImageList.put(index, hotImage);
+		disabledImageList.put(index, disabledImage);
 		return index;
 	}
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ToolItem.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ToolItem.java
@@ -1135,8 +1135,11 @@ void updateImages (boolean enabled) {
 			if (!enabled) image2 = hot = disabled;
 		}
 		info.iImage = imageList.add (image2);
-		disabledImageList.add (disabled);
-		hotImageList.add (hot != null ? hot : image2);
+		// Use the slot index from the normal image list as authoritative source
+		// for the image ordering and reuse it for the disabled and hot lists so all
+		// three stay index-aligned.
+		disabledImageList.putAt (info.iImage, disabled);
+		hotImageList.putAt (info.iImage, hot != null ? hot : image2);
 		parent.setImageList (imageList);
 		parent.setDisabledImageList (disabledImageList);
 		parent.setHotImageList (hotImageList);
@@ -1171,7 +1174,11 @@ void updateImages (boolean enabled) {
 			imageList.put (info.iImage, image2);
 		}
 		if (hotImageList != null) {
-			hotImageList.put (info.iImage, hot != null ? hot : image2);
+			// Mirror the normal list: when it stores no image for this slot
+			// (image2 == null, i.e. the item's image was cleared) the button stops
+			// referencing this slot (iImage becomes I_IMAGENONE below), so free the
+			// hot slot too instead of leaving the old hot image behind.
+			hotImageList.put (info.iImage, image2 != null ? (hot != null ? hot : image2) : null);
 		}
 		if (image == null) info.iImage = OS.I_IMAGENONE;
 	}

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ToolItem.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ToolItem.java
@@ -1141,7 +1141,13 @@ void updateImages (boolean enabled) {
 			if (!enabled) image2 = hot = disabled;
 		}
 
-		parent.putImage(info.iImage, image2, hot != null ? hot : image2, disabled);
+		/*
+		* When the normal image is cleared (image2 == null) the button stops
+		* referencing this slot (iImage becomes I_IMAGENONE below), so the hot
+		* image must be freed too instead of leaving the old hot image behind
+		* for a later item that reuses this slot.
+		*/
+		parent.putImage(info.iImage, image2, image2 != null ? (hot != null ? hot : image2) : null, disabled);
 		if (image == null) info.iImage = OS.I_IMAGENONE;
 	}
 


### PR DESCRIPTION
> [!IMPORTANT]
> This change is based on and should thus be merged after:
> - https://github.com/eclipse-platform/eclipse.platform.swt/pull/3504
> - https://github.com/eclipse-platform/eclipse.platform.swt/pull/3508
> - https://github.com/eclipse-platform/eclipse.platform.swt/pull/3513
> - https://github.com/eclipse-platform/eclipse.platform.swt/pull/3515

### Problem

On Windows a `ToolItem` could render **another item's hot (hover) or disabled icon** — no multiple monitors and no image disposal required. Setting an image, then a hot image, then clearing the image while adding a new item to the tool bar is already enough to trigger it.

A tool bar keeps three native image lists (normal, hot, disabled), but each button stores a **single** image index that addresses all three lists at once. The three lists therefore have to stay index-aligned. Two code paths in `ToolItem.updateImages` broke that invariant:

- **Clearing the normal image while a hot image is still set** freed the normal and disabled slots but kept the hot slot occupied. A later item that reused the freed normal slot then rendered the first item's stale hot icon on hover.
- **Adding a first image** appended it to each list with three independent `add()` calls. Once the lists' free-slot patterns diverged (as caused by the first defect), those calls could return different indices. Only the normal list's index is written to the button, so its slot could end up pointing at another item's hot or disabled image.

Contributes to #3466.

### Fix

Enforce one index per item across all three lists:

- Free the hot slot too when the normal image is cleared, so the hot list's free-slot pattern no longer diverges from the normal and disabled lists.
- Derive the slot index **once** from the normal list and write the hot and disabled lists at that exact index (instead of relying on three independent `add()` calls returning matching indices). `ToolBar.updateOrientation` adopts the same discipline.

This is implemented with a small `ImageList.putAt(index, image)` that stores an image at a caller-chosen index (appending when the index equals the current size, otherwise replacing or, for a `null` image, clearing the slot). `add(image)` is now implemented on top of it by first computing the target index.

### Reproduction

Run the snippet below and **hover the mouse over the second (blue) button**:

- **Before the fix:** the blue button turns **green** — it renders the first item's leftover hot image, even though it has no hot image of its own.
- **After the fix:** the blue button stays **blue**.

**Before (wrong behavior):**
<img width="346" height="143" alt="image" src="https://github.com/user-attachments/assets/12d50fce-4e1a-46c2-8be5-169854e67e9c" />

**After (corrected behavior):**
<img width="346" height="143" alt="image" src="https://github.com/user-attachments/assets/c1621ff0-86f3-4fe2-8cf3-e7ab97e244d3" />

```java
/*
 * Reproduction for a Win32 tool bar item rendering another item's hot (hover)
 * icon, without any multiple monitors or image disposal involved.
 *
 * Steps performed below:
 *   - item0 gets a RED normal image and a GREEN hot image
 *   - item0's image is cleared (setImage(null)) while the hot image stays set
 *   - item1 gets a BLUE normal image and NO hot image
 *
 * Hover the mouse over the second (blue) button:
 *   Expected (fixed): it stays BLUE (item1 has no hot image).
 *   Bug:              it turns GREEN, i.e. item1 renders item0's leftover hot image.
 */
import org.eclipse.swt.SWT;
import org.eclipse.swt.graphics.Color;
import org.eclipse.swt.graphics.GC;
import org.eclipse.swt.graphics.Image;
import org.eclipse.swt.graphics.RGB;
import org.eclipse.swt.layout.GridLayout;
import org.eclipse.swt.widgets.Display;
import org.eclipse.swt.widgets.Label;
import org.eclipse.swt.widgets.Shell;
import org.eclipse.swt.widgets.ToolBar;
import org.eclipse.swt.widgets.ToolItem;

public class ToolItemHotImageReproduction {

	public static void main(String[] args) {
		Display display = new Display();
		Image red = solidImage(display, new RGB(220, 40, 40));
		Image green = solidImage(display, new RGB(40, 180, 40));
		Image blue = solidImage(display, new RGB(40, 40, 220));

		Shell shell = new Shell(display);
		shell.setLayout(new GridLayout());
		shell.setText("ToolItem hot image reproduction");

		ToolBar bar = new ToolBar(shell, SWT.FLAT);

		ToolItem item0 = new ToolItem(bar, SWT.PUSH);
		item0.setImage(red);
		item0.setHotImage(green); // item0 shows GREEN on hover
		item0.setImage(null);     // clear item0's image; its hot image stays set

		ToolItem item1 = new ToolItem(bar, SWT.PUSH);
		item1.setImage(blue);     // item1: BLUE, no hot image

		Label hint = new Label(shell, SWT.WRAP);
		hint.setText("Hover the mouse over the second (blue) button.\n"
				+ "Expected: it stays BLUE (it has no hot image).\n"
				+ "Bug: it turns GREEN (item0's leftover hot image).");

		shell.setSize(360, 150);
		shell.open();
		while (!shell.isDisposed()) {
			if (!display.readAndDispatch()) display.sleep();
		}

		red.dispose();
		green.dispose();
		blue.dispose();
		display.dispose();
	}

	private static Image solidImage(Display display, RGB rgb) {
		Image image = new Image(display, 16, 16);
		GC gc = new GC(image);
		Color color = new Color(display, rgb);
		gc.setBackground(color);
		gc.fillRectangle(image.getBounds());
		gc.dispose();
		return image;
	}
}
```
