### PR TITLE
[Win32] Fix BrowserFunction missing on first page

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Browser/win32/org/eclipse/swt/browser/Edge.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Browser/win32/org/eclipse/swt/browser/Edge.java
@@ -85,7 +85,13 @@ class Edge extends WebBrowser {
 	boolean inNewWindow;
 	private boolean inEvaluate;
 	HashMap<Long, LocationEvent> navigations = new HashMap<>();
-	/** Maps BrowserFunction index to the script ID from AddScriptToExecuteOnDocumentCreated. */
+	/**
+	 * Maps BrowserFunction index to the script ID from AddScriptToExecuteOnDocumentCreated. An entry
+	 * is added synchronously when the (asynchronous) registration is issued, with a {@code null}
+	 * value until the registration completes and provides the script ID. Therefore a contained key
+	 * denotes a function whose script is already registered, which ensures that a function's script
+	 * is registered exactly once.
+	 */
 	private final Map<Integer, String> functionScriptIds = new HashMap<>();
 	private int ignoreGotFocus;
 	private boolean ignoreFocusIn;
@@ -386,6 +392,11 @@ class WebViewProvider {
 		webViewWrapper.webView_11 = initializeWebView_11(webView);
 		webViewWrapper.webView_12 = initializeWebView_12(webView);
 		webViewWrapper.webView_13 = initializeWebView_13(webView);
+		// Register the scripts of all BrowserFunctions created during initialization
+		// before completing the future below, as that synchronously runs queued
+		// navigation tasks (e.g. from setUrl()/setText()) and thus may already create
+		// the first document
+		registerPendingFunctionScripts(webView);
 		boolean success = webViewWrapperFuture.complete(webViewWrapper);
 		// Release the webViews if the webViewWrapperFuture has already timed out and completed exceptionally
 		if(!success && webViewWrapperFuture.isCompletedExceptionally()) {
@@ -397,6 +408,10 @@ class WebViewProvider {
 
 	private void abortInitialization() {
 		webViewWrapperFuture.cancel(true);
+	}
+
+	boolean isInitialized() {
+		return webViewWrapperFuture.isDone();
 	}
 
 	void releaseWebView() {
@@ -1839,38 +1854,77 @@ public boolean setUrl(String url, String postData, String[] headers) {
 }
 
 /**
- * Registers the function script persistently via AddScriptToExecuteOnDocumentCreated so it is
- * injected on every future document creation before any page scripts run, avoiding the race
- * condition between async function injection and navigation completion.
- * If called while inside a WebView2 callback, the persistent registration is deferred via
- * {@link Display#asyncExec(Runnable)} so it completes once the callback returns.
+ * Registers a BrowserFunction persistently via AddScriptToExecuteOnDocumentCreated so it is
+ * injected on every future document creation before any page scripts run.
+ * <p>
+ * The registration is issued immediately, but without waiting for its (asynchronous) completion:
+ * what makes a function available on a page is <em>issuing</em> the registration before the
+ * navigation that creates the document is issued to WebView2 - not waiting for the registration to
+ * complete. Since nothing is blocked on the completion, this can also safely be issued from within
+ * a WebView2 callback without risking a deadlock.
+ * <p>
+ * If the browser is not yet initialized when the function is created, the registration is issued by
+ * {@link WebViewProvider#initializeWebView(ICoreWebView2Controller)} (via
+ * {@link #registerPendingFunctionScripts(ICoreWebView2)}) before the first navigation, so functions
+ * created concurrently with initialization are available on the first loaded page. Note that
+ * {@code super.createFunction(function)} below may itself complete the initialization, since it
+ * executes the function's script and thus pumps the event loop until the browser is initialized.
+ * Independent of which of the two registers the script, {@link #registerFunctionScript(ICoreWebView2, int, String)}
+ * ensures it is registered exactly once.
  * See <a href="https://github.com/eclipse-platform/eclipse.platform.swt/issues/20">issue #20</a>.
  */
 @Override
 public void createFunction(BrowserFunction function) {
 	super.createFunction(function);
-	int functionIndex = function.index;
-	String functionString = function.functionString;
-	if (inCallback > 0) {
-		// Cannot wait for a callback result while already inside a WebView2 callback;
-		// defer the persistent registration to after the callback completes.
-		browser.getDisplay().asyncExec(() -> {
-			if (browser.isDisposed() || !functions.containsKey(functionIndex)) return;
-			registerFunctionScript(functionIndex, functionString);
-		});
-		return;
+	if (webViewProvider.isInitialized()) {
+		registerFunctionScript(webViewProvider.getWebView(false), function.index, function.functionString);
 	}
-	registerFunctionScript(functionIndex, functionString);
 }
 
-private void registerFunctionScript(int functionIndex, String functionString) {
-	String[] scriptId = new String[1];
-	callAndWait(scriptId, completion ->
-		webViewProvider.getWebView(false).AddScriptToExecuteOnDocumentCreated(
-			stringToWstr(functionString), completion.getAddress()));
-	if (scriptId[0] != null) {
-		functionScriptIds.put(functionIndex, scriptId[0]);
+private void registerPendingFunctionScripts(ICoreWebView2 webView) {
+	for (Map.Entry<Integer, BrowserFunction> entry : functions.entrySet()) {
+		BrowserFunction function = entry.getValue();
+		if (function.functionString != null) {
+			registerFunctionScript(webView, entry.getKey(), function.functionString);
+		}
 	}
+}
+
+/**
+ * Issues the registration of a function's document-created script on the given WebView without
+ * blocking for the asynchronous completion. Functions whose script is already registered are
+ * skipped, so it does not matter whether the registration is issued by
+ * {@link #createFunction(BrowserFunction)} or {@link #registerPendingFunctionScripts(ICoreWebView2)}.
+ * <p>
+ * The resulting script ID is stored in {@link #functionScriptIds} once the completion callback
+ * fires; if the function was deregistered again in the meantime, the script is removed right away
+ * instead, so an immediately following deregistration does not leak the script.
+ */
+private void registerFunctionScript(ICoreWebView2 webView, int functionIndex, String functionString) {
+	if (functionScriptIds.containsKey(functionIndex)) {
+		// The script of this function has already been registered
+		return;
+	}
+	functionScriptIds.put(functionIndex, null);
+	IUnknown completion = newCallback((result, scriptIdPointer) -> {
+		if ((int) result == COM.S_OK) {
+			String scriptId = wstrToString(scriptIdPointer, false);
+			if (functions.containsKey(functionIndex)) {
+				functionScriptIds.put(functionIndex, scriptId);
+			} else if (!browser.isDisposed()) {
+				webView.RemoveScriptToExecuteOnDocumentCreated(stringToWstr(scriptId));
+			}
+		} else {
+			functionScriptIds.remove(functionIndex);
+		}
+		return COM.S_OK;
+	});
+	int hr = webView.AddScriptToExecuteOnDocumentCreated(stringToWstr(functionString), completion.getAddress());
+	if (hr != OS.S_OK) {
+		functionScriptIds.remove(functionIndex);
+		System.err.println("Registering browser function failed with result " + hr + " for function: " + functionString);
+	}
+	completion.Release();
 }
 
 @Override
@@ -1881,6 +1935,8 @@ void deregisterFunction(BrowserFunction function) {
 		webViewProvider.getWebView(true).RemoveScriptToExecuteOnDocumentCreated(
 			stringToWstr(scriptId));
 	}
+	// If scriptId == null, an asynchronous registration has not stored its ID yet; its completion
+	// callback detects the now-removed function (via the functions map) and removes the script itself.
 }
 
 }

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_browser_Browser.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_browser_Browser.java
@@ -3046,6 +3046,133 @@ public void test_BrowserFunction_availableOnLoad_concurrentInstances_issue20() {
 }
 
 /**
+ * Regression test: a BrowserFunction created from <em>inside</em> another BrowserFunction's
+ * callback must be registered and available on a page that is navigated to from within that same
+ * callback.
+ * <p>
+ * On the Edge/WebView2 backend this exercises function creation while a WebView2 callback is on the
+ * stack. Registration must be issued (before the navigation queued in the same callback) without
+ * blocking, since blocking inside a callback would deadlock.
+ */
+@Test
+public void test_BrowserFunction_createFunctionInsideCallback() {
+	assumeTrue(isEdge, "BrowserFunction availability before the page's inline scripts is specific to the Edge/WebView2 implementation");
+	AtomicBoolean innerCalled = new AtomicBoolean(false);
+
+	// 'inner' is only created when 'outer' is invoked from JavaScript, i.e. inside a callback.
+	class Inner extends BrowserFunction {
+		Inner() {
+			super(browser, "inner");
+		}
+		@Override
+		public Object function(Object[] arguments) {
+			innerCalled.set(true);
+			return null;
+		}
+	}
+	class Outer extends BrowserFunction {
+		Outer() {
+			super(browser, "outer");
+		}
+		@Override
+		public Object function(Object[] arguments) {
+			new Inner(); // create a new BrowserFunction from inside a callback
+			// Navigate to a page whose inline script calls the just-created function.
+			browser.setText("<html><body><script>inner();</script></body></html>");
+			return null;
+		}
+	}
+	new Outer();
+
+	// Trigger outer() once, after the first page has loaded.
+	AtomicBoolean outerTriggered = new AtomicBoolean(false);
+	browser.addProgressListener(completedAdapter(e -> {
+		if (outerTriggered.compareAndSet(false, true)) {
+			browser.execute("outer();");
+		}
+	}));
+	browser.setText("<html><body>first page</body></html>");
+
+	shell.open();
+	assertTrue(waitForPassCondition(innerCalled::get),
+		"BrowserFunction created inside a callback was not available on the page navigated to from that callback");
+}
+
+/**
+ * Regression test for issue #20: a BrowserFunction created while the browser is still initializing
+ * must be available <em>before</em> the first loaded page's own inline scripts run - not merely
+ * after the page finished loading. This combines concurrent initialization (the browser is not
+ * awaited) with a page whose inline script immediately calls the function.
+ */
+@Test
+public void test_BrowserFunction_availableBeforePageScripts_concurrentInit_issue20() {
+	assumeTrue(isEdge, "BrowserFunction availability before the page's inline scripts is specific to the Edge/WebView2 implementation");
+	AtomicBoolean functionCalled = new AtomicBoolean(false);
+
+	// Use new Browser() directly (not the createBrowser() helper that waits for initialization) so
+	// the browser is still initializing while we navigate and register the function.
+	Browser b = new Browser(shell, SWT.NONE);
+	createdBroswers.add(b);
+	// Mirror the bug's order: request the navigation first, then create the function - both before
+	// initialization completes.
+	b.setText("<html><body><script>options();</script></body></html>");
+	new BrowserFunction(b, "options") {
+		@Override
+		public Object function(Object[] arguments) {
+			functionCalled.set(true);
+			return null;
+		}
+	};
+
+	shell.open();
+	assertTrue(waitForPassCondition(functionCalled::get),
+		"BrowserFunction 'options' was not available before the first page's inline script ran during concurrent initialization");
+}
+
+/**
+ * Regression test for issue #20: when multiple BrowserFunctions are created while the browser is
+ * still initializing, all of them must be available on the first loaded page.
+ */
+@Test
+public void test_BrowserFunction_multipleFunctionsDuringConcurrentInit_issue20() {
+	assumeFalse(SwtTestUtil.isCocoa, "BrowserFunction availability during concurrent initialization is not reliable on Cocoa");
+	AtomicReference<Object> result = new AtomicReference<>();
+	AtomicReference<SWTException> failure = new AtomicReference<>();
+
+	Browser b = new Browser(shell, SWT.NONE);
+	createdBroswers.add(b);
+	b.setUrl("about:blank");
+	new BrowserFunction(b, "f1") {
+		@Override
+		public Object function(Object[] arguments) {
+			return 1;
+		}
+	};
+	new BrowserFunction(b, "f2") {
+		@Override
+		public Object function(Object[] arguments) {
+			return 2;
+		}
+	};
+	b.addProgressListener(completedAdapter(e -> {
+		try {
+			result.set(b.evaluate("return f1() + f2();"));
+		} catch (SWTException ex) {
+			failure.set(ex);
+		}
+	}));
+
+	shell.open();
+	waitForPassCondition(() -> result.get() != null || failure.get() != null);
+	if (failure.get() != null) {
+		throw failure.get();
+	}
+	assertNotNull(result.get(), "Neither BrowserFunction was available on the first loaded page");
+	assertEquals(3.0, ((Number) result.get()).doubleValue(),
+		"Both BrowserFunctions created during concurrent initialization must be available on the first page");
+}
+
+/**
  * Regression test: a disposed BrowserFunction must no longer be available (re-injected) after a
  * subsequent navigation. This verifies that deregistration removes the persistent document-created
  * script (whose ID is captured asynchronously on the Edge backend).


### PR DESCRIPTION
Fixes #3370 — the sporadic failure of `test_BrowserFunction_availableOnLoad_concurrentInstances_issue20` on the Edge/WebView2 backend.

Builds on top of #3478 (BrowserFunction dispose/redefine regression tests) and employs the regression tests added there — #3478 should be merged first.

## Problem

A `BrowserFunction` created while an Edge browser is still initializing (with a navigation queued via `setUrl`/`setText`) could be missing on the first loaded page. `AddScriptToExecuteOnDocumentCreated` was issued only *after* the queued navigation and raced with document creation, so the function was sometimes not registered when the page's document was created — surfacing as `SWTException: <function> is not defined`.

## Fix

Register the document-created scripts of all pending `BrowserFunction`s inside `WebViewProvider.initializeWebView()`, before completing the initialization future (which synchronously runs the queued navigation). This is the only point that is reliably "after init, before the first navigation", since the `CompletableFuture` navigation chain cannot be preempted retroactively.

Registration is now issued asynchronously: what makes a function land on a page is *issuing* the registration before the navigation is issued to WebView2, not *waiting* for its completion. This also removes the previous `inCallback > 0` deferral (an async call cannot deadlock inside a WebView2 callback) and the separate synchronous registration method, leaving a single registration method and a single branch in `createFunction`. `deregisterFunction` stays correct for a registration whose script ID has not arrived yet (its async completion detects the removed function and removes the script itself).

## Tests

Adds regression tests for function creation during concurrent initialization: creating a function from inside a callback, availability before the first page's inline scripts run, and multiple functions registered before initialization completes. These complement the dispose/redefine regression tests from #3478.

## Reproducer

The underlying race is a sub-millisecond window and cannot be forced deterministically through the public API with a single browser. The following standalone reproducer makes it deterministic in practice by stressing concurrent initialization: before the fix it reports `options is not defined` within a few iterations; after the fix it completes all iterations cleanly.

<details>
<summary>Standalone reproducer (Windows/Edge)</summary>

```java
/*******************************************************************************
 * Copyright (c) 2026 Contributors to the Eclipse Foundation.
 *
 * This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License 2.0
 * which accompanies this distribution, and is available at
 * https://www.eclipse.org/legal/epl-2.0/
 *
 * SPDX-License-Identifier: EPL-2.0
 *******************************************************************************/
package org.eclipse.swt.tests.junit;

import java.util.ArrayList;
import java.util.List;
import java.util.concurrent.atomic.AtomicReference;

import org.eclipse.swt.SWT;
import org.eclipse.swt.SWTException;
import org.eclipse.swt.browser.Browser;
import org.eclipse.swt.browser.BrowserFunction;
import org.eclipse.swt.browser.ProgressAdapter;
import org.eclipse.swt.browser.ProgressEvent;
import org.eclipse.swt.layout.FillLayout;
import org.eclipse.swt.widgets.Display;
import org.eclipse.swt.widgets.Shell;

/**
 * Standalone reproducer for the Edge/WebView2 BrowserFunction registration race fixed by this change.
 *
 * <p>A {@link BrowserFunction} created while a {@link Browser} is still initializing (and while a
 * navigation queued via {@code setUrl}/{@code setText} is pending) must be available on the first
 * loaded page. Before the fix, {@code AddScriptToExecuteOnDocumentCreated} was issued <em>after</em>
 * the navigation, so it raced with document creation and the function was sometimes undefined,
 * producing {@code SWTException: options is not defined}.
 *
 * <p>The underlying race is a sub-millisecond timing window, so it cannot be forced deterministically
 * through the public SWT API with a single browser. This reproducer makes it <em>deterministic in
 * practice</em> by stressing the exact scenario: it creates several browsers that initialize
 * concurrently (their initialization pumps the shared event loop and perturbs each other's timing),
 * repeated over many iterations. Before the fix it reports failures within the first few iterations;
 * after the fix it completes all iterations with zero failures.
 *
 * <p>Run it standalone via {@link #main(String[])} on Windows (Edge backend), or call
 * {@link #reproduce(Display, int, int)} from a test.
 */
public final class BrowserFunctionConcurrentInitReproducer {

	private BrowserFunctionConcurrentInitReproducer() {
	}

	/** Number of browsers initialized concurrently in a single iteration. */
	private static final int DEFAULT_BROWSERS_PER_ITERATION = 8;
	/** Number of iterations to run when stressing the scenario. */
	private static final int DEFAULT_ITERATIONS = 50;
	/** Maximum time to wait for all browsers of one iteration to resolve. */
	private static final int ITERATION_TIMEOUT_MILLIS = 30_000;

	/** Result of a single browser within an iteration. */
	private enum Result {
		PENDING, AVAILABLE, MISSING
	}

	public static void main(String[] args) {
		Display display = new Display();
		try {
			Shell shell = new Shell(display);
			shell.setLayout(new FillLayout());
			Browser probe = new Browser(shell, SWT.NONE);
			boolean isEdge = "edge".equals(probe.getBrowserType());
			probe.dispose();
			if (!isEdge) {
				System.out.println("This reproducer targets the Edge/WebView2 backend; current backend is '"
						+ probe.getBrowserType() + "'. Nothing to reproduce.");
				return;
			}

			int failures = reproduce(display, DEFAULT_ITERATIONS, DEFAULT_BROWSERS_PER_ITERATION);
			if (failures > 0) {
				System.out.println("\nREPRODUCED: 'options' was missing in " + failures
						+ " case(s). This indicates the AddScriptToExecuteOnDocumentCreated race.");
				System.exit(1);
			} else {
				System.out.println("\nNo failures observed across " + DEFAULT_ITERATIONS + " iterations of "
						+ DEFAULT_BROWSERS_PER_ITERATION + " concurrent browsers. The race appears fixed.");
			}
		} finally {
			display.dispose();
		}
	}

	/**
	 * Runs the concurrent-initialization scenario and returns the number of browsers for which the
	 * BrowserFunction was <em>not</em> available on the loaded page (i.e. reproductions of the bug).
	 *
	 * @param display            the display to run on (must be the calling thread's display)
	 * @param iterations         number of iterations to run
	 * @param browsersPerIteration number of browsers initialized concurrently per iteration
	 * @return the total number of reproductions observed
	 */
	public static int reproduce(Display display, int iterations, int browsersPerIteration) {
		int totalFailures = 0;
		for (int iteration = 0; iteration < iterations; iteration++) {
			totalFailures += runSingleIteration(display, iteration, browsersPerIteration);
			if (totalFailures > 0) {
				// Fail fast: one reproduction is enough to demonstrate the defect.
				break;
			}
		}
		return totalFailures;
	}

	private static int runSingleIteration(Display display, int iteration, int browsersPerIteration) {
		Shell shell = new Shell(display);
		shell.setLayout(new FillLayout());
		List<Browser> browsers = new ArrayList<>();
		List<Result[]> results = new ArrayList<>();
		List<AtomicReference<SWTException>> exceptions = new ArrayList<>();

		try {
			for (int i = 0; i < browsersPerIteration; i++) {
				final Result[] result = { Result.PENDING };
				final AtomicReference<SWTException> exception = new AtomicReference<>();
				results.add(result);
				exceptions.add(exception);

				// Deliberately do NOT wait for initialization: keep all browsers initializing
				// concurrently, which is the timing that exposes the race (issue #20).
				final Browser browser = new Browser(shell, SWT.NONE);
				browser.setUrl("about:blank");
				new BrowserFunction(browser, "options") {
					@Override
					public Object function(Object[] arguments) {
						return null;
					}
				};
				browser.addProgressListener(new ProgressAdapter() {
					@Override
					public void completed(ProgressEvent event) {
						try {
							browser.evaluate("options();");
							result[0] = Result.AVAILABLE;
						} catch (SWTException ex) {
							result[0] = Result.MISSING;
							exception.set(ex);
						}
					}
				});
				browsers.add(browser);
			}

			shell.open();
			waitUntilResolved(display, results);

			int failures = 0;
			for (int i = 0; i < results.size(); i++) {
				Result r = results.get(i)[0];
				if (r != Result.AVAILABLE) {
					failures++;
					SWTException ex = exceptions.get(i).get();
					System.out.println("Iteration " + iteration + ", browser " + i + ": " + r
							+ (ex != null ? " (" + ex.getMessage() + ")" : " (timed out)"));
				}
			}
			if (failures == 0) {
				System.out.println("Iteration " + iteration + ": OK (" + browsersPerIteration + " browsers)");
			}
			return failures;
		} finally {
			for (Browser browser : browsers) {
				if (!browser.isDisposed()) {
					browser.dispose();
				}
			}
			shell.dispose();
			// Let Edge process pending disposal work between iterations.
			while (display.readAndDispatch()) {
				// drain
			}
		}
	}

	private static void waitUntilResolved(Display display, List<Result[]> results) {
		long deadline = System.currentTimeMillis() + ITERATION_TIMEOUT_MILLIS;
		// Periodically wake the display so the deadline is honored even if no browser event arrives.
		Runnable[] wake = new Runnable[1];
		wake[0] = () -> {
			if (!display.isDisposed()) {
				display.timerExec(100, wake[0]);
			}
		};
		display.timerExec(100, wake[0]);
		try {
			while (System.currentTimeMillis() < deadline && !allResolved(results)) {
				if (!display.readAndDispatch()) {
					display.sleep();
				}
			}
		} finally {
			display.timerExec(-1, wake[0]);
		}
	}

	private static boolean allResolved(List<Result[]> results) {
		for (Result[] result : results) {
			if (result[0] == Result.PENDING) {
				return false;
			}
		}
		return true;
	}
}
```
</details>

