### PR TITLE
Convert MacGeneratorView from ViewPart to an e4 part

### DIFF
--- a/bundles/org.eclipse.swt.tools/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.swt.tools/META-INF/MANIFEST.MF
@@ -11,7 +11,10 @@ Bundle-RequiredExecutionEnvironment: JavaSE-21
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.29.0",
  org.eclipse.core.resources;bundle-version="3.4.0",
  org.eclipse.jdt.core;bundle-version="3.4.0",
- org.eclipse.ui;bundle-version="3.4.0",
  org.eclipse.jface.text;bundle-version="3.4.0",
- org.eclipse.swt
+ org.eclipse.swt,
+ org.eclipse.e4.core.di;bundle-version="1.9.0",
+ org.eclipse.e4.ui.di;bundle-version="1.5.0",
+ org.eclipse.e4.ui.model.workbench;bundle-version="2.4.0"
+Import-Package: jakarta.annotation;version="[2.0.0,4.0.0)"
 Automatic-Module-Name: org.eclipse.swt.tools

--- a/bundles/org.eclipse.swt.tools/plugin.xml
+++ b/bundles/org.eclipse.swt.tools/plugin.xml
@@ -7,14 +7,14 @@
             id="org.eclipse.swt.dev.tools"
             name="%viewCategory">
       </category>
-      <view
+      <e4view
             allowMultiple="false"
             category="org.eclipse.swt.dev.tools"
             class="org.eclipse.swt.tools.views.MacGeneratorView"
             icon="icons/mac.gif"
             id="org.eclipse.swt.tools.views.MacGeneratorView"
             name="%macViewName">
-      </view>
+      </e4view>
    </extension>
 
    <extension point="org.eclipse.ui.editors.templates">

--- a/bundles/org.eclipse.swt.tools/src/org/eclipse/swt/tools/views/MacGeneratorView.java
+++ b/bundles/org.eclipse.swt.tools/src/org/eclipse/swt/tools/views/MacGeneratorView.java
@@ -18,16 +18,19 @@ import java.util.*;
 import org.eclipse.core.resources.*;
 import org.eclipse.core.runtime.*;
 import org.eclipse.core.runtime.jobs.*;
-import org.eclipse.jface.action.*;
+import org.eclipse.e4.core.di.annotations.*;
+import org.eclipse.e4.ui.di.*;
+import org.eclipse.e4.ui.model.application.ui.basic.*;
+import org.eclipse.e4.ui.model.application.ui.menu.*;
 import org.eclipse.swt.*;
 import org.eclipse.swt.tools.internal.*;
 import org.eclipse.swt.widgets.*;
-import org.eclipse.ui.*;
-import org.eclipse.ui.part.*;
+
+import jakarta.annotation.*;
 
 
-public class MacGeneratorView extends ViewPart {
-	private Action generateAction;
+public class MacGeneratorView {
+	private static final String GENERATE_ICON = "platform:/plugin/org.eclipse.swt.tools/icons/mac.gif";
 	private MacGeneratorUI ui;
 	private IResource root;
 	IResourceChangeListener listener;
@@ -105,8 +108,8 @@ public class MacGeneratorView extends ViewPart {
 	 * This is a callback that will allow us
 	 * to create the viewer and initialize it.
 	 */
-	@Override
-	public void createPartControl(Composite parent) {
+	@PostConstruct
+	public void createPartControl(Composite parent, MPart part) {
 		if (root == null) {
 			Label label = new Label(parent, SWT.WRAP);
 			label.setText("Project org.eclipse.swt with folder \"Eclipse SWT PI/cocoa\" was not found in the workspace.");
@@ -120,29 +123,36 @@ public class MacGeneratorView extends ViewPart {
 		ui.setActionsVisible(false);
 		ui.open(parent);
 
-		makeActions();
-		contributeToActionBars();
+		contributeToPart(part);
 	}
 
-	private void contributeToActionBars() {
-		IActionBars bars = getViewSite().getActionBars();
-		fillLocalPullDown(bars.getMenuManager());
-		fillLocalToolBar(bars.getToolBarManager());
+	private void contributeToPart(MPart part) {
+		if (part.getToolbar() == null) {
+			MToolBar toolBar = MMenuFactory.INSTANCE.createToolBar();
+			MDirectToolItem item = MMenuFactory.INSTANCE.createDirectToolItem();
+			item.setLabel("Generate");
+			item.setTooltip("Generate");
+			item.setIconURI(GENERATE_ICON);
+			item.setObject(this);
+			toolBar.getChildren().add(item);
+			part.setToolbar(toolBar);
+		}
+		if (part.getMenus().stream().noneMatch(menu -> menu.getTags().contains("ViewMenu"))) {
+			MMenu menu = MMenuFactory.INSTANCE.createMenu();
+			menu.getTags().add("ViewMenu");
+			MDirectMenuItem item = MMenuFactory.INSTANCE.createDirectMenuItem();
+			item.setLabel("Generate");
+			item.setIconURI(GENERATE_ICON);
+			item.setObject(this);
+			menu.getChildren().add(item);
+			part.getMenus().add(menu);
+		}
 	}
 	
-	@Override
+	@PreDestroy
 	public void dispose() {
 		IWorkspace workspace = ResourcesPlugin.getWorkspace();
 		workspace.removeResourceChangeListener(listener);
-		super.dispose();
-	}
-
-	private void fillLocalPullDown(IMenuManager manager) {
-		manager.add(generateAction);
-	}
-
-	private void fillLocalToolBar(IToolBarManager manager) {
-		manager.add(generateAction);
 	}
 	
 	void refresh() {
@@ -153,29 +163,17 @@ public class MacGeneratorView extends ViewPart {
 		}
 	}
 	
+	@Execute
 	void generate() {
 		if (job != null) return;
 		job = new GenJob();
 		job.schedule();
 	}
 
-	private void makeActions() {
-		generateAction = new Action() {
-			@Override
-			public void run() {
-				generate();
-			}
-		};
-		generateAction.setText("Generate");
-		generateAction.setToolTipText("Generate");
-		generateAction.setImageDescriptor(PlatformUI.getWorkbench().getSharedImages().
-			getImageDescriptor(ISharedImages.IMG_ETOOL_SAVE_EDIT));
-	}
-
 	/**
 	 * Passing the focus request to the viewer's control.
 	 */
-	@Override
+	@Focus
 	public void setFocus() {
 		if (ui != null) ui.setFocus();
 	}


### PR DESCRIPTION
Register the view with e4view, use @PostConstruct, @Focus and @PreDestroy, and contribute the Generate tool bar and view menu items through the part model. This drops the dependency on org.eclipse.ui and the workbench bundles it pulls in.

Assisted-by: Anthropic Claude Code (claude-fable-5-1)