### PR TITLE
[Win32] Remove obsolete zoom cases for image providers

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Image.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Image.java
@@ -2419,9 +2419,6 @@ private class ImageDataLoaderStreamProviderWrapper extends ImageFromImageDataPro
 
 	@Override
 	int nearestAvailableZoom(int zoom) {
-		if (ImageDataLoader.isDynamicallySizable(new ByteArrayInputStream(this.inputStreamData))) {
-			return zoom;
-		}
 		return FileFormat.DEFAULT_ZOOM;
 	}
 }
@@ -2674,9 +2671,6 @@ private class ImageFileNameProviderWrapper extends BaseImageProviderWrapper<Imag
 
 	@Override
 	int nearestAvailableZoom(int zoom) {
-		if (provider instanceof ImageDataAtSizeProvider) {
-			return zoom;
-		}
 		return DPIUtil.validateAndGetImagePathAtZoom(provider, zoom).zoom();
 	}
 
@@ -2926,9 +2920,6 @@ private class ImageDataProviderWrapper extends BaseImageProviderWrapper<ImageDat
 
 	@Override
 	int nearestAvailableZoom(int zoom) {
-		if (provider instanceof ImageDataAtSizeProvider) {
-			return zoom;
-		}
 		return DPIUtil.validateAndGetImageDataAtZoom (provider, zoom).zoom();
 	}
 }


### PR DESCRIPTION
The nearestAvailableZoom() calculation in images was introduced to get or create persistent image handle for reasonable zooms when requesting an image at a specific size, so that repeated recreation of such a handle is avoided. With that change, some unnecessary zoom cases have been introduced that are removed by this change:
- Images based on FileNameProvider never make use of an ImageDataAtSizeProvider, since their dynamic sizing is derived from the file name rather than the provider type, so that case is dead code from a copy
- In case the image is dynamically sizable (e.g., because the stream contains dynamically sizable data or an ImageDataAtSizeProvider is used), the HandleAtSize consumer of nearestAvailableZoom() does not even come to this code because it already used the dynamic sizing capabilities to derive a temporary handle at the requested size.