### PR TITLE
[Win32] Validate results of image handle queries before using them

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Image.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/Image.java
@@ -3132,18 +3132,25 @@ private class DestroyableImageHandle implements InternalImageHandle {
 		switch (type) {
 		case SWT.BITMAP:
 			BITMAP bm = new BITMAP();
-			OS.GetObject(handle, BITMAP.sizeof, bm);
+			if (OS.GetObject(handle, BITMAP.sizeof, bm) == 0) {
+				SWT.error(SWT.ERROR_INVALID_IMAGE);
+			}
 			return new Point(bm.bmWidth, bm.bmHeight);
 		case SWT.ICON:
 			ICONINFO info = new ICONINFO();
-			OS.GetIconInfo(handle, info);
+			if (!OS.GetIconInfo(handle, info)) {
+				SWT.error(SWT.ERROR_INVALID_IMAGE);
+			}
 			long hBitmap = info.hbmColor;
 			if (hBitmap == 0) hBitmap = info.hbmMask;
 			bm = new BITMAP();
-			OS.GetObject(hBitmap, BITMAP.sizeof, bm);
-			if (hBitmap == info.hbmMask) bm.bmHeight /= 2;
+			int queriedBytes = OS.GetObject(hBitmap, BITMAP.sizeof, bm);
 			if (info.hbmColor != 0) OS.DeleteObject(info.hbmColor);
 			if (info.hbmMask != 0) OS.DeleteObject(info.hbmMask);
+			if (queriedBytes == 0) {
+				SWT.error(SWT.ERROR_INVALID_IMAGE);
+			}
+			if (hBitmap == info.hbmMask) bm.bmHeight /= 2;
 			return new Point(bm.bmWidth, bm.bmHeight);
 		default:
 			SWT.error(SWT.ERROR_INVALID_IMAGE);
@@ -3161,7 +3168,11 @@ private class DestroyableImageHandle implements InternalImageHandle {
 
 		/* Change the background color in the image */
 		BITMAP bm = new BITMAP();
-		OS.GetObject(handle(), BITMAP.sizeof, bm);
+		if (OS.GetObject(handle(), BITMAP.sizeof, bm) == 0) {
+			/* Release the HDC for the device */
+			device.internal_dispose_GC(hDC, null);
+			SWT.error(SWT.ERROR_INVALID_IMAGE);
+		}
 		long hdcMem = OS.CreateCompatibleDC(hDC);
 		OS.SelectObject(hdcMem, handle());
 		int maxColors = 1 << bm.bmBitsPixel;
@@ -3186,12 +3197,18 @@ private class DestroyableImageHandle implements InternalImageHandle {
 		switch (type) {
 			case SWT.ICON: {
 				ICONINFO info = new ICONINFO();
-				OS.GetIconInfo(handle(), info);
+				if (!OS.GetIconInfo(handle(), info)) {
+					SWT.error(SWT.ERROR_INVALID_IMAGE);
+				}
 				/* Get the basic BITMAP information */
 				long hBitmap = info.hbmColor;
 				if (hBitmap == 0) hBitmap = info.hbmMask;
 				bm = new BITMAP();
-				OS.GetObject(hBitmap, BITMAP.sizeof, bm);
+				if (OS.GetObject(hBitmap, BITMAP.sizeof, bm) == 0) {
+					if (info.hbmColor != 0) OS.DeleteObject(info.hbmColor);
+					if (info.hbmMask != 0) OS.DeleteObject(info.hbmMask);
+					SWT.error(SWT.ERROR_INVALID_IMAGE);
+				}
 				depth = bm.bmPlanes * bm.bmBitsPixel;
 				width = bm.bmWidth;
 				if (hBitmap == info.hbmMask) bm.bmHeight /= 2;
@@ -3326,7 +3343,9 @@ private class DestroyableImageHandle implements InternalImageHandle {
 			case SWT.BITMAP: {
 				/* Get the basic BITMAP information */
 				bm = new BITMAP();
-				OS.GetObject(handle(), BITMAP.sizeof, bm);
+				if (OS.GetObject(handle(), BITMAP.sizeof, bm) == 0) {
+					SWT.error(SWT.ERROR_INVALID_IMAGE);
+				}
 				depth = bm.bmPlanes * bm.bmBitsPixel;
 				width = bm.bmWidth;
 				height = bm.bmHeight;
@@ -3337,7 +3356,16 @@ private class DestroyableImageHandle implements InternalImageHandle {
 				DIBSECTION dib = null;
 				if (isDib) {
 					dib = new DIBSECTION();
-					OS.GetObject(handle(), DIBSECTION.sizeof, dib);
+					/*
+					 * Only a complete DIBSECTION provides a valid image size. If the
+					 * object is not a DIB section, GetObject only fills the BITMAP part
+					 * and returns its size instead.
+					 */
+					if (OS.GetObject(handle(), DIBSECTION.sizeof, dib) != DIBSECTION.sizeof) {
+						/* Release the HDC for the device */
+						device.internal_dispose_GC(hDC, null);
+						SWT.error(SWT.ERROR_INVALID_IMAGE);
+					}
 				}
 				/* Calculate number of colors */
 				int numColors = 0;

--- a/tests/org.eclipse.swt.tests.win32/JUnit Tests/org/eclipse/swt/graphics/ImageWin32Tests.java
+++ b/tests/org.eclipse.swt.tests.win32/JUnit Tests/org/eclipse/swt/graphics/ImageWin32Tests.java
@@ -13,13 +13,17 @@
  *******************************************************************************/
 package org.eclipse.swt.graphics;
 
-
 import static org.eclipse.swt.tests.win32.SwtWin32TestUtil.assertImageDataEqualsIgnoringAlphaInData;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.SWTException;
 import org.eclipse.swt.internal.DPIUtil;
+import org.eclipse.swt.internal.win32.BITMAP;
 import org.eclipse.swt.internal.win32.OS;
 import org.eclipse.swt.widgets.Display;
 import org.junit.jupiter.api.BeforeEach;
@@ -220,6 +224,21 @@ public class ImageWin32Tests {
 			} finally {
 				copy.dispose();
 			}
+		} finally {
+			image.dispose();
+		}
+	}
+
+	public void test_getImageDataOnDestroyedHandleFailsWithoutCrashing() {
+		long hBitmap = createBitmapHandle(20, 10);
+		Image image = Image.win32_new(display, SWT.BITMAP, hBitmap, 100);
+		try {
+			assertTrue(OS.DeleteObject(hBitmap), "Failed to destroy the bitmap for the test");
+			assumeTrue(OS.GetObject(hBitmap, BITMAP.sizeof, new BITMAP()) == 0,
+					"The destroyed handle value has already been reused by the OS");
+			SWTException exception = assertThrows(SWTException.class, () -> image.getImageData(100),
+					"Retrieving image data for a destroyed handle must fail with an exception");
+			assertEquals(SWT.ERROR_INVALID_IMAGE, exception.code, "Unexpected error code");
 		} finally {
 			image.dispose();
 		}

--- a/tests/org.eclipse.swt.tests.win32/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.swt.tests.win32/META-INF/MANIFEST.MF
@@ -9,6 +9,7 @@ Eclipse-BundleShape: dir
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Automatic-Module-Name: org.eclipse.swt.tests.win32
 Import-Package: org.junit.jupiter.api;version="[5.13.0,6.0.0)",
+ org.junit.jupiter.api.function;version="[5.13.0,6.0.0)",
  org.junit.jupiter.params;version="[5.13.0,6.0.0)",
  org.junit.jupiter.params.provider;version="[5.13.0,6.0.0)",
  org.junit.platform.suite.api;version="[1.13.0,2.0.0)"


### PR DESCRIPTION
## Problem

While analyzing a JVM crash in `Image.getImageData()`, it turned out that the results of `GetObject` and `GetIconInfo` are used without ever being checked.

`OS.GetObject` is declared with `no_in`, so the native struct is not initialized from the Java object before the call. If the call fails, for example because the queried OS handle has already been destroyed, the struct is never written and the Java `BITMAP` or `DIBSECTION` object keeps whatever the native stack happened to contain at that moment.

That garbage is then used as if it were valid image information: an arbitrary `bmBits` pointer makes the image look like a DIB section, and an arbitrary `biSizeImage` becomes the length of a `MoveMemory` copy from that pointer. Instead of reporting a problem, this terminates the VM with an `EXCEPTION_ACCESS_VIOLATION`, which is how the analyzed crash manifested.

## Fix

The result is checked wherever an image handle queries the OS handle it manages, so that a stale or otherwise invalid handle is reported as `ERROR_INVALID_IMAGE`. This is independent of the reason why a handle became invalid and therefore also covers causes that are not addressed by any other change.

Those are the queries that can encounter a stale handle, since they are the only ones reading a handle that is stored and whose lifetime is managed elsewhere. `Image` performs further unchecked queries, either on handles it has just created itself, where a failure means resource exhaustion rather than an invalid handle, or on handles owned by another image. Those can be hardened separately, each with the error handling their surrounding code requires.

For the `DIBSECTION` query the result must be the full struct size rather than just non-zero, since `GetObject` fills only the `BITMAP` part and returns its size if the object is not a DIB section, which would leave the image size uninitialized.

The added test verifies that retrieving image data for a handle that has been destroyed behind SWT's back raises an exception instead of terminating the VM. It is guarded by an assumption, because the OS may reuse the destroyed handle value before it is queried, in which case there is nothing to observe. Users may now see an `SWTException` where a process previously died or silently continued with corrupted image data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
