### PR TITLE
[win32] Resolve tab stops entirely in points in TextLayout.computeRuns()

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/graphics/TextLayoutWin32Tests.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/graphics/TextLayoutWin32Tests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 Yatta Solutions
+ * Copyright (c) 2024, 2026 Yatta Solutions and others
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -15,16 +15,26 @@ package org.eclipse.swt.graphics;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.swt.*;
 import org.eclipse.swt.internal.*;
 import org.eclipse.swt.widgets.*;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.*;
+import org.junit.jupiter.params.*;
+import org.junit.jupiter.params.provider.*;
 
 @ExtendWith(PlatformSpecificExecutionExtension.class)
 @ExtendWith(WithMonitorSpecificScalingExtension.class)
 class TextLayoutWin32Tests {
 	final static String text = "This is a text for testing.";
+	private static final String MONOSPACED_FONT = "Courier New";
+	private static final int TAB_STOP_TOLERANCE_IN_POINTS = 2;
 
 	@Test
 	public void testGetBoundPublicAPIshouldReturnTheSameValueRegardlessOfZoomLevel() {
@@ -68,6 +78,53 @@ class TextLayoutWin32Tests {
 
 		assertNotEquals(layout.nativeZoom, scaledLayout.nativeZoom, "The native zoom for the TextLayouts must differ");
 		assertEquals(unscaledBounds.height, scaledBounds.height, 1, "The public API for getBounds with vertical indent > 0 should give a similar result for any zoom level");
+	}
+
+	@ParameterizedTest
+	@ValueSource(ints = { 100, 125, 150, 175, 200 })
+	public void testTabAfterSpacesReachesTheNextTabStop(int zoom) {
+		Display display = Display.getDefault();
+		assumeTrue(isFontInstalled(display, MONOSPACED_FONT), MONOSPACED_FONT + " is not installed");
+
+		List<String> violations = new ArrayList<>();
+		for (int fontHeight = 8; fontHeight <= 20; fontHeight++) {
+			Font font = Font.win32_new(new Font(display, MONOSPACED_FONT, fontHeight, SWT.NORMAL), zoom);
+			for (int tabLength : new int[] { 2, 3, 4, 8 }) {
+				String spaces = " ".repeat(tabLength);
+				// StyledText derives its single tab stop from the width of a run of spaces
+				int tabWidth = boundsWidth(display, font, null, spaces);
+				int spacesThenTab = boundsWidth(display, font, new int[] { tabWidth }, spaces + "\t");
+				int twiceTheSpaces = boundsWidth(display, font, new int[] { tabWidth }, spaces + spaces);
+				if (Math.abs(spacesThenTab - twiceTheSpaces) > TAB_STOP_TOLERANCE_IN_POINTS) {
+					violations.add(fontHeight + "pt with tab length " + tabLength + ": width " + spacesThenTab
+							+ " instead of " + twiceTheSpaces);
+				}
+			}
+		}
+
+		assertTrue(violations.isEmpty(), "A tab placed exactly on a tab stop must advance to the next one, but at zoom "
+				+ zoom + "% it did not for " + violations);
+	}
+
+	private static int boundsWidth(Display display, Font font, int[] tabs, String content) {
+		TextLayout layout = new TextLayout(display);
+		try {
+			layout.setFont(font);
+			layout.setTabs(tabs);
+			layout.setText(content);
+			return layout.getBounds().width;
+		} finally {
+			layout.dispose();
+		}
+	}
+
+	private static boolean isFontInstalled(Display display, String name) {
+		for (FontData fontData : display.getFontList(null, true)) {
+			if (name.equalsIgnoreCase(fontData.getName())) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/TextLayout.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/TextLayout.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2022 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -387,9 +387,15 @@ void computeRuns (GC gc) {
 	for (int i=0; i<allRuns.length - 1; i++) {
 		StyleItem run = allRuns[i];
 		if (tabsInPixels != null && run.tab) {
+			/*
+			 * Whether a stop is still ahead has to be decided in points, the unit setTabs()
+			 * defined it in. In pixels a stop the pen sits exactly on can round to one pixel
+			 * past the pen, collapsing the tab instead of advancing to the next stop.
+			 */
+			int lineWidthInPoints = DPIUtil.pixelToPoint(lineWidth, getZoom(gc));
 			int tabsLength = tabsInPixels.length, j;
 			for (j = 0; j < tabsLength; j++) {
-				if (tabsInPixels[j] > lineWidth) {
+				if (tabs[j] > lineWidthInPoints) {
 					run.width = tabsInPixels[j] - lineWidth;
 					break;
 				}
@@ -398,7 +404,7 @@ void computeRuns (GC gc) {
 				int tabX = tabsInPixels[tabsLength-1];
 				int lastTabWidth = tabsLength > 1 ? tabsInPixels[tabsLength-1] - tabsInPixels[tabsLength-2] : tabsInPixels[0];
 				if (lastTabWidth > 0) {
-					while (tabX <= lineWidth) tabX += lastTabWidth;
+					while (DPIUtil.pixelToPoint(tabX, getZoom(gc)) <= lineWidthInPoints) tabX += lastTabWidth;
 					run.width = tabX - lineWidth;
 				}
 			}

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/TextLayout.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/TextLayout.java
@@ -379,33 +379,37 @@ void computeRuns (GC gc) {
 	}
 	SCRIPT_LOGATTR logAttr = new SCRIPT_LOGATTR();
 	SCRIPT_PROPERTIES properties = new SCRIPT_PROPERTIES();
-	int wrapIndentInPixels = DPIUtil.pointToPixel(wrapIndent, getZoom(gc));
-	int indentInPixels = DPIUtil.pointToPixel(indent, getZoom(gc));
-	int wrapWidthInPixels = DPIUtil.pointToPixel(wrapWidth, getZoom(gc));
-	int[] tabsInPixels = Win32DPIUtils.pointToPixel(tabs, getZoom(gc));
+	int zoom = getZoom(gc);
+	int wrapIndentInPixels = DPIUtil.pointToPixel(wrapIndent, zoom);
+	int indentInPixels = DPIUtil.pointToPixel(indent, zoom);
+	int wrapWidthInPixels = DPIUtil.pointToPixel(wrapWidth, zoom);
 	int lineWidth = indentInPixels, lineStart = 0, lineCount = 1;
 	for (int i=0; i<allRuns.length - 1; i++) {
 		StyleItem run = allRuns[i];
-		if (tabsInPixels != null && run.tab) {
+		if (tabs != null && run.tab) {
 			/*
-			 * Whether a stop is still ahead has to be decided in points, the unit setTabs()
-			 * defined it in. In pixels a stop the pen sits exactly on can round to one pixel
-			 * past the pen, collapsing the tab instead of advancing to the next stop.
+			 * The stop is resolved entirely in points, the unit setTabs() defined it in, and
+			 * only the resulting position is converted. Accumulating in pixels instead would
+			 * round every step and let the positions drift past the last stop.
 			 */
-			int lineWidthInPoints = DPIUtil.pixelToPoint(lineWidth, getZoom(gc));
-			int tabsLength = tabsInPixels.length, j;
+			int lineWidthInPoints = DPIUtil.pixelToPoint(lineWidth, zoom);
+			int widthInPoints = 0;
+			boolean stopFound = false;
+			int tabsLength = tabs.length, j;
 			for (j = 0; j < tabsLength; j++) {
 				if (tabs[j] > lineWidthInPoints) {
-					run.width = tabsInPixels[j] - lineWidth;
+					widthInPoints = tabs[j] - lineWidthInPoints;
+					stopFound = true;
 					break;
 				}
 			}
 			if (j == tabsLength) {
-				int tabX = tabsInPixels[tabsLength-1];
-				int lastTabWidth = tabsLength > 1 ? tabsInPixels[tabsLength-1] - tabsInPixels[tabsLength-2] : tabsInPixels[0];
+				int tabX = tabs[tabsLength-1];
+				int lastTabWidth = tabsLength > 1 ? tabs[tabsLength-1] - tabs[tabsLength-2] : tabs[0];
 				if (lastTabWidth > 0) {
-					while (DPIUtil.pixelToPoint(tabX, getZoom(gc)) <= lineWidthInPoints) tabX += lastTabWidth;
-					run.width = tabX - lineWidth;
+					while (tabX <= lineWidthInPoints) tabX += lastTabWidth;
+					widthInPoints = tabX - lineWidthInPoints;
+					stopFound = true;
 				}
 			}
 
@@ -414,18 +418,21 @@ void computeRuns (GC gc) {
 			 * The extra tabs are removed in merge.
 			 */
 			int length = run.length;
-			if (length > 1) {
+			if (length > 1 && stopFound) {
 				int stop = j + length - 1;
 				if (stop < tabsLength) {
-					run.width += tabsInPixels[stop] - tabsInPixels[j];
+					widthInPoints += tabs[stop] - tabs[j];
 				} else {
 					if (j < tabsLength) {
-						run.width += tabsInPixels[tabsLength-1] - tabsInPixels[j];
+						widthInPoints += tabs[tabsLength-1] - tabs[j];
 						length -= (tabsLength - 1) - j;
 					}
-					int lastTabWidth = tabsLength > 1 ? tabsInPixels[tabsLength-1] - tabsInPixels[tabsLength-2] : tabsInPixels[0];
-					run.width += lastTabWidth * (length - 1);
+					int lastTabWidth = tabsLength > 1 ? tabs[tabsLength-1] - tabs[tabsLength-2] : tabs[0];
+					widthInPoints += lastTabWidth * (length - 1);
 				}
+			}
+			if (stopFound) {
+				run.width = DPIUtil.pointToPixel(lineWidthInPoints + widthInPoints, zoom) - lineWidth;
 			}
 		}
 		if (wrapWidth != -1 && lineWidth + run.width > wrapWidthInPixels && !run.tab && !run.lineBreak) {


### PR DESCRIPTION
Stacked on #3493, which contains the actual fix. Only the second commit belongs to this PR; it will show on its own once #3493 is merged.

The tab stop handling in `TextLayout.computeRuns()` mixes units: the stop is selected in points while the resulting position and the adjustment for merged consecutive tabs are accumulated from the pixel-converted stops. This keeps the whole computation in points and converts once, when the final position is known, so the pixel copy of the stops disappears and the merged-tab adjustment works on the same values as the lookup.

Besides being easier to follow, it removes a rounding drift: each step past the last tab stop currently rounds separately, so the positions can end up a pixel away from the stop the caller defined. No behavior change for well-formed tab stops.
