### PR TITLE
[GTK4] Fix ToolBar background not being applied

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/ToolBar.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/ToolBar.java
@@ -604,8 +604,14 @@ int setBounds (int x, int y, int width, int height, boolean move, boolean resize
 
 @Override
 void setBackgroundGdkRGBA (long context, long handle, GdkRGBA rgba) {
+	/*
+	 * On GTK4 the tool bar is a GtkBox carrying the "toolbar" style class, so its CSS
+	 * node is named "box" and a plain "toolbar" selector never matches, leaving the
+	 * tool bar with the theme background instead of the requested one.
+	 */
+	String selector = GTK.GTK4 ? "box.toolbar" : "toolbar";
 	// Form background string
-	String css = "toolbar {background-color: " + display.gtk_rgba_to_css_string(rgba) + ";}";
+	String css = selector + " {background-color: " + display.gtk_rgba_to_css_string(rgba) + ";}";
 
 	// Cache background color
 	this.cssBackground = css;


### PR DESCRIPTION
ToolBar hardcoded the CSS selector "toolbar" when building the background rule. That is the CSS node name of GTK3's GtkToolbar, but GTK4 removed that widget: createHandle builds a GtkBox and adds "toolbar" as a style class, so the node is named "box". The rule therefore matched nothing and the tool bar kept the theme background instead of the requested one.

This is visible for example in the Eclipse find/replace overlay, where the tool bars show up as grey boxes on an otherwise white overlay.

Use "box.toolbar" as the selector on GTK4, which fixes both an explicit setBackground(Color) and an inherited background via setBackgroundMode().

Assisted-by: Anthropic Claude Code (claude-opus-5)