### PR TITLE
[GTK] Neutralize horizontal ToolBar padding

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/org/eclipse/swt/internal/gtk/swt_theming_fixes_gtk_3_20.css
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/org/eclipse/swt/internal/gtk/swt_theming_fixes_gtk_3_20.css
@@ -1,6 +1,10 @@
+/* Horizontal padding is neutralized so that adjacent ToolBars keep the same item
+   pitch as items within a single ToolBar. */
 toolbar {
 	padding-top: 2px;
 	padding-bottom: 2px;
+	padding-left: 0px;
+	padding-right: 0px;
 }
 
 toolbar button {


### PR DESCRIPTION
Fixes #3536.

SWT's GTK theming fixes already zero the vertical toolbar padding but leave the horizontal padding to the theme. That is invisible inside one ToolBar, but where two sit side by side each adds its own padding at the seam, which is why the view toolbar, the view menu and the min/max buttons in every view's tab area are unevenly spaced. With this change the pitch is uniform across the whole strip, and no e4 change is needed.

Worth knowing before merging: this also removes the leading inset from every ToolBar, so the first item shifts 4px left and each bar is 7px narrower. Spacing between items is unchanged.

It is also GTK3-only. On GTK4 the ToolBar is a GtkBox with a `toolbar` CSS class, so a bare `toolbar` node selector does not match, which means the existing vertical fix is already inert there. I would rather handle that separately than add unverified CSS here.