### PR TITLE
Do not leave the tab folder GC in advanced graphics mode

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CTabFolderRenderer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Custom Widgets/common/org/eclipse/swt/custom/CTabFolderRenderer.java
@@ -741,18 +741,34 @@ public class CTabFolderRenderer {
 		int diameter = 8;
 		int x = closeRect.x + (closeRect.width - diameter) / 2;
 		int y = closeRect.y + (closeRect.height - diameter) / 2;
+		/*
+		 * Alpha and anti-aliasing switch the GC to GDI+ on Windows. All tabs share one
+		 * GC, so tabs painted afterwards would use different text metrics and lose
+		 * their clipping. Leaving the advanced mode resets the clipping, hence the save
+		 * and restore.
+		 */
+		Region clipping = null;
+		if (!gc.getAdvanced()) {
+			clipping = new Region();
+			gc.getClipping(clipping);
+		}
 		Color originalBackground = gc.getBackground();
 		int originalAlpha = gc.getAlpha();
+		int originalAntialias = gc.getAntialias();
 		gc.setBackground(gc.getForeground());
 		if (!selected) {
 			gc.setAlpha(140);
 		}
-		int originalAntialias = gc.getAntialias();
 		gc.setAntialias(SWT.ON);
 		gc.fillOval(x, y, diameter, diameter);
 		gc.setAntialias(originalAntialias);
 		gc.setAlpha(originalAlpha);
 		gc.setBackground(originalBackground);
+		if (clipping != null) {
+			gc.setAdvanced(false);
+			gc.setClipping(clipping);
+			clipping.dispose();
+		}
 	}
 
 	private void drawCloseLines(GC gc, int x, int y, int lineLength, boolean hot) {

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_custom_CTabFolder.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_custom_CTabFolder.java
@@ -44,6 +44,7 @@ import org.eclipse.swt.custom.SashForm;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.Font;
 import org.eclipse.swt.graphics.FontData;
+import org.eclipse.swt.graphics.GC;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.graphics.Rectangle;
@@ -1096,6 +1097,61 @@ public void test_dirtyIndicator_closesWhenCloseEnabled() {
 		assertEquals(2, ctabFolder.getItemCount(), "Item count should decrease by 1");
 	} catch (NoSuchFieldException | IllegalAccessException e) {
 		fail("Failed to access closeRect via reflection: " + e.getMessage());
+	}
+}
+
+/**
+ * All tabs are painted with the same GC, so the dirty indicator must not leave it in
+ * advanced graphics mode.
+ */
+@Test
+public void test_dirtyIndicator_doesNotChangeAdvancedGraphicsMode() {
+	makeCleanEnvironment(SWT.CLOSE);
+	shell.setLayout(new FillLayout());
+
+	for (int i = 0; i < 2; i++) {
+		CTabItem item = new CTabItem(ctabFolder, SWT.NONE);
+		item.setText("Tab " + i);
+	}
+	ctabFolder.setDirtyIndicatorStyle(true);
+	// the dirty item is painted before the selected one, which is painted last
+	ctabFolder.getItem(0).setShowDirty(true);
+	ctabFolder.setSelection(1);
+	shell.setSize(800, 400);
+	SwtTestUtil.openShell(shell);
+	processEvents();
+
+	assertTrue(getCloseRect(ctabFolder.getItem(0)).width > 0, "dirty indicator is not laid out");
+
+	// paint into an image so that the test does not depend on the display sending paint events
+	Rectangle bounds = ctabFolder.getBounds();
+	Image image = new Image(shell.getDisplay(), bounds.width, bounds.height);
+	GC gc = new GC(image);
+	try {
+		boolean advancedBefore = gc.getAdvanced();
+
+		Event paint = new Event();
+		paint.gc = gc;
+		paint.width = bounds.width;
+		paint.height = bounds.height;
+		ctabFolder.notifyListeners(SWT.Paint, paint);
+
+		assertEquals(advancedBefore, gc.getAdvanced(),
+				"Painting the dirty indicator must not change the advanced graphics mode of the GC");
+	} finally {
+		gc.dispose();
+		image.dispose();
+	}
+}
+
+private static Rectangle getCloseRect(CTabItem item) {
+	try {
+		Field closeRect = CTabItem.class.getDeclaredField("closeRect");
+		closeRect.setAccessible(true);
+		return (Rectangle) closeRect.get(item);
+	} catch (NoSuchFieldException | IllegalAccessException e) {
+		fail("Failed to access closeRect via reflection: " + e.getMessage());
+		return null;
 	}
 }
 

