### PR TITLE
[Win32] Add missing null check in Table tooltip positioning #3487

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Table.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Table.java
@@ -7161,9 +7161,11 @@ private LRESULT positionTooltip(NMHDR hdr, long lParam) {
 				long hwndToolTip = OS.SendMessage(handle, OS.LVM_GETTOOLTIPS, 0, 0);
 				int flags = OS.SWP_NOACTIVATE | OS.SWP_NOZORDER;
 				Rectangle adjustedTooltipBounds = getDisplay().fitRectangleBoundsIntoMonitorWithCursor(toolRect);
-				OS.SetWindowPos(hwndToolTip, 0, adjustedTooltipBounds.x, adjustedTooltipBounds.y,
-						adjustedTooltipBounds.width, adjustedTooltipBounds.height, flags);
-				result = LRESULT.ONE;
+				if (adjustedTooltipBounds != null) {
+					OS.SetWindowPos(hwndToolTip, 0, adjustedTooltipBounds.x, adjustedTooltipBounds.y,
+							adjustedTooltipBounds.width, adjustedTooltipBounds.height, flags);
+					result = LRESULT.ONE;
+				}
 			} else if (isCustomToolTip()) {
 				RECT itemRect = getItemBounds(pinfo, item, hDC);
 				NMTTDISPINFO lpnmtdi = new NMTTDISPINFO();


### PR DESCRIPTION
Table and tree implementations contain a tooltip repositioning functionality to make a tooltip fit into a single monitor. The reason is that tooltips spanning multiple monitors of different zoom can freeze the UI thread on Windows.

While in the Tree implementation the repositioning was properly guarded with a null check for the adjusted position, this check is missing in the Table implementation can lead to a NullPointerException in case the calculated result is actually null. This change fixes that by adding an according null check, which effectively skips the tooltip repositioning in case the correct monitor to fit into could not be found.

Fixes https://github.com/eclipse-platform/eclipse.platform.swt/issues/3487

Originally introduced with: https://github.com/eclipse-platform/eclipse.platform.swt/pull/2241