### PR TITLE
[GTK] Accept "jpg" as GdkPixbuf format name for JPEG

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/internal/NativeImageLoader.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/internal/NativeImageLoader.java
@@ -200,7 +200,7 @@ public class NativeImageLoader {
 		case "bmp" -> SWT.IMAGE_BMP;
 		case "gif" -> SWT.IMAGE_GIF;
 		case "ico" -> SWT.IMAGE_ICO;
-		case "jpeg" -> SWT.IMAGE_JPEG;
+		case "jpeg", "jpg" -> SWT.IMAGE_JPEG;
 		case "png" -> SWT.IMAGE_PNG;
 		case "tiff" -> SWT.IMAGE_TIFF;
 		case "svg" -> SWT.IMAGE_SVG;


### PR DESCRIPTION
Extracted from https://github.com/eclipse-platform/eclipse.platform.swt/pull/2103

Assisted-by: Anthropic Claude Code (claude-fable-5-1)