### PR TITLE
Handle CreateCoreWebView2EnvironmentWithOptions ERROR_NOT_SUPPORTED

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Browser/win32/org/eclipse/swt/browser/Edge.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Browser/win32/org/eclipse/swt/browser/Edge.java
@@ -311,12 +311,16 @@ static int callAndWait(long[] ppv, ToIntFunction<IUnknown> callable) {
 		return COM.S_OK;
 	});
 	ppv[0] = 0;
-	phr[0] = callable.applyAsInt(completion);
-	// "completion" callback may be called asynchronously,
-	// so keep processing next OS message that may call it
-	processOSMessagesUntil(() -> phr[0] != COM.S_OK || ppv[0] != 0, exception -> {
-		throw exception;
-	}, Display.getCurrent());
+	int cr = callable.applyAsInt(completion);
+	if (cr != COM.S_OK) {
+		phr[0] = cr;
+	} else {
+		// "completion" callback may be called asynchronously,
+		// so keep processing next OS message that may call it
+		processOSMessagesUntil(() -> phr[0] != COM.S_OK || ppv[0] != 0, exception -> {
+			throw exception;
+		}, Display.getCurrent());
+	}
 	completion.Release();
 	return phr[0];
 }
@@ -331,12 +335,16 @@ int callAndWait(String[] pstr, ToIntFunction<IUnknown> callable) {
 		return COM.S_OK;
 	});
 	pstr[0] = null;
-	phr[0] = callable.applyAsInt(completion);
-	// "completion" callback may be called asynchronously,
-	// so keep processing next OS message that may call it
-	processOSMessagesUntil(() -> phr[0] != COM.S_OK || pstr[0] != null, exception -> {
-		throw exception;
-	}, browser.getDisplay());
+	int cr = callable.applyAsInt(completion);
+	if (cr != COM.S_OK) {
+		phr[0] = cr;
+	} else {
+		// "completion" callback may be called asynchronously,
+		// so keep processing next OS message that may call it
+		processOSMessagesUntil(() -> phr[0] != COM.S_OK || pstr[0] != null, exception -> {
+			throw exception;
+		}, browser.getDisplay());
+	}
 	completion.Release();
 	return phr[0];
 }
@@ -659,6 +667,9 @@ WebViewEnvironment createEnvironment() {
 	options.Release();
 	if (hr == OS.HRESULT_FROM_WIN32(OS.ERROR_FILE_NOT_FOUND)) {
 		SWT.error(SWT.ERROR_NOT_IMPLEMENTED, null, " [WebView2 runtime not found]");
+	}
+	if (hr == OS.HRESULT_FROM_WIN32(OS.ERROR_NOT_SUPPORTED)) {
+		SWT.error(SWT.ERROR_INVALID_ARGUMENT, null, String.format(" [Invalid WebView2 directory: %s. Please ensure that '%s' points to a WebView2 application directory (which usually ends with \\EdgeWebView\\Application\\<Version>)]", browserDir, BROWSER_DIR_PROP));
 	}
 	if (hr != COM.S_OK) error(SWT.ERROR_NO_HANDLES, hr);
 	ICoreWebView2Environment environment = new ICoreWebView2Environment(ppv[0]);

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/win32/org/eclipse/swt/internal/win32/OS.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/win32/org/eclipse/swt/internal/win32/OS.java
@@ -426,6 +426,7 @@ public class OS extends C {
 	public static final int EN_CHANGE = 0x300;
 	public static final int EP_EDITTEXT = 1;
 	public static final int ERROR_FILE_NOT_FOUND = 0x2;
+	public static final int ERROR_NOT_SUPPORTED = 0x32;
 	public static final int ERROR_INVALID_STATE = 0x139F;
 	public static final int ERROR_NO_MORE_ITEMS = 0x103;
 	public static final int ERROR_CANCELED = 0x4C7;

--- a/bundles/org.eclipse.swt/Readme.WebView2.md
+++ b/bundles/org.eclipse.swt/Readme.WebView2.md
@@ -38,9 +38,11 @@ the `Browser` will automatically fall back to the Internet Explorer backend.
 ### Browser Directory
 
 WebView2 backend will automatically locate runtimes and Edge installations.
-The path to the Edge binary directory can also be set manually using the
+The path to the WebView2 binary directory can also be set manually using the
 `org.eclipse.swt.browser.EdgeDir` system property. This is also
 required when bundling fixed-version WebView2 binaries.
+
+_Note_: The directory pointed to by `org.eclipse.swt.browser.EdgeDir` must contain the WebView2 binary (`msedgewebview2.exe`, usually in `\EdgeWebView\Application\<Version>`), **not** the Edge application binary (`msedge.exe`, usually in `\Edge\Application\<Version>`).
 
 ### User Directory
 


### PR DESCRIPTION
When passing a Edge binary directory to
'org.eclipse.swt.browser.EdgeDir',
CreateCoreWebView2EnvironmentWithOptions
returns HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED) instead of HRESULT_FROM_WIN32(ERROR_FILE_NOT_FOUND) which is thrown for other invalid directories.

In this case, the passed completion callback exits immediately before the processOSMessagesUntil(..) loop starts spinning. This previously caused the return value being overwritten in callAndWait(long[], ToIntFunction<IUnknown>), leading to a permanent UI freeze.

Fixes https://github.com/eclipse-platform/eclipse.platform.swt/issues/3499