### PR TITLE
[Win32] Release DPI change callback also on failure

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Control.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Control.java
@@ -6062,10 +6062,15 @@ private static class DPIChangeProcessingCallback  {
 		// Has to have TIMERPROC signature, see https://learn.microsoft.com/en-us/windows/win32/api/winuser/nc-winuser-timerproc
 		Callback callback = new Callback(this, "run", void.class, new Type[] { int.class, int.class, int.class, int.class} );
 		this.operation = () -> {
-			if (!control.isDisposed()) {
-				dpiChangeProcessing.run();
+			try {
+				if (!control.isDisposed()) {
+					dpiChangeProcessing.run();
+				}
+			} finally {
+				// The callback must be released in any case, as callback slots are a
+				// limited resource and leaking them makes further scheduling fail
+				callback.dispose();
 			}
-			callback.dispose();
 		};
 		this.address = callback.getAddress();
 	}


### PR DESCRIPTION
When a zoom change is processed asynchronously, a native callback is allocated for the timer triggering the processing and is released again once the processing has been performed. If the processing fails, the callback is never released.

Callback slots are a limited resource shared by the whole application, so repeatedly failing zoom change processing eventually exhausts them. From then on, allocating a callback fails, which makes the scheduling of the zoom change processing silently fall back to performing it synchronously and can break unrelated functionality relying on callbacks as well.

The callback is now released independently of the outcome of the processing. There is no automated test for this, as the leak is only observable by exhausting the application-wide callback pool, which cannot be provoked in a test without affecting everything else running in the same process. The change has no effect on the successful case, in which the callback was already released.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
