### PR TITLE
Use assertThrows in widget and Region tests

### DIFF
--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_Region.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_Region.java
@@ -14,6 +14,7 @@
  *******************************************************************************/
 package org.eclipse.swt.tests.junit;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import org.eclipse.swt.SWTException;
@@ -57,25 +58,12 @@ public void test_ConstructorLorg_eclipse_swt_graphics_Device() {
 
 @Test
 public void test_add$I() {
-	Region reg = new Region(display);
-	try {
-		reg.add((int[])null);
-		reg.dispose();
-		fail("no exception thrown for adding a null rectangle");
-	}
-	catch (IllegalArgumentException e) {
-	}
-	reg.dispose();
-	try {
-		reg.add(new int[]{});
-		reg.dispose();
-		fail("no exception thrown on disposed region");
-	}
-	catch (SWTException e) {
-	}
-	reg.dispose();
+	Region emptyRegion = new Region(display);
+	assertThrows(IllegalArgumentException.class, () -> emptyRegion.add((int[]) null), "no exception thrown for adding a null rectangle");
+	emptyRegion.dispose();
+	assertThrows(SWTException.class, () -> emptyRegion.add(new int[]{}), "no exception thrown on disposed region");
 
-	reg = new Region(display);
+	Region reg = new Region(display);
 	reg.add(new int[] {0,0, 50,0, 50,25, 0,25});
 	Rectangle box = reg.getBounds();
 	reg.dispose();
@@ -112,21 +100,11 @@ public void test_addLorg_eclipse_swt_graphics_Rectangle() {
 	// add a second rectangle
 	reg.add(new Rectangle(200, 200, 10,10));
 
-	try {
-		reg.add((Rectangle)null);
-		fail("no exception thrown for adding a null rectangle");
-	}
-	catch (IllegalArgumentException e) {
-	}
+	assertThrows(IllegalArgumentException.class, () -> reg.add((Rectangle)null), "no exception thrown for adding a null rectangle");
 
 	reg.dispose();
 
-	try {
-		reg.add(new Rectangle(20,30,10,5));
-		fail("no exception thrown for adding a rectangle after Region got disposed");
-	}
-	catch (SWTException e) {
-	}
+	assertThrows(SWTException.class, () -> reg.add(new Rectangle(20,30,10,5)), "no exception thrown for adding a rectangle after Region got disposed");
 }
 
 @Test
@@ -138,34 +116,21 @@ public void test_addLorg_eclipse_swt_graphics_Region() {
 	reg1.add(reg2);
 	reg2.dispose();
 
-	try {
-		reg1.add((Region)null);
-		fail("no exception thrown for adding a null region");
-	}
-	catch (IllegalArgumentException e) {
-	}
+	assertThrows(IllegalArgumentException.class, () -> reg1.add((Region)null), "no exception thrown for adding a null region");
 
-	try {
-		reg2 = new Region(display);
-		reg2.add(new Rectangle(1,1,100,200));
-		reg2.dispose();
-		reg1.add(reg2);
-		fail("no exception thrown for adding to a Region a Region which got disposed");
-	}
-	catch (IllegalArgumentException e) {
-	}
+	Region disposedRegion = new Region(display);
+	disposedRegion.add(new Rectangle(1,1,100,200));
+	disposedRegion.dispose();
+	assertThrows(IllegalArgumentException.class, () -> reg1.add(disposedRegion), "no exception thrown for adding to a Region a Region which got disposed");
 
 	reg1.dispose();
 
+	Region liveRegion = new Region(display);
 	try {
-		reg2 = new Region(display);
-		reg2.add(new Rectangle(1,1,100,200));
-		reg1.add(reg2);
-		fail("no exception thrown for adding a Region to a Region which got disposed");
-	}
-	catch (SWTException e) {
+		liveRegion.add(new Rectangle(1,1,100,200));
+		assertThrows(SWTException.class, () -> reg1.add(liveRegion), "no exception thrown for adding a Region to a Region which got disposed");
 	} finally {
-		if (reg2 != null) reg2.dispose();
+		liveRegion.dispose();
 	}
 }
 
@@ -177,16 +142,11 @@ public void test_containsII() {
 	Point pointInRect2 = new Point(1049,1009);
 	Point pointNotInRect12 = new Point(49,110);
 
-	Region reg = new Region(display);
-	reg.dispose();
-	try {
-		reg.contains(pointInRect1.x, pointInRect1.y);
-		fail("no exception thrown on disposed region");
-	}
-	catch (Exception e) {
-	}
+	Region disposedRegion = new Region(display);
+	disposedRegion.dispose();
+	assertThrows(Exception.class, () -> disposedRegion.contains(pointInRect1.x, pointInRect1.y), "no exception thrown on disposed region");
 
-	reg = new Region(display);
+	Region reg = new Region(display);
 	if (reg.contains(pointInRect1.x, pointInRect1.y)) {
 		reg.dispose();
 		fail("Empty region should not contain point");
@@ -217,16 +177,11 @@ public void test_containsLorg_eclipse_swt_graphics_Point() {
 	Point pointInRect2 = new Point(1049,1009);
 	Point pointNotInRect12 = new Point(49,110);
 
-	Region reg = new Region(display);
-	reg.dispose();
-	try {
-		reg.contains(pointInRect1);
-		fail("no exception thrown on disposed region");
-	}
-	catch (Exception e) {
-	}
+	Region disposedRegion = new Region(display);
+	disposedRegion.dispose();
+	assertThrows(Exception.class, () -> disposedRegion.contains(pointInRect1), "no exception thrown on disposed region");
 
-	reg = new Region(display);
+	Region reg = new Region(display);
 	if (reg.contains(pointInRect1)) {
 		reg.dispose();
 		fail("Empty region should not contain point");
@@ -315,22 +270,17 @@ public void test_equalsLjava_lang_Object() {
 
 @Test
 public void test_getBounds() {
-	Region reg = new Region(display);
-	reg.dispose();
+	Region disposedRegion = new Region(display);
+	disposedRegion.dispose();
 
-	try {
-		reg.getBounds();
-		fail("Region disposed should throw Exception");
-	}
-	catch (Exception e) {
-	}
+	assertThrows(Exception.class, () -> disposedRegion.getBounds(), "Region disposed should throw Exception");
 
 	Rectangle rect1 = new Rectangle(10,10,50,30);
 	Rectangle rect2 = new Rectangle(100,100,10,10);
 	// the rectangle enclosing the two preceding rectangles
 	Rectangle rect12Bounds = new Rectangle(10,10,100,100);
 
-	reg = new Region(display);
+	Region reg = new Region(display);
 	reg.add(rect1);
 	Rectangle rect1Bis = reg.getBounds();
 	if (rect1Bis.x != rect1.x || rect1Bis.y != rect1.y ||
@@ -391,16 +341,11 @@ public void test_intersectLorg_eclipse_swt_graphics_Rectangle() {
 	Rectangle rect4 = new Rectangle(48,24,10,10);
 	Rectangle rect5 = new Rectangle(24,20,24,10);
 
-	Region reg = new Region(display);
-	reg.dispose();
-	try {
-		reg.intersect(rect1);
-		fail("no exception thrown on disposed region");
-	}
-	catch (SWTException e) {
-	}
+	Region disposedRegion = new Region(display);
+	disposedRegion.dispose();
+	assertThrows(SWTException.class, () -> disposedRegion.intersect(rect1), "no exception thrown on disposed region");
 
-	reg = new Region(display);
+	Region reg = new Region(display);
 	reg.intersect(rect1);
 	if (!reg.isEmpty()) {
 		reg.dispose();
@@ -447,20 +392,14 @@ public void test_intersectLorg_eclipse_swt_graphics_Rectangle() {
 
 @Test
 public void test_intersectLorg_eclipse_swt_graphics_Region() {
-	Region reg = new Region(display);
 	Region reg1 = new Region(display);
 	reg1.add(new Rectangle(0,0,48,24));
 
-	reg.dispose();
-	try {
-		reg.intersect(reg1);
-		reg1.dispose();
-		fail("no exception thrown on disposed region");
-	}
-	catch (SWTException e) {
-	}
+	Region disposedRegion = new Region(display);
+	disposedRegion.dispose();
+	assertThrows(SWTException.class, () -> disposedRegion.intersect(reg1), "no exception thrown on disposed region");
 
-	reg = new Region(display);
+	Region reg = new Region(display);
 	reg.intersect(reg1);
 	if (!reg.isEmpty()) {
 		reg.dispose();
@@ -548,16 +487,11 @@ public void test_intersectsIIII() {
 	Rectangle rectNotInter12 = new Rectangle(40,50,5,15);
 
 
-	Region reg = new Region(display);
-	reg.dispose();
-	try {
-		reg.intersects(rectInter1.x, rectInter1.y, rectInter1.width, rectInter1.height);
-		fail("no exception thrown on disposed region");
-	}
-	catch (Exception e) {
-	}
+	Region disposedRegion = new Region(display);
+	disposedRegion.dispose();
+	assertThrows(Exception.class, () -> disposedRegion.intersects(rectInter1.x, rectInter1.y, rectInter1.width, rectInter1.height), "no exception thrown on disposed region");
 
-	reg = new Region(display);
+	Region reg = new Region(display);
 	if (reg.intersects(rect1.x, rect1.y, rect1.width, rect1.height)) {
 		reg.dispose();
 		fail("intersects can't return true on empty region");
@@ -603,16 +537,11 @@ public void test_intersectsLorg_eclipse_swt_graphics_Rectangle() {
 	Rectangle rectNotInter12 = new Rectangle(40,50,5,15);
 
 
-	Region reg = new Region(display);
-	reg.dispose();
-	try {
-		reg.intersects(rectInter1);
-		fail("no exception thrown on disposed region");
-	}
-	catch (Exception e) {
-	}
+	Region disposedRegion = new Region(display);
+	disposedRegion.dispose();
+	assertThrows(Exception.class, () -> disposedRegion.intersects(rectInter1), "no exception thrown on disposed region");
 
-	reg = new Region(display);
+	Region reg = new Region(display);
 	if (reg.intersects(rect1)) {
 		reg.dispose();
 		fail("intersects can't return true on empty region");
@@ -682,25 +611,12 @@ public void test_isEmpty() {
 
 @Test
 public void test_subtract$I() {
-	Region reg = new Region(display);
-	try {
-		reg.subtract((int[])null);
-		reg.dispose();
-		fail("no exception thrown for subtract a null array");
-	}
-	catch (IllegalArgumentException e) {
-	}
-	reg.dispose();
-	try {
-		reg.subtract(new int[]{});
-		reg.dispose();
-		fail("no exception thrown on disposed region");
-	}
-	catch (SWTException e) {
-	}
-	reg.dispose();
+	Region emptyRegion = new Region(display);
+	assertThrows(IllegalArgumentException.class, () -> emptyRegion.subtract((int[]) null), "no exception thrown for subtract a null array");
+	emptyRegion.dispose();
+	assertThrows(SWTException.class, () -> emptyRegion.subtract(new int[]{}), "no exception thrown on disposed region");
 
-	reg = new Region(display);
+	Region reg = new Region(display);
 	reg.add(new int[] {0,0, 50,0, 50,25, 0,25});
 	reg.subtract(new int[] {0,0, 50,0, 50,20, 0,20});
 	Rectangle box = reg.getBounds();
@@ -731,16 +647,11 @@ public void test_subtractLorg_eclipse_swt_graphics_Rectangle() {
 	Rectangle rect4 = new Rectangle(50,25,10,10);
 	Rectangle rect5 = new Rectangle(0,0,60,20);
 
-	Region reg = new Region(display);
-	reg.dispose();
-	try {
-		reg.subtract(rect1);
-		fail("no exception thrown on disposed region");
-	}
-	catch (SWTException e) {
-	}
+	Region disposedRegion = new Region(display);
+	disposedRegion.dispose();
+	assertThrows(SWTException.class, () -> disposedRegion.subtract(rect1), "no exception thrown on disposed region");
 
-	reg = new Region(display);
+	Region reg = new Region(display);
 	reg.subtract(rect1);
 	if (!reg.isEmpty()) {
 		reg.dispose();
@@ -791,17 +702,11 @@ public void test_subtractLorg_eclipse_swt_graphics_Region() {
 	Region reg1 = new Region(display);
 	reg1.add(new Rectangle(0,0,50,25));
 
-	Region reg = new Region(display);
-	reg.dispose();
-	try {
-		reg.subtract(reg1);
-		reg1.dispose();
-		fail("no exception thrown on disposed region");
-	}
-	catch (SWTException e) {
-	}
+	Region disposedRegion = new Region(display);
+	disposedRegion.dispose();
+	assertThrows(SWTException.class, () -> disposedRegion.subtract(reg1), "no exception thrown on disposed region");
 
-	reg = new Region(display);
+	Region reg = new Region(display);
 	reg.subtract(reg1);
 	if (!reg.isEmpty()) {
 		reg.dispose();

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Button.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Button.java
@@ -17,8 +17,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
@@ -75,12 +75,7 @@ public void test_ConstructorLorg_eclipse_swt_widgets_CompositeI() {
 
 	new Button(shell, SWT.PUSH | SWT.CHECK);
 
-	try {
-		new Button(null, 0);
-		fail("No exception thrown for parent == null");
-	}
-	catch (IllegalArgumentException e) {
-	}
+	assertThrows(IllegalArgumentException.class, () -> new Button(null, 0), "No exception thrown for parent == null");
 }
 
 @Test
@@ -96,21 +91,13 @@ public void test_addSelectionListenerLorg_eclipse_swt_events_SelectionListener()
 		}
 	};
 
-	try {
-		button.addSelectionListener(null);
-		fail("No exception thrown for addSelectionListener with null argument");
-	} catch (IllegalArgumentException e) {
-	}
+	assertThrows(IllegalArgumentException.class, () -> button.addSelectionListener(null), "No exception thrown for addSelectionListener with null argument");
 
 	button.addSelectionListener(listener);
 	button.notifyListeners(SWT.Selection, new Event());
 	assertTrue(listenerCalled);
 
-	try {
-		button.removeSelectionListener(null);
-		fail("No exception thrown for removeSelectionListener with null argument");
-	} catch (IllegalArgumentException e) {
-	}
+	assertThrows(IllegalArgumentException.class, () -> button.removeSelectionListener(null), "No exception thrown for removeSelectionListener with null argument");
 	listenerCalled = false;
 	button.removeSelectionListener(listener);
 	button.notifyListeners(SWT.Selection, new Event());
@@ -362,26 +349,21 @@ public void test_setForegroundAlphaRadiokButton() {
 
 @Test
 public void test_setImageLorg_eclipse_swt_graphics_Image() {
-	Image image = button.getImage();
-	button.setImage(image);
-	assertEquals(image, button.getImage());
+	Image initialImage = button.getImage();
+	button.setImage(initialImage);
+	assertEquals(initialImage, button.getImage());
 
 	button.setImage(null);
 	assertNull(button.getImage());
 
 	ImageGcDrawer noOpGcDrawer = (gc, width, height) -> {};
-	image = new Image(shell.getDisplay(), noOpGcDrawer, 10, 10);
+	Image image = new Image(shell.getDisplay(), noOpGcDrawer, 10, 10);
 	button.setImage(image);
 	assertEquals(image, button.getImage());
 
 	button.setImage(null);
 	image.dispose();
-	try {
-		button.setImage(image);
-		button.setImage(null);
-		fail("No exception thrown for disposed image");
-	} catch (IllegalArgumentException e) {
-	}
+	assertThrows(IllegalArgumentException.class, () -> button.setImage(image), "No exception thrown for disposed image");
 }
 
 @Test
@@ -435,12 +417,7 @@ public void test_setTextLjava_lang_String() {
 		assertEquals(cases[i], button.getText());
 	}
 
-	try {
-		button.setText(null);
-		fail("No exception thrown for text == null");
-	}
-	catch (IllegalArgumentException e) {
-	}
+	assertThrows(IllegalArgumentException.class, () -> button.setText(null), "No exception thrown for text == null");
 
 	button.setText("");
 }

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Canvas.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Canvas.java
@@ -16,7 +16,7 @@ package org.eclipse.swt.tests.junit;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Font;
@@ -55,12 +55,7 @@ protected void setWidget(Widget w) {
 @Override
 @Test
 public void test_ConstructorLorg_eclipse_swt_widgets_CompositeI() {
-	try {
-		new Canvas(null, SWT.NONE);
-		fail("No exception thrown for parent == null");
-	}
-	catch (IllegalArgumentException e) {
-	}
+	assertThrows(IllegalArgumentException.class, () -> new Canvas(null, SWT.NONE), "No exception thrown for parent == null");
 }
 
 @Test

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Combo.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Combo.java
@@ -20,7 +20,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import java.util.concurrent.atomic.AtomicInteger;
@@ -1061,12 +1060,7 @@ public void test_consistency_Segments () {
 		}
 		listenerCalled = true;
 	};
-	try {
-		combo.addSegmentListener(null);
-		fail("No exception thrown for addSegmentListener(null)");
-	}
-	catch (IllegalArgumentException e) {
-	}
+	assertThrows(IllegalArgumentException.class, () -> combo.addSegmentListener(null), "No exception thrown for addSegmentListener(null)");
 	combo.addSegmentListener(sl1);
 	doSegmentsTest(true);
 

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Composite.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Composite.java
@@ -15,8 +15,8 @@ package org.eclipse.swt.tests.junit;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -55,12 +55,7 @@ public void setUp() {
 @Override
 @Test
 public void test_ConstructorLorg_eclipse_swt_widgets_CompositeI() {
-	try {
-		composite = new Composite(null, 0);
-		fail("No exception thrown");
-	}
-	catch (IllegalArgumentException e) {
-	}
+	assertThrows(IllegalArgumentException.class, () -> new Composite(null, 0), "No exception thrown for parent == null");
 
 	int[] cases = {SWT.H_SCROLL, SWT.V_SCROLL, SWT.H_SCROLL | SWT.V_SCROLL};
 	for (int style : cases)

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_CoolItem.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_CoolItem.java
@@ -16,8 +16,8 @@ package org.eclipse.swt.tests.junit;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Point;
@@ -51,30 +51,15 @@ public void test_ConstructorLorg_eclipse_swt_widgets_CoolBarI() {
 	CoolBar coolBar = new CoolBar(shell, 0);
 	new CoolItem(coolBar, 0);
 
-	try {
-		new CoolItem(null, 0);
-		fail("No exception thrown for parent == null");
-	}
-	catch (IllegalArgumentException e) {
-	}
+	assertThrows(IllegalArgumentException.class, () -> new CoolItem(null, 0), "No exception thrown for parent == null");
 }
 
 @Test
 public void test_ConstructorLorg_eclipse_swt_widgets_CoolBarII() {
 	CoolBar coolBar = new CoolBar(shell, 0);
 	CoolItem coolItem = new CoolItem(coolBar, 0, 0);
-	try {
-		coolItem = new CoolItem(coolBar, 0, -1);
-		fail("No exception thrown for index == -1");
-	}
-	catch (IllegalArgumentException e){
-	}
-	try {
-		coolItem = new CoolItem(coolBar, 0, 2);
-		fail("No exception thrown for index == 2");
-	}
-	catch (IllegalArgumentException e){
-	}
+	assertThrows(IllegalArgumentException.class, () -> new CoolItem(coolBar, 0, -1), "No exception thrown for index == -1");
+	assertThrows(IllegalArgumentException.class, () -> new CoolItem(coolBar, 0, 2), "No exception thrown for index == 2");
 	assertEquals(1, coolBar.getItemCount());
 	coolItem = new CoolItem(coolBar, 0, 1);
 	assertEquals(2, coolBar.getItemCount());
@@ -198,22 +183,12 @@ public void test_setControlLorg_eclipse_swt_widgets_Control() {
 		assertEquals(size2, coolItem.getSize());
 	}
 
-	button = new Button(coolBar, SWT.PUSH);
-	button.dispose();
-	try {
-		coolItem.setControl(button);
-		fail("No exception when control.isDisposed()");
-	}
-	catch (IllegalArgumentException e) {
-	}
+	Button disposedButton = new Button(coolBar, SWT.PUSH);
+	disposedButton.dispose();
+	assertThrows(IllegalArgumentException.class, () -> coolItem.setControl(disposedButton), "No exception when control.isDisposed()");
 
-	button = new Button(shell, SWT.PUSH);
-	try {
-		coolItem.setControl(button);
-		fail("No exception thrown when control has wrong parent");
-	}
-	catch (IllegalArgumentException e) {
-	}
+	Button wrongParentButton = new Button(shell, SWT.PUSH);
+	assertThrows(IllegalArgumentException.class, () -> coolItem.setControl(wrongParentButton), "No exception thrown when control has wrong parent");
 }
 
 @Test

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_ExpandBar.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_ExpandBar.java
@@ -18,7 +18,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -132,12 +131,7 @@ public void test_addExpandListenerItemExpandedAdapterLorg_eclipse_swt_events_Exp
 @Override
 @Test
 public void test_ConstructorLorg_eclipse_swt_widgets_CompositeI() {
-	try {
-		new ExpandBar(null, 0);
-		fail("No exception thrown for parent == null");
-	}
-	catch (IllegalArgumentException e) {
-	}
+	assertThrows(IllegalArgumentException.class, () -> new ExpandBar(null, 0), "No exception thrown for parent == null");
 }
 
 @Test
@@ -161,17 +155,11 @@ public void test_getItemI() {
 	}
 
 	expandBar = new ExpandBar(shell, 0);
-	number = 5;
 	items = new ExpandItem[number];
 	for (int i = 0; i<number ; i++){
 		items[i] = new ExpandItem(expandBar, 0);
 	}
-	try {
-		expandBar.getItem(number);
-		fail("No exception thrown for illegal index argument");
-	}
-	catch (IllegalArgumentException e) {
-	}
+	assertThrows(IllegalArgumentException.class, () -> expandBar.getItem(number), "No exception thrown for illegal index argument");
 }
 
 @Test
@@ -209,12 +197,7 @@ public void test_indexOfLorg_eclipse_swt_widgets_ExpandItem() {
 		items[i] = new ExpandItem(expandBar, 0);
 	}
 	for (int i = 0; i < number; i++) {
-		try {
-			expandBar.indexOf(null);
-			fail("No exception thrown for expandItem == null");
-		}
-		catch (IllegalArgumentException e) {
-		}
+		assertThrows(IllegalArgumentException.class, () -> expandBar.indexOf(null), "No exception thrown for expandItem == null");
 	}
 }
 

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_ExpandItem.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_ExpandItem.java
@@ -15,8 +15,8 @@ package org.eclipse.swt.tests.junit;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Button;
@@ -44,12 +44,7 @@ public void setUp() {
 
 @Test
 public void test_ConstructorLorg_eclipse_swt_widgets_ExpandItemI() {
-	try {
-		new ExpandItem(null, SWT.NULL);
-		fail("No exception thrown for parent == null");
-	}
-	catch (IllegalArgumentException e) {
-	}
+	assertThrows(IllegalArgumentException.class, () -> new ExpandItem(null, SWT.NULL), "No exception thrown for parent == null");
 }
 
 @Test
@@ -88,22 +83,12 @@ public void test_setControlLorg_eclipse_swt_widgets_Control() {
 	Button button = new Button(expandBar, SWT.PUSH);
 	expandItem.setControl(button);
 
-	button = new Button(expandBar, SWT.PUSH);
-	button.dispose();
-	try {
-		expandItem.setControl(button);
-		fail("No exception when control.isDisposed()");
-	}
-	catch (IllegalArgumentException e) {
-	}
+	Button disposedButton = new Button(expandBar, SWT.PUSH);
+	disposedButton.dispose();
+	assertThrows(IllegalArgumentException.class, () -> expandItem.setControl(disposedButton), "No exception when control.isDisposed()");
 
-	button = new Button(shell, SWT.PUSH);
-	try {
-		expandItem.setControl(button);
-		fail("No exception thrown when control has wrong parent");
-	}
-	catch (IllegalArgumentException e) {
-	}
+	Button wrongParentButton = new Button(shell, SWT.PUSH);
+	assertThrows(IllegalArgumentException.class, () -> expandItem.setControl(wrongParentButton), "No exception thrown when control has wrong parent");
 }
 
 @Test
@@ -138,11 +123,7 @@ public void test_setImageLorg_eclipse_swt_graphics_Image() {
 public void test_setTextLjava_lang_String() {
 	expandItem.setText("ABCDEFG");
 	assertEquals("ABCDEFG", expandItem.getText());
-	try {
-		expandItem.setText(null);
-		fail("No exception thrown for addArmListener with null argument");
-	} catch (IllegalArgumentException e) {
-	}
+	assertThrows(IllegalArgumentException.class, () -> expandItem.setText(null), "No exception thrown for addArmListener with null argument");
 	expandItem.setText("ABCDEFG");
 	assertTrue(expandItem.getText().startsWith("ABCDEFG"));
 }

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_List.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_List.java
@@ -18,7 +18,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.SWTError;
@@ -50,11 +49,7 @@ public void setUp() {
 @Override
 @Test
 public void test_ConstructorLorg_eclipse_swt_widgets_CompositeI() {
-	try {
-		list = new List(null, 0);
-		fail("No exception thrown"); //should never get here
-	} catch (IllegalArgumentException e) {
-	}
+	assertThrows(IllegalArgumentException.class, () -> new List(null, 0), "No exception thrown for parent == null");
 
 	int[] cases =
 		{
@@ -70,11 +65,7 @@ public void test_ConstructorLorg_eclipse_swt_widgets_CompositeI() {
 
 @Test
 public void test_addLjava_lang_String() {
-	try {
-		list.add(null);
-		fail("No exception thrown");
-	} catch (IllegalArgumentException e) {
-	}
+	assertThrows(IllegalArgumentException.class, () -> list.add(null), "No exception thrown");
 	list.add("");
 	assertArrayEquals(new String[] {""}, list.getItems());
 	list.add("some \n text");
@@ -86,11 +77,7 @@ public void test_addLjava_lang_String() {
 
 	setSingleList();
 
-	try {
-		list.add(null);
-		fail("No exception thrown");
-	} catch (IllegalArgumentException e) {
-	}
+	assertThrows(IllegalArgumentException.class, () -> list.add(null), "No exception thrown");
 
 	list.add("");
 	assertArrayEquals(new String[] {""}, list.getItems());
@@ -102,11 +89,7 @@ public void test_addLjava_lang_String() {
 
 @Test
 public void test_addLjava_lang_StringI() {
-	try {
-		list.add("some text", 2);
-		fail("No exception thrown");
-	} catch (IllegalArgumentException e) {
-	}
+	assertThrows(IllegalArgumentException.class, () -> list.add("some text", 2), "No exception thrown");
 	assertEquals(0, list.getItemCount());
 
 	list.add("", 0);
@@ -116,27 +99,15 @@ public void test_addLjava_lang_StringI() {
 	list.add("some text", 0);
 	assertArrayEquals(new String[] {"some text", "", "some \n text" }, list.getItems());
 
-	try {
-		list.add(null, 0);
-		fail("No exception thrown string == null");
-	} catch (IllegalArgumentException e) {
-	}
+	assertThrows(IllegalArgumentException.class, () -> list.add(null, 0), "No exception thrown string == null");
 
-	try {
-		list.add("string", -1);
-		fail("No exception thrown index < 0");
-	} catch (IllegalArgumentException e) {
-	}
+	assertThrows(IllegalArgumentException.class, () -> list.add("string", -1), "No exception thrown index < 0");
 
 	// test single-selection list
 
 	setSingleList();
 
-	try {
-		list.add("some text", 2);
-		fail("No exception thrown");
-	} catch (IllegalArgumentException e) {
-	}
+	assertThrows(IllegalArgumentException.class, () -> list.add("some text", 2), "No exception thrown");
 
 	assertEquals(0, list.getItemCount());
 
@@ -147,17 +118,9 @@ public void test_addLjava_lang_StringI() {
 	list.add("some text", 0);
 	assertArrayEquals(new String[] {"some text", "", "some \n text" }, list.getItems());
 
-	try {
-		list.add(null, 0);
-		fail("No exception thrown string == null");
-	} catch (IllegalArgumentException e) {
-	}
+	assertThrows(IllegalArgumentException.class, () -> list.add(null, 0), "No exception thrown string == null");
 
-	try {
-		list.add("string", -1);
-		fail("No exception thrown index < 0");
-	} catch (IllegalArgumentException e) {
-	}
+	assertThrows(IllegalArgumentException.class, () -> list.add("string", -1), "No exception thrown index < 0");
 }
 
 @Test
@@ -226,11 +189,7 @@ public void test_deselect$I() {
 	list.setItems(items);
 	list.setSelection(items);
 	assertArrayEquals(list.getSelection(), items);
-	try {
-		list.deselect(null);
-		fail("No exception thrown");
-	} catch (IllegalArgumentException e) {
-	}
+	assertThrows(IllegalArgumentException.class, () -> list.deselect(null), "No exception thrown");
 	assertArrayEquals(list.getSelection(), items);
 	list.deselect(new int[] {
 	});
@@ -250,11 +209,7 @@ public void test_deselect$I() {
 	list.setItems(items);
 	list.setSelection(new String[] { "item3" });
 	assertArrayEquals(list.getSelection(), new String[] { "item3" });
-	try {
-		list.deselect(null);
-		fail("No exception thrown");
-	} catch (IllegalArgumentException e) {
-	}
+	assertThrows(IllegalArgumentException.class, () -> list.deselect(null), "No exception thrown");
 
 	assertArrayEquals(list.getSelection(), new String[] { "item3" });
 	list.deselect(new int[] {});
@@ -481,34 +436,18 @@ public void test_getItemHeight() {
 public void test_getItemI() {
 	String[] items = { "item0", "item1", "item2", "item3" };
 	list.setItems(items);
-	try {
-		list.getItem(5);
-		fail("No exception thrown");
-	} catch (IllegalArgumentException e) {
-	}
+	assertThrows(IllegalArgumentException.class, () -> list.getItem(5), "No exception thrown");
 
-	try {
-		list.getItem(-1);
-		fail("No exception thrown for index < 0");
-	} catch (IllegalArgumentException e) {
-	}
+	assertThrows(IllegalArgumentException.class, () -> list.getItem(-1), "No exception thrown for index < 0");
 
 	assertEquals(list.getItem(3), "item3");
 
 
 	setSingleList();
 	list.setItems(items);
-	try {
-		list.getItem(5);
-		fail("No exception thrown");
-	} catch (IllegalArgumentException e) {
-	}
+	assertThrows(IllegalArgumentException.class, () -> list.getItem(5), "No exception thrown");
 
-	try {
-		list.getItem(-1);
-		fail("No exception thrown for index < 0");
-	} catch (IllegalArgumentException e) {
-	}
+	assertThrows(IllegalArgumentException.class, () -> list.getItem(-1), "No exception thrown for index < 0");
 
 	//assert(":a:", list.getItem(5)==null);
 	assertEquals("item3", list.getItem(3));
@@ -615,11 +554,7 @@ public void test_getSelectionCount() {
 	assertEquals(3, list.getSelectionCount());
 
 	list.deselectAll();
-	try {
-		list.setSelection((String[]) null);
-		fail("No exception thrown for selection == null");
-	} catch (IllegalArgumentException e) {
-	}
+	assertThrows(IllegalArgumentException.class, () -> list.setSelection((String[]) null), "No exception thrown for selection == null");
 	assertEquals(list.getSelectionCount(), 0);
 
 
@@ -748,11 +683,7 @@ public void test_indexOfLjava_lang_String() {
 	assertEquals(list.indexOf("text3"), 2);
 	assertEquals(list.indexOf("text4"), -1);
 
-	try {
-		list.indexOf(null);
-		fail("No exception thrown for item == null");
-	} catch (IllegalArgumentException e) {
-	}
+	assertThrows(IllegalArgumentException.class, () -> list.indexOf(null), "No exception thrown for item == null");
 
 	String[] items2 = { "text1", "text2", "text2" }; //two identical
 
@@ -772,11 +703,7 @@ public void test_indexOfLjava_lang_String() {
 	assertEquals(-1, list.indexOf("text4"));
 
 
-	try {
-		list.indexOf(null);
-		fail("No exception thrown");
-	} catch (IllegalArgumentException e) {
-	}
+	assertThrows(IllegalArgumentException.class, () -> list.indexOf(null), "No exception thrown");
 
 
 	assertEquals(1, list.indexOf("text2"));
@@ -797,11 +724,7 @@ public void test_indexOfLjava_lang_StringI() {
 	list.setItems(items2);
 	assertEquals(list.indexOf("text2", 2), 2);
 
-	try {
-		list.indexOf(null, 0);
-		fail("No exception thrown for string == null");
-	} catch (IllegalArgumentException e) {
-	}
+	assertThrows(IllegalArgumentException.class, () -> list.indexOf(null, 0), "No exception thrown for string == null");
 
 	setSingleList();
 
@@ -811,11 +734,7 @@ public void test_indexOfLjava_lang_StringI() {
 	assertEquals(1, list.indexOf("text2", 1));
 	assertEquals(2, list.indexOf("text2", 2));
 
-	try {
-		list.indexOf(null, 0);
-		fail("No exception thrown for string == null");
-	} catch (IllegalArgumentException e) {
-	}
+	assertThrows(IllegalArgumentException.class, () -> list.indexOf(null, 0), "No exception thrown for string == null");
 }
 
 @Test
@@ -845,11 +764,7 @@ public void test_isSelectedI() {
 
 @Test
 public void test_remove$I() {
-	try {
-		list.remove((int[]) null);
-		fail("No exception thrown for indices == null");
-	} catch (IllegalArgumentException e) {
-	}
+	assertThrows(IllegalArgumentException.class, () -> list.remove((int[]) null), "No exception thrown for indices == null");
 
 	String[] items = { "text0", "text1", "text2", "text3" };
 
@@ -863,35 +778,19 @@ public void test_remove$I() {
 	list.setItems(items);
 
 	// index > number of elements in list
-	try {
-		list.remove(new int[] { 4, 1});
-		fail("No exception thrown");
-	} catch (IllegalArgumentException e) {
-	}
+	assertThrows(IllegalArgumentException.class, () -> list.remove(new int[] { 4, 1}), "No exception thrown");
 	assertArrayEquals(list.getItems(), items);
 
-	try {
-		list.remove(new int[] { 3, 1, -1 });
-		fail("No exception thrown");
-	} catch (IllegalArgumentException e) {
-	}
+	assertThrows(IllegalArgumentException.class, () -> list.remove(new int[] { 3, 1, -1 }), "No exception thrown");
 	assertArrayEquals(list.getItems(), items);
 
 	list.setItems(items);
 	assertEquals(list.getItemCount(), 4);
 
-	try {
-		list.remove(new int[] { -1, -1 });
-		fail("No exception thrown");
-	} catch (IllegalArgumentException e) {
-	}
+	assertThrows(IllegalArgumentException.class, () -> list.remove(new int[] { -1, -1 }), "No exception thrown");
 	assertArrayEquals(list.getItems(), items);
 
-	try {
-		list.remove(new int[] { -2, -1 });
-		fail("No exception thrown");
-	} catch (IllegalArgumentException e) {
-	}
+	assertThrows(IllegalArgumentException.class, () -> list.remove(new int[] { -2, -1 }), "No exception thrown");
 	assertArrayEquals(list.getItems(), items);
 
 	list.setItems(items);
@@ -909,12 +808,7 @@ public void test_remove$I() {
 
 	setSingleList();
 
-	try {
-		int[] indices = null;
-		list.remove(indices);
-		fail("No exception thrown for indices == null");
-	} catch (IllegalArgumentException e) {
-	}
+	assertThrows(IllegalArgumentException.class, () -> list.remove((int[]) null), "No exception thrown for indices == null");
 
 	list.setItems(items);
 	assertEquals(4, list.getItemCount());
@@ -934,29 +828,17 @@ public void test_remove$I() {
 	assertEquals(4, list.getItemCount());
 
 	// index > number of elements in list
-	try {
-		list.remove(new int[] { 4, 1});
-		fail("No exception thrown");
-	} catch (IllegalArgumentException e) {
-	}
+	assertThrows(IllegalArgumentException.class, () -> list.remove(new int[] { 4, 1}), "No exception thrown");
 	assertArrayEquals(list.getItems(), items);
 
-	try {
-		list.remove(new int[] { 3, 1, -1 });
-		fail("No exception thrown");
-	} catch (IllegalArgumentException e) {
-	}
+	assertThrows(IllegalArgumentException.class, () -> list.remove(new int[] { 3, 1, -1 }), "No exception thrown");
 	assertArrayEquals(list.getItems(), items);
 
 
 	list.setItems(items);
 	assertEquals(4, list.getItemCount());
 
-	try {
-		list.remove(new int[] { -1, -1 });
-		fail("No exception thrown");
-	} catch (IllegalArgumentException e) {
-	}
+	assertThrows(IllegalArgumentException.class, () -> list.remove(new int[] { -1, -1 }), "No exception thrown");
 
 	assertArrayEquals(items, list.getItems());
 
@@ -1003,18 +885,10 @@ public void test_removeI() {
 	list.setItems(items);
 	assertEquals(list.getItemCount(), 3);
 
-	try {
-		list.remove(3);
-		fail("No exception thrown");
-	} catch (IllegalArgumentException e) {
-	}
+	assertThrows(IllegalArgumentException.class, () -> list.remove(3), "No exception thrown");
 	assertEquals(list.getItemCount(), 3);
 
-	try {
-		list.remove(-1);
-		fail("No exception thrown");
-	} catch (IllegalArgumentException e) {
-	}
+	assertThrows(IllegalArgumentException.class, () -> list.remove(-1), "No exception thrown");
 	assertEquals(list.getItemCount(), 3);
 
 	list.remove(1);
@@ -1024,19 +898,11 @@ public void test_removeI() {
 	list.setItems(items);
 	assertEquals(list.getItemCount(), 3);
 
-	try {
-		list.remove(3, 4);
-		fail("No exception thrown");
-	} catch (IllegalArgumentException e) {
-	}
+	assertThrows(IllegalArgumentException.class, () -> list.remove(3, 4), "No exception thrown");
 
 	assertEquals(list.getItemCount(), 3);
 
-	try {
-		list.remove(3, 3);
-		fail("No exception thrown");
-	} catch (IllegalArgumentException e) {
-	}
+	assertThrows(IllegalArgumentException.class, () -> list.remove(3, 3), "No exception thrown");
 
 	assertEquals(list.getItemCount(), 3);
 
@@ -1057,18 +923,10 @@ public void test_removeI() {
 	setSingleList();
 	list.setItems(items);
 	assertEquals(3, list.getItemCount());
-	try {
-		list.remove(3);
-		fail("No exception thrown");
-	} catch (IllegalArgumentException e) {
-	}
+	assertThrows(IllegalArgumentException.class, () -> list.remove(3), "No exception thrown");
 	assertEquals(3, list.getItemCount());
 	/////////////////////////////////////////////////
-	try {
-		list.remove(-1);
-		fail("No exception thrown");
-	} catch (IllegalArgumentException e) {
-	}
+	assertThrows(IllegalArgumentException.class, () -> list.remove(-1), "No exception thrown");
 
 	assertEquals(3, list.getItemCount());
 	////////////////////////////////////////////////
@@ -1097,19 +955,11 @@ public void test_removeII() {
 	list.setItems(items);
 	assertEquals(3, list.getItemCount());
 
-	try {
-		list.remove(3, 4);
-		fail("No exception thrown");
-	} catch (IllegalArgumentException e) {
-	}
+	assertThrows(IllegalArgumentException.class, () -> list.remove(3, 4), "No exception thrown");
 
 	assertEquals(3, list.getItemCount());
 
-	try {
-		list.remove(3, 3);
-		fail("No exception thrown");
-	} catch (IllegalArgumentException e) {
-	}
+	assertThrows(IllegalArgumentException.class, () -> list.remove(3, 3), "No exception thrown");
 	assertEquals(3, list.getItemCount());
 
 	list.remove(0, 0);
@@ -1119,18 +969,10 @@ public void test_removeII() {
 	list.setItems(items);
 	assertEquals(3, list.getItemCount());
 
-	try {
-		list.remove(-1, 1);
-		fail("No exception thrown for start index < 0");
-	} catch (IllegalArgumentException e) {
-	}
+	assertThrows(IllegalArgumentException.class, () -> list.remove(-1, 1), "No exception thrown for start index < 0");
 	assertEquals(3, list.getItemCount());
 
-	try {
-		list.remove(3, 4);
-		fail("No exception thrown");
-	} catch (IllegalArgumentException e) {
-	}
+	assertThrows(IllegalArgumentException.class, () -> list.remove(3, 4), "No exception thrown");
 	assertEquals(3, list.getItemCount());
 
 	list.remove(0, 2);
@@ -1139,11 +981,7 @@ public void test_removeII() {
 	list.setItems(items);
 	assertEquals(3, list.getItemCount());
 
-	try {
-		list.remove(3, 3);
-		fail("No exception thrown");
-	} catch (IllegalArgumentException e) {
-	}
+	assertThrows(IllegalArgumentException.class, () -> list.remove(3, 3), "No exception thrown");
 	assertEquals(3, list.getItemCount());
 
 	list.remove(2, 0);
@@ -1155,28 +993,16 @@ public void test_removeII() {
 	list.setItems(items);
 	assertEquals(3, list.getItemCount());
 	//////////////////////////////////////////////////////////////
-	try {
-		list.remove(3, 4);
-		fail("No exception thrown");
-	} catch (IllegalArgumentException e) {
-	}
+	assertThrows(IllegalArgumentException.class, () -> list.remove(3, 4), "No exception thrown");
 
 	assertEquals(3, list.getItemCount());
 	/////////////////////////////////////////////////////////
-	try {
-		list.remove(3, 3);
-		fail("No exception thrown");
-	} catch (IllegalArgumentException e) {
-	}
+	assertThrows(IllegalArgumentException.class, () -> list.remove(3, 3), "No exception thrown");
 
 	assertEquals(3, list.getItemCount());
 	//////////////////////////////////////////////////////////////
 
-	try {
-		list.remove(-1, 1);
-		fail("No exception thrown for start index < 0");
-	} catch (IllegalArgumentException e) {
-	}
+	assertThrows(IllegalArgumentException.class, () -> list.remove(-1, 1), "No exception thrown for start index < 0");
 	assertEquals(3, list.getItemCount());
 
 	list.remove(1, 2);
@@ -1187,11 +1013,7 @@ public void test_removeII() {
 	list.setItems(items);
 	assertEquals(3, list.getItemCount());
 
-	try {
-		list.remove(2, 10);
-		fail("No exception thrown");
-	} catch (IllegalArgumentException e) {
-	}
+	assertThrows(IllegalArgumentException.class, () -> list.remove(2, 10), "No exception thrown");
 	assertEquals(3, list.getItemCount());
 	assertEquals("text2", list.getItem(1));
 
@@ -1206,18 +1028,10 @@ public void test_removeLjava_lang_String() {
 	list.setItems(items);
 	assertEquals(list.getItemCount(), 4);
 
-	try {
-		list.remove((String) null);
-		fail("No exception thrown");
-	} catch (IllegalArgumentException e) {
-	}
+	assertThrows(IllegalArgumentException.class, () -> list.remove((String) null), "No exception thrown");
 	assertEquals(list.getItemCount(), 4);
 
-	try {
-		list.remove("items989");
-		fail("No exception thrown");
-	} catch (IllegalArgumentException e) {
-	}
+	assertThrows(IllegalArgumentException.class, () -> list.remove("items989"), "No exception thrown");
 	assertEquals(list.getItemCount(), 4);
 
 	list.setItems(items);
@@ -1234,18 +1048,10 @@ public void test_removeLjava_lang_String() {
 	list.setItems(items);
 	assertEquals(4, list.getItemCount());
 
-	try {
-		list.remove((String) null);
-		fail("No exception thrown");
-	} catch (IllegalArgumentException e) {
-	}
+	assertThrows(IllegalArgumentException.class, () -> list.remove((String) null), "No exception thrown");
 	assertEquals(4, list.getItemCount());
 	////////////////////////////////////////
-	try {
-		list.remove("items989");
-		fail("No exception thrown");
-	} catch (IllegalArgumentException e) {
-	}
+	assertThrows(IllegalArgumentException.class, () -> list.remove("items989"), "No exception thrown");
 	assertEquals(4, list.getItemCount());
 
 
@@ -1261,11 +1067,7 @@ public void test_removeLjava_lang_String() {
 
 @Test
 public void test_select$I() {
-	try {
-		list.select((int[]) null);
-		fail("No exception thrown");
-	} catch (IllegalArgumentException e) {
-	}
+	assertThrows(IllegalArgumentException.class, () -> list.select((int[]) null), "No exception thrown");
 
 	String[] items = { "item0", "item1", "item2", "item3" };
 	list.setItems(items);
@@ -1317,11 +1119,7 @@ public void test_select$I() {
 	setSingleList();
 	list.setItems(items);
 
-	try {
-		list.select((int[]) null);
-		fail("No exception thrown");
-	} catch (IllegalArgumentException e) {
-	}
+	assertThrows(IllegalArgumentException.class, () -> list.select((int[]) null), "No exception thrown");
 
 	list.select(new int[]{ -1 });
 	assertArrayEquals(list.getSelectionIndices(), new int[] {});
@@ -1600,30 +1398,18 @@ public void test_setItemILjava_lang_String() {
 	assertEquals(list.getItemCount(), 0);
 	int[] cases = { -10, 0, 10 };
 	for (int index : cases) {
-		try {
-			list.setItem(index, null);
-			fail("No exception thrown");
-		} catch (IllegalArgumentException e) {
-		}
+		assertThrows(IllegalArgumentException.class, () -> list.setItem(index, null), "No exception thrown");
 	}
 	assertEquals(list.getItemCount(), 0);
 
 	for (int index : cases) {
-		try {
-			list.setItem(index, "");
-			fail("No exception thrown");
-		} catch (IllegalArgumentException e) {
-		}
+		assertThrows(IllegalArgumentException.class, () -> list.setItem(index, ""), "No exception thrown");
 	}
 	assertEquals(list.getItemCount(), 0);
 
 	int cases2[] = { 10, 15, 0 };
 	for (int index : cases2) {
-		try {
-			list.setItem(index, "fred");
-			fail("No exception thrown");
-		} catch (IllegalArgumentException e) {
-		}
+		assertThrows(IllegalArgumentException.class, () -> list.setItem(index, "fred"), "No exception thrown");
 		assertEquals(list.getItemCount(), 0);
 	}
 
@@ -1634,22 +1420,14 @@ public void test_setItemILjava_lang_String() {
 	setSingleList();
 	assertEquals(0, list.getItemCount());
 	for (int index : cases) {
-		try {
-			list.setItem(index, null);
-			fail("No exception thrown");
-		} catch (IllegalArgumentException e) {
-		}
+		assertThrows(IllegalArgumentException.class, () -> list.setItem(index, null), "No exception thrown");
 
 	}
 
 
 	setSingleList();
 	for (int index : cases) {
-		try {
-			list.setItem(index, "");
-			fail("No exception thrown");
-		} catch (IllegalArgumentException e) {
-		}
+		assertThrows(IllegalArgumentException.class, () -> list.setItem(index, ""), "No exception thrown");
 	}
 
 	assertEquals(0, list.getItemCount());
@@ -1657,11 +1435,7 @@ public void test_setItemILjava_lang_String() {
 
 	setSingleList();
 	for (int index : cases2) {
-		try {
-			list.setItem(index, "fred");
-			fail("No exception thrown");
-		} catch (IllegalArgumentException e) {
-		}
+		assertThrows(IllegalArgumentException.class, () -> list.setItem(index, "fred"), "No exception thrown");
 
 		assertEquals(0, list.getItemCount());
 	}
@@ -1674,11 +1448,7 @@ public void test_setItemILjava_lang_String() {
 
 @Test
 public void test_setItems$Ljava_lang_String() {
-	try {
-		list.setItems((String[])null);
-		fail("No exception thrown for items == null");
-	} catch (IllegalArgumentException e) {
-	}
+	assertThrows(IllegalArgumentException.class, () -> list.setItems((String[])null), "No exception thrown for items == null");
 
 	// TODO An SWTError should never happen and should not
 	// be part of the test case.  List should throw an
@@ -1705,11 +1475,7 @@ public void test_setItems$Ljava_lang_String() {
 		assertArrayEquals(items, list.getItems());
 	}
 
-	try {
-		list.setItems((String[])null);
-		fail("No exception thrown");
-	} catch (IllegalArgumentException e) {
-	}
+	assertThrows(IllegalArgumentException.class, () -> list.setItems((String[])null), "No exception thrown");
 
 
 	setSingleList();
@@ -1719,11 +1485,7 @@ public void test_setItems$Ljava_lang_String() {
 	}
 
 
-	try {
-		list.setItems((String[])null);
-		fail("No exception thrown");
-	} catch (IllegalArgumentException e) {
-	}
+	assertThrows(IllegalArgumentException.class, () -> list.setItems((String[])null), "No exception thrown");
 }
 
 @Test
@@ -1735,11 +1497,7 @@ public void test_setSelection$I() {
 	list.setSelection(new int [0]);
 	assertArrayEquals(list.getSelectionIndices(), new int[0]);
 
-	try {
-		list.setSelection((int[]) null);
-		fail("No exception thrown for MULTI: setSelection((int[]) null)");
-	} catch (IllegalArgumentException e) {
-	}
+	assertThrows(IllegalArgumentException.class, () -> list.setSelection((int[]) null), "No exception thrown for MULTI: setSelection((int[]) null)");
 
 	list.setSelection(new int [] {2});
 	assertArrayEquals(list.getSelectionIndices(), new int[] {2});
@@ -1793,11 +1551,7 @@ public void test_setSelection$I() {
 	assertArrayEquals(list.getSelectionIndices(), new int[0]);
 	assertEquals(list.getFocusIndex(), -1);
 
-	try {
-		list.setSelection((int[]) null);
-		fail("No exception thrown for EMPTY MULTI: setSelection((int[]) null)");
-	} catch (IllegalArgumentException e) {
-	}
+	assertThrows(IllegalArgumentException.class, () -> list.setSelection((int[]) null), "No exception thrown for EMPTY MULTI: setSelection((int[]) null)");
 
 	list.setSelection(new int [] {0});
 	assertArrayEquals(list.getSelectionIndices(), new int[0]);
@@ -1827,11 +1581,7 @@ public void test_setSelection$I() {
 	list.setSelection(new int [0]);
 	assertArrayEquals(list.getSelectionIndices(), new int[0]);
 
-	try {
-		list.setSelection((int[]) null);
-		fail("No exception thrown for SINGLE: setSelection((int[]) null)");
-	} catch (IllegalArgumentException e) {
-	}
+	assertThrows(IllegalArgumentException.class, () -> list.setSelection((int[]) null), "No exception thrown for SINGLE: setSelection((int[]) null)");
 
 	list.setSelection(new int [] {2});
 	assertArrayEquals(list.getSelectionIndices(), new int[] {2});
@@ -1880,11 +1630,7 @@ public void test_setSelection$I() {
 	assertArrayEquals(list.getSelectionIndices(), new int[0]);
 	assertEquals(list.getFocusIndex(), -1);
 
-	try {
-		list.setSelection((int[]) null);
-		fail("No exception thrown for EMPTY SINGLE: setSelection((int[]) null)");
-	} catch (IllegalArgumentException e) {
-	}
+	assertThrows(IllegalArgumentException.class, () -> list.setSelection((int[]) null), "No exception thrown for EMPTY SINGLE: setSelection((int[]) null)");
 
 	list.setSelection(new int [] {0});
 	assertArrayEquals(list.getSelectionIndices(), new int[0]);
@@ -1919,11 +1665,7 @@ public void test_setSelection$Ljava_lang_String() {
 		assertEquals(list.getFocusIndex(), -1);
 	}
 
-	try {
-		list.setSelection((String[]) null);
-		fail("No exception thrown");
-	} catch (IllegalArgumentException e) {
-	}
+	assertThrows(IllegalArgumentException.class, () -> list.setSelection((String[]) null), "No exception thrown");
 
 	list.setSelection(new String [] {"fred 2"});
 	assertArrayEquals(list.getSelection(), new String [] {"fred 2"});
@@ -1966,11 +1708,7 @@ public void test_setSelection$Ljava_lang_String() {
 	assertArrayEquals(list.getSelection(), new String[0]);
 	assertEquals(list.getFocusIndex(), -1);
 
-	try {
-		list.setSelection((String[]) null);
-		fail("No exception thrown");
-	} catch (IllegalArgumentException e) {
-	}
+	assertThrows(IllegalArgumentException.class, () -> list.setSelection((String[]) null), "No exception thrown");
 
 	list.setSelection(new String [] {"fred 0"});
 	assertArrayEquals(list.getSelection(), new String[0]);
@@ -1988,11 +1726,7 @@ public void test_setSelection$Ljava_lang_String() {
 	list.setSelection(new String [0]);
 	assertArrayEquals(list.getSelection(), new String[0]);
 
-	try {
-		list.setSelection((String[]) null);
-		fail("No exception thrown");
-	} catch (IllegalArgumentException e) {
-	}
+	assertThrows(IllegalArgumentException.class, () -> list.setSelection((String[]) null), "No exception thrown");
 
 	list.setSelection(new String [] {"fred 2"});
 	assertArrayEquals(list.getSelection(), new String[] {"fred 2"});
@@ -2032,11 +1766,7 @@ public void test_setSelection$Ljava_lang_String() {
 	assertArrayEquals(list.getSelection(), new String[0]);
 	assertEquals(list.getFocusIndex(), -1);
 
-	try {
-		list.setSelection((String[]) null);
-		fail("No exception thrown");
-	} catch (IllegalArgumentException e) {
-	}
+	assertThrows(IllegalArgumentException.class, () -> list.setSelection((String[]) null), "No exception thrown");
 
 	list.setSelection(new String [] {"fred 0"});
 	assertArrayEquals(list.getSelection(), new String[0]);

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_TabFolder.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_TabFolder.java
@@ -15,8 +15,8 @@ package org.eclipse.swt.tests.junit;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -48,12 +48,7 @@ public void setUp() {
 @Override
 @Test
 public void test_ConstructorLorg_eclipse_swt_widgets_CompositeI() {
-	try {
-		new TabFolder(null, 0);
-		fail("No exception thrown for parent == null");
-	}
-	catch (IllegalArgumentException e) {
-	}
+	assertThrows(IllegalArgumentException.class, () -> new TabFolder(null, 0), "No exception thrown for parent == null");
 }
 
 @Override
@@ -108,26 +103,11 @@ public void test_getItemI() {
 	for (int i = 0; i < number; i++) {
 		assertEquals(items[i], tabFolder.getItem(i));
 	}
-	try {
-		tabFolder.getItem(number);
-		fail("No exception thrown for illegal index argument");
-	}
-	catch (IllegalArgumentException e) {
-	}
+	assertThrows(IllegalArgumentException.class, () -> tabFolder.getItem(number), "No exception thrown for illegal index argument");
 
-	try {
-		tabFolder.getItem(number+1);
-		fail("No exception thrown for illegal index argument");
-	}
-	catch (IllegalArgumentException e) {
-	}
+	assertThrows(IllegalArgumentException.class, () -> tabFolder.getItem(number+1), "No exception thrown for illegal index argument");
 
-	try {
-		tabFolder.getItem(-1);
-		fail("No exception thrown for index == -1");
-	}
-	catch (IllegalArgumentException e) {
-	}
+	assertThrows(IllegalArgumentException.class, () -> tabFolder.getItem(-1), "No exception thrown for index == -1");
 }
 
 @Test
@@ -226,12 +206,7 @@ public void test_indexOfLorg_eclipse_swt_widgets_TabItem() {
 		tis[i] = new TabItem(tabFolder, 0);
 	}
 	for (int i = 0; i<number ; i++){
-		try {
-			tabFolder.indexOf(null);
-			fail("No exception thrown for tabItem == null");
-		}
-		catch (IllegalArgumentException e) {
-		}
+		assertThrows(IllegalArgumentException.class, () -> tabFolder.indexOf(null), "No exception thrown for tabItem == null");
 	}
 
 	//
@@ -312,25 +287,11 @@ public void test_setSelectionI() {
 	TabItem[] items = new TabItem[number];
 	for (int i = 0; i < number; i++)
 		items[i] = new TabItem(tabFolder, 0);
-	try {
-		tabFolder.setSelection((TabItem) null);
-		fail("No exception thrown for selection == null");
-	}
-	catch (IllegalArgumentException e) {
-	}
-	finally {
-		assertArrayEquals(new TabItem[]{items[0]}, tabFolder.getSelection());
-	}
+	assertThrows(IllegalArgumentException.class, () -> tabFolder.setSelection((TabItem) null), "No exception thrown for selection == null");
+	assertArrayEquals(new TabItem[]{items[0]}, tabFolder.getSelection());
 
-	try {
-		tabFolder.setSelection((TabItem[]) null);
-		fail("No exception thrown for selection == null");
-	}
-	catch (IllegalArgumentException e) {
-	}
-	finally {
-		assertArrayEquals(new TabItem[]{items[0]}, tabFolder.getSelection());
-	}
+	assertThrows(IllegalArgumentException.class, () -> tabFolder.setSelection((TabItem[]) null), "No exception thrown for selection == null");
+	assertArrayEquals(new TabItem[]{items[0]}, tabFolder.getSelection());
 
 	//
 	makeCleanEnvironment();
@@ -390,18 +351,12 @@ public void test_setSelectionI() {
 	//
 	makeCleanEnvironment();
 
+	TabItem[] recreatedItems = new TabItem[number];
 	for (int i = 0; i < number; i++)
-		items[i] = new TabItem(tabFolder, 0);
-	try {
-		tabFolder.setSelection( new TabItem[]{items[0], null});
-		tabFolder.setSelection( new TabItem[]{null});
-		fail("No exception thrown for selection == null");
-	}
-	catch (IllegalArgumentException e) {
-	}
-	finally {
-		assertArrayEquals(new TabItem[]{items[0]}, tabFolder.getSelection());
-	}
+		recreatedItems[i] = new TabItem(tabFolder, 0);
+	assertThrows(IllegalArgumentException.class, () -> tabFolder.setSelection(new TabItem[]{recreatedItems[0], null}), "No exception thrown for a null item in the selection");
+	assertThrows(IllegalArgumentException.class, () -> tabFolder.setSelection(new TabItem[]{null}), "No exception thrown for selection == null");
+	assertArrayEquals(new TabItem[]{recreatedItems[0]}, tabFolder.getSelection());
 }
 
 /* custom */

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Table.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Table.java
@@ -18,8 +18,8 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -51,12 +51,7 @@ public void setUp() {
 @Override
 @Test
 public void test_ConstructorLorg_eclipse_swt_widgets_CompositeI() {
-	try {
-		new Table(null, 0);
-		fail("No exception thrown for parent == null");
-	}
-	catch (IllegalArgumentException e) {
-	}
+	assertThrows(IllegalArgumentException.class, () -> new Table(null, 0), "No exception thrown for parent == null");
 }
 
 @Override
@@ -92,12 +87,7 @@ public void test_deselect$I() {
 	table.selectAll();
 	assertEquals(number, table.getSelectionCount());
 
-	try{
-		table.deselect(null);
-		fail("No exception thrown for selection == null");
-	}
-	catch (IllegalArgumentException e) {
-	}
+	assertThrows(IllegalArgumentException.class, () -> table.deselect(null), "No exception thrown for selection == null");
 	assertEquals(number, table.getSelectionCount());
 	table.selectAll();
 
@@ -257,36 +247,16 @@ public void test_getColumnCount() {
 
 @Test
 public void test_getColumnI() {
-	try {
-		table.getColumn(0);
-		fail("No exception thrown for index out of range");
-	}
-	catch (IllegalArgumentException e) {
-	}
+	assertThrows(IllegalArgumentException.class, () -> table.getColumn(0), "No exception thrown for index out of range");
 	TableColumn column0 = new TableColumn(table, SWT.LEFT);
-	try {
-		table.getColumn(1);
-		fail("No exception thrown for index out of range");
-	}
-	catch (IllegalArgumentException e) {
-	}
+	assertThrows(IllegalArgumentException.class, () -> table.getColumn(1), "No exception thrown for index out of range");
 	assertEquals(column0, table.getColumn(0));
 	TableColumn column1 = new TableColumn(table, SWT.LEFT);
 	assertEquals(column1, table.getColumn(1));
 	column1.dispose();
-	try {
-		table.getColumn(1);
-		fail("No exception thrown for index out of range");
-	}
-	catch (IllegalArgumentException e) {
-	}
+	assertThrows(IllegalArgumentException.class, () -> table.getColumn(1), "No exception thrown for index out of range");
 	column0.dispose();
-	try {
-		table.getColumn(0);
-		fail("No exception thrown for index out of range");
-	}
-	catch (IllegalArgumentException e) {
-	}
+	assertThrows(IllegalArgumentException.class, () -> table.getColumn(0), "No exception thrown for index out of range");
 }
 
 @Test
@@ -372,19 +342,9 @@ public void test_getItemI() {
 
 	for (int i = 0; i < number; i++)
 		assertEquals(items[i], table.getItem(i));
-	try {
-		table.getItem(number);
-		fail("No exception thrown for illegal index argument");
-	}
-	catch (IllegalArgumentException e) {
-	}
+	assertThrows(IllegalArgumentException.class, () -> table.getItem(number), "No exception thrown for illegal index argument");
 
-	try {
-		table.getItem(number+1);
-		fail("No exception thrown for illegal index argument");
-	}
-	catch (IllegalArgumentException e) {
-	}
+	assertThrows(IllegalArgumentException.class, () -> table.getItem(number+1), "No exception thrown for illegal index argument");
 
 	// note: SWT.SINGLE
 	makeCleanEnvironment(true);
@@ -394,19 +354,9 @@ public void test_getItemI() {
 	for (int i = 0; i < number; i++) {
 		assertEquals(items[i], table.getItem(i));
 	}
-	try {
-		table.getItem(number);
-		fail("No exception thrown for illegal index argument");
-	}
-	catch (IllegalArgumentException e) {
-	}
+	assertThrows(IllegalArgumentException.class, () -> table.getItem(number), "No exception thrown for illegal index argument");
 
-	try {
-		table.getItem(number+1);
-		fail("No exception thrown for illegal index argument");
-	}
-	catch (IllegalArgumentException e) {
-	}
+	assertThrows(IllegalArgumentException.class, () -> table.getItem(number+1), "No exception thrown for illegal index argument");
 }
 
 @Test
@@ -640,12 +590,7 @@ public void test_indexOfLorg_eclipse_swt_widgets_TableItem() {
 	}
 
 	for (int i = 0; i < number; i++) {
-		try {
-			table.indexOf((TableItem)null);
-			fail("No exception thrown for tableItem == null");
-		}
-		catch (IllegalArgumentException e) {
-		}
+		assertThrows(IllegalArgumentException.class, () -> table.indexOf((TableItem)null), "No exception thrown for tableItem == null");
 	}
 
 	// another table
@@ -683,12 +628,7 @@ public void test_indexOfLorg_eclipse_swt_widgets_TableItem() {
 	}
 
 	for (int i = 0; i < number; i++) {
-		try {
-			table.indexOf((TableItem)null);
-			fail("No exception thrown for tableItem == null");
-		}
-		catch (IllegalArgumentException e) {
-		}
+		assertThrows(IllegalArgumentException.class, () -> table.indexOf((TableItem)null), "No exception thrown for tableItem == null");
 	}
 
 	makeCleanEnvironment(true);
@@ -767,26 +707,11 @@ public void test_remove$I() {
 	TableItem[] items = new TableItem[number];
 	for (int i = 0; i < number; i++)
 		items[i] = new TableItem(table, 0);
-	try {
-		table.remove(null);
-		fail("No exception thrown for tableItems == null");
-	}
-	catch (IllegalArgumentException e) {
-	}
+	assertThrows(IllegalArgumentException.class, () -> table.remove(null), "No exception thrown for tableItems == null");
 
-	try {
-		table.remove(new int[] {2, 1, 0, -100, 5, 5, 2, 1, 0, 0, 0});
-		fail("No exception thrown for illegal index arguments");
-	}
-	catch (IllegalArgumentException e) {
-	}
+	assertThrows(IllegalArgumentException.class, () -> table.remove(new int[] {2, 1, 0, -100, 5, 5, 2, 1, 0, 0, 0}), "No exception thrown for illegal index arguments");
 
-	try {
-		table.remove(new int[] {2, 1, 0, number, 5, 5, 2, 1, 0, 0, 0});
-		fail("No exception thrown for illegal index arguments");
-	}
-	catch (IllegalArgumentException e) {
-	}
+	assertThrows(IllegalArgumentException.class, () -> table.remove(new int[] {2, 1, 0, number, 5, 5, 2, 1, 0, 0, 0}), "No exception thrown for illegal index arguments");
 
 	table.remove(new int[] {});
 
@@ -847,10 +772,7 @@ public void test_removeII() {
 	TableItem[] items = new TableItem[number];
 	for (int i = 0; i < number; i++)
 		items[i] = new TableItem(table, 0);
-	try {
-		table.remove(-number, number + 100);
-		fail("No exception thrown for illegal index range");
-	} catch (IllegalArgumentException e) {}
+	assertThrows(IllegalArgumentException.class, () -> table.remove(-number, number + 100), "No exception thrown for illegal index range");
 
 	makeCleanEnvironment(false);
 
@@ -871,10 +793,7 @@ public void test_removeII() {
 	items = new TableItem[number];
 	for (int i = 0; i < number; i++)
 		items[i] = new TableItem(table, 0);
-	try {
-		table.remove(2, 100);
-		fail("No exception thrown for illegal index range");
-	} catch (IllegalArgumentException e) {}
+	assertThrows(IllegalArgumentException.class, () -> table.remove(2, 100), "No exception thrown for illegal index range");
 	assertArrayEquals(items, table.getItems());
 
 	makeCleanEnvironment(false);
@@ -882,10 +801,7 @@ public void test_removeII() {
 	items = new TableItem[number];
 	for (int i = 0; i < number; i++)
 		items[i] = new TableItem(table, 0);
-	try {
-		table.remove(2, number);
-		fail("No exception thrown for illegal index range");
-	} catch (IllegalArgumentException e) {}
+	assertThrows(IllegalArgumentException.class, () -> table.remove(2, number), "No exception thrown for illegal index range");
 	assertArrayEquals(items, table.getItems());
 
 	makeCleanEnvironment(false);
@@ -937,20 +853,14 @@ public void test_removeII() {
 
 	for (int i = 0; i < number; i++)
 		items[i] = new TableItem(table, 0);
-	try {
-		table.remove(-20, -10);
-		fail("No exception thrown for illegal index range");
-	} catch (IllegalArgumentException e) {}
+	assertThrows(IllegalArgumentException.class, () -> table.remove(-20, -10), "No exception thrown for illegal index range");
 	assertArrayEquals(items, table.getItems());
 
 	makeCleanEnvironment(false);
 
 	for (int i = 0; i < number; i++)
 		items[i] = new TableItem(table, 0);
-	try {
-		table.remove(20, 40);
-		fail("No exception thrown for illegal index range");
-	} catch (IllegalArgumentException e) {}
+	assertThrows(IllegalArgumentException.class, () -> table.remove(20, 40), "No exception thrown for illegal index range");
 	assertArrayEquals(items, table.getItems());
 
 	makeCleanEnvironment(false);
@@ -998,10 +908,7 @@ public void test_removeII() {
 	for (int i = 0; i < number; i++)
 		items[i] = new TableItem(table, 0);
 	assertEquals(number, table.getItemCount());
-	try {
-		table.remove(-10, 2);
-		fail("No exception thrown for illegal index range");
-	} catch (IllegalArgumentException e) {}
+	assertThrows(IllegalArgumentException.class, () -> table.remove(-10, 2), "No exception thrown for illegal index range");
 	assertEquals(number, table.getItemCount());
 	if (SwtTestUtil.fCheckSWTPolicy) {
 		table.remove(10, 2);
@@ -1016,10 +923,7 @@ public void test_removeII() {
 	for (int i = 3; i < number; i++) {
 		assertFalse(items[i].isDisposed());
 	}
-	try {
-		table.remove(1, 200);
-		fail("No exception thrown for illegal index range");
-	} catch (IllegalArgumentException e) {}
+	assertThrows(IllegalArgumentException.class, () -> table.remove(1, 200), "No exception thrown for illegal index range");
 	assertEquals(number - 3, table.getItemCount());
 	assertArrayEquals(new TableItem[] {items[3], items[4]}, table.getItems());
 
@@ -1038,29 +942,23 @@ public void test_removeII() {
 
 	for (int i = 0; i < number; i++)
 		items[i] = new TableItem(table, 0);
-	try {
-		table.remove(number, number);
-		fail("No exception thrown for illegal index range");
-	} catch (IllegalArgumentException e) {}
+	assertThrows(IllegalArgumentException.class, () -> table.remove(number, number), "No exception thrown for illegal index range");
 
 	makeCleanEnvironment(false);
 
 	for (int i = 0; i < number; i++)
 		items[i] = new TableItem(table, 0);
-	try {
-		table.remove(number, number + 100);
-		fail("No exception thrown for illegal index range");
-	} catch (IllegalArgumentException e) {}
+	assertThrows(IllegalArgumentException.class, () -> table.remove(number, number + 100), "No exception thrown for illegal index range");
 
 	makeCleanEnvironment(false);
 
-	number = 15;
-	items = new TableItem[number];
-	for (int i = 0; i < number; i++)
+	int largerNumber = 15;
+	items = new TableItem[largerNumber];
+	for (int i = 0; i < largerNumber; i++)
 		items[i] = new TableItem(table, 0);
 
 	table.remove(new int[] {2, 1, 0, 5, 5});
-	assertEquals(number-4, table.getItemCount());
+	assertEquals(largerNumber-4, table.getItemCount());
 	assertTrue(items[0].isDisposed());
 	assertTrue(items[1].isDisposed());
 	assertTrue(items[2].isDisposed());
@@ -1071,12 +969,7 @@ public void test_removeII() {
 
 @Test
 public void test_select$I() {
-	try {
-		table.select(null);
-		fail("No exception thrown for selection == null");
-	}
-	catch (IllegalArgumentException e) {
-	}
+	assertThrows(IllegalArgumentException.class, () -> table.select(null), "No exception thrown for selection == null");
 
 	int number = 15;
 	TableItem[] items = new TableItem[number];
@@ -1128,15 +1021,8 @@ public void test_select$I() {
 	for (int i = 0; i < number; i++)
 		items[i] = new TableItem(table, 0);
 
-	try {
-		table.select(null);
-		fail("No exception thrown for selection == null");
-	}
-	catch (IllegalArgumentException e) {
-	}
-	finally {
-		assertEquals(0, table.getSelectionCount());
-	}
+	assertThrows(IllegalArgumentException.class, () -> table.select(null), "No exception thrown for selection == null");
+	assertEquals(0, table.getSelectionCount());
 
 	table.select(new int[] {0});
 	assertArrayEquals(new int[] {0}, table.getSelectionIndices());
@@ -1329,69 +1215,33 @@ public void test_setColumnOrder$I() {
 	assertArrayEquals(table.getColumnOrder(), new int[0]);
 	table.setColumnOrder(new int[0]);
 	assertArrayEquals(table.getColumnOrder(), new int[0]);
-	try {
-		table.setColumnOrder(null);
-		fail("No exception thrown for null argument");
-	} catch (IllegalArgumentException ex) {}
-	try {
-		table.setColumnOrder(new int[1]);
-		fail("No exception thrown for invalid argument");
-	} catch (IllegalArgumentException ex) {}
+	assertThrows(IllegalArgumentException.class, () -> table.setColumnOrder(null), "No exception thrown for null argument");
+	assertThrows(IllegalArgumentException.class, () -> table.setColumnOrder(new int[1]), "No exception thrown for invalid argument");
 
 	TableColumn column0 = new TableColumn(table, SWT.NONE);
 	TableColumn column1 = new TableColumn(table, SWT.NONE);
 	TableColumn column2 = new TableColumn(table, SWT.NONE);
 	assertArrayEquals(table.getColumnOrder(), new int[]{0, 1, 2});
-	try {
-		table.setColumnOrder(null);
-		fail("No exception thrown for null argument");
-	} catch (IllegalArgumentException ex) {}
-	try {
-		table.setColumnOrder(new int[0]);
-		fail("No exception thrown for invalid argument");
-	} catch (IllegalArgumentException ex) {}
-	try {
-		table.setColumnOrder(new int[]{0,1});
-		fail("No exception thrown for invalid argument");
-	} catch (IllegalArgumentException ex) {}
-	try {
-		table.setColumnOrder(new int[]{0, 1, 2, 3});
-		fail("No exception thrown for invalid argument");
-	} catch (IllegalArgumentException ex) {}
-	try {
-		table.setColumnOrder(new int[]{0, 0, 1});
-		fail("No exception thrown for invalid argument");
-	} catch (IllegalArgumentException ex) {}
-	try {
-		table.setColumnOrder(new int[]{3, 0, 1});
-		fail("No exception thrown for invalid argument");
-	} catch (IllegalArgumentException ex) {}
+	assertThrows(IllegalArgumentException.class, () -> table.setColumnOrder(null), "No exception thrown for null argument");
+	assertThrows(IllegalArgumentException.class, () -> table.setColumnOrder(new int[0]), "No exception thrown for invalid argument");
+	assertThrows(IllegalArgumentException.class, () -> table.setColumnOrder(new int[]{0,1}), "No exception thrown for invalid argument");
+	assertThrows(IllegalArgumentException.class, () -> table.setColumnOrder(new int[]{0, 1, 2, 3}), "No exception thrown for invalid argument");
+	assertThrows(IllegalArgumentException.class, () -> table.setColumnOrder(new int[]{0, 0, 1}), "No exception thrown for invalid argument");
+	assertThrows(IllegalArgumentException.class, () -> table.setColumnOrder(new int[]{3, 0, 1}), "No exception thrown for invalid argument");
 	table.setColumnOrder(new int[]{2, 1, 0});
 	assertArrayEquals(table.getColumnOrder(), new int[] {2, 1, 0});
 	column2.dispose();
 	assertArrayEquals(table.getColumnOrder(), new int[] {1, 0});
-	try {
-		table.setColumnOrder(new int[]{0, 1, 2});
-		fail("No exception thrown for invalid argument");
-	} catch (IllegalArgumentException ex) {}
+	assertThrows(IllegalArgumentException.class, () -> table.setColumnOrder(new int[]{0, 1, 2}), "No exception thrown for invalid argument");
 	column1.dispose();
 	assertArrayEquals(table.getColumnOrder(), new int[]{0});
 	column0.dispose();
 	assertArrayEquals(table.getColumnOrder(), new int[0]);
-	try {
-		table.setColumnOrder(new int[1]);
-		fail("No exception thrown for invalid argument");
-	} catch (IllegalArgumentException ex) {}
+	assertThrows(IllegalArgumentException.class, () -> table.setColumnOrder(new int[1]), "No exception thrown for invalid argument");
 	Table table2 = new Table(table.getParent(), SWT.NONE);
 	table2.dispose();
-	try {
-		table2.getColumnOrder();
-		fail("No exception thrown for widget is Disposed");
-	} catch (SWTException ex) {}
-	try {
-		table2.setColumnOrder(new int[0]);
-		fail("No exception thrown for widget is Disposed");
-	} catch (SWTException ex) {}
+	assertThrows(SWTException.class, () -> table2.getColumnOrder(), "No exception thrown for widget is Disposed");
+	assertThrows(SWTException.class, () -> table2.setColumnOrder(new int[0]), "No exception thrown for widget is Disposed");
 }
 
 @Override
@@ -1456,23 +1306,13 @@ public void test_setItemCountI() {
 	assertEquals(4, table.indexOf(table.getItems()[4]));
 	table.setItemCount(3);
 	assertEquals(3, table.getItemCount());
-	try {
-		table.getItem(4);
-		fail("No exception thrown for illegal index argument");
-	}
-	catch (IllegalArgumentException e) {
-	}
+	assertThrows(IllegalArgumentException.class, () -> table.getItem(4), "No exception thrown for illegal index argument");
 	table.setItemCount(40);
 	assertEquals(40, table.getItemCount());
 	table.getItem(39);
 	table.setItemCount(0);
 	assertEquals(0, table.getItemCount());
-	try {
-		table.getItem(39);
-		fail("No exception thrown for illegal index argument");
-	}
-	catch (IllegalArgumentException e) {
-	}
+	assertThrows(IllegalArgumentException.class, () -> table.getItem(39), "No exception thrown for illegal index argument");
 }
 
 @Test
@@ -1495,12 +1335,7 @@ public void test_setSelection$I() {
 	TableItem[] items = new TableItem[number];
 	for (int i = 0; i < number; i++)
 		items[i] = new TableItem(table, 0);
-	try {
-		table.setSelection((int[]) null);
-		fail("No exception thrown for selection == null");
-	}
-	catch (IllegalArgumentException e) {
-	}
+	assertThrows(IllegalArgumentException.class, () -> table.setSelection((int[]) null), "No exception thrown for selection == null");
 
 	table.setSelection(new int[]{});
 	assertArrayEquals(new int[]{}, table.getSelectionIndices());
@@ -1532,15 +1367,8 @@ public void test_setSelection$I() {
 	for (int i = 0; i < number; i++)
 		items[i] = new TableItem(table, 0);
 
-	try {
-		table.setSelection((int[]) null);
-		fail("No exception thrown for selection range == null");
-	}
-	catch (IllegalArgumentException e) {
-	}
-	finally {
-		assertEquals(0, table.getSelectionCount());
-	}
+	assertThrows(IllegalArgumentException.class, () -> table.setSelection((int[]) null), "No exception thrown for selection range == null");
+	assertEquals(0, table.getSelectionCount());
 
 	table.setSelection(new int[] {});
 	assertArrayEquals(new int[] {}, table.getSelectionIndices());
@@ -1579,25 +1407,11 @@ public void test_setSelection$Lorg_eclipse_swt_widgets_TableItem() {
 	TableItem[] items = new TableItem[number];
 	for (int i = 0; i < number; i++)
 		items[i] = new TableItem(table, 0);
-	try {
-		table.setSelection((TableItem[]) null);
-		fail("No exception thrown for selection range == null");
-	}
-	catch (IllegalArgumentException e) {
-	}
-	finally {
-		assertEquals(0, table.getSelectionCount());
-	}
+	assertThrows(IllegalArgumentException.class, () -> table.setSelection((TableItem[]) null), "No exception thrown for selection range == null");
+	assertEquals(0, table.getSelectionCount());
 
-	try {
-		table.setSelection((TableItem) null);
-		fail("No exception thrown for selection == null");
-	}
-	catch (IllegalArgumentException e) {
-	}
-	finally {
-		assertEquals(0, table.getSelectionCount());
-	}
+	assertThrows(IllegalArgumentException.class, () -> table.setSelection((TableItem) null), "No exception thrown for selection == null");
+	assertEquals(0, table.getSelectionCount());
 
 	table.setSelection(new TableItem[]{});
 	assertEquals(0, table.getSelectionCount());

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_TableColumn.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_TableColumn.java
@@ -15,8 +15,8 @@ package org.eclipse.swt.tests.junit;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.SWTException;
@@ -47,46 +47,21 @@ public void setUp() {
 
 @Test
 public void test_ConstructorLorg_eclipse_swt_widgets_TableI() {
-	try {
-		new TableColumn(null, SWT.NULL);
-		fail("No exception thrown for parent == null");
-	}
-	catch (IllegalArgumentException e) {
-	}
+	assertThrows(IllegalArgumentException.class, () -> new TableColumn(null, SWT.NULL), "No exception thrown for parent == null");
 }
 
 @Test
 public void test_ConstructorLorg_eclipse_swt_widgets_TableII() {
-	try {
-		new TableColumn(null, SWT.NULL, 0);
-		fail("No exception thrown for parent == null");
-	}
-	catch (IllegalArgumentException e) {
-	}
+	assertThrows(IllegalArgumentException.class, () -> new TableColumn(null, SWT.NULL, 0), "No exception thrown for parent == null");
 
-	try {
-		new TableColumn(table, SWT.NULL, -1);
-		fail("No exception thrown for index == -1");
-	}
-	catch (IllegalArgumentException e) {
-	}
+	assertThrows(IllegalArgumentException.class, () -> new TableColumn(table, SWT.NULL, -1), "No exception thrown for index == -1");
 
-	try {
-		new TableColumn(table, SWT.NULL, 2);
-		fail("No exception thrown for illegal index argument");
-	}
-	catch (IllegalArgumentException e) {
-	}
+	assertThrows(IllegalArgumentException.class, () -> new TableColumn(table, SWT.NULL, 2), "No exception thrown for illegal index argument");
 }
 
 @Test
 public void test_addSelectionListenerLorg_eclipse_swt_events_SelectionListener() {
-	try {
-		tableColumn.addSelectionListener(null);
-		fail("No exception thrown for selectionListener == null");
-	}
-	catch (IllegalArgumentException e) {
-	}
+	assertThrows(IllegalArgumentException.class, () -> tableColumn.addSelectionListener(null), "No exception thrown for selectionListener == null");
 }
 
 @Test
@@ -138,12 +113,7 @@ public void test_removeSelectionListenerLorg_eclipse_swt_events_SelectionListene
 	tableColumn.removeSelectionListener(listener);
 	tableColumn.addSelectionListener(listener);
 	tableColumn.removeSelectionListener(listener);
-	try {
-		tableColumn.removeSelectionListener(null);
-		fail("No exception thrown for selectionListener == null");
-	}
-	catch (IllegalArgumentException e) {
-	}
+	assertThrows(IllegalArgumentException.class, () -> tableColumn.removeSelectionListener(null), "No exception thrown for selectionListener == null");
 }
 
 @Test
@@ -189,14 +159,8 @@ public void test_setMoveableZ() {
 
 	TableColumn tableColumn2 = new TableColumn(tableColumn.getParent(), SWT.NONE);
 	tableColumn2.dispose();
-	try {
-		tableColumn2.getMoveable();
-		fail("No exception thrown for widget is Disposed");
-	} catch (SWTException ex) {}
-	try {
-		tableColumn2.setMoveable(true);
-		fail("No exception thrown for widget is Disposed");
-	} catch (SWTException ex) {}
+	assertThrows(SWTException.class, () -> tableColumn2.getMoveable(), "No exception thrown for widget is Disposed");
+	assertThrows(SWTException.class, () -> tableColumn2.setMoveable(true), "No exception thrown for widget is Disposed");
 }
 
 @Test
@@ -221,12 +185,7 @@ public void test_setTextLjava_lang_String() {
 	tableColumn.setText("text");
 	assertEquals(tableColumn.getText(), "text");
 
-	try {
-		tableColumn.setText(null);
-		fail("No exception thrown for column header == null");
-	}
-	catch (IllegalArgumentException e) {
-	}
+	assertThrows(IllegalArgumentException.class, () -> tableColumn.setText(null), "No exception thrown for column header == null");
 }
 
 /* custom */

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_TableItem.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_TableItem.java
@@ -18,7 +18,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Color;
@@ -440,13 +439,9 @@ public void test_setBackgroundILorg_eclipse_swt_graphics_Color() {
 	tableItem.setBackground(null);
 	assertEquals(table.getBackground(),tableItem.getBackground(0));
 
-	try {
-		Color color = new Color(255, 0, 0);
-		color.dispose();
-		tableItem.setBackground(color);
-		fail("No exception thrown for color disposed");
-	} catch (IllegalArgumentException e) {
-	}
+	Color disposedColor = new Color(255, 0, 0);
+	disposedColor.dispose();
+	assertThrows(IllegalArgumentException.class, () -> tableItem.setBackground(disposedColor), "No exception thrown for color disposed");
 }
 
 @Test
@@ -457,11 +452,7 @@ public void test_setBackgroundLorg_eclipse_swt_graphics_Color() {
 	tableItem.setBackground(null);
 	assertEquals(table.getBackground(),tableItem.getBackground());
 	color.dispose();
-	try {
-		tableItem.setBackground(color);
-		fail("No exception thrown for color disposed");
-	} catch (IllegalArgumentException e) {
-	}
+	assertThrows(IllegalArgumentException.class, () -> tableItem.setBackground(color), "No exception thrown for color disposed");
 }
 
 @Test
@@ -483,11 +474,11 @@ public void test_setCheckedZ() {
 @Test
 public void test_setFontLorg_eclipse_swt_graphics_Font() {
 	Display display = tableItem.getDisplay();
-	Font font = tableItem.getFont();
-	tableItem.setFont(font);
-	assertEquals(tableItem.getFont(), font);
+	Font initialFont = tableItem.getFont();
+	tableItem.setFont(initialFont);
+	assertEquals(tableItem.getFont(), initialFont);
 
-	font = new Font(display, SwtTestUtil.testFontName, 10, SWT.NORMAL);
+	Font font = new Font(display, SwtTestUtil.testFontName, 10, SWT.NORMAL);
 	tableItem.setFont(font);
 	assertEquals(tableItem.getFont(), font);
 
@@ -495,12 +486,7 @@ public void test_setFontLorg_eclipse_swt_graphics_Font() {
 	assertEquals(tableItem.getFont(), table.getFont());
 
 	font.dispose();
-	try {
-		tableItem.setFont(font);
-		tableItem.setFont(null);
-		fail("No exception thrown for disposed font");
-	} catch (IllegalArgumentException e) {
-	}
+	assertThrows(IllegalArgumentException.class, () -> tableItem.setFont(font), "No exception thrown for disposed font");
 }
 
 @Test
@@ -546,12 +532,7 @@ public void test_setFontILorg_eclipse_swt_graphics_Font() {
 	font.dispose();
 	font2.dispose();
 
-	try {
-		tableItem.setFont(0, font);
-		tableItem.setFont(0, null);
-		fail("No exception thrown for disposed font");
-	} catch (IllegalArgumentException e) {
-	}
+	assertThrows(IllegalArgumentException.class, () -> tableItem.setFont(0, font), "No exception thrown for disposed font");
 }
 
 @Test
@@ -593,13 +574,9 @@ public void test_setForegroundILorg_eclipse_swt_graphics_Color() {
 	tableItem.setForeground(null);
 	assertEquals(table.getForeground(),tableItem.getForeground(0));
 
-	try {
-		Color color = new Color(255, 0, 0);
-		color.dispose();
-		tableItem.setForeground(color);
-		fail("No exception thrown for color disposed");
-	} catch (IllegalArgumentException e) {
-	}
+	Color disposedColor = new Color(255, 0, 0);
+	disposedColor.dispose();
+	assertThrows(IllegalArgumentException.class, () -> tableItem.setForeground(disposedColor), "No exception thrown for color disposed");
 }
 
 @Test
@@ -610,11 +587,7 @@ public void test_setForegroundLorg_eclipse_swt_graphics_Color() {
 	tableItem.setForeground(null);
 	assertEquals(table.getForeground(),tableItem.getForeground());
 	color.dispose();
-	try {
-		tableItem.setForeground(color);
-		fail("No exception thrown for color disposed");
-	} catch (IllegalArgumentException e) {
-	}
+	assertThrows(IllegalArgumentException.class, () -> tableItem.setForeground(color), "No exception thrown for color disposed");
 }
 
 @Test
@@ -659,12 +632,7 @@ public void test_setImage$Lorg_eclipse_swt_graphics_Image() {
 	for (int i = 0; i < images.length; i++) {
 		assertEquals(images[i], tableItem.getImage(i));
 	}
-	try {
-		tableItem.setImage((Image []) null);
-		fail("No exception thrown for images == null");
-	}
-	catch (IllegalArgumentException e) {
-	}
+	assertThrows(IllegalArgumentException.class, () -> tableItem.setImage((Image []) null), "No exception thrown for images == null");
 }
 
 @Test
@@ -700,12 +668,7 @@ public void test_setImageILorg_eclipse_swt_graphics_Image() {
 	assertEquals(images[0], tableItem.getImage(0));
 
 	images[0].dispose();
-	try {
-		tableItem.setImage(0, images[0]);
-		tableItem.setImage(0, null);
-		fail("No exception thrown for disposed font");
-	} catch (IllegalArgumentException e) {
-	}
+	assertThrows(IllegalArgumentException.class, () -> tableItem.setImage(0, images[0]), "No exception thrown for disposed image");
 }
 
 @SuppressWarnings("deprecation")
@@ -727,12 +690,7 @@ public void test_setText$Ljava_lang_String() {
 	final String TestString = "test";
 	final String TestStrings[] = new String[] {TestString, TestString + "1", TestString + "2"};
 
-	try {
-		tableItem.setText((String []) null);
-		fail("No exception thrown for strings == null");
-	}
-	catch (IllegalArgumentException e) {
-	}
+	assertThrows(IllegalArgumentException.class, () -> tableItem.setText((String []) null), "No exception thrown for strings == null");
 
 	/*
 	* Test the getText/setText API with a Table that has only
@@ -820,19 +778,9 @@ public void test_setTextILjava_lang_String(){
 	assertEquals(0, tableItem.getText(-1).length());
 
 
-	try {
-		tableItem.setText(-1, null);
-		fail("No exception thrown for string == null");
-	}
-	catch (IllegalArgumentException e) {
-	}
+	assertThrows(IllegalArgumentException.class, () -> tableItem.setText(-1, null), "No exception thrown for string == null");
 
-	try {
-		tableItem.setText(0, null);
-		fail("No exception thrown for string == null");
-	}
-	catch (IllegalArgumentException e) {
-	}
+	assertThrows(IllegalArgumentException.class, () -> tableItem.setText(0, null), "No exception thrown for string == null");
 
 
 	/*

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Tree.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Tree.java
@@ -19,8 +19,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -59,12 +59,7 @@ public void setUp() {
 @Override
 @Test
 public void test_ConstructorLorg_eclipse_swt_widgets_CompositeI() {
-	try {
-		tree = new Tree(null, 0);
-		fail("No exception thrown for parent == null");
-	}
-	catch (IllegalArgumentException e) {
-	}
+	assertThrows(IllegalArgumentException.class, () -> new Tree(null, 0), "No exception thrown for parent == null");
 
 	int[] cases = {0, SWT.BORDER};
 	for (int style : cases)
@@ -126,36 +121,16 @@ public void test_getColumnCount() {
 
 @Test
 public void test_getColumnI() {
-	try {
-		tree.getColumn(0);
-		fail("No exception thrown for index out of range");
-	}
-	catch (IllegalArgumentException e) {
-	}
+	assertThrows(IllegalArgumentException.class, () -> tree.getColumn(0), "No exception thrown for index out of range");
 	TreeColumn column0 = new TreeColumn(tree, SWT.LEFT);
-	try {
-		tree.getColumn(1);
-		fail("No exception thrown for index out of range");
-	}
-	catch (IllegalArgumentException e) {
-	}
+	assertThrows(IllegalArgumentException.class, () -> tree.getColumn(1), "No exception thrown for index out of range");
 	assertEquals(column0, tree.getColumn(0));
 	TreeColumn column1 = new TreeColumn(tree, SWT.LEFT);
 	assertEquals(column1, tree.getColumn(1));
 	column1.dispose();
-	try {
-		tree.getColumn(1);
-		fail("No exception thrown for index out of range");
-	}
-	catch (IllegalArgumentException e) {
-	}
+	assertThrows(IllegalArgumentException.class, () -> tree.getColumn(1), "No exception thrown for index out of range");
 	column0.dispose();
-	try {
-		tree.getColumn(0);
-		fail("No exception thrown for index out of range");
-	}
-	catch (IllegalArgumentException e) {
-	}
+	assertThrows(IllegalArgumentException.class, () -> tree.getColumn(0), "No exception thrown for index out of range");
 }
 
 @Test
@@ -218,26 +193,11 @@ public void test_getItemI() {
 
 	for (int i = 0; i < number; i++)
 		assertEquals(items[i], tree.getItem(i));
-	try {
-		tree.getItem(number);
-		fail("No exception thrown for illegal index argument");
-	}
-	catch (IllegalArgumentException e) {
-	}
+	assertThrows(IllegalArgumentException.class, () -> tree.getItem(number), "No exception thrown for illegal index argument");
 
-	try {
-		tree.getItem(number+1);
-		fail("No exception thrown for illegal index argument");
-	}
-	catch (IllegalArgumentException e) {
-	}
+	assertThrows(IllegalArgumentException.class, () -> tree.getItem(number+1), "No exception thrown for illegal index argument");
 
-	try {
-		tree.getItem(-1);
-		fail("No exception thrown for illegal index argument");
-	}
-	catch (IllegalArgumentException e) {
-	}
+	assertThrows(IllegalArgumentException.class, () -> tree.getItem(-1), "No exception thrown for illegal index argument");
 }
 
 @Test
@@ -428,23 +388,13 @@ public void test_setItemCountI() {
 	assertEquals(4, tree.indexOf(tree.getItems()[4]));
 	tree.setItemCount(3);
 	assertEquals(3, tree.getItemCount());
-	try {
-		tree.getItem(4);
-		fail("No exception thrown for illegal index argument");
-	}
-	catch (IllegalArgumentException e) {
-	}
+	assertThrows(IllegalArgumentException.class, () -> tree.getItem(4), "No exception thrown for illegal index argument");
 	tree.setItemCount(40);
 	assertEquals(40, tree.getItemCount());
 	tree.getItem(39);
 	tree.setItemCount(0);
 	assertEquals(0, tree.getItemCount());
-	try {
-		tree.getItem(39);
-		fail("No exception thrown for illegal index argument");
-	}
-	catch (IllegalArgumentException e) {
-	}
+	assertThrows(IllegalArgumentException.class, () -> tree.getItem(39), "No exception thrown for illegal index argument");
 }
 
 @Test
@@ -484,12 +434,7 @@ public void test_setSelection$Lorg_eclipse_swt_widgets_TreeItem() {
 	assertArrayEquals(new TreeItem[] {}, tree.getSelection());
 	assertEquals(0, tree.getSelectionCount());
 
-	try {
-		tree.setSelection((TreeItem[]) null);
-		fail("No exception thrown for items == null");
-	}
-	catch (IllegalArgumentException e) {
-	}
+	assertThrows(IllegalArgumentException.class, () -> tree.setSelection((TreeItem[]) null), "No exception thrown for items == null");
 
 	tree.setSelection(new TreeItem[]{null});
 	assertEquals(0, tree.getSelectionCount());
@@ -565,12 +510,7 @@ public void test_setSelection$Lorg_eclipse_swt_widgets_TreeItem() {
 	assertArrayEquals(new TreeItem[] {}, tree.getSelection());
 	assertEquals(0, tree.getSelectionCount());
 
-	try {
-		tree.setSelection((TreeItem[]) null);
-		fail("No exception thrown for items == null");
-	}
-	catch (IllegalArgumentException e) {
-	}
+	assertThrows(IllegalArgumentException.class, () -> tree.setSelection((TreeItem[]) null), "No exception thrown for items == null");
 
 	tree.setSelection(new TreeItem[]{items[10]});
 	assertArrayEquals(new TreeItem[] {items[10]}, tree.getSelection());
@@ -641,11 +581,9 @@ public void test_setTopItemLorg_eclipse_swt_widgets_TreeItem() {
 	TreeItem top2 = tree.getTopItem();
 	shell.setVisible(false);
 	assertEquals(top, top2);
+	shell.setVisible(true);
 	try {
-		shell.setVisible(true);
-		tree.setTopItem(null);
-		fail("No exception thrown for item == null");
-	} catch (IllegalArgumentException e) {
+		assertThrows(IllegalArgumentException.class, () -> tree.setTopItem(null), "No exception thrown for item == null");
 	} finally {
 		shell.setVisible (false);
 	}
@@ -653,12 +591,7 @@ public void test_setTopItemLorg_eclipse_swt_widgets_TreeItem() {
 
 @Test
 public void test_showItemLorg_eclipse_swt_widgets_TreeItem() {
-	try {
-		tree.showItem(null);
-		fail("No exception thrown for item == null");
-	}
-	catch (IllegalArgumentException e) {
-	}
+	assertThrows(IllegalArgumentException.class, () -> tree.showItem(null), "No exception thrown for item == null");
 
 	int number = 20;
 	TreeItem[] items = new TreeItem[number];

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_TreeColumn.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_TreeColumn.java
@@ -15,8 +15,8 @@ package org.eclipse.swt.tests.junit;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 import java.util.ArrayList;
@@ -50,46 +50,21 @@ public void setUp() {
 
 @Test
 public void test_ConstructorLorg_eclipse_swt_widgets_TreeI() {
-	try {
-		new TreeColumn(null, SWT.NULL);
-		fail("No exception thrown for parent == null");
-	}
-	catch (IllegalArgumentException e) {
-	}
+	assertThrows(IllegalArgumentException.class, () -> new TreeColumn(null, SWT.NULL), "No exception thrown for parent == null");
 }
 
 @Test
 public void test_ConstructorLorg_eclipse_swt_widgets_TreeII() {
-	try {
-		new TreeColumn(null, SWT.NULL, 0);
-		fail("No exception thrown for parent == null");
-	}
-	catch (IllegalArgumentException e) {
-	}
+	assertThrows(IllegalArgumentException.class, () -> new TreeColumn(null, SWT.NULL, 0), "No exception thrown for parent == null");
 
-	try {
-		new TreeColumn(tree, SWT.NULL, -1);
-		fail("No exception thrown for index == -1");
-	}
-	catch (IllegalArgumentException e) {
-	}
+	assertThrows(IllegalArgumentException.class, () -> new TreeColumn(tree, SWT.NULL, -1), "No exception thrown for index == -1");
 
-	try {
-		new TreeColumn(tree, SWT.NULL, 2);
-		fail("No exception thrown for illegal index argument");
-	}
-	catch (IllegalArgumentException e) {
-	}
+	assertThrows(IllegalArgumentException.class, () -> new TreeColumn(tree, SWT.NULL, 2), "No exception thrown for illegal index argument");
 }
 
 @Test
 public void test_addSelectionListenerLorg_eclipse_swt_events_SelectionListener() {
-	try {
-		treeColumn.addSelectionListener(null);
-		fail("No exception thrown for selectionListener == null");
-	}
-	catch (IllegalArgumentException e) {
-	}
+	assertThrows(IllegalArgumentException.class, () -> treeColumn.addSelectionListener(null), "No exception thrown for selectionListener == null");
 }
 
 @Test
@@ -142,12 +117,7 @@ public void test_removeSelectionListenerLorg_eclipse_swt_events_SelectionListene
 	treeColumn.removeSelectionListener(listener);
 	treeColumn.addSelectionListener(listener);
 	treeColumn.removeSelectionListener(listener);
-	try {
-		treeColumn.removeSelectionListener(null);
-		fail("No exception thrown for selectionListener == null");
-	}
-	catch (IllegalArgumentException e) {
-	}
+	assertThrows(IllegalArgumentException.class, () -> treeColumn.removeSelectionListener(null), "No exception thrown for selectionListener == null");
 }
 
 @Test
@@ -200,12 +170,7 @@ public void test_setTextLjava_lang_String() {
 	treeColumn.setText("text");
 	assertEquals(treeColumn.getText(), "text");
 
-	try {
-		treeColumn.setText(null);
-		fail("No exception thrown for column header == null");
-	}
-	catch (IllegalArgumentException e) {
-	}
+	assertThrows(IllegalArgumentException.class, () -> treeColumn.setText(null), "No exception thrown for column header == null");
 }
 
 @Test


### PR DESCRIPTION
Replace the try/fail/catch idiom with assertThrows, removing the empty catch blocks it required.

Locals captured by the new lambdas that were reused as scratch variables are split into separate finals, and static imports of Assertions.fail left unused are removed.

Assisted-by: Anthropic Claude Code (claude-opus-5[1m])