### PR TITLE
[GTK] Always dispose the StyledText snippet display

### DIFF
--- a/tests/org.eclipse.swt.tests.gtk/ManualTests/org/eclipse/swt/tests/gtk/snippets/Bug528691_StyledTextNull.java
+++ b/tests/org.eclipse.swt.tests.gtk/ManualTests/org/eclipse/swt/tests/gtk/snippets/Bug528691_StyledTextNull.java
@@ -32,21 +32,23 @@ public class Bug528691_StyledTextNull {
 	public static void main(String[] args) {
 		final Display display = new Display();
 
-		final Shell shell = new Shell(display);
-		shell.setLayout(new FillLayout());
+		try {
+			final Shell shell = new Shell(display);
+			shell.setLayout(new FillLayout());
 
-		final StyledText styledText = new StyledText(shell, SWT.BORDER);
-		styledText.setText("hello\u0000world");
+			final StyledText styledText = new StyledText(shell, SWT.BORDER);
+			styledText.setText("hello\u0000world");
 
-		shell.setSize(500, 400);
-		shell.open();
+			shell.setSize(500, 400);
+			shell.open();
 
-		while (!shell.isDisposed()) {
-			if (!display.readAndDispatch()) {
-				display.sleep();
+			while (!shell.isDisposed()) {
+				if (!display.readAndDispatch()) {
+					display.sleep();
+				}
 			}
+		} finally {
+			display.dispose();
 		}
-
-		display.dispose();
 	}
 }


### PR DESCRIPTION
Hi. We are researchers from Mahidol University, Thailand, and the State University of Ceará, Brazil, working on a research project for improving open-source projects by using the latest accepted answer from Stack Overflow that matched your code snippet. We found this recommendation for improving your code from https://stackoverflow.com/a/56297618.

Note: Our study is approved by the Institutional Review Board of Mahidol University. You can find the participant information sheet explaining this study https://drive.google.com/file/d/1ml5AqrtWQ9pnifTQyTFTcWQmwp6RuPA7/view?usp=sharing.

----

## Proposed change

Wrapped the manual snippet event loop in try/finally so its SWT Display is disposed after failures as well as normal exit.
