### PR TITLE
Remove unused accessors from the PNG chunk classes

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/image/PngChunk.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/image/PngChunk.java
@@ -82,28 +82,10 @@ PngChunk(int dataLength) {
 }
 
 /**
- * Get the PngChunk's reference byteArray;
- */
-byte[] getReference() {
-	return reference;
-}
-
-/**
  * Set the PngChunk's reference byteArray;
  */
 void setReference(byte[] reference) {
 	this.reference = reference;
-}
-
-/**
- * Get the 16-bit integer from the reference byte
- * array at the given offset.
- */
-int getInt16(int offset) {
-	int answer = 0;
-	answer |= (reference[offset] & 0xFF) << 8;
-	answer |= (reference[offset + 1] & 0xFF);
-	return answer;
 }
 
 /**

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/image/PngIdatChunk.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/image/PngIdatChunk.java
@@ -60,8 +60,4 @@ void validate(PngFileReadState readState, PngIhdrChunk headerChunk) {
 	super.validate(readState, headerChunk);
 }
 
-byte getDataByteAtOffset(int offset) {
-	return reference[DATA_OFFSET + offset];
-}
-
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/image/PngIhdrChunk.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/image/PngIhdrChunk.java
@@ -158,28 +158,12 @@ void setColorType(byte value) {
 }
 
 /**
- * Get the image's compression method.
- * This value must be 0.
- */
-byte getCompressionMethod() {
-	return compressionMethod;
-}
-
-/**
  * Set the image's compression method.
  * This value must be 0.
  */
 void setCompressionMethod(byte value) {
 	reference[COMPRESSION_METHOD_OFFSET] = value;
 	compressionMethod = value;
-}
-
-/**
- * Get the image's filter method.
- * This value must be 0.
- */
-byte getFilterMethod() {
-	return filterMethod;
 }
 
 /**


### PR DESCRIPTION
Five accessors in the PNG chunk classes have no callers anywhere in the repository: `PngChunk.getReference`, `PngChunk.getInt16`, `PngIhdrChunk.getCompressionMethod`, `PngIhdrChunk.getFilterMethod` and `PngIdatChunk.getDataByteAtOffset`. All five are package-private, so nothing outside `org.eclipse.swt.internal.image` could have been calling them either.

Only the getters go. The matching setters are all still in use, and the `compressionMethod` and `filterMethod` fields are still read by `PngIhdrChunk.validate` and `getFilterMethodString`, so neither field is left write-only.

Verified by compiling the gtk, win32 and cocoa bundles from source with javac and ecj, and by decoding the 608 images in this repository with a build from before and after the change; the decoded pixel data, palettes and transparency masks are byte-identical.