### PR TITLE
Archive compilelogs to diagnose intermittent compiler warnings

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -329,7 +329,7 @@ pipeline {
 			post {
 				always {
 					junit allowEmptyResults: true, testResults: 'eclipse.platform.swt/tests/*.test*/target/surefire-reports/*.xml'
-					archiveArtifacts allowEmptyArchive: true, artifacts: '**/*.log,*/binaries/*/target/*.jar,*/bundles/*/target/*.jar', excludes: '**/*-sources.jar'
+					archiveArtifacts allowEmptyArchive: true, artifacts: '**/*.log,**/target/compilelogs/*.xml,*/binaries/*/target/*.jar,*/bundles/*/target/*.jar', excludes: '**/*-sources.jar'
 					discoverGitReferenceBuild referenceJob: 'eclipse.platform.swt/master'
 					// To accept unstable builds (test errors or new warnings introduced by third party changes) as reference using "ignoreQualityGate:true"
 					recordIssues enabledForFailure: true, publishAllIssues: true, ignoreQualityGate: true, tools: [


### PR DESCRIPTION
The Compiler check occasionally reports Unnecessary @SuppressWarnings ("restriction") on files a change does not touch, because the platform fragment carrying the org.eclipse.swt.internal classes sometimes lands on the compile classpath without the host's discouraged access rules.

target/compilelogs/*.xml records the exact -classpath ECJ was invoked with, including access rules, so archiving it makes that state comparable between builds.

Assisted-by: Anthropic Claude Code (claude-opus-5[1m])