### PR TITLE
[Win32] Do not adopt the source image's OS handle in an image copy

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Image.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Image.java
@@ -2196,17 +2196,31 @@ private class ExistingImageHandleProviderWrapper extends AbstractImageProviderWr
 
 	private final int width;
 	private final int height;
-	private final long handle;
-	private final int zoomForHandle;
+	/**
+	 * The zoom the image has an OS handle for that has not been derived from
+	 * another one. Image data for every other zoom is scaled from it.
+	 */
+	private final int baseZoom;
 
 	public ExistingImageHandleProviderWrapper(long handle, int zoomForHandle) {
-		this.handle = handle;
-		this.zoomForHandle = zoomForHandle;
+		this.baseZoom = zoomForHandle;
 		InternalImageHandle imageHandle = imageHandleManager.getOrCreate(zoomForHandle, () -> new DestroyableImageHandle(handle, zoomForHandle, -1));
 
 		ImageData baseData = imageHandle.getImageData();
 		this.width = DPIUtil.pixelToPoint(baseData.width, zoomForHandle);
 		this.height = DPIUtil.pixelToPoint(baseData.height, zoomForHandle);
+	}
+
+	/**
+	 * Creates the wrapper for a copy of an image that has been created for an
+	 * existing handle. Since the copy creates and owns its own OS handles, it only
+	 * inherits the base zoom and the size of the copied image, but never refers to
+	 * the handle of the copied image.
+	 */
+	private ExistingImageHandleProviderWrapper(int baseZoom, int width, int height) {
+		this.baseZoom = baseZoom;
+		this.width = width;
+		this.height = height;
 	}
 
 	@Override
@@ -2223,12 +2237,12 @@ private class ExistingImageHandleProviderWrapper extends AbstractImageProviderWr
 
 	@Override
 	AbstractImageProviderWrapper createCopy(Image image) {
-		return image.new ExistingImageHandleProviderWrapper(handle, zoomForHandle);
+		return image.new ExistingImageHandleProviderWrapper(baseZoom, width, height);
 	}
 
 	@Override
 	public Collection<Integer> getPreservedZoomLevels() {
-		return Collections.singleton(zoomForHandle);
+		return Collections.singleton(baseZoom);
 	}
 
 	@Override
@@ -2244,7 +2258,7 @@ private class ExistingImageHandleProviderWrapper extends AbstractImageProviderWr
 
 	@Override
 	int nearestAvailableZoom(int zoom) {
-		return zoomForHandle;
+		return baseZoom;
 	}
 }
 

--- a/tests/org.eclipse.swt.tests.win32/JUnit Tests/org/eclipse/swt/graphics/ImageWin32Tests.java
+++ b/tests/org.eclipse.swt.tests.win32/JUnit Tests/org/eclipse/swt/graphics/ImageWin32Tests.java
@@ -20,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.internal.DPIUtil;
+import org.eclipse.swt.internal.win32.OS;
 import org.eclipse.swt.widgets.Display;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -203,6 +204,55 @@ public class ImageWin32Tests {
 		ImageData copiedImageData = new Image(display, image, SWT.IMAGE_COPY).getImageData();
 		assertImageDataEqualsIgnoringAlphaInData(imageData, copiedImageData);
 		image.dispose();
+	}
+
+	@Test
+	public void test_copyOfImageForExistingHandleDoesNotShareTheHandle() {
+		long hBitmap = createBitmapHandle(20, 10);
+		Image image = Image.win32_new(display, SWT.BITMAP, hBitmap, 100);
+		try {
+			Image copy = new Image(display, image, SWT.IMAGE_COPY);
+			try {
+				assertEquals(hBitmap, Image.win32_getHandle(image, 100),
+						"The image the handle was created for must still own that handle");
+				assertNotEquals(hBitmap, Image.win32_getHandle(copy, 100),
+						"A copy of an image must not adopt the handle of the copied image");
+			} finally {
+				copy.dispose();
+			}
+		} finally {
+			image.dispose();
+		}
+	}
+
+	@Test
+	public void test_imageForExistingHandleStaysUsableAfterCopyIsDisposed() {
+		long hBitmap = createBitmapHandle(20, 10);
+		Image image = Image.win32_new(display, SWT.BITMAP, hBitmap, 100);
+		try {
+			new Image(display, image, SWT.IMAGE_COPY).dispose();
+			ImageData imageData = image.getImageData(100);
+			assertEquals(20, imageData.width, "Image data must still have the width of the wrapped bitmap");
+			assertEquals(10, imageData.height, "Image data must still have the height of the wrapped bitmap");
+		} finally {
+			image.dispose();
+		}
+	}
+
+	/**
+	 * Creates an OS bitmap handle that is not owned by any {@link Image} yet, so
+	 * that its ownership can be handed over to
+	 * {@link Image#win32_new(Device, int, long, int)}.
+	 */
+	private long createBitmapHandle(int width, int height) {
+		long hDC = display.internal_new_GC(null);
+		try {
+			long hBitmap = OS.CreateCompatibleBitmap(hDC, width, height);
+			assertNotEquals(0, hBitmap, "Failed to create a bitmap for the test");
+			return hBitmap;
+		} finally {
+			display.internal_dispose_GC(hDC, null);
+		}
 	}
 
 	private static void fillImage(Image image, Color fillColor) {


### PR DESCRIPTION
## Problem

While analyzing a JVM crash in `Image.getImageData()`, it turned out that copying an image that has been created for an existing OS handle via `Image.win32_new(...)` makes both images share a single `HBITMAP` instead of providing the copy with a bitmap of its own.

The provider wrapper of such an image registers the handle it is created for in the handle manager of the image it belongs to. Since the copying constructor creates that wrapper before it populates the handle manager of the copy, the subsequent lookup finds the entry for the source's handle and reuses it, so no bitmap is ever created for the copy.

Both images then own and eventually destroy the same handle. Disposing one of them leaves the other one reporting a live handle for a bitmap the OS may already have reused for an unrelated object. Retrieving image data from that image returns corrupted data or terminates the VM with an `EXCEPTION_ACCESS_VIOLATION`, and disposing it afterwards frees the handle value a second time, silently destroying whatever the OS has meanwhile associated with it.

## Fix

The copy gets a dedicated wrapper creation that inherits only the base zoom and the size of the copied image and never refers to its handle. Creating the handles is left to the copying constructor, which fills the handle manager of the copy with its own, newly created handles anyway. As the handle of the copied image is not referred to at all anymore, the wrapper does not keep it either, which is also why the remaining zoom information has been renamed to express the role it actually plays.

The added tests verify that an image created for an existing handle keeps ownership of that handle while its copy uses a different one, and that it still provides correct image data after the copy has been disposed, which is the regression test for the crash described above. The only change users may notice is that copying such an image now allocates an OS bitmap of its own, which is what was intended in the first place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
