### PR TITLE
[Build] Run API check and javadoc only once per operating system

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,6 +28,15 @@ on:
         type: boolean
         required: false
         default: false
+      api_check:
+        description: |
+          Run the API tools check and generate the javadoc (one of true, false)
+
+          Both only depend on the Java sources, so enable this for a single job
+          per operating system.
+        type: boolean
+        required: false
+        default: false
       gtk:
         description: |
           (Required on Linux only) GTK version to use (one of gtk3, gtk4)
@@ -108,7 +117,7 @@ jobs:
         --threads 1C
         -DforkCount=1
         '-Dnative=${{ inputs.native }}'
-        -Papi-check -Pjavadoc
+        ${{ inputs.api_check && '-Papi-check -Pjavadoc' || '' }}
         '-Dtycho.baseline.replace=none'
         --fail-at-end
         -DskipNativeTests=false

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -93,6 +93,8 @@ jobs:
       native: gtk.linux.x86_64
       gtk: ${{ matrix.gtk }}
       gdk_backend: ${{ matrix.gdk_backend }}
+      # All Linux jobs build the same Java sources, so check the API and javadoc only once
+      api_check: ${{ matrix.gtk == 'gtk3' && matrix.gdk_backend == 'x11' }}
       performance: ${{ contains(github.event.pull_request.labels.*.name, 'performance') }}
       runtodotests: ${{ contains(github.event.pull_request.labels.*.name, 'runtodotests') }}
 
@@ -110,6 +112,7 @@ jobs:
       runner: windows-latest
       java: ${{ matrix.java }}
       native: win32.win32.x86_64
+      api_check: true
       performance: ${{ contains(github.event.pull_request.labels.*.name, 'performance') }}
       runtodotests: ${{ contains(github.event.pull_request.labels.*.name, 'runtodotests') }}
 
@@ -128,5 +131,7 @@ jobs:
       runner: ${{ matrix.arch == 'x86_64' && 'macos-15-intel' || 'macos-latest' }}
       java: ${{ matrix.java }}
       native: cocoa.macosx.${{ matrix.arch }}
+      # Both macOS fragments compile the same Java sources, so check the API and javadoc only once
+      api_check: ${{ matrix.arch == 'aarch64' }}
       performance: ${{ contains(github.event.pull_request.labels.*.name, 'performance') }}
       runtodotests: ${{ contains(github.event.pull_request.labels.*.name, 'runtodotests') }}


### PR DESCRIPTION
The reusable build workflow always passed `-Papi-check -Pjavadoc`, so the API tools check and the javadoc generation ran in all six PR jobs. Neither depends on the GTK version, the GDK backend or the target architecture, only on the Java sources, so the three Linux jobs and the two macOS jobs were computing identical results. I verified the macOS case rather than assuming it: the two cocoa fragments compile the same source folders and their jars contain an identical set of 768 class files with identical sizes and an identical `.api_description` apart from the component id.

A new boolean input `api_check` (default false) now gates both profiles, and `maven.yml` enables it for exactly one job per operating system: gtk3/x11 on Linux, the single Windows job and aarch64 on macOS. That takes the API check and javadoc from six runs down to three, which cuts a few minutes off the slowest jobs without losing any coverage. Unlike most Eclipse repos, SWT does have a genuinely different API surface per gtk/win32/cocoa fragment, so the check deliberately stays per operating system instead of collapsing to a single global run.

Fixes https://github.com/eclipse-platform/eclipse.platform.swt/issues/3484