### PR TITLE
[GTK4] Fix empty lazily-populated submenus (e.g. File > New)

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/org/eclipse/swt/internal/gtk/OS.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/org/eclipse/swt/internal/gtk/OS.java
@@ -411,6 +411,7 @@ public class OS extends C {
 	public static final byte[] hide = ascii("hide");
 	public static final byte[] icon_release = ascii("icon-release");
 	public static final byte[] insert_text = ascii("insert-text");
+	public static final byte[] items_changed = ascii("items-changed");
 	public static final byte[] key_press_event = ascii("key-press-event");
 	public static final byte[] key_release_event = ascii("key-release-event");
 	public static final byte[] key_pressed = ascii("key-pressed");

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Display.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Display.java
@@ -135,12 +135,14 @@ public class Display extends Device implements Executor {
 	long changeValueProc;
 	long snapshotDrawProc, keyPressReleaseProc, focusProc, windowActiveProc, enterMotionProc, leaveProc,
 		 scrollProc, resizeProc, layoutProc, activateProc, gesturePressReleaseProc;
+	long menuItemsChangedProc;
 	long notifyProc;
 	long computeSizeProc;
 	Callback windowCallback2, windowCallback3, windowCallback4, windowCallback5, windowCallback6;
 	Callback changeValue;
 	Callback snapshotDraw, keyPressReleaseCallback, focusCallback, windowActiveCallback, enterMotionCallback, computeSizeCallback,
 			 scrollCallback, leaveCallback, resizeCallback, layoutCallback, activateCallback, gesturePressReleaseCallback;
+	Callback menuItemsChangedCallback;
 	Callback notifyCallback;
 	EventTable eventTable, filterTable;
 	static String APP_NAME = "SWT"; //$NON-NLS-1$
@@ -3633,6 +3635,10 @@ void initializeCallbacks () {
 		activateCallback = new Callback(this, "activateProc", void.class, new Type[] {long.class, long.class, long.class}); //$NON-NLS-1$
 		activateProc = activateCallback.getAddress();
 
+		menuItemsChangedCallback = new Callback(this, "menuItemsChangedProc", void.class, new Type[] {
+				long.class, int.class, int.class, int.class, long.class}); //$NON-NLS-1$
+		menuItemsChangedProc = menuItemsChangedCallback.getAddress();
+
 		computeSizeCallback = new Callback(this, "computeSizeProc", void.class, new Type[] {long.class, long.class, long.class}); //$NON-NLS-1$
 		computeSizeProc = computeSizeCallback.getAddress();
 	}
@@ -4670,6 +4676,10 @@ void releaseDisplay () {
 		activateCallback.dispose();
 		activateCallback = null;
 		activateProc = 0;
+
+		menuItemsChangedCallback.dispose();
+		menuItemsChangedCallback = null;
+		menuItemsChangedProc = 0;
 
 		computeSizeCallback.dispose();
 		computeSizeCallback = null;
@@ -6143,6 +6153,11 @@ void activateProc(long action, long parameter, long user_data) {
 	if(widget == null) return;
 
 	widget.gtk_activate(user_data);
+}
+
+void menuItemsChangedProc(long model, int position, int removed, int added, long user_data) {
+	Widget widget = getWidget(user_data);
+	if (widget instanceof Menu menu) menu.modelItemsChanged();
 }
 
 void resizeProc(long handle, int width, int height) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Menu.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Menu.java
@@ -944,6 +944,86 @@ long gtk_map (long widget) {
 	return super.gtk_map(widget);
 }
 
+/**
+ * Re-runs the CASCADE submenu SHOW/HIDE wiring after the menu structure changed
+ * while already mapped. The initial wiring at
+ * {@link #gtk_map}/{@link #gtk_show} only covers submenus that existed then;
+ * ones attached, replaced or rebuilt later would otherwise never get their
+ * {@link SWT#Show} event, making lazily-populated submenus appear empty.
+ */
+private void reconnectDropDownMenuSignalsIfMapped() {
+	if (!GTK.GTK4) return;
+	if ((style & SWT.BAR) != 0) {
+		if (handle != 0 && GTK.gtk_widget_get_mapped(handle)) {
+			connectDropDownMenuSignals();
+		}
+	} else if ((style & SWT.POP_UP) != 0) {
+		if (handle != 0 && GTK.gtk_widget_get_mapped(handle)) {
+			connectCascadeSubMenuSignals(this, handle);
+		}
+	} else if ((style & SWT.DROP_DOWN) != 0) {
+		if (popoverHandle != 0 && GTK.gtk_widget_get_mapped(popoverHandle)) {
+			connectCascadeSubMenuSignals(this, popoverHandle);
+		}
+	}
+}
+
+/**
+ * Hooks this menu's {@code items-changed} handler on the given {@code GMenu}
+ * model (no-op for {@code 0}), routing back via {@link #handle}. Connected in the
+ * signal's <em>after</em> phase so it runs once GTK's {@code GtkMenuTracker} has
+ * already (re)built the nested GtkPopoverMenu widgets, letting re-wiring run
+ * synchronously.
+ */
+void hookItemsChanged(long model) {
+	if (GTK.GTK4 && model != 0) {
+		long closure = OS.g_cclosure_new(display.menuItemsChangedProc, handle, 0);
+		OS.g_signal_connect_closure(model, OS.items_changed, closure, true);
+	}
+}
+
+/**
+ * Called when this menu's {@code GMenuModel} emitted {@code items-changed} (its
+ * content was modified after creation). Re-runs the CASCADE submenu wiring from
+ * the nearest mapped ancestor so any nested GtkPopoverMenu GTK (re)built gets its
+ * {@link SWT#Show} routed to the SWT DROP_DOWN submenu. Runs synchronously (see
+ * {@link #hookItemsChanged(long)}); a cheap no-op if no ancestor is mapped.
+ */
+void modelItemsChanged() {
+	if (!GTK.GTK4 || isDisposed()) return;
+	Menu root = this;
+	while (root.cascade != null && root.cascade.parent != null && !root.cascade.parent.isDisposed()) {
+		root = root.cascade.parent;
+	}
+	root.reconnectDropDownMenuSignalsIfMapped();
+}
+
+/**
+ * Wires the SHOW/HIDE signals of the given DROP_DOWN {@code submenu} to the
+ * discovered {@code popover} GtkPopoverMenu widget, refreshing the SWT-side
+ * cache. If the submenu was previously wired to a now-stale popover (e.g. GTK
+ * rebuilt the widget after a model change), the stale handle is released first.
+ */
+private void wireSubMenuPopover(Menu submenu, long popover) {
+	if (submenu.popoverHandle == popover) return;
+	if (submenu.popoverHandle != 0) {
+		/*
+		 * Release the stale popover we previously cached (mirrors deregister()). Its
+		 * SHOW/HIDE closures are deliberately left connected: GTK normally destroys the
+		 * widget along with the model change, and should it survive, removeWidget() above
+		 * means its handlers no longer resolve to a widget and simply no-op.
+		 */
+		display.removeWidget(submenu.popoverHandle);
+		OS.g_object_unref(submenu.popoverHandle);
+		submenu.popoverHandle = 0;
+	}
+	OS.g_object_ref(popover);
+	submenu.popoverHandle = popover;
+	display.addWidget(popover, submenu);
+	OS.g_signal_connect_closure_by_id(popover, display.signalIds[SHOW], 0, display.getClosure(SHOW), false);
+	OS.g_signal_connect_closure_by_id(popover, display.signalIds[HIDE], 0, display.getClosure(HIDE), false);
+}
+
 private void connectDropDownMenuSignals() {
 	if (items == null) return;
 	long barItem = GTK4.gtk_widget_get_first_child(handle);
@@ -951,17 +1031,13 @@ private void connectDropDownMenuSignals() {
 	for (MenuItem menuItem : items) {
 		if (barItem == 0) break;
 		if ((menuItem.style & SWT.SEPARATOR) != 0) continue;
-		if (menuItem.menu != null && menuItem.menu.popoverHandle == 0) {
+		if (menuItem.menu != null) {
 			long popover = findGtkPopoverMenuChild(barItem);
-			if (popover != 0) {
-				OS.g_object_ref(popover);
-				menuItem.menu.popoverHandle = popover;
-				display.addWidget(popover, menuItem.menu);
-				OS.g_signal_connect_closure_by_id(popover, display.signalIds[SHOW], 0, display.getClosure(SHOW), false);
-				OS.g_signal_connect_closure_by_id(popover, display.signalIds[HIDE], 0, display.getClosure(HIDE), false);
-				/*
-				 * Also connect SHOW/HIDE signals for nested CASCADE submenus.
-				 */
+			/* Re-wire when the discovered popover differs from the cache (initial or GTK rebuilt it). */
+			if (popover != 0 && menuItem.menu.popoverHandle != popover) {
+				wireSubMenuPopover(menuItem.menu, popover);
+			}
+			if (menuItem.menu.popoverHandle != 0) {
 				connectCascadeSubMenuSignals(menuItem.menu);
 			}
 		}
@@ -973,30 +1049,33 @@ private void connectCascadeSubMenuSignals(Menu menu) {
 	connectCascadeSubMenuSignals(menu, menu.popoverHandle);
 }
 
+/**
+ * Connects SHOW/HIDE signals for the CASCADE submenus of the given menu. A
+ * submenu whose GtkPopoverMenu is not (yet) present is simply skipped; the next
+ * pass triggered by MAP, SHOW or "items-changed" picks it up.
+ */
 private void connectCascadeSubMenuSignals(Menu menu, long parentPopoverHandle) {
 	if (menu == null || parentPopoverHandle == 0 || menu.items == null) return;
 	for (MenuItem item : menu.items) {
 		if ((item.style & SWT.CASCADE) != 0 && item.menu != null) {
-			/*
-			 * item.menu is the CASCADE submenu (always SWT.DROP_DOWN style).
-			 * Its popoverHandle is 0 until we find and register its GtkPopoverMenu.
-			 * Skip if already connected (popoverHandle != 0).
-			 */
-			if (item.menu.popoverHandle != 0) continue;
+			/* Re-discover every pass: a rebuild can make GTK replace the widget,
+			 * leaving a stale handle whose SHOW never fires (submenu appears empty). */
 			long nestedPopover = findNestedPopoverForModel(parentPopoverHandle, item.menu.modelHandle);
 			if (nestedPopover != 0) {
-				OS.g_object_ref(nestedPopover);
-				item.menu.popoverHandle = nestedPopover;
-				display.addWidget(nestedPopover, item.menu);
-				OS.g_signal_connect_closure_by_id(nestedPopover, display.signalIds[SHOW], 0, display.getClosure(SHOW), false);
-				OS.g_signal_connect_closure_by_id(nestedPopover, display.signalIds[HIDE], 0, display.getClosure(HIDE), false);
-				// Recurse to handle further nested CASCADE submenus
+				if (item.menu.popoverHandle != nestedPopover) {
+					wireSubMenuPopover(item.menu, nestedPopover);
+				}
 				connectCascadeSubMenuSignals(item.menu);
 			}
 		}
 	}
 }
 
+/**
+ * Recursively searches the widget subtree rooted at {@code parentWidget} for the
+ * nested GtkPopoverMenu whose GMenuModel is {@code targetModel}, returning its
+ * handle or {@code 0} if it is not (yet) present.
+ */
 private long findNestedPopoverForModel(long parentWidget, long targetModel) {
 	if (parentWidget == 0 || targetModel == 0) return 0;
 	long child = GTK4.gtk_widget_get_first_child(parentWidget);
@@ -1056,7 +1135,7 @@ long gtk_show (long widget) {
 		return 0;
 	}
 	sendEvent (SWT.Show);
-	/* Retry cascade submenu signal hookup once the DROP_DOWN popover is shown. */
+	/* Wire cascade submenu SHOW/HIDE signals once the DROP_DOWN popover is shown. */
 	if (GTK.GTK4 && (style & SWT.DROP_DOWN) != 0 && popoverHandle != 0) {
 		connectCascadeSubMenuSignals(this, popoverHandle);
 	}
@@ -1116,15 +1195,26 @@ void hookEvents() {
 		GTK4.gtk_shortcut_controller_set_scope(shortcutController, GTK.GTK_SHORTCUT_SCOPE_GLOBAL);
 		GTK4.gtk_widget_add_controller(parent.handle, shortcutController);
 
+		/*
+		 * Hook "items-changed" so content (re)built after creation re-runs the submenu
+		 * wiring (see modelItemsChanged). Items go into per-section models and the
+		 * signal does not propagate to the top model, so hook every section too
+		 * (SEPARATOR sections in MenuItem.createHandle).
+		 */
+		hookItemsChanged(modelHandle);
+		if (sections != null && !sections.isEmpty()) {
+			hookItemsChanged(sections.getFirst().getSectionHandle());
+		}
+
 		if ((style & SWT.DROP_DOWN) == 0) {
 			OS.g_signal_connect_closure_by_id(handle, display.signalIds[SHOW], 0, display.getClosure(SHOW), false);
 			OS.g_signal_connect_closure_by_id(handle, display.signalIds[HIDE], 0, display.getClosure(HIDE), false);
 			if ((style & (SWT.BAR | SWT.POP_UP)) != 0) {
 				/*
-				 * Connect MAP signal on the GtkPopoverMenuBar so that once it is
-				 * realized and its internal GtkPopoverMenuBarItem children exist,
-				 * we can find the GtkPopoverMenu for each DROP_DOWN submenu and
-				 * route SHOW/HIDE signals back to the SWT DROP_DOWN Menu.
+				 * Connect MAP signal on the GtkPopoverMenuBar so that once it is realized and
+				 * its internal GtkPopoverMenuBarItem children exist, we can find the
+				 * GtkPopoverMenu for each DROP_DOWN submenu and route SHOW/HIDE signals back to
+				 * the SWT DROP_DOWN Menu.
 				 */
 				OS.g_signal_connect_closure_by_id(handle, display.signalIds[MAP], 0, display.getClosure(MAP), false);
 			}

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/MenuItem.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/MenuItem.java
@@ -264,6 +264,12 @@ void createHandle(int index) {
 			case SWT.SEPARATOR:
 				modelHandle = OS.g_menu_new();
 				handle = OS.g_menu_item_new_section(null, modelHandle);
+				/*
+				 * A separator starts a new section GMenu; observe it for
+				 * "items-changed" too so submenus added into this section later get
+				 * wired (see Menu#hookItemsChanged and issue #3451).
+				 */
+				parent.hookItemsChanged(modelHandle);
 				break;
 			case SWT.RADIO:
 				long stringVariantType = OS.g_variant_type_new(OS.G_VARIANT_TYPE_STRING);
@@ -1148,6 +1154,18 @@ public void setMenu (Menu menu) {
 
 		OS.g_menu_remove(section.getSectionHandle(), section.getItemPosition(this));
 		OS.g_menu_insert_item(section.getSectionHandle(), section.getItemPosition(this), handle);
+
+		/*
+		 * If a DROP_DOWN is attached while its parent is already mapped (contributions
+		 * added/rebuilt after the parent was shown, e.g. workspace restore), wire its
+		 * SHOW/HIDE now; otherwise SWT.Show never fires and the submenu appears empty
+		 * (issue #3451). The g_menu calls above already emit "items-changed" on the
+		 * section model, so this is normally redundant; go through modelItemsChanged()
+		 * anyway so both paths re-wire from the same (root) menu.
+		 */
+		if (menu != null) {
+			parent.modelItemsChanged();
+		}
 	} else {
 		long accelGroup = getAccelGroup ();
 		if (accelGroup != 0) removeAccelerators (accelGroup);


### PR DESCRIPTION
Wire nested GtkPopoverMenu SHOW/HIDE via the model's "items-changed" signal (connected in the after phase, so GTK has already rebuilt the popover) and re-discover popovers on each pass to handle GTK rebuilds. Replaces the previous fixed-count retry.

Fixes https://github.com/eclipse-platform/eclipse.platform.swt/issues/3451