### PR TITLE
[Win32] Use primary monitor zoom in Display.getBounds() scaling

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/widgets/DisplayWin32Test.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/widgets/DisplayWin32Test.java
@@ -1,9 +1,9 @@
 package org.eclipse.swt.widgets;
 
 import static org.eclipse.swt.internal.DPIUtil.setMonitorSpecificScaling;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
+import org.eclipse.swt.graphics.*;
 import org.eclipse.swt.internal.*;
 import org.eclipse.swt.internal.win32.*;
 import org.junit.jupiter.api.*;
@@ -102,6 +102,25 @@ class DisplayWin32Test {
 		display.setRescalingAtRuntime(false);
 		assertFalse(display.isRescalingAtRuntime());
 		assertExpectedDpiAwareness(OS.DPI_AWARENESS_CONTEXT_SYSTEM_AWARE);
+	}
+
+	// https://github.com/eclipse-platform/eclipse.platform.swt/issues/3530
+	@Test
+	public void getBoundsAndGetClientAreaUseZoomOfPrimaryMonitor_MatchingGCZoom() throws Exception {
+		Display display = Display.getDefault();
+
+		DPIUtil.setDeviceZoom(200); // must not be considered
+		Rectangle bounds1 = display.getBounds();
+		Rectangle clientArea1 = display.getClientArea();
+		DPIUtil.setDeviceZoom(100); // must not be considered
+		Rectangle bounds2 = display.getBounds();
+		Rectangle clientArea2 = display.getClientArea();
+
+		assertEquals(bounds2.width, bounds1.width);
+		assertEquals(clientArea2.width, clientArea1.width);
+
+		GC gc = new GC(display);
+		assertEquals(display.getPrimaryMonitor().getZoom(), gc.getGCData().nativeZoom);
 	}
 
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Display.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Display.java
@@ -1592,7 +1592,7 @@ public Menu getMenuBar () {
 @Override
 public Rectangle getBounds() {
 	checkDevice ();
-	return Win32DPIUtils.pixelToPoint(getBoundsInPixels(), DPIUtil.getDeviceZoom());
+	return Win32DPIUtils.pixelToPoint(getBoundsInPixels(), getDeviceZoom());
 }
 
 Rectangle getBoundsInPixels () {
@@ -1665,7 +1665,7 @@ int getClickCount (int type, int button, long hwnd, long lParam) {
 @Override
 public Rectangle getClientArea () {
 	checkDevice ();
-	return Win32DPIUtils.pixelToPoint(getClientAreaInPixels(), DPIUtil.getDeviceZoom());
+	return Win32DPIUtils.pixelToPoint(getClientAreaInPixels(), getDeviceZoom());
 }
 
 Rectangle getClientAreaInPixels () {


### PR DESCRIPTION
`Display.getBounds()` must not be affected by _"zoom-of-the-last-moved-shell"_, which currently `DPIUtil.getDeviceZoom()` represents on Windows.

Instead, `Display.getBounds()` should be consistent with the way a GC for the display is created: via `Display.getDeviceZoom()`, which in turn uses the zoom of the primary monitor.

The same applies to `Display.getClientArea()` as well.

Fixes #3530.