### PR TITLE
[Win32] Consolidate tool bar image lists in ToolBarImageLists

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ToolBar.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ToolBar.java
@@ -55,7 +55,8 @@ public class ToolBar extends Composite {
 	ToolItem [] items;
 	ToolItem [] tabItemList;
 	boolean ignoreResize, ignoreMouse;
-	private ImageList imageList, disabledImageList, hotImageList;
+	private ToolBarImageLists imageLists;
+
 	static final long ToolBarProc;
 	static final TCHAR ToolBarClass = new TCHAR (OS.TOOLBARCLASSNAME, true);
 	static {
@@ -150,21 +151,10 @@ public ToolBar (Composite parent, int style) {
  * Note that the icon size of an image list is defined by the first image added to it.
  */
 int addImage(Rectangle imageBounds, Image image, Image hotImage, Image disabledImage) {
-	int listStyle = style & SWT.RIGHT_TO_LEFT;
-	if (imageList == null) {
-		imageList = display.getImageListToolBar(listStyle, imageBounds.width, imageBounds.height, getAutoscalingZoom());
+	if (imageLists == null) {
+		imageLists = createImageLists(imageBounds.width, imageBounds.height);
 	}
-	if (hotImageList == null) {
-		hotImageList = display.getImageListToolBarHot(listStyle, imageBounds.width, imageBounds.height,
-				getAutoscalingZoom());
-	}
-	if (disabledImageList == null) {
-		disabledImageList = display.getImageListToolBarDisabled(listStyle, imageBounds.width, imageBounds.height,
-				getAutoscalingZoom());
-	}
-	int index = imageList.add(image);
-	hotImageList.add(hotImage);
-	disabledImageList.add(disabledImage);
+	int index = imageLists.add(image, hotImage, disabledImage);
 	refreshImageLists(true);
 	return index;
 }
@@ -225,8 +215,20 @@ public void layout (boolean changed) {
 	super.layout(changed);
 }
 
+private void clearAndReleaseImageLists() {
+	if (imageLists != null) {
+		OS.SendMessage(handle, OS.TB_SETIMAGELIST, 0, 0);
+		OS.SendMessage(handle, OS.TB_SETHOTIMAGELIST, 0, 0);
+		OS.SendMessage(handle, OS.TB_SETDISABLEDIMAGELIST, 0, 0);
+		imageLists.release();
+		imageLists = null;
+	}
+}
+
 void clearImage(int index) {
-	putImage(index, null, null, null);
+	if (imageLists != null) {
+		imageLists.clear(index);
+	}
 }
 
 void clearSizeCache(boolean changed) {
@@ -405,6 +407,10 @@ void createHandle () {
 	OS.SendMessage (handle, OS.TB_SETEXTENDEDSTYLE, 0, bits);
 }
 
+private ToolBarImageLists createImageLists(int width, int height) {
+	return ToolBarImageLists.create(display, style & SWT.RIGHT_TO_LEFT, width, height, getAutoscalingZoom());
+}
+
 void createItem (ToolItem item, int index) {
 	int count = (int)OS.SendMessage (handle, OS.TB_BUTTONCOUNT, 0, 0);
 	if (!(0 <= index && index <= count)) error (SWT.ERROR_INVALID_RANGE);
@@ -470,9 +476,9 @@ void destroyItem (ToolItem item) {
 	* an image and one is never assigned, this is not a problem.
 	*/
 	if ((info.fsStyle & OS.BTNS_SEP) == 0 && info.iImage != OS.I_IMAGENONE) {
-		if (imageList != null) imageList.put (info.iImage, null);
-		if (hotImageList != null) hotImageList.put (info.iImage, null);
-		if (disabledImageList != null) disabledImageList.put (info.iImage, null);
+		if (imageLists != null) {
+			imageLists.clear(info.iImage);
+		}
 	}
 	OS.SendMessage (handle, OS.TB_DELETEBUTTON, index, 0);
 	if (item.id == lastFocusId) lastFocusId = -1;
@@ -876,22 +882,16 @@ boolean mnemonicMatch (char ch) {
 }
 
 void putImage(int index, Image image, Image hotImage, Image disabledImage) {
-	if (imageList != null) {
-		imageList.put(index, image);
-	}
-	if (hotImageList != null) {
-		hotImageList.put(index, hotImage);
-	}
-	if (disabledImageList != null) {
-		disabledImageList.put(index, disabledImage);
+	if (imageLists != null) {
+		imageLists.put(index, image, hotImage, disabledImage);
 	}
 }
 
 private void refreshImageLists(boolean itemsChanged) {
 	int zoom = getAutoscalingZoom();
-	long imageListHandle = getImageListHandle(imageList, zoom);
-	long hotImageListHandle = getImageListHandle(hotImageList, zoom);
-	long disabledImageListHandle = getImageListHandle(disabledImageList, zoom);
+	long imageListHandle = imageLists.getImageListHandle(zoom);
+	long hotImageListHandle = imageLists.getHotImageListHandle(zoom);
+	long disabledImageListHandle = imageLists.getDisabledImageListHandle(zoom);
 	boolean imageListOutdated = isImageListOutdated(OS.TB_GETIMAGELIST, imageListHandle);
 	boolean hotImageListOutdated = isImageListOutdated(OS.TB_GETHOTIMAGELIST, hotImageListHandle);
 	boolean disabledImageListOutdated = isImageListOutdated(OS.TB_GETDISABLEDIMAGELIST, disabledImageListHandle);
@@ -917,10 +917,6 @@ private void refreshImageLists(boolean itemsChanged) {
 	}
 }
 
-private static long getImageListHandle(ImageList imageList, int zoom) {
-	return imageList != null ? imageList.getHandle(zoom) : 0;
-}
-
 private boolean isImageListOutdated(int getMessageCode, long expectedHandle) {
 	return OS.SendMessage(handle, getMessageCode, 0, 0) != expectedHandle;
 }
@@ -942,27 +938,6 @@ void releaseChildren (boolean destroy) {
 void releaseWidget () {
 	super.releaseWidget ();
 	clearAndReleaseImageLists();
-}
-
-private void clearAndReleaseImageLists() {
-	ImageList releasedImageList = imageList;
-	ImageList releasedHotImageList = hotImageList;
-	ImageList releasedDisabledImageList = disabledImageList;
-	imageList = hotImageList = disabledImageList = null;
-	refreshImageLists(false);
-	releaseImageLists(releasedImageList, releasedHotImageList, releasedDisabledImageList);
-}
-
-private void releaseImageLists(ImageList imageList, ImageList hotImageList, ImageList disabledImageList) {
-	if (imageList != null) {
-		display.releaseToolImageList (imageList);
-	}
-	if (hotImageList != null) {
-		display.releaseToolHotImageList (hotImageList);
-	}
-	if (disabledImageList != null) {
-		display.releaseToolDisabledImageList (disabledImageList);
-	}
 }
 
 @Override
@@ -1250,14 +1225,10 @@ String toolTipText (NMTTDISPINFO hdr) {
 @Override
 void updateOrientation () {
 	super.updateOrientation ();
-	if (imageList != null) {
-		Point sizeInPoints = imageList.getImageSize();
-		ImageList oldImageList = imageList;
-		ImageList oldHotImageList = hotImageList;
-		ImageList oldDisabledImageList = disabledImageList;
-		imageList = display.getImageListToolBar (style & SWT.RIGHT_TO_LEFT, sizeInPoints.x, sizeInPoints.y, getAutoscalingZoom());
-		hotImageList = display.getImageListToolBarHot (style & SWT.RIGHT_TO_LEFT, sizeInPoints.x, sizeInPoints.y, getAutoscalingZoom());
-		disabledImageList = display.getImageListToolBarDisabled (style & SWT.RIGHT_TO_LEFT, sizeInPoints.x, sizeInPoints.y, getAutoscalingZoom());
+	if (imageLists != null) {
+		Point size = imageLists.getImageSize();
+		ToolBarImageLists oldImageLists = imageLists;
+		imageLists = createImageLists(size.x, size.y);
 		TBBUTTONINFO info = new TBBUTTONINFO ();
 		info.cbSize = TBBUTTONINFO.sizeof;
 		info.dwMask = OS.TBIF_IMAGE;
@@ -1268,20 +1239,12 @@ void updateOrientation () {
 			if (item.image == null) continue;
 			OS.SendMessage (handle, OS.TB_GETBUTTONINFO, item.id, info);
 			if (info.iImage != OS.I_IMAGENONE) {
-				Image image = oldImageList.get(info.iImage);
-				Image hot = oldHotImageList.get(info.iImage);
-				Image disabled = oldDisabledImageList.get(info.iImage);
-				oldImageList.put(info.iImage, null);
-				oldHotImageList.put(info.iImage, null);
-				oldDisabledImageList.put(info.iImage, null);
-				info.iImage = imageList.add(image);
-				hotImageList.add(hot);
-				disabledImageList.add(disabled);
+				info.iImage = imageLists.moveFrom(oldImageLists, info.iImage);
 				OS.SendMessage (handle, OS.TB_SETBUTTONINFO, item.id, info);
 			}
 		}
 		refreshImageLists(false);
-		releaseImageLists(oldImageList, oldHotImageList, oldDisabledImageList);
+		oldImageLists.release();
 		OS.InvalidateRect (handle, null, true);
 	}
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ToolBarImageLists.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ToolBarImageLists.java
@@ -1,0 +1,95 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Vector Informatik GmbH and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.swt.widgets;
+
+import org.eclipse.swt.graphics.*;
+import org.eclipse.swt.internal.*;
+
+/**
+ * Owns the normal, hot and disabled image lists of a tool bar as a single unit.
+ * The three lists are always created, filled, cleared and released together, so
+ * they are of equal image size and the index returned when adding an item's
+ * images addresses that item in all three of them.
+ * <p>
+ * Synchronizing the image lists with the native tool bar is up to the owning
+ * tool bar, which retrieves the handles to set via
+ * {@link #getImageListHandle(int)} and its hot and disabled counterparts.
+ */
+class ToolBarImageLists {
+	private final Display display;
+
+	private final ImageList imageList, disabledImageList, hotImageList;
+
+	private ToolBarImageLists(Display display, ImageList imageList, ImageList hotImageList,
+			ImageList disabledImageList) {
+		this.display = display;
+		this.imageList = imageList;
+		this.hotImageList = hotImageList;
+		this.disabledImageList = disabledImageList;
+	}
+
+	static ToolBarImageLists create(Display display, int style, int width, int height, int zoom) {
+		ImageList imageList = display.getImageListToolBar(style, width, height, zoom);
+		ImageList hotImageList = display.getImageListToolBarHot(style, width, height, zoom);
+		ImageList disabledImageList = display.getImageListToolBarDisabled(style, width, height, zoom);
+		return new ToolBarImageLists(display, imageList, hotImageList, disabledImageList);
+	}
+
+	void clear(int index) {
+		imageList.put(index, null);
+		hotImageList.put(index, null);
+		disabledImageList.put(index, null);
+	}
+
+	void release() {
+		display.releaseToolImageList(imageList);
+		display.releaseToolHotImageList(hotImageList);
+		display.releaseToolDisabledImageList(disabledImageList);
+	}
+
+	int add(Image image, Image hotImage, Image disabledImage) {
+		int index = imageList.add(image);
+		hotImageList.add(hotImage);
+		disabledImageList.add(disabledImage);
+		return index;
+	}
+
+	void put(int index, Image image, Image hotImage, Image disabledImage) {
+		imageList.put(index, image);
+		hotImageList.put(index, hotImage);
+		disabledImageList.put(index, disabledImage);
+	}
+
+	int moveFrom(ToolBarImageLists source, int index) {
+		Image image = source.imageList.get(index);
+		Image hotImage = source.hotImageList.get(index);
+		Image disabledImage = source.disabledImageList.get(index);
+		source.clear(index);
+		return add(image, hotImage, disabledImage);
+	}
+
+	long getImageListHandle(int zoom) {
+		return imageList.getHandle(zoom);
+	}
+
+	long getHotImageListHandle(int zoom) {
+		return hotImageList.getHandle(zoom);
+	}
+
+	long getDisabledImageListHandle(int zoom) {
+		return disabledImageList.getHandle(zoom);
+	}
+
+	Point getImageSize() {
+		return imageList.getImageSize();
+	}
+
+}


### PR DESCRIPTION
> [!IMPORTANT]
> This change is based on and should thus be merged after:
> - https://github.com/eclipse-platform/eclipse.platform.swt/pull/3504
> - https://github.com/eclipse-platform/eclipse.platform.swt/pull/3508
> - https://github.com/eclipse-platform/eclipse.platform.swt/pull/3513

`ToolBar`'s three image lists were still three separate fields that were created, filled, cleared, moved and released individually in `addImage`, `putImage`, `destroyItem`, `releaseWidget` and `updateOrientation`, even though they only ever change together and have to stay index-aligned.

This change introduces `ToolBarImageLists`, which owns the three `ImageLists` as one unit and offers the operations on them as single calls. Synchronizing the image lists with the native control remains in `ToolBar`, which retrieves the handles to set from `ToolBarImageLists`. `ToolBar`'s `addImage`/`putImage`/`clearImage` API (and therefore `ToolItem`, which only calls that API) is unaffected; this change is entirely internal to `ToolBar`.

This is a behavior-preserving internal refactor; it does not itself change what is rendered.

Related to https://github.com/eclipse-platform/eclipse.platform.swt/issues/3466

_Note:_ This change is human-crafted and was only slightly revised and documented with the help of AI

This is the fourth of multiple incremental steps to enhance ImageList handling and consistency inside ToolBar. This is supposed to be merged for 2026-12 M1.