--- a/tests/org.eclipse.swt.tests/ManualTests/org/eclipse/swt/tests/manual/Issue3522_CTabFolderDirtyIndicatorTextJump.java
+++ b/tests/org.eclipse.swt.tests/ManualTests/org/eclipse/swt/tests/manual/Issue3522_CTabFolderDirtyIndicatorTextJump.java
@@ -1,0 +1,70 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Vogella GmbH and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Vogella GmbH - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.swt.tests.manual;
+
+import org.eclipse.swt.*;
+import org.eclipse.swt.custom.*;
+import org.eclipse.swt.graphics.*;
+import org.eclipse.swt.layout.*;
+import org.eclipse.swt.widgets.*;
+
+/**
+ * Press the two buttons alternately: the text of the selected tab must look exactly the
+ * same, no matter whether the dirty tab is repainted along with it or not.
+ */
+public class Issue3522_CTabFolderDirtyIndicatorTextJump {
+
+	public static void main(String[] args) {
+		Display display = new Display();
+		Shell shell = new Shell(display);
+		shell.setLayout(new GridLayout(2, false));
+
+		CTabFolder folder = new CTabFolder(shell, SWT.BORDER | SWT.CLOSE);
+		folder.setLayoutData(new GridData(SWT.FILL, SWT.TOP, true, false, 2, 1));
+		folder.setUnselectedCloseVisible(false);
+		folder.setDirtyIndicatorStyle(true);
+
+		CTabItem selectedItem = new CTabItem(folder, SWT.NONE);
+		selectedItem.setText("TestClass.java");
+		CTabItem dirtyItem = new CTabItem(folder, SWT.NONE);
+		dirtyItem.setText("module-info.java");
+		dirtyItem.setShowDirty(true);
+		folder.setSelection(selectedItem);
+
+		Button redrawAll = new Button(shell, SWT.PUSH);
+		redrawAll.setText("Repaint all tabs (dirty indicator is painted first)");
+		redrawAll.addListener(SWT.Selection, event -> {
+			folder.redraw();
+			folder.update();
+		});
+
+		Button redrawSelected = new Button(shell, SWT.PUSH);
+		redrawSelected.setText("Repaint selected tab only");
+		redrawSelected.addListener(SWT.Selection, event -> {
+			Rectangle bounds = selectedItem.getBounds();
+			folder.redraw(bounds.x, bounds.y, bounds.width, bounds.height, false);
+			folder.update();
+		});
+
+		shell.setSize(700, 200);
+		shell.open();
+		while (!shell.isDisposed()) {
+			if (!display.readAndDispatch()) {
+				display.sleep();
+			}
+		}
+		display.dispose();
+	}
+}


### PR DESCRIPTION
Fixes #3522

`CTabFolderRenderer.drawDirtyIndicator()` uses alpha and anti-aliasing, which switch the GC to GDI+ on Windows and are not undone by restoring alpha and anti-aliasing. All tabs share one GC and the selected tab is painted last, so tabs painted after a dirty indicator were measured with GDI+ text metrics and their text was elided, and on the double-buffered paint they lost their clipping because `getClipping(Region)` no longer round-trips. That is the jumping text of this issue and the vanishing tab @Phillipus reported in it.

The fix leaves the advanced mode again after drawing the indicator and restores the clipping, which `setAdvanced(false)` resets. It is a no-op on GTK and macOS, where the GC is always advanced.

Verified on Windows 11 at 150% and emulated 100% zoom: both symptoms reproduce on master and are gone with the change, the tab strip is then pixel identical for every repaint geometry, and repainting is about 20% faster on a folder with 20 dirty tabs. The new regression test fails without the change and passes with it. `Test_org_eclipse_swt_custom_CTabFolder` shows the same 3 failures as clean master at 150% zoom.
