### PR TITLE
[GTK4] Show the box of unchecked check menu items

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/org/eclipse/swt/internal/gtk/swt_theming_fixes_gtk_4_0_0.css
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/gtk/org/eclipse/swt/internal/gtk/swt_theming_fixes_gtk_4_0_0.css
@@ -21,3 +21,13 @@ popover.swt-popover-shell > contents {
     min-width: 0;
     min-height: 0;
 }
+/*
+ * GTK themes draw the box of a check menu item only once it is checked, showing
+ * a bare checkmark otherwise, whereas radio items always show their circle. Give
+ * the check indicator a visible outline so an unchecked check menu item still
+ * shows its checkbox. currentColor keeps it correct in light and dark themes;
+ * this file must not carry a hard-coded color (see Device.overrideThemeValues).
+ */
+popover.menu check {
+    border-color: currentColor;
+}


### PR DESCRIPTION
GTK themes draw the box of a check menu item only once it is checked, showing a bare checkmark otherwise, while radio menu items always show their circle. A CHECK MenuItem that is not selected therefore appears as a blank row on GTK4, with no hint that it is a toggle.

Give the check indicator of popover menus a visible outline in SWT's GTK4 theming fixes, so an unchecked check menu item still shows its checkbox. The outline uses currentColor to follow the menu's text color, keeping it correct in both light and dark themes - this file must not carry a hard-coded color (see Device.overrideThemeValues).

Assisted-by: Anthropic Claude Code (claude-opus-4-8)