### PR TITLE
Do not override exec-maven-version from parent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -173,7 +173,6 @@
                bundles/org.eclipse.swt.tools with the java source-file launcher. -->
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>exec-maven-plugin</artifactId>
-          <version>3.6.3</version>
           <configuration>
             <forceJava>true</forceJava>
             <executable>java</executable>


### PR DESCRIPTION
https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/4039 made the version managed by parent thus drop the local version.