### PR TITLE
Restore swt-bundles artifactId for the bundles aggregator

### DIFF
--- a/bundles/build.properties
+++ b/bundles/build.properties
@@ -1,0 +1,15 @@
+###############################################################################
+# Copyright (c) 2025, 2026 Hannes Wellmann and others.
+#
+# This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#     Hannes Wellmann - initial API and implementation
+###############################################################################
+
+pom.model.artifactId = swt-bundles


### PR DESCRIPTION
#3549 removed bundles/build.properties, which dropped the pom.model.artifactId = swt-bundles override. The pomless aggregator for bundles/ now resolves to org.eclipse.platform:bundles:4.42.0-SNAPSHOT, the same coordinates equinox gives its own bundles/ folder via pom.model.groupId. In the platform aggregator build the 44 pomless equinox bundles then fail with "Non-resolvable parent POM org.eclipse.platform:bundles".

This restores the file with only the artifactId override; the obsolete tycho.pomless.parent line stays removed. Verified with mvn validate from the aggregator root against current equinox and SWT master: it fails without this file and passes with it.