### PR TITLE
Simplify return type of positionTooltip(NMHDR, long)

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Table.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Table.java
@@ -7124,15 +7124,13 @@ LRESULT wmNotifyToolTip (NMHDR hdr, long wParam, long lParam) {
 			LRESULT result = super.wmNotify (hdr, wParam, lParam);
 			if (result != null) return result;
 			if (toolTipText != null) break;
-			result = positionTooltip(hdr, lParam);
-			return result;
+			return positionTooltip(hdr, lParam) ? LRESULT.ONE : null;
 		}
 	}
 	return null;
 }
 
-private LRESULT positionTooltip(NMHDR hdr, long lParam) {
-	LRESULT result = null;
+private boolean positionTooltip(NMHDR hdr, long lParam) {
 	LVHITTESTINFO pinfo = new LVHITTESTINFO ();
 	int pos = OS.GetMessagePos ();
 	POINT pt = new POINT();
@@ -7164,7 +7162,7 @@ private LRESULT positionTooltip(NMHDR hdr, long lParam) {
 				if (adjustedTooltipBounds != null) {
 					OS.SetWindowPos(hwndToolTip, 0, adjustedTooltipBounds.x, adjustedTooltipBounds.y,
 							adjustedTooltipBounds.width, adjustedTooltipBounds.height, flags);
-					result = LRESULT.ONE;
+					return true;
 				}
 			} else if (isCustomToolTip()) {
 				RECT itemRect = getItemBounds(pinfo, item, hDC);
@@ -7185,7 +7183,7 @@ private LRESULT positionTooltip(NMHDR hdr, long lParam) {
 					string.getChars (0, string.length (), chars, 0);
 					shell.setToolTipText (lpnmtdi, chars);
 					OS.MoveMemory (lParam, lpnmtdi, NMTTDISPINFO.sizeof);
-					result = LRESULT.ONE;
+					return true;
 				}
 			}
 		}
@@ -7193,7 +7191,7 @@ private LRESULT positionTooltip(NMHDR hdr, long lParam) {
 		if (newFont != 0) OS.SelectObject (hDC, oldFont);
 		OS.ReleaseDC (handle, hDC);
 	}
-	return result;
+	return false;
 }
 
 private RECT getItemBounds(LVHITTESTINFO pinfo, TableItem item, long hDC) {


### PR DESCRIPTION
Follow-up for https://github.com/eclipse-platform/eclipse.platform.swt/issues/3487#issuecomment-5213922904, simplifying the return type of `Table.positionTooltip(NMHDR hdr, long lParam)`.

This changes the methods return type to `boolean` instead of `LRESULT` since the current implementation only ever returns `LRESULT.ONE` or `null`.

Relates to https://github.com/eclipse-platform/eclipse.platform.swt/pull/3491