### PR TITLE
Tolerate slow CI agents when launching the remote clipboard helper

### DIFF
--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/RemoteClipboard.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/RemoteClipboard.java
@@ -40,6 +40,8 @@ public class RemoteClipboard implements ClipboardCommands {
 	 * debug the Swing side.
 	 */
 	private static boolean DEBUG_REMOTE = false;
+	/** Generous because loaded CI agents have needed more than 10 seconds to start the remote. */
+	private static final int REMOTE_STARTUP_TIMEOUT_MS = 60_000;
 	private ClipboardCommands remote;
 	private Process remoteClipboardProcess;
 	private Path remoteClipboardTempDir;
@@ -50,7 +52,7 @@ public class RemoteClipboard implements ClipboardCommands {
 		int port = DEBUG_REMOTE ? ClipboardCommands.DEFAULT_PORT : launchRemote();
 		try {
 			Registry reg = LocateRegistry.getRegistry("127.0.0.1", port);
-			long stopTime = System.currentTimeMillis() + 10000;
+			long stopTime = System.currentTimeMillis() + REMOTE_STARTUP_TIMEOUT_MS;
 			do {
 				try {
 					remote = (ClipboardCommands) reg.lookup(ClipboardCommands.ID);
@@ -140,7 +142,7 @@ public class RemoteClipboard implements ClipboardCommands {
 		remoteClipboardProcess = pb.start();
 
 		// Read server output to find the port
-		int port = SwtTestUtil.runOperationInThread(() -> {
+		int port = SwtTestUtil.runOperationInThread(REMOTE_STARTUP_TIMEOUT_MS, () -> {
 			BufferedReader reader = new BufferedReader(new InputStreamReader(remoteClipboardProcess.getInputStream()));
 			String line;
 			while ((line = reader.readLine()) != null) {


### PR DESCRIPTION
The AWT/Swing helper process normally starts in about a second, but on heavily loaded agents it has taken longer than the 10 second limit, failing every clipboard test that launches it. Allow 60 seconds for the process to start and bind its RMI registry.

Assisted-by: Anthropic Claude Code (claude-fable-5-1)