### PR TITLE
Use alpha for less bold bullet in CTabFolderRenderer.drawDirtyIndicator

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CTabFolderRenderer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CTabFolderRenderer.java
@@ -756,9 +756,7 @@ public class CTabFolderRenderer {
 		int originalAlpha = gc.getAlpha();
 		int originalAntialias = gc.getAntialias();
 		gc.setBackground(gc.getForeground());
-		if (!selected) {
-			gc.setAlpha(140);
-		}
+		gc.setAlpha(selected ? 190 : 140);
 		gc.setAntialias(SWT.ON);
 		gc.fillOval(x, y, diameter, diameter);
 		gc.setAntialias(originalAntialias);


### PR DESCRIPTION
Fixes https://github.com/eclipse-platform/eclipse.platform.swt/issues/3520