### PR TITLE
[Win32] Fix NPE in tool bar image list refresh on DPI change

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/widgets/ToolBarWin32Tests.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Tests/win32/org/eclipse/swt/widgets/ToolBarWin32Tests.java
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package org.eclipse.swt.widgets;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.*;
@@ -186,6 +187,37 @@ class ToolBarWin32Tests {
 					TIMEOUT_MILLIS), "every tool item must render its own icon after an orientation change");
 		} finally {
 			disposeAll(icons, display);
+		}
+	}
+
+	/**
+	 * A tool bar without images has no image lists, which a zoom change must
+	 * tolerate. Failing there leaves every control visited afterwards at the old zoom.
+	 */
+	@Test
+	void testZoomChangeWithImagelessToolBarRescalesFollowingControls() {
+		Display display = new Display();
+		Image icon = solidIcon(display, 16, new RGB(220, 40, 40));
+		try {
+			Shell shell = new Shell(display);
+			shell.setLayout(new FillLayout(SWT.VERTICAL));
+			ToolBar barWithoutImages = new ToolBar(shell, SWT.FLAT);
+			new ToolItem(barWithoutImages, SWT.PUSH).setText("No icon");
+			ToolBar followingBar = new ToolBar(shell, SWT.FLAT);
+			createItems(followingBar, icon);
+			shell.setSize(500, 180);
+			shell.open();
+
+			int newZoom = shell.getAutoscalingZoom() * 2;
+			DPITestUtil.changeDPIZoom(shell, newZoom);
+
+			assertEquals(newZoom, barWithoutImages.getAutoscalingZoom(),
+					"a tool bar without images must process a zoom change");
+			assertEquals(newZoom, followingBar.getAutoscalingZoom(),
+					"a control after a tool bar without images must still process the zoom change");
+		} finally {
+			icon.dispose();
+			display.dispose();
 		}
 	}
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ToolBar.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/ToolBar.java
@@ -888,6 +888,9 @@ void putImage(int index, Image image, Image hotImage, Image disabledImage) {
 }
 
 private void refreshImageLists(boolean itemsChanged) {
+	if (imageLists == null) {
+		return;
+	}
 	int zoom = getAutoscalingZoom();
 	long imageListHandle = imageLists.getImageListHandle(zoom);
 	long hotImageListHandle = imageLists.getHotImageListHandle(zoom);


### PR DESCRIPTION
`ToolBar.refreshImageLists()` dereferences `imageLists` without a null check, unlike `putImage()` and `clearImage()`. A tool bar whose items never had an image has no image lists, so every zoom change throws an NPE. `CTabFolder` creates such a tool bar for its chevron, so every part stack of an Eclipse or RCP application is affected.

The exception escapes `Composite.handleDPIChange()` in the middle of its children loop, so all following siblings keep the old zoom and are mis-sized, which cuts off the trailing items of a tool bar. This is what the field reports of disappearing tool bar buttons after a display scaling change describe.

The fix skips the refresh when there are no image lists. It is a regression from 184cbfb46d and not part of any release. A new win32 test places an image-less tool bar before one with images and checks that both pick up the new zoom, which fails with the NPE without the fix.
