### PR TITLE
GTK4: Fix empty popup for disabled CASCADE menu items

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/MenuItem.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/MenuItem.java
@@ -295,7 +295,22 @@ void createHandle(int index) {
 				break;
 			case SWT.CASCADE:
 				modelHandle = OS.g_menu_new();
-				handle = OS.g_menu_item_new_submenu(Converter.javaStringToCString(""), modelHandle);
+				/*
+				 * Give the CASCADE item an action so it can be enabled/disabled like
+				 * on the other platforms and like GTK3. A plain submenu item created
+				 * via g_menu_item_new_submenu has no action, so its GtkModelButton is
+				 * always sensitive: setEnabled(false) would be a no-op and the (possibly
+				 * empty) submenu could still be opened. Attaching a SimpleAction makes
+				 * the item follow the action's enabled state. While the action is
+				 * enabled, activating the item still navigates into the submenu (the
+				 * action is not triggered); while disabled, the item is insensitive and
+				 * the submenu cannot be opened.
+				 */
+				actionHandle = OS.g_simple_action_new(Converter.javaStringToCString(String.valueOf(this.hashCode())), 0);
+				OS.g_action_map_add_action(parent.actionGroup, actionHandle);
+				actionName = String.valueOf(parent.hashCode()) + "." + String.valueOf(this.hashCode());
+				handle = OS.g_menu_item_new(Converter.javaStringToCString(""), Converter.javaStringToCString(actionName));
+				OS.g_menu_item_set_submenu(handle, modelHandle);
 				break;
 			case SWT.PUSH:
 			default:
@@ -523,10 +538,6 @@ public boolean getEnabled () {
 	checkWidget();
 
 	if (GTK.GTK4) {
-		if ((style & SWT.CASCADE) != 0) {
-			return true;
-		}
-
 		return OS.g_action_get_enabled(actionHandle);
 	} else {
 		return GTK.gtk_widget_get_sensitive(handle);

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_MenuItem.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_MenuItem.java
@@ -195,6 +195,19 @@ public void test_setEnabledZ() {
 	assertFalse(menuItem.getEnabled());
 }
 
+@Test
+public void test_setEnabledZ_cascade() {
+	MenuItem cascadeItem = new MenuItem(menu, SWT.CASCADE);
+	Menu subMenu = new Menu(shell, SWT.DROP_DOWN);
+	cascadeItem.setMenu(subMenu);
+	assertTrue(cascadeItem.getEnabled());
+	cascadeItem.setEnabled(false);
+	assertFalse(cascadeItem.getEnabled());
+	cascadeItem.setEnabled(true);
+	assertTrue(cascadeItem.getEnabled());
+	cascadeItem.dispose();
+}
+
 @Tag("gtk4-todo")
 @Override
 @Test


### PR DESCRIPTION
On GTK4 a SWT.CASCADE menu item was created via g_menu_item_new_submenu which has no associated action. setEnabled() only manipulates the item's action, so calling setEnabled(false) on a cascade item was a no-op: the item stayed sensitive and opened an empty popover. getEnabled() also hard-coded true for cascade items. On GTK3 the same call correctly greys out the item via gtk_widget_set_sensitive.

This affected e.g. Navigate > Back/Forward, which Eclipse disables when there is nothing to navigate to: on GTK4 they remained enabled and showed an empty menu.

Create cascade items with a backing SimpleAction (g_menu_item_new plus g_menu_item_set_submenu) so their sensitivity can be toggled, and return the action's enabled state from getEnabled() for all GTK4 items. The activate signal is not wired for cascade items, so opening the submenu still works and navigation is not hijacked.