### PR TITLE
[GTK] Stop decoding the image file on every draw at zoom != 100

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/graphics/GC.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/graphics/GC.java
@@ -913,9 +913,14 @@ void drawImage(Image srcImage, int srcX, int srcY, int srcWidth, int srcHeight, 
 	/* Refresh Image as per zoom level, if required. */
 	srcImage.refreshImageForZoom ();
 
-	ImageData srcImageData = srcImage.getImageData();
-	int imgWidth = srcImageData.width;
-	int imgHeight = srcImageData.height;
+	int imgWidth = srcImage.width;
+	int imgHeight = srcImage.height;
+	if (imgWidth == -1 || imgHeight == -1) {
+		/* Images wrapped around a native handle carry no dimensions, see Image.gtk_new. */
+		ImageData srcImageData = srcImage.getImageData();
+		imgWidth = srcImageData.width;
+		imgHeight = srcImageData.height;
+	}
 	if (srcWidth == 0 && srcHeight == 0) {
 		srcWidth = imgWidth;
 		srcHeight = imgHeight;

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_GC.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_GC.java
@@ -30,6 +30,9 @@ import static org.junit.jupiter.api.Assumptions.assumeFalse;
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.ref.WeakReference;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -59,6 +62,7 @@ import org.eclipse.swt.widgets.Shell;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -71,6 +75,9 @@ import org.junit.jupiter.params.provider.ValueSource;
 public class Test_org_eclipse_swt_graphics_GC {
 
 private static final int IMAGE_SIZE = 200;
+
+@TempDir
+static Path tempFolder;
 
 @BeforeEach
 public void setUp() {
@@ -1206,6 +1213,65 @@ RGB getRealRGB(Color color) {
 	colorImage.dispose();
 	int pixel = imageData.getPixel(0, 0);
 	return palette.getRGB(pixel);
+}
+
+/**
+ * Drawing reads the image dimensions from the image itself. Obtaining them through
+ * ImageData used to decode the file again on every draw at a device zoom other than 100.
+ */
+@Test
+public void test_drawImage_doesNotReReadImageFileAtNonDefaultZoom() throws IOException {
+	Path file = tempFolder.resolve("volatile-collapseall.png");
+	Files.copy(SwtTestUtil.getPath("collapseall.png", tempFolder), file);
+	int previousDeviceZoom = DPIUtil.getDeviceZoom();
+	Image fileImage = null;
+	try {
+		DPIUtil.setDeviceZoom(200);
+		gc.dispose();
+		gc = new GC(image);
+		fileImage = new Image(display, file.toString());
+		ImageData beforeDelete = drawToFreshTarget(fileImage);
+		assertFalse(Arrays.equals(blankTargetData(), beforeDelete.data), "the reference draw produced no pixels");
+
+		Files.delete(file);
+
+		ImageData afterDelete = drawToFreshTarget(fileImage);
+		ImageDataTestHelper.assertImageDataEqual(beforeDelete, afterDelete, beforeDelete);
+		gc.drawImage(fileImage, 0, 0);
+	} finally {
+		try {
+			// Windows GCs retain image operations and copy live sources when they are disposed.
+			gc.dispose();
+			if (fileImage != null) {
+				fileImage.dispose();
+			}
+		} finally {
+			DPIUtil.setDeviceZoom(previousDeviceZoom);
+			Files.deleteIfExists(file);
+		}
+	}
+}
+
+private byte[] blankTargetData() {
+	Image target = new Image(display, IMAGE_SIZE, IMAGE_SIZE);
+	try {
+		return target.getImageData().data;
+	} finally {
+		target.dispose();
+	}
+}
+
+private ImageData drawToFreshTarget(Image source) {
+	Rectangle bounds = source.getBounds();
+	Image target = new Image(display, IMAGE_SIZE, IMAGE_SIZE);
+	GC targetGc = new GC(target);
+	try {
+		targetGc.drawImage(source, 0, 0, bounds.width, bounds.height, 0, 0, bounds.width * 2, bounds.height * 2);
+		return target.getImageData();
+	} finally {
+		targetGc.dispose();
+		target.dispose();
+	}
 }
 
 private void executeWithNonDefaultDeviceZoom(Runnable executable) {


### PR DESCRIPTION
The internal `drawImage` that every public overload funnels into read the source dimensions from `srcImage.getImageData()`, which is `getImageData(100)`.
At a device zoom other than 100 that misses the fast path and does `new ImageData(fileName)`, a full open and decode of the image file, for SVG a full re-parse and re-rasterize, just to obtain two integers the `Image` already knows.
An `ImageGcDrawer` image paid the same way, by running the drawer callback once per draw.
Taking the dimensions from the `Image` removes that, with a fallback for images wrapped around a native handle by `Image.gtk_new`, which carry none and have no provider, so the fallback reads the in-memory cairo surface and never a file.

Measured with `strace -f -e trace=openat` over 100 draws of one `Image` at zoom 200, opens per draw fall from 1.00 to 0.00 for the 9 argument overload and from 2.00 to 1.00 for the 5 argument one; the remaining open there is the `CachedImageAtSize` path of #3505, addressed separately in #3506.
Cocoa already takes its dimensions from `NSImage.size()` and win32 from `getBounds()`, so this brings GTK in line with both.

Two cases change behavior, both where `getBounds()` and `getImageData()` already disagreed, and in both the new value is the one that agrees with `getBounds()`.
A non-proportional asset set (16 pixels at 100%, 33 at 200%) now paints the last point row and column that were previously clipped, and a provider handing out the same file at every zoom now validates the source rectangle against the bounds, so passing `getImageData()` dimensions there raises `ERROR_INVALID_ARGUMENT` where it previously drew.
Everything else renders identically, verified as matching SHA-256 of the drawn `ImageData` across both overloads, three files and zoom 100, 150 and 200.

The new test deletes the image file after the first draw, so any further read fails loudly; it was confirmed to fail before the change and pass after.
It runs on all platforms although the fix is GTK only, so the win32 and macOS workflow results are worth a look rather than a rubber stamp.

Fixes https://github.com/eclipse-platform/eclipse.platform.swt/issues/3507
