### PR TITLE
[Win32] Mark image handles as disposed before destroying them

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Image.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Image.java
@@ -3473,12 +3473,17 @@ private class DestroyableImageHandle implements InternalImageHandle {
 
 	void destroy() {
 		if (isDisposed) return;
-		if (type == SWT.ICON) {
-			OS.DestroyIcon (handle());
-		} else {
-			OS.DeleteObject (handle());
-		}
+		/*
+		 * Mark the handle as disposed before it is actually destroyed, so that it is
+		 * never reported as usable while it is already gone. The raw handle has to be
+		 * used for destruction, since handle() returns 0 for a disposed handle.
+		 */
 		isDisposed = true;
+		if (type == SWT.ICON) {
+			OS.DestroyIcon (handle);
+		} else {
+			OS.DeleteObject (handle);
+		}
 	}
 }
 


### PR DESCRIPTION
## Problem

While analyzing a JVM crash in `Image.getImageData()`, it turned out that an image handle is marked as disposed only after the OS handle has already been freed. Within that window the handle object reports itself as alive and hands out a handle value that the OS may already have recycled for an unrelated object, so anything observing the handle in between operates on a foreign or invalid one.

This is a hazard rather than a defect with a known reproduction: the window is short and no current code path observes a handle while it is open. It is the same class of problem as the crash that led to this analysis though, where an image kept reporting a live handle for a bitmap that had already been destroyed elsewhere.

## Fix

The handle is marked as disposed before it is destroyed, so it never appears usable while it is already gone. Destruction consequently has to read the raw handle value, since the accessor returns 0 for a handle that is marked as disposed.

There are no tests for this change, as no code path currently observes a handle within that window. A test would have to trigger the destruction through reflection and would then assert the implementation rather than any behavior of `Image`, and it would have to be rewritten by anyone restructuring the class. Accordingly, there is no behavioral change users could notice, the change removes a hazard at no runtime cost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
