### PR TITLE
[Win32] Free the DIB of a transferred image only once

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/win32/org/eclipse/swt/dnd/ImageTransfer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Drag and Drop/win32/org/eclipse/swt/dnd/ImageTransfer.java
@@ -184,9 +184,9 @@ public Object nativeToJava(TransferData transferData) {
 				}
 			}
 			final int DEFAULT_IMAGE_STORAGE_ZOOM = 100;
+			/* The image takes ownership of the DIB and destroys it on disposal */
 			Image image = Image.win32_new(null, SWT.BITMAP, memDib, DEFAULT_IMAGE_STORAGE_ZOOM);
 			ImageData data = image.getImageData ();
-			OS.DeleteObject(memDib);
 			image.dispose();
 			return data;
 		} finally {


### PR DESCRIPTION
## Problem

While analyzing a JVM crash in `Image.getImageData()`, it turned out that reading an image from the clipboard frees the same OS handle twice.

The DIB created for the incoming image is wrapped in an `Image` via `Image.win32_new`, which passes the ownership of that handle to the image. The DIB is nevertheless also destroyed explicitly, so the handle is freed once by that call and once more when the image is disposed.

The second free targets a handle value that the OS may already have recycled for an unrelated object, which is then silently destroyed and leaves its owner with a dangling handle. What fails afterwards is whichever code uses that object next, so the failure is neither attributable to the clipboard nor reproducible on demand. This is an independent route into the crash mentioned above and it needs no image copy.

## Fix

The destruction is left to the image, which owns the handle. This is not covered by a dedicated test: the second free is unobservable unless the OS happens to recycle the handle value between the two frees, which are consecutive statements, so a test can neither enforce the recycling nor detect its absence. Without recycling, the second free merely returns `FALSE` and the returned `ImageData` is correct either way, which is why the existing clipboard round trip test in `Test_org_eclipse_swt_dnd_ImageTransfer` passes with and without the defect.

That test does cover the risk this change actually carries, namely that the image data must still be transferred correctly once the explicit destruction is gone. That the image alone releases the handle was verified separately by repeating the wrapping, reading and disposal and checking that the handle is destroyed in every iteration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
