### PR TITLE
Use Java 25 in builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -74,7 +74,7 @@ pipeline {
 		label 'ubuntu-latest'
 	}
 	tools {
-		jdk 'temurin-jdk21-latest'
+		jdk 'temurin-jdk25-latest'
 		maven 'apache-maven-latest'
 	}
 	environment {


### PR DESCRIPTION
Needed for the javadoc profile to work as it now can accept Java 25.