### PR TITLE
[GTK4] Fix use-after-free crash in window-active focus handling

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Control.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Control.java
@@ -57,7 +57,6 @@ public abstract class Control extends Widget implements Drawable {
 	static final boolean DISABLE_EMOJI = Boolean.getBoolean("SWT_GTK_INPUT_HINT_NO_EMOJI");
 
 	long fixedHandle;
-	long firstFixedHandle = 0;
 	long keyController;
 	long redrawWindow, enableWindow, provider;
 	int drawCount, backgroundAlpha = 255;
@@ -3969,17 +3968,15 @@ void gtk4_focus_enter_event(long controller, long event) {
 void gtk4_focus_window_event(long handle, long event) {
 	super.gtk4_focus_window_event(handle, event);
 
-	if(firstFixedHandle == 0) {
-		long child = handle;
-		//3rd child of shell will be SWTFixed
-		for(int i = 0; i<3; i++) {
-			child = GTK4.gtk_widget_get_first_child(child);
-		}
-		firstFixedHandle = child != 0 ? child:0;
-	}
-
-	if(firstFixedHandle !=0 && GTK.gtk_widget_has_focus(firstFixedHandle)) {
-		if(event == SWT.FocusIn)sendFocusEvent(SWT.FocusIn);
+	// Send the focus event when the receiver's focusable client-area SwtFixed
+	// (this.handle) holds the keyboard focus. Reference it directly rather than walking
+	// a fixed number of first-children from the window: that depth assumption is
+	// fragile, follows only first-children (so with a menu bar it reached the first menu
+	// bar item, not the content fixed), and a cached child handle would dangle once that
+	// widget was destroyed - the next window-active event then called
+	// gtk_widget_has_focus on freed memory (SIGSEGV).
+	if (this.handle != 0 && GTK.gtk_widget_has_focus(this.handle)) {
+		if (event == SWT.FocusIn) sendFocusEvent(SWT.FocusIn);
 		else sendFocusEvent(SWT.FocusOut);
 	}
 }


### PR DESCRIPTION
Control.gtk4_focus_window_event located the shell's focusable client SwtFixed by walking a fixed three levels of first-children from the window and caching the result. The cached handle was never invalidated, so once that widget was destroyed - a view or perspective change, or the shell being disposed on close - the next window-active event called gtk_widget_has_focus on freed memory and crashed with a SIGSEGV in GLib's type check.

The walk was also unreliable: following only first-children, it reached the first menu bar item rather than the client fixed whenever the shell had a menu bar. Reference this.handle directly instead - the receiver's client-area SwtFixed, which is the intended focusable widget and needs no walking or caching.

Assisted-by: Anthropic Claude Code (claude-opus-4-8)