### PR TITLE
Avoid re-reading the image file on every scaled drawImage

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/graphics/Image.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/graphics/Image.java
@@ -1909,6 +1909,8 @@ private CachedImageAtSize cachedImageAtSize = new CachedImageAtSize();
 
 private class CachedImageAtSize {
 	private Image image;
+	/** File already found not to be dynamically sizable, so re-reading it cannot help. */
+	private String nonSizableFileName;
 
 	public void destroy() {
 		if (image != null) {
@@ -1959,9 +1961,17 @@ private class CachedImageAtSize {
 		}
 		if (imageFileNameProvider != null) {
 			String fileName = DPIUtil.validateAndGetImagePathAtZoom(imageFileNameProvider, 100).element();
-			if (ImageDataLoader.isDynamicallySizable(fileName)) {
-				ImageData imageDataAtSize = ImageDataLoader.loadBySize(fileName, targetWidth, targetHeight);
-				return Optional.of(imageDataAtSize);
+			if (fileName.equals(nonSizableFileName)) {
+				return Optional.empty();
+			}
+			try (InputStream stream = new BufferedInputStream(new FileInputStream(fileName))) {
+				if (ImageDataLoader.isDynamicallySizable(stream)) {
+					nonSizableFileName = null;
+					return Optional.of(ImageDataLoader.loadBySize(stream, targetWidth, targetHeight));
+				}
+				nonSizableFileName = fileName;
+			} catch (IOException e) {
+				SWT.error(SWT.ERROR_IO, e);
 			}
 		}
 		return Optional.empty();

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/ImageDataLoader.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/ImageDataLoader.java
@@ -45,10 +45,6 @@ class ImageDataLoader {
 		return ImageLoader.canLoadAtZoom(filename, fileZoom, targetZoom);
 	}
 
-	static boolean isDynamicallySizable(String filename) {
-		return ImageLoader.isDynamicallySizable(filename);
-	}
-
 	static boolean isDynamicallySizable(InputStream stream) {
 		return ImageLoader.isDynamicallySizable(stream);
 	}
@@ -67,12 +63,6 @@ class ImageDataLoader {
 
 	public static ImageData loadBySize(InputStream stream, int width, int height) {
 		ImageData data = new ImageLoader().loadBySize(stream, width, height);
-		if (data == null) SWT.error(SWT.ERROR_INVALID_IMAGE);
-		return data;
-	}
-
-	public static ImageData loadBySize(String filename, int width, int height) {
-		ImageData data = new ImageLoader().loadBySize(filename, width, height);
 		if (data == null) SWT.error(SWT.ERROR_INVALID_IMAGE);
 		return data;
 	}

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/ImageLoader.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/ImageLoader.java
@@ -209,29 +209,10 @@ List<ElementAtZoom<ImageData>> loadByZoom(String filename, int fileZoom, int tar
 	return null;
 }
 
-ImageData loadBySize(String filename, int width, int height) {
-	if (filename == null) SWT.error(SWT.ERROR_NULL_ARGUMENT);
-	try (InputStream stream = new FileInputStream(filename)) {
-		return loadBySize(stream, width, height);
-	} catch (IOException e) {
-		SWT.error(SWT.ERROR_IO, e);
-	}
-	return null;
-}
-
 static boolean canLoadAtZoom(String filename, int fileZoom, int targetZoom) {
 	if (filename == null) SWT.error(SWT.ERROR_NULL_ARGUMENT);
 	try (InputStream stream = new FileInputStream(filename)) {
 		return canLoadAtZoom(stream, fileZoom, targetZoom);
-	} catch (IOException e) {
-		SWT.error(SWT.ERROR_IO, e);
-	}
-	return false;
-}
-
-static boolean isDynamicallySizable(String filename) {
-	try (InputStream stream = new FileInputStream(filename)) {
-		return FileFormat.isDynamicallySizableFormat(stream);
 	} catch (IOException e) {
 		SWT.error(SWT.ERROR_IO, e);
 	}

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/image/FileFormat.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/image/FileFormat.java
@@ -72,8 +72,21 @@ public abstract class FileFormat {
 
 	private static final int MAX_SIGNATURE_BYTES = 18 + 2; // e.g. Win-BMP or OS2-BMP plus a safety-margin
 
+	/**
+	 * Answers whether the stream holds a format that can be loaded at an arbitrary size.
+	 * A stream that supports mark is rewound to its current position afterwards.
+	 */
 	public static boolean isDynamicallySizableFormat(InputStream is) {
+		boolean rewind = is.markSupported();
+		if (rewind) is.mark(MAX_SIGNATURE_BYTES);
 		Optional<FileFormat> format = determineFileFormat(new LEDataInputStream(is, MAX_SIGNATURE_BYTES));
+		if (rewind) {
+			try {
+				is.reset();
+			} catch (IOException e) {
+				SWT.error(SWT.ERROR_IO, e);
+			}
+		}
 		return format.isPresent() && !(format.get() instanceof StaticImageFileFormat);
 	}
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/graphics/Image.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/graphics/Image.java
@@ -970,6 +970,8 @@ private CachedImageAtSize cachedImageAtSize = new CachedImageAtSize();
 
 private class CachedImageAtSize {
 	private Image image;
+	/** File already found not to be dynamically sizable, so re-reading it cannot help. */
+	private String nonSizableFileName;
 
 	public void destroy() {
 		if (image != null) {
@@ -1020,9 +1022,17 @@ private class CachedImageAtSize {
 		}
 		if (imageFileNameProvider != null) {
 			String fileName = DPIUtil.validateAndGetImagePathAtZoom(imageFileNameProvider, 100).element();
-			if (ImageDataLoader.isDynamicallySizable(fileName)) {
-				ImageData imageDataAtSize = ImageDataLoader.loadBySize(fileName, targetWidth, targetHeight);
-				return Optional.of(imageDataAtSize);
+			if (fileName.equals(nonSizableFileName)) {
+				return Optional.empty();
+			}
+			try (InputStream stream = new BufferedInputStream(new FileInputStream(fileName))) {
+				if (ImageDataLoader.isDynamicallySizable(stream)) {
+					nonSizableFileName = null;
+					return Optional.of(ImageDataLoader.loadBySize(stream, targetWidth, targetHeight));
+				}
+				nonSizableFileName = fileName;
+			} catch (IOException e) {
+				SWT.error(SWT.ERROR_IO, e);
 			}
 		}
 		return Optional.empty();

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Image.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Image.java
@@ -2630,6 +2630,9 @@ private abstract class BaseImageProviderWrapper<T> extends DynamicImageProviderW
 }
 
 private class ImageFileNameProviderWrapper extends BaseImageProviderWrapper<ImageFileNameProvider> {
+	/** File already found not to be dynamically sizable, so re-reading it cannot help. */
+	private String nonSizableFileName;
+
 	ImageFileNameProviderWrapper(ImageFileNameProvider provider) {
 		super(provider, ImageFileNameProvider.class);
 		// Checks for the contract of the passed provider require
@@ -2879,10 +2882,18 @@ private class ImageFileNameProviderWrapper extends BaseImageProviderWrapper<Imag
 	@Override
 	protected Optional<ImageData> loadImageDataAtExactSize(int targetWidth, int targetHeight) {
 		String fileName = DPIUtil.validateAndGetImagePathAtZoom(this.provider, 100).element();
-		if (ImageDataLoader.isDynamicallySizable(fileName)) {
-			ImageData imageDataAtSize = ImageDataLoader.loadBySize(fileName, targetWidth, targetHeight);
-			ImageData adaptedImageDataAtSize = adaptImageDataIfDisabledOrGray(imageDataAtSize);
-			return Optional.of(adaptedImageDataAtSize);
+		if (fileName.equals(nonSizableFileName)) {
+			return Optional.empty();
+		}
+		try (InputStream stream = new BufferedInputStream(new FileInputStream(fileName))) {
+			if (ImageDataLoader.isDynamicallySizable(stream)) {
+				nonSizableFileName = null;
+				ImageData imageDataAtSize = ImageDataLoader.loadBySize(stream, targetWidth, targetHeight);
+				return Optional.of(adaptImageDataIfDisabledOrGray(imageDataAtSize));
+			}
+			nonSizableFileName = fileName;
+		} catch (IOException e) {
+			SWT.error(SWT.ERROR_IO, e);
 		}
 		return Optional.empty();
 	}

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_Image.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_Image.java
@@ -34,6 +34,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
 import org.eclipse.swt.SWT;
@@ -1221,6 +1222,78 @@ public void test_gcOnImageGcDrawer_imageDataAtNonDeviceZoom() {
 		redOverwritingGc.dispose();
 		image.dispose();
 		DPIUtil.setDeviceZoom(originalDeviceZoom);
+	}
+}
+
+/**
+ * Whether a file can be loaded at an arbitrary size never changes, so the scaled
+ * drawImage must determine it once instead of re-reading the file on every draw.
+ * Deleting the file after the first draw makes any further read fail loudly.
+ */
+@Test
+public void test_drawImageAtSize_doesNotReReadFileOfNonSizableFormat() throws IOException {
+	Path file = tempFolder.resolve("volatile-collapseall.png");
+	Files.copy(Path.of(getPath("collapseall.png")), file);
+	int previousDeviceZoom = DPIUtil.getDeviceZoom();
+	DPIUtil.setDeviceZoom(100);
+	try {
+		Image image = new Image(display, file.toString());
+		Image target = new Image(display, 64, 64);
+		GC gc = new GC(target);
+		try {
+			Rectangle bounds = image.getBounds();
+			gc.drawImage(image, 0, 0, bounds.width * 2, bounds.height * 2);
+
+			Files.delete(file);
+
+			gc.drawImage(image, 0, 0, bounds.width * 2, bounds.height * 2);
+			gc.drawImage(image, 0, 0, bounds.width * 3, bounds.height * 3);
+		} finally {
+			gc.dispose();
+			target.dispose();
+			image.dispose();
+		}
+	} finally {
+		DPIUtil.setDeviceZoom(previousDeviceZoom);
+		Files.deleteIfExists(file);
+	}
+}
+
+/**
+ * An Image may be backed by different files over its lifetime, so what is known about
+ * one file must not be applied to the next one.
+ */
+@Test
+public void test_drawImageAtSize_reevaluatesSizabilityWhenFileNameChanges() throws IOException {
+	Path sizableFile = tempFolder.resolve("switchable-collapseall.svg");
+	Files.copy(Path.of(getPath("collapseall.svg")), sizableFile);
+	AtomicReference<String> currentFile = new AtomicReference<>(getPath("collapseall.png"));
+	ImageFileNameProvider switchingProvider = zoom -> zoom == 100 ? currentFile.get() : null;
+	int previousDeviceZoom = DPIUtil.getDeviceZoom();
+	DPIUtil.setDeviceZoom(100);
+	try {
+		Image image = new Image(display, switchingProvider);
+		Image target = new Image(display, 64, 64);
+		GC gc = new GC(target);
+		try {
+			// learns that the PNG cannot be loaded at an arbitrary size
+			gc.drawImage(image, 0, 0, 20, 20);
+
+			currentFile.set(sizableFile.toString());
+			gc.drawImage(image, 0, 0, 20, 20);
+
+			// if the SVG were still treated as non-sizable, it would never be read at all
+			Files.delete(sizableFile);
+			assertThrows(SWTException.class, () -> gc.drawImage(image, 0, 0, 24, 24),
+					"the file of a sizable image must be read again for a new size");
+		} finally {
+			gc.dispose();
+			target.dispose();
+			image.dispose();
+		}
+	} finally {
+		DPIUtil.setDeviceZoom(previousDeviceZoom);
+		Files.deleteIfExists(sizableFile);
 	}
 }
 


### PR DESCRIPTION
The scaled `GC.drawImage` overload sniffed the backing file on every draw to ask whether it can be loaded at an arbitrary size, then discarded the answer, so every PNG, GIF or JPEG icon was reopened on each repaint.
Sizability is a property of the file, so the `Image` now remembers a file found not to be sizable, keyed on the resolved file name because an `Image` may be backed by different files over its lifetime.
For sizable files the sniff and the load share one open: `Image` opens the stream once and `FileFormat` rewinds it after reading the signature.

Measured with `strace` on Linux/GTK at zoom 100, opens per scaled draw drop from 1.00 to 0.01 for PNG and from 2.00 to 1.00 for SVG at alternating sizes, with bit-identical rendering.
At zoom 200 one open per draw remains from #3507, fixed separately in #3510, and the size cache never hitting there is #3511.
A file replaced in place at the same path is no longer re-sniffed for the lifetime of the `Image`.

Fixes https://github.com/eclipse-platform/eclipse.platform.swt/issues/3505
