### PR TITLE
[Win32] Consolidate tool bar image list release and disposal

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ToolBar.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ToolBar.java
@@ -482,19 +482,7 @@ void destroyItem (ToolItem item) {
 	item.id = -1;
 	int count = (int)OS.SendMessage (handle, OS.TB_BUTTONCOUNT, 0, 0);
 	if (count == 0) {
-		if (imageList != null) {
-			OS.SendMessage (handle, OS.TB_SETIMAGELIST, 0, 0);
-			display.releaseToolImageList (imageList);
-		}
-		if (hotImageList != null) {
-			OS.SendMessage (handle, OS.TB_SETHOTIMAGELIST, 0, 0);
-			display.releaseToolHotImageList (hotImageList);
-		}
-		if (disabledImageList != null) {
-			OS.SendMessage (handle, OS.TB_SETDISABLEDIMAGELIST, 0, 0);
-			display.releaseToolDisabledImageList (disabledImageList);
-		}
-		imageList = hotImageList = disabledImageList = null;
+		clearAndReleaseImageLists();
 		items = new ToolItem [4];
 	}
 	if ((style & SWT.VERTICAL) != 0) setRowCount (count - 1);
@@ -953,19 +941,28 @@ void releaseChildren (boolean destroy) {
 @Override
 void releaseWidget () {
 	super.releaseWidget ();
+	clearAndReleaseImageLists();
+}
+
+private void clearAndReleaseImageLists() {
+	ImageList releasedImageList = imageList;
+	ImageList releasedHotImageList = hotImageList;
+	ImageList releasedDisabledImageList = disabledImageList;
+	imageList = hotImageList = disabledImageList = null;
+	refreshImageLists(false);
+	releaseImageLists(releasedImageList, releasedHotImageList, releasedDisabledImageList);
+}
+
+private void releaseImageLists(ImageList imageList, ImageList hotImageList, ImageList disabledImageList) {
 	if (imageList != null) {
-		OS.SendMessage (handle, OS.TB_SETIMAGELIST, 0, 0);
 		display.releaseToolImageList (imageList);
 	}
 	if (hotImageList != null) {
-		OS.SendMessage (handle, OS.TB_SETHOTIMAGELIST, 0, 0);
 		display.releaseToolHotImageList (hotImageList);
 	}
 	if (disabledImageList != null) {
-		OS.SendMessage (handle, OS.TB_SETDISABLEDIMAGELIST, 0, 0);
 		display.releaseToolDisabledImageList (disabledImageList);
 	}
-	imageList = hotImageList = disabledImageList = null;
 }
 
 @Override
@@ -1255,9 +1252,12 @@ void updateOrientation () {
 	super.updateOrientation ();
 	if (imageList != null) {
 		Point sizeInPoints = imageList.getImageSize();
-		ImageList newImageList = display.getImageListToolBar (style & SWT.RIGHT_TO_LEFT, sizeInPoints.x, sizeInPoints.y, getAutoscalingZoom());
-		ImageList newHotImageList = display.getImageListToolBarHot (style & SWT.RIGHT_TO_LEFT, sizeInPoints.x, sizeInPoints.y, getAutoscalingZoom());
-		ImageList newDisabledImageList = display.getImageListToolBarDisabled (style & SWT.RIGHT_TO_LEFT, sizeInPoints.x, sizeInPoints.y, getAutoscalingZoom());
+		ImageList oldImageList = imageList;
+		ImageList oldHotImageList = hotImageList;
+		ImageList oldDisabledImageList = disabledImageList;
+		imageList = display.getImageListToolBar (style & SWT.RIGHT_TO_LEFT, sizeInPoints.x, sizeInPoints.y, getAutoscalingZoom());
+		hotImageList = display.getImageListToolBarHot (style & SWT.RIGHT_TO_LEFT, sizeInPoints.x, sizeInPoints.y, getAutoscalingZoom());
+		disabledImageList = display.getImageListToolBarDisabled (style & SWT.RIGHT_TO_LEFT, sizeInPoints.x, sizeInPoints.y, getAutoscalingZoom());
 		TBBUTTONINFO info = new TBBUTTONINFO ();
 		info.cbSize = TBBUTTONINFO.sizeof;
 		info.dwMask = OS.TBIF_IMAGE;
@@ -1268,25 +1268,20 @@ void updateOrientation () {
 			if (item.image == null) continue;
 			OS.SendMessage (handle, OS.TB_GETBUTTONINFO, item.id, info);
 			if (info.iImage != OS.I_IMAGENONE) {
-				Image image = imageList.get(info.iImage);
-				Image hot = hotImageList.get(info.iImage);
-				Image disabled = disabledImageList.get(info.iImage);
-				imageList.put(info.iImage, null);
-				hotImageList.put(info.iImage, null);
-				disabledImageList.put(info.iImage, null);
-				info.iImage = newImageList.add(image);
-				newHotImageList.add(hot);
-				newDisabledImageList.add(disabled);
+				Image image = oldImageList.get(info.iImage);
+				Image hot = oldHotImageList.get(info.iImage);
+				Image disabled = oldDisabledImageList.get(info.iImage);
+				oldImageList.put(info.iImage, null);
+				oldHotImageList.put(info.iImage, null);
+				oldDisabledImageList.put(info.iImage, null);
+				info.iImage = imageList.add(image);
+				hotImageList.add(hot);
+				disabledImageList.add(disabled);
 				OS.SendMessage (handle, OS.TB_SETBUTTONINFO, item.id, info);
 			}
 		}
-		display.releaseToolImageList (imageList);
-		display.releaseToolHotImageList (hotImageList);
-		display.releaseToolDisabledImageList (disabledImageList);
-		imageList = newImageList;
-		hotImageList = newHotImageList;
-		disabledImageList = newDisabledImageList;
 		refreshImageLists(false);
+		releaseImageLists(oldImageList, oldHotImageList, oldDisabledImageList);
 		OS.InvalidateRect (handle, null, true);
 	}
 }


### PR DESCRIPTION
> [!IMPORTANT]
> This change is based on and should thus be merged after:
> - https://github.com/eclipse-platform/eclipse.platform.swt/pull/3504
> - https://github.com/eclipse-platform/eclipse.platform.swt/pull/3508

`ToolBar`'s `destroyItem` (when the last button is removed) and `releaseWidget` each released the three image lists and cleared their native references with near-identical, duplicated code; `updateOrientation` released and swapped them inline as well. Consolidates all three into shared `clearAndReleaseImageLists`/`releaseImageLists` helpers built on top of `refreshImageLists`. All of them refresh with `itemsChanged=false`: in `destroyItem` and `releaseWidget` no tool bar buttons remain that the drop-down padding workaround would have to protect, and in `updateOrientation` the buttons are only re-pointed at their migrated images rather than added or recreated.

`updateOrientation` released the old image lists before pointing the native tool bar at the new ones, leaving a window where the control could reference an already-disposed image list. It now assigns the fields to the freshly created lists upfront, migrating each button's images from the old lists (kept in local variables) into them, and only refreshes the native references and releases the old lists afterwards, matching `clearAndReleaseImageLists`.


Related to https://github.com/eclipse-platform/eclipse.platform.swt/issues/3466

_Note:_ This change is human-crafted and was only slightly revised and documented with the help of AI

This is the third  of multiple incremental steps to enhance ImageList handling and consistency inside ToolBar. This is supposed to be merged for 2026-12 M1